### PR TITLE
Add additional timeboard graph request marker parameters

### DIFF
--- a/datadog/resource_datadog_timeboard.go
+++ b/datadog/resource_datadog_timeboard.go
@@ -126,6 +126,18 @@ func resourceDatadogTimeboard() *schema.Resource {
 					Type:     schema.TypeString,
 					Optional: true,
 				},
+				"max": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"min": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"dim": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+				},
 			},
 		},
 	}

--- a/datadog/resource_datadog_timeboard_test.go
+++ b/datadog/resource_datadog_timeboard_test.go
@@ -80,6 +80,9 @@ resource "datadog_timeboard" "acceptance_test" {
       label = "High Latency"
       type = "error solid"
       value = "y > 100"
+      max = "0.8"
+      min = "0"
+      dim = "y"
     }
     yaxis {
       max = "50"
@@ -167,6 +170,9 @@ func TestAccDatadogTimeboard_update(t *testing.T) {
 			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.marker.0.label", "High Latency"),
 			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.marker.0.type", "error solid"),
 			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.marker.0.value", "y > 100"),
+			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.marker.0.max", "0.8"),
+			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.marker.0.min", "0"),
+			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.marker.0.dim", "y"),
 			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.yaxis.max", "50"),
 			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.yaxis.scale", "sqrt"),
 			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.1.title", "ELB Requests"),


### PR DESCRIPTION
This addresses #50.

I don't know if any of the previous parameters have been deprecated or not, but this change allows me to generate marker sections that match those generated using the DataDog web interface.