### PR TITLE
Update docs to explicitly note changing layout requires recreate

### DIFF
--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -536,7 +536,7 @@ The following arguments are supported:
 - `title` - (Required) Title of the dashboard.
 - `widget` - (Required) Nested block describing a widget. The structure of this block is described [below](dashboard.html#nested-widget-blocks). Multiple `widget` blocks are allowed within a `datadog_dashboard` resource
 - `layout_type` - (Required) Layout type of the dashboard. Available values are: `ordered` (previous timeboard) or `free` (previous screenboard layout).
-<br>**Note: This value cannot be changed. Converting a dashboard from `free` <-> `ordered` requires destroying and re-creating the dashboard.**
+<br>**Note: This value cannot be changed. Converting a dashboard from `free` <-> `ordered` requires destroying and re-creating the dashboard.** Instead of using `ForceNew`, this is a manual action as many underlying widget configs need to be updated to work for the updated layout, otherwise the new dashboard won't be created properly.
 - `description` - (Optional) Description of the dashboard.
 - `is_read_only` - (Optional) Whether this dashboard is read-only. If `true`, only the author and admins can make changes to it.
 - `notify_list` - (Optional) List of handles of users to notify when changes are made to this dashboard.


### PR DESCRIPTION
Explicitly note that changing the layout type requires a destroy + re create of the dashboard.
Addresses - https://github.com/terraform-providers/terraform-provider-datadog/pull/286