### PR TITLE
New data sources for widgets

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,7 +22,7 @@ test: fmtcheck
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
-	DD_API_KEY=fake DD_APP_KEY=fake RECORD=false TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout=10m
+	DD_API_KEY=fake DD_APP_KEY=fake RECORD=false TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout=15m
 
 testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m

--- a/datadog/cassettes/TestAccDatadogDashboard_import.yaml
+++ b/datadog/cassettes/TestAccDatadogDashboard_import.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"description":"Created using the Datadog provider in Terraform","id":"","is_read_only":true,"layout_type":"ordered","notify_list":[],"template_variable_presets":[{"name":"preset_1","template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}]},{"name":"preset_2","template_variables":[{"name":"var_1","value":"var_1_value"}]}],"template_variables":[{"default":"aws","name":"var_1","prefix":"host"},{"default":"autoscaling","name":"var_2","prefix":"service_name"}],"title":"Acceptance Test Ordered Dashboard","widgets":[{"definition":{"alert_id":"895605","time":{"live_span":"1h"},"title":"Widget Title","type":"alert_graph","viz_type":"timeseries"}},{"definition":{"alert_id":"895605","precision":3,"text_align":"center","title":"Widget Title","type":"alert_value","unit":"b"}},{"definition":{"requests":[{"change_type":"absolute","compare_to":"week_before","increase_good":true,"order_by":"name","order_dir":"desc","q":"avg:system.load.1{env:staging} by {account}","show_present":true}],"time":{"live_span":"1h"},"title":"Widget Title","type":"change"}},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging} by {account}","style":{"palette":"warm"}}],"time":{"live_span":"1h"},"title":"Widget Title","type":"distribution"}},{"definition":{"check":"aws.ecs.agent_connected","group_by":["account","cluster"],"grouping":"cluster","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"time":{"live_span":"1h"},"title":"Widget Title","type":"check_status"}},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging} by {account}","style":{"palette":"warm"}}],"time":{"live_span":"1h"},"title":"Widget Title","type":"heatmap","yaxis":{"include_zero":true,"max":"2","min":"1","scale":"sqrt"}}},{"definition":{"group":["host","region"],"no_group_hosts":true,"no_metric_hosts":true,"node_type":"container","requests":{"fill":{"q":"avg:system.load.1{*} by {host}"},"size":{"q":"avg:memcache.uptime{*} by {host}"}},"scope":["region:us-east-1","aws_account:727006795293"],"style":{"fill_max":"20","fill_min":"10","palette":"yellow_to_green","palette_flip":true},"title":"Widget Title","type":"hostmap"}},{"definition":{"background_color":"pink","content":"note text","font_size":"14","show_tick":true,"text_align":"center","tick_edge":"left","tick_pos":"50%","type":"note"}},{"definition":{"autoscale":true,"custom_unit":"xx","precision":4,"requests":[{"aggregator":"sum","conditional_formats":[{"comparator":"\u003c","hide_value":false,"palette":"white_on_green","value":2},{"comparator":"\u003e","hide_value":false,"palette":"white_on_red","value":2.2}],"q":"avg:system.load.1{env:staging} by {account}"}],"text_align":"right","time":{"live_span":"1h"},"title":"Widget Title","type":"query_value"}},{"definition":{"color_by_groups":["account","apm-role-group"],"requests":{"x":{"aggregator":"max","q":"avg:system.cpu.user{*} by {service, account}"},"y":{"aggregator":"min","q":"avg:system.mem.used{*} by {service, account}"}},"time":{"live_span":"1h"},"title":"Widget Title","type":"scatterplot","xaxis":{"include_zero":true,"label":"x","max":"2000","min":"1","scale":"pow"},"yaxis":{"include_zero":false,"label":"y","max":"2222","min":"5","scale":"log"}}},{"definition":{"events":[{"q":"sources:test tags:1"},{"q":"sources:test tags:2"}],"legend_size":"2","markers":[{"display_type":"error dashed","label":" z=6 ","value":"y=4"},{"display_type":"ok solid","label":" x=8 ","value":"10 \u003c y \u003c 999"}],"requests":[{"display_type":"line","metadata":[{"alias_name":"Alpha","expression":"avg:system.cpu.user{app:general} by {env}"}],"q":"avg:system.cpu.user{app:general} by {env}","style":{"line_type":"dashed","line_width":"thin","palette":"warm"}},{"display_type":"area","log_query":{"compute":{"aggregation":"count","facet":"@duration","interval":5000},"group_by":[{"facet":"host","limit":10,"sort":{"aggregation":"avg","facet":"@duration","order":"desc"}}],"index":"mcnulty","search":{"query":"status:info"}}},{"apm_query":{"compute":{"aggregation":"count","facet":"@duration","interval":5000},"group_by":[{"facet":"resource_name","limit":50,"sort":{"aggregation":"avg","facet":"@string_query.interval","order":"desc"}}],"index":"apm-search","search":{"query":"type:web"}},"display_type":"bars"},{"display_type":"area","process_query":{"filter_by":["active"],"limit":50,"metric":"process.stat.cpu.total_pct","search_by":"error"}}],"show_legend":true,"time":{"live_span":"1h"},"title":"Widget Title","type":"timeseries","yaxis":{"include_zero":false,"max":"100","scale":"log"}}},{"definition":{"requests":[{"conditional_formats":[{"comparator":"\u003c","hide_value":false,"palette":"white_on_green","value":2},{"comparator":"\u003e","hide_value":false,"palette":"white_on_red","value":2.2}],"q":"avg:system.cpu.user{app:general} by {env}"}],"title":"Widget Title","type":"toplist"}},{"definition":{"layout_type":"ordered","title":"Group Widget","type":"group","widgets":[{"definition":{"background_color":"yellow","content":"cluster note widget","font_size":"16","show_tick":false,"text_align":"left","tick_edge":"left","tick_pos":"50%","type":"note"}},{"definition":{"alert_id":"123","time":{"live_span":"1h"},"title":"Alert Graph","type":"alert_graph","viz_type":"toplist"}}]}},{"definition":{"show_error_budget":true,"slo_id":"56789","time_windows":["7d","previous_week"],"title":"Widget Title","type":"slo","view_mode":"overall","view_type":"detail"}},{"definition":{"requests":[{"aggregator":"sum","conditional_formats":[{"comparator":"\u003c","hide_value":false,"palette":"white_on_green","value":2},{"comparator":"\u003e","hide_value":false,"palette":"white_on_red","value":2.2}],"limit":10,"q":"avg:system.load.1{env:staging} by {account}"}],"time":{"live_span":"1h"},"title":"Widget Title","type":"query_table"}}]}
+      {"description":"Created using the Datadog provider in Terraform","id":"","is_read_only":true,"layout_type":"ordered","notify_list":[],"template_variable_presets":[{"name":"preset_1","template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}]},{"name":"preset_2","template_variables":[{"name":"var_1","value":"var_1_value"}]}],"template_variables":[{"default":"aws","name":"var_1","prefix":"host"},{"default":"autoscaling","name":"var_2","prefix":"service_name"}],"title":"Acceptance Test Ordered Dashboard","widgets":[{"definition":{"alert_id":"895605","time":{"live_span":"1h"},"title":"Widget Title","type":"alert_graph","viz_type":"timeseries"}},{"definition":{"alert_id":"895605","precision":3,"text_align":"center","title":"Widget Title","type":"alert_value","unit":"b"}},{"definition":{"requests":[{"change_type":"absolute","compare_to":"week_before","increase_good":true,"order_by":"name","order_dir":"desc","q":"avg:system.load.1{env:staging} by {account}","show_present":true}],"time":{"live_span":"1h"},"title":"Widget Title","type":"change"}},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging} by {account}","style":{"palette":"warm"}}],"show_legend":false,"time":{"live_span":"1h"},"title":"Widget Title","type":"distribution"}},{"definition":{"check":"aws.ecs.agent_connected","group_by":["account","cluster"],"grouping":"cluster","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"time":{"live_span":"1h"},"title":"Widget Title","type":"check_status"}},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging} by {account}","style":{"palette":"warm"}}],"show_legend":false,"time":{"live_span":"1h"},"title":"Widget Title","type":"heatmap","yaxis":{"include_zero":true,"max":"2","min":"1","scale":"sqrt"}}},{"definition":{"group":["host","region"],"no_group_hosts":true,"no_metric_hosts":true,"node_type":"container","requests":{"fill":{"q":"avg:system.load.1{*} by {host}"},"size":{"q":"avg:memcache.uptime{*} by {host}"}},"scope":["region:us-east-1","aws_account:727006795293"],"style":{"fill_max":"20","fill_min":"10","palette":"yellow_to_green","palette_flip":true},"title":"Widget Title","type":"hostmap"}},{"definition":{"background_color":"pink","content":"note text","font_size":"14","show_tick":true,"text_align":"center","tick_edge":"left","tick_pos":"50%","type":"note"}},{"definition":{"autoscale":true,"custom_unit":"xx","precision":4,"requests":[{"aggregator":"sum","conditional_formats":[{"comparator":"\u003c","hide_value":false,"palette":"white_on_green","value":2},{"comparator":"\u003e","hide_value":false,"palette":"white_on_red","value":2.2}],"q":"avg:system.load.1{env:staging} by {account}"}],"text_align":"right","time":{"live_span":"1h"},"title":"Widget Title","type":"query_value"}},{"definition":{"color_by_groups":["account","apm-role-group"],"requests":{"x":{"aggregator":"max","q":"avg:system.cpu.user{*} by {service, account}"},"y":{"aggregator":"min","q":"avg:system.mem.used{*} by {service, account}"}},"time":{"live_span":"1h"},"title":"Widget Title","type":"scatterplot","xaxis":{"include_zero":true,"label":"x","max":"2000","min":"1","scale":"pow"},"yaxis":{"include_zero":false,"label":"y","max":"2222","min":"5","scale":"log"}}},{"definition":{"events":[{"q":"sources:test tags:1"},{"q":"sources:test tags:2"}],"legend_size":"2","markers":[{"display_type":"error dashed","label":" z=6 ","value":"y=4"},{"display_type":"ok solid","label":" x=8 ","value":"10 \u003c y \u003c 999"}],"requests":[{"display_type":"line","metadata":[{"alias_name":"Alpha","expression":"avg:system.cpu.user{app:general} by {env}"}],"q":"avg:system.cpu.user{app:general} by {env}","style":{"line_type":"dashed","line_width":"thin","palette":"warm"}},{"display_type":"area","log_query":{"compute":{"aggregation":"count","facet":"@duration","interval":5000},"group_by":[{"facet":"host","limit":10,"sort":{"aggregation":"avg","facet":"@duration","order":"desc"}}],"index":"mcnulty","search":{"query":"status:info"}}},{"apm_query":{"compute":{"aggregation":"count","facet":"@duration","interval":5000},"group_by":[{"facet":"resource_name","limit":50,"sort":{"aggregation":"avg","facet":"@string_query.interval","order":"desc"}}],"index":"apm-search","search":{"query":"type:web"}},"display_type":"bars"},{"display_type":"area","process_query":{"filter_by":["active"],"limit":50,"metric":"process.stat.cpu.total_pct","search_by":"error"}},{"display_type":"bars","security_query":{"compute":{"aggregation":"count"},"group_by":[{"facet":"status"}],"index":"signal","search":{"query":"status:(high OR critical)"}}},{"display_type":"bars","rum_query":{"compute":{"aggregation":"count"},"group_by":[{"facet":"service"}],"index":"rum","search":{"query":"status:info"}}}],"show_legend":true,"time":{"live_span":"1h"},"title":"Widget Title","type":"timeseries","yaxis":{"include_zero":false,"max":"100","scale":"log"}}},{"definition":{"requests":[{"conditional_formats":[{"comparator":"\u003c","hide_value":false,"palette":"white_on_green","value":2},{"comparator":"\u003e","hide_value":false,"palette":"white_on_red","value":2.2}],"q":"avg:system.cpu.user{app:general} by {env}"}],"title":"Widget Title","type":"toplist"}},{"definition":{"layout_type":"ordered","title":"Group Widget","type":"group","widgets":[{"definition":{"background_color":"yellow","content":"cluster note widget","font_size":"16","show_tick":false,"text_align":"left","tick_edge":"left","tick_pos":"50%","type":"note"}},{"definition":{"alert_id":"123","time":{"live_span":"1h"},"title":"Alert Graph","type":"alert_graph","viz_type":"toplist"}}]}},{"definition":{"show_error_budget":true,"slo_id":"56789","time_windows":["7d","previous_week"],"title":"Widget Title","type":"slo","view_mode":"overall","view_type":"detail"}},{"definition":{"requests":[{"aggregator":"sum","conditional_formats":[{"comparator":"\u003c","hide_value":false,"palette":"white_on_green","value":2},{"comparator":"\u003e","hide_value":false,"palette":"white_on_red","value":2.2}],"limit":10,"q":"avg:system.load.1{env:staging} by {account}"}],"time":{"live_span":"1h"},"title":"Widget Title","type":"query_table"}}]}
     form: {}
     headers:
       Accept:
@@ -13,43 +13,44 @@ interactions:
       Dd-Operation-Id:
       - CreateDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
     url: https://api.datadoghq.com/api/v1/dashboard
     method: POST
   response:
     body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":"Nicholas Muesch","template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"rgg-gtv-2sx","title":"Acceptance
-      Test Ordered Dashboard","url":"/dashboard/rgg-gtv-2sx/acceptance-test-ordered-dashboard","created_at":"2020-06-15T15:52:55.634935+00:00","modified_at":"2020-06-15T15:52:55.634935+00:00","author_handle":"nicholas.muesch@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
-      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":7718718870866810},{"definition":{"title":"Widget
-      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":2259659517650449},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"7j3-9mf-ub5","title":"Acceptance
+      Test Ordered Dashboard","url":"/dashboard/7j3-9mf-ub5/acceptance-test-ordered-dashboard","created_at":"2020-07-27T15:30:44.779300+00:00","modified_at":"2020-07-27T15:30:44.779300+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
+      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":8703460318206405},{"definition":{"title":"Widget
+      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":4663531293783662},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
       by {account}","show_present":true,"increase_good":true,"order_by":"name"}],"title":"Widget
-      Title","type":"change","time":{"live_span":"1h"}},"id":7510492339957753},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","time":{"live_span":"1h"}},"id":3745667864721328},{"definition":{"title":"Widget
-      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":8717189187634603},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"time":{"live_span":"1h"},"type":"heatmap","title":"Widget
-      Title"},"id":3189470194766778},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
+      Title","type":"change","time":{"live_span":"1h"}},"id":3786279037028240},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":4868091045450726},{"definition":{"title":"Widget
+      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":5144245788952582},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
+      Title","show_legend":false,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":603258090547376},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
       Title","node_type":"container","no_metric_hosts":true,"scope":["region:us-east-1","aws_account:727006795293"],"requests":{"size":{"q":"avg:memcache.uptime{*}
-      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":602446704727500},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
-      text","show_tick":true,"background_color":"pink"},"id":22018145864219},{"definition":{"autoscale":true,"title":"Widget
+      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":4740067701952169},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
+      text","show_tick":true,"background_color":"pink"},"id":3022225614582049},{"definition":{"autoscale":true,"title":"Widget
       Title","text_align":"right","custom_unit":"xx","precision":4,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":4337897217652900},{"definition":{"title":"Widget
+      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":8515772567511399},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"max":"2222","min":"5","scale":"log","label":"y"},"color_by_groups":["account","apm-role-group"],"xaxis":{"include_zero":true,"max":"2000","min":"1","scale":"pow","label":"x"},"time":{"live_span":"1h"},"requests":{"y":{"q":"avg:system.mem.used{*}
       by {service, account}","aggregator":"min"},"x":{"q":"avg:system.cpu.user{*}
-      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":8353938331614156},{"definition":{"title":"Widget
+      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":8463059092044388},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"scale":"log","max":"100"},"markers":[{"display_type":"error
       dashed","value":"y=4","label":" z=6 "},{"display_type":"ok solid","value":"10
       < y < 999","label":" x=8 "}],"events":[{"q":"sources:test tags:1"},{"q":"sources:test
       tags:2"}],"show_legend":true,"time":{"live_span":"1h"},"legend_size":"2","type":"timeseries","requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","style":{"line_width":"thin","palette":"warm","line_type":"dashed"},"display_type":"line","metadata":[{"expression":"avg:system.cpu.user{app:general}
-      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"}]},"id":5006685172366903},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
+      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"},{"display_type":"bars","security_query":{"index":"signal","search":{"query":"status:(high
+      OR critical)"},"group_by":[{"facet":"status"}],"compute":{"aggregation":"count"}}},{"rum_query":{"index":"rum","search":{"query":"status:info"},"group_by":[{"facet":"service"}],"compute":{"aggregation":"count"}},"display_type":"bars"}]},"id":3386652248538803},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"toplist","title":"Widget
-      Title"},"id":2720082503893472},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
-      note widget","show_tick":false,"background_color":"yellow"},"id":4338191889083278},{"definition":{"alert_id":"123","title":"Alert
-      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":7695144653164086}],"layout_type":"ordered","type":"group","title":"Group
-      Widget"},"id":7661082510522807},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
-      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":8986275005169463},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      Title"},"id":6192096461598520},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
+      note widget","show_tick":false,"background_color":"yellow"},"id":344365360506961},{"definition":{"alert_id":"123","title":"Alert
+      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":5427188636150195}],"layout_type":"ordered","type":"group","title":"Group
+      Widget"},"id":6204712051511488},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
+      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":5147590025261966},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
       by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}],"limit":10}],"title":"Widget
-      Title","type":"query_table","time":{"live_span":"1h"}},"id":8907742562879124}],"layout_type":"ordered"}'
+      Title","type":"query_table","time":{"live_span":"1h"}},"id":8738841365296731}],"layout_type":"ordered"}'
     headers:
       Cache-Control:
       - no-cache
@@ -60,13 +61,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:52:55 GMT
+      - Mon, 27 Jul 2020 15:30:44 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 22-Jun-2020 15:52:55 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 15:30:43 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -75,9 +76,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - 6qTaw+brNWWnKD6ULH8747/TVkPK0wedRsruOmMITJcYBkJ/Eac9bUO9jP1Btfl5
+      - sg8vzlrAXfi82gDuSEBUxkn5dG85uDtr4RhaVLNn521TM8s6JdimiKDHvX2NhFjo
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -92,43 +93,44 @@ interactions:
       Dd-Operation-Id:
       - GetDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/rgg-gtv-2sx
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/7j3-9mf-ub5
     method: GET
   response:
     body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":"Nicholas Muesch","template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"rgg-gtv-2sx","title":"Acceptance
-      Test Ordered Dashboard","url":"/dashboard/rgg-gtv-2sx/acceptance-test-ordered-dashboard","created_at":"2020-06-15T15:52:55.634935+00:00","modified_at":"2020-06-15T15:52:55.634935+00:00","author_handle":"nicholas.muesch@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
-      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":7718718870866810},{"definition":{"title":"Widget
-      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":2259659517650449},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"7j3-9mf-ub5","title":"Acceptance
+      Test Ordered Dashboard","url":"/dashboard/7j3-9mf-ub5/acceptance-test-ordered-dashboard","created_at":"2020-07-27T15:30:44.779300+00:00","modified_at":"2020-07-27T15:30:44.779300+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
+      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":8703460318206405},{"definition":{"title":"Widget
+      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":4663531293783662},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
       by {account}","show_present":true,"increase_good":true,"order_by":"name"}],"title":"Widget
-      Title","type":"change","time":{"live_span":"1h"}},"id":7510492339957753},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","time":{"live_span":"1h"}},"id":3745667864721328},{"definition":{"title":"Widget
-      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":8717189187634603},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"time":{"live_span":"1h"},"type":"heatmap","title":"Widget
-      Title"},"id":3189470194766778},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
+      Title","type":"change","time":{"live_span":"1h"}},"id":3786279037028240},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":4868091045450726},{"definition":{"title":"Widget
+      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":5144245788952582},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
+      Title","show_legend":false,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":603258090547376},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
       Title","node_type":"container","no_metric_hosts":true,"scope":["region:us-east-1","aws_account:727006795293"],"requests":{"size":{"q":"avg:memcache.uptime{*}
-      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":602446704727500},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
-      text","show_tick":true,"background_color":"pink"},"id":22018145864219},{"definition":{"autoscale":true,"title":"Widget
+      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":4740067701952169},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
+      text","show_tick":true,"background_color":"pink"},"id":3022225614582049},{"definition":{"autoscale":true,"title":"Widget
       Title","text_align":"right","custom_unit":"xx","precision":4,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":4337897217652900},{"definition":{"title":"Widget
+      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":8515772567511399},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"max":"2222","min":"5","scale":"log","label":"y"},"color_by_groups":["account","apm-role-group"],"xaxis":{"include_zero":true,"max":"2000","min":"1","scale":"pow","label":"x"},"time":{"live_span":"1h"},"requests":{"y":{"q":"avg:system.mem.used{*}
       by {service, account}","aggregator":"min"},"x":{"q":"avg:system.cpu.user{*}
-      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":8353938331614156},{"definition":{"title":"Widget
+      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":8463059092044388},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"scale":"log","max":"100"},"markers":[{"display_type":"error
       dashed","value":"y=4","label":" z=6 "},{"display_type":"ok solid","value":"10
       < y < 999","label":" x=8 "}],"events":[{"q":"sources:test tags:1"},{"q":"sources:test
       tags:2"}],"show_legend":true,"time":{"live_span":"1h"},"legend_size":"2","type":"timeseries","requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","style":{"line_width":"thin","palette":"warm","line_type":"dashed"},"display_type":"line","metadata":[{"expression":"avg:system.cpu.user{app:general}
-      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"}]},"id":5006685172366903},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
+      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"},{"display_type":"bars","security_query":{"index":"signal","search":{"query":"status:(high
+      OR critical)"},"group_by":[{"facet":"status"}],"compute":{"aggregation":"count"}}},{"rum_query":{"index":"rum","search":{"query":"status:info"},"group_by":[{"facet":"service"}],"compute":{"aggregation":"count"}},"display_type":"bars"}]},"id":3386652248538803},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"toplist","title":"Widget
-      Title"},"id":2720082503893472},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
-      note widget","show_tick":false,"background_color":"yellow"},"id":4338191889083278},{"definition":{"alert_id":"123","title":"Alert
-      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":7695144653164086}],"layout_type":"ordered","type":"group","title":"Group
-      Widget"},"id":7661082510522807},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
-      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":8986275005169463},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      Title"},"id":6192096461598520},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
+      note widget","show_tick":false,"background_color":"yellow"},"id":344365360506961},{"definition":{"alert_id":"123","title":"Alert
+      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":5427188636150195}],"layout_type":"ordered","type":"group","title":"Group
+      Widget"},"id":6204712051511488},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
+      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":5147590025261966},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
       by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}],"limit":10}],"title":"Widget
-      Title","type":"query_table","time":{"live_span":"1h"}},"id":8907742562879124}],"layout_type":"ordered"}'
+      Title","type":"query_table","time":{"live_span":"1h"}},"id":8738841365296731}],"layout_type":"ordered"}'
     headers:
       Cache-Control:
       - no-cache
@@ -139,13 +141,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:52:55 GMT
+      - Mon, 27 Jul 2020 15:30:45 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 22-Jun-2020 15:52:55 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 15:30:45 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -154,9 +156,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - jety+2H6BA1H4x31+wzy5BjqI2NDwh54fgbjSYyrLU0p2tWQPCCTKspX7sHO7u1n
+      - 3OCRM/4FZbkllI4iloi1acHDABD1SJi2aj2fysEPLLsOVOk5Ki6mi6IOsVG7JIay
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -171,43 +173,44 @@ interactions:
       Dd-Operation-Id:
       - GetDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/rgg-gtv-2sx
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/7j3-9mf-ub5
     method: GET
   response:
     body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":"Nicholas Muesch","template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"rgg-gtv-2sx","title":"Acceptance
-      Test Ordered Dashboard","url":"/dashboard/rgg-gtv-2sx/acceptance-test-ordered-dashboard","created_at":"2020-06-15T15:52:55.634935+00:00","modified_at":"2020-06-15T15:52:55.634935+00:00","author_handle":"nicholas.muesch@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
-      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":7718718870866810},{"definition":{"title":"Widget
-      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":2259659517650449},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"7j3-9mf-ub5","title":"Acceptance
+      Test Ordered Dashboard","url":"/dashboard/7j3-9mf-ub5/acceptance-test-ordered-dashboard","created_at":"2020-07-27T15:30:44.779300+00:00","modified_at":"2020-07-27T15:30:44.779300+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
+      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":8703460318206405},{"definition":{"title":"Widget
+      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":4663531293783662},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
       by {account}","show_present":true,"increase_good":true,"order_by":"name"}],"title":"Widget
-      Title","type":"change","time":{"live_span":"1h"}},"id":7510492339957753},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","time":{"live_span":"1h"}},"id":3745667864721328},{"definition":{"title":"Widget
-      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":8717189187634603},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"time":{"live_span":"1h"},"type":"heatmap","title":"Widget
-      Title"},"id":3189470194766778},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
+      Title","type":"change","time":{"live_span":"1h"}},"id":3786279037028240},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":4868091045450726},{"definition":{"title":"Widget
+      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":5144245788952582},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
+      Title","show_legend":false,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":603258090547376},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
       Title","node_type":"container","no_metric_hosts":true,"scope":["region:us-east-1","aws_account:727006795293"],"requests":{"size":{"q":"avg:memcache.uptime{*}
-      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":602446704727500},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
-      text","show_tick":true,"background_color":"pink"},"id":22018145864219},{"definition":{"autoscale":true,"title":"Widget
+      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":4740067701952169},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
+      text","show_tick":true,"background_color":"pink"},"id":3022225614582049},{"definition":{"autoscale":true,"title":"Widget
       Title","text_align":"right","custom_unit":"xx","precision":4,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":4337897217652900},{"definition":{"title":"Widget
+      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":8515772567511399},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"max":"2222","min":"5","scale":"log","label":"y"},"color_by_groups":["account","apm-role-group"],"xaxis":{"include_zero":true,"max":"2000","min":"1","scale":"pow","label":"x"},"time":{"live_span":"1h"},"requests":{"y":{"q":"avg:system.mem.used{*}
       by {service, account}","aggregator":"min"},"x":{"q":"avg:system.cpu.user{*}
-      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":8353938331614156},{"definition":{"title":"Widget
+      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":8463059092044388},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"scale":"log","max":"100"},"markers":[{"display_type":"error
       dashed","value":"y=4","label":" z=6 "},{"display_type":"ok solid","value":"10
       < y < 999","label":" x=8 "}],"events":[{"q":"sources:test tags:1"},{"q":"sources:test
       tags:2"}],"show_legend":true,"time":{"live_span":"1h"},"legend_size":"2","type":"timeseries","requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","style":{"line_width":"thin","palette":"warm","line_type":"dashed"},"display_type":"line","metadata":[{"expression":"avg:system.cpu.user{app:general}
-      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"}]},"id":5006685172366903},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
+      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"},{"display_type":"bars","security_query":{"index":"signal","search":{"query":"status:(high
+      OR critical)"},"group_by":[{"facet":"status"}],"compute":{"aggregation":"count"}}},{"rum_query":{"index":"rum","search":{"query":"status:info"},"group_by":[{"facet":"service"}],"compute":{"aggregation":"count"}},"display_type":"bars"}]},"id":3386652248538803},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"toplist","title":"Widget
-      Title"},"id":2720082503893472},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
-      note widget","show_tick":false,"background_color":"yellow"},"id":4338191889083278},{"definition":{"alert_id":"123","title":"Alert
-      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":7695144653164086}],"layout_type":"ordered","type":"group","title":"Group
-      Widget"},"id":7661082510522807},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
-      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":8986275005169463},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      Title"},"id":6192096461598520},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
+      note widget","show_tick":false,"background_color":"yellow"},"id":344365360506961},{"definition":{"alert_id":"123","title":"Alert
+      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":5427188636150195}],"layout_type":"ordered","type":"group","title":"Group
+      Widget"},"id":6204712051511488},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
+      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":5147590025261966},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
       by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}],"limit":10}],"title":"Widget
-      Title","type":"query_table","time":{"live_span":"1h"}},"id":8907742562879124}],"layout_type":"ordered"}'
+      Title","type":"query_table","time":{"live_span":"1h"}},"id":8738841365296731}],"layout_type":"ordered"}'
     headers:
       Cache-Control:
       - no-cache
@@ -218,13 +221,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:53:02 GMT
+      - Mon, 27 Jul 2020 15:30:49 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 22-Jun-2020 15:53:02 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 15:30:49 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -233,9 +236,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - e8t0cvW5uVKXk1zUsTcAcDpqv28dgy+lCs/R2sCfbKW6stomFiq2a4ijzxRdPBn5
+      - BsieYxalcMaIS+cTbK9YL1FxnAIiDF/6CFe3/lefzTTUruWB5XaSb08KP3lTATlu
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -250,43 +253,44 @@ interactions:
       Dd-Operation-Id:
       - GetDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/rgg-gtv-2sx
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/7j3-9mf-ub5
     method: GET
   response:
     body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":"Nicholas Muesch","template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"rgg-gtv-2sx","title":"Acceptance
-      Test Ordered Dashboard","url":"/dashboard/rgg-gtv-2sx/acceptance-test-ordered-dashboard","created_at":"2020-06-15T15:52:55.634935+00:00","modified_at":"2020-06-15T15:52:55.634935+00:00","author_handle":"nicholas.muesch@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
-      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":7718718870866810},{"definition":{"title":"Widget
-      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":2259659517650449},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"7j3-9mf-ub5","title":"Acceptance
+      Test Ordered Dashboard","url":"/dashboard/7j3-9mf-ub5/acceptance-test-ordered-dashboard","created_at":"2020-07-27T15:30:44.779300+00:00","modified_at":"2020-07-27T15:30:44.779300+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
+      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":8703460318206405},{"definition":{"title":"Widget
+      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":4663531293783662},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
       by {account}","show_present":true,"increase_good":true,"order_by":"name"}],"title":"Widget
-      Title","type":"change","time":{"live_span":"1h"}},"id":7510492339957753},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","time":{"live_span":"1h"}},"id":3745667864721328},{"definition":{"title":"Widget
-      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":8717189187634603},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"time":{"live_span":"1h"},"type":"heatmap","title":"Widget
-      Title"},"id":3189470194766778},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
+      Title","type":"change","time":{"live_span":"1h"}},"id":3786279037028240},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":4868091045450726},{"definition":{"title":"Widget
+      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":5144245788952582},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
+      Title","show_legend":false,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":603258090547376},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
       Title","node_type":"container","no_metric_hosts":true,"scope":["region:us-east-1","aws_account:727006795293"],"requests":{"size":{"q":"avg:memcache.uptime{*}
-      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":602446704727500},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
-      text","show_tick":true,"background_color":"pink"},"id":22018145864219},{"definition":{"autoscale":true,"title":"Widget
+      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":4740067701952169},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
+      text","show_tick":true,"background_color":"pink"},"id":3022225614582049},{"definition":{"autoscale":true,"title":"Widget
       Title","text_align":"right","custom_unit":"xx","precision":4,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":4337897217652900},{"definition":{"title":"Widget
+      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":8515772567511399},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"max":"2222","min":"5","scale":"log","label":"y"},"color_by_groups":["account","apm-role-group"],"xaxis":{"include_zero":true,"max":"2000","min":"1","scale":"pow","label":"x"},"time":{"live_span":"1h"},"requests":{"y":{"q":"avg:system.mem.used{*}
       by {service, account}","aggregator":"min"},"x":{"q":"avg:system.cpu.user{*}
-      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":8353938331614156},{"definition":{"title":"Widget
+      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":8463059092044388},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"scale":"log","max":"100"},"markers":[{"display_type":"error
       dashed","value":"y=4","label":" z=6 "},{"display_type":"ok solid","value":"10
       < y < 999","label":" x=8 "}],"events":[{"q":"sources:test tags:1"},{"q":"sources:test
       tags:2"}],"show_legend":true,"time":{"live_span":"1h"},"legend_size":"2","type":"timeseries","requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","style":{"line_width":"thin","palette":"warm","line_type":"dashed"},"display_type":"line","metadata":[{"expression":"avg:system.cpu.user{app:general}
-      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"}]},"id":5006685172366903},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
+      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"},{"display_type":"bars","security_query":{"index":"signal","search":{"query":"status:(high
+      OR critical)"},"group_by":[{"facet":"status"}],"compute":{"aggregation":"count"}}},{"rum_query":{"index":"rum","search":{"query":"status:info"},"group_by":[{"facet":"service"}],"compute":{"aggregation":"count"}},"display_type":"bars"}]},"id":3386652248538803},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"toplist","title":"Widget
-      Title"},"id":2720082503893472},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
-      note widget","show_tick":false,"background_color":"yellow"},"id":4338191889083278},{"definition":{"alert_id":"123","title":"Alert
-      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":7695144653164086}],"layout_type":"ordered","type":"group","title":"Group
-      Widget"},"id":7661082510522807},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
-      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":8986275005169463},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      Title"},"id":6192096461598520},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
+      note widget","show_tick":false,"background_color":"yellow"},"id":344365360506961},{"definition":{"alert_id":"123","title":"Alert
+      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":5427188636150195}],"layout_type":"ordered","type":"group","title":"Group
+      Widget"},"id":6204712051511488},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
+      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":5147590025261966},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
       by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}],"limit":10}],"title":"Widget
-      Title","type":"query_table","time":{"live_span":"1h"}},"id":8907742562879124}],"layout_type":"ordered"}'
+      Title","type":"query_table","time":{"live_span":"1h"}},"id":8738841365296731}],"layout_type":"ordered"}'
     headers:
       Cache-Control:
       - no-cache
@@ -297,13 +301,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:53:02 GMT
+      - Mon, 27 Jul 2020 15:30:49 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 22-Jun-2020 15:53:02 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 15:30:49 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -312,9 +316,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - AZX6w/8zD+VN3BjlP7mTxsWKLW39bs6QmKw7eyNlBdxzsMsZp5eTFn4umzElZK4n
+      - 0NKmGyvxoU/01+VE4+5ciHt/qhU00FGqdaV53YRG0QEVDHNDHIhr2nlk2iUuC2i4
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -329,43 +333,44 @@ interactions:
       Dd-Operation-Id:
       - GetDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/rgg-gtv-2sx
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/7j3-9mf-ub5
     method: GET
   response:
     body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":"Nicholas Muesch","template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"rgg-gtv-2sx","title":"Acceptance
-      Test Ordered Dashboard","url":"/dashboard/rgg-gtv-2sx/acceptance-test-ordered-dashboard","created_at":"2020-06-15T15:52:55.634935+00:00","modified_at":"2020-06-15T15:52:55.634935+00:00","author_handle":"nicholas.muesch@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
-      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":7718718870866810},{"definition":{"title":"Widget
-      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":2259659517650449},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"7j3-9mf-ub5","title":"Acceptance
+      Test Ordered Dashboard","url":"/dashboard/7j3-9mf-ub5/acceptance-test-ordered-dashboard","created_at":"2020-07-27T15:30:44.779300+00:00","modified_at":"2020-07-27T15:30:44.779300+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
+      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":8703460318206405},{"definition":{"title":"Widget
+      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":4663531293783662},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
       by {account}","show_present":true,"increase_good":true,"order_by":"name"}],"title":"Widget
-      Title","type":"change","time":{"live_span":"1h"}},"id":7510492339957753},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","time":{"live_span":"1h"}},"id":3745667864721328},{"definition":{"title":"Widget
-      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":8717189187634603},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"time":{"live_span":"1h"},"type":"heatmap","title":"Widget
-      Title"},"id":3189470194766778},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
+      Title","type":"change","time":{"live_span":"1h"}},"id":3786279037028240},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":4868091045450726},{"definition":{"title":"Widget
+      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":5144245788952582},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
+      Title","show_legend":false,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":603258090547376},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
       Title","node_type":"container","no_metric_hosts":true,"scope":["region:us-east-1","aws_account:727006795293"],"requests":{"size":{"q":"avg:memcache.uptime{*}
-      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":602446704727500},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
-      text","show_tick":true,"background_color":"pink"},"id":22018145864219},{"definition":{"autoscale":true,"title":"Widget
+      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":4740067701952169},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
+      text","show_tick":true,"background_color":"pink"},"id":3022225614582049},{"definition":{"autoscale":true,"title":"Widget
       Title","text_align":"right","custom_unit":"xx","precision":4,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":4337897217652900},{"definition":{"title":"Widget
+      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":8515772567511399},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"max":"2222","min":"5","scale":"log","label":"y"},"color_by_groups":["account","apm-role-group"],"xaxis":{"include_zero":true,"max":"2000","min":"1","scale":"pow","label":"x"},"time":{"live_span":"1h"},"requests":{"y":{"q":"avg:system.mem.used{*}
       by {service, account}","aggregator":"min"},"x":{"q":"avg:system.cpu.user{*}
-      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":8353938331614156},{"definition":{"title":"Widget
+      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":8463059092044388},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"scale":"log","max":"100"},"markers":[{"display_type":"error
       dashed","value":"y=4","label":" z=6 "},{"display_type":"ok solid","value":"10
       < y < 999","label":" x=8 "}],"events":[{"q":"sources:test tags:1"},{"q":"sources:test
       tags:2"}],"show_legend":true,"time":{"live_span":"1h"},"legend_size":"2","type":"timeseries","requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","style":{"line_width":"thin","palette":"warm","line_type":"dashed"},"display_type":"line","metadata":[{"expression":"avg:system.cpu.user{app:general}
-      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"}]},"id":5006685172366903},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
+      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"},{"display_type":"bars","security_query":{"index":"signal","search":{"query":"status:(high
+      OR critical)"},"group_by":[{"facet":"status"}],"compute":{"aggregation":"count"}}},{"rum_query":{"index":"rum","search":{"query":"status:info"},"group_by":[{"facet":"service"}],"compute":{"aggregation":"count"}},"display_type":"bars"}]},"id":3386652248538803},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"toplist","title":"Widget
-      Title"},"id":2720082503893472},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
-      note widget","show_tick":false,"background_color":"yellow"},"id":4338191889083278},{"definition":{"alert_id":"123","title":"Alert
-      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":7695144653164086}],"layout_type":"ordered","type":"group","title":"Group
-      Widget"},"id":7661082510522807},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
-      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":8986275005169463},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      Title"},"id":6192096461598520},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
+      note widget","show_tick":false,"background_color":"yellow"},"id":344365360506961},{"definition":{"alert_id":"123","title":"Alert
+      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":5427188636150195}],"layout_type":"ordered","type":"group","title":"Group
+      Widget"},"id":6204712051511488},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
+      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":5147590025261966},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
       by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}],"limit":10}],"title":"Widget
-      Title","type":"query_table","time":{"live_span":"1h"}},"id":8907742562879124}],"layout_type":"ordered"}'
+      Title","type":"query_table","time":{"live_span":"1h"}},"id":8738841365296731}],"layout_type":"ordered"}'
     headers:
       Cache-Control:
       - no-cache
@@ -376,13 +381,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:53:06 GMT
+      - Mon, 27 Jul 2020 15:30:52 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 22-Jun-2020 15:53:06 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 15:30:52 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -391,9 +396,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - kg+/Cls6zaJcT2blJLlU62BwgGePGdpqSwWrJ0xEIvzmSMWHXxGNsiyEzBPJ1a96
+      - vG5kxpR47Wd0uZGIzWkStfMxs3cmVIjKYEHLQf0xQiHS0P2BwlwJHwTESUSKlcdO
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -408,43 +413,44 @@ interactions:
       Dd-Operation-Id:
       - GetDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/rgg-gtv-2sx
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/7j3-9mf-ub5
     method: GET
   response:
     body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":"Nicholas Muesch","template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"rgg-gtv-2sx","title":"Acceptance
-      Test Ordered Dashboard","url":"/dashboard/rgg-gtv-2sx/acceptance-test-ordered-dashboard","created_at":"2020-06-15T15:52:55.634935+00:00","modified_at":"2020-06-15T15:52:55.634935+00:00","author_handle":"nicholas.muesch@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
-      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":7718718870866810},{"definition":{"title":"Widget
-      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":2259659517650449},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"7j3-9mf-ub5","title":"Acceptance
+      Test Ordered Dashboard","url":"/dashboard/7j3-9mf-ub5/acceptance-test-ordered-dashboard","created_at":"2020-07-27T15:30:44.779300+00:00","modified_at":"2020-07-27T15:30:44.779300+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
+      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":8703460318206405},{"definition":{"title":"Widget
+      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":4663531293783662},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
       by {account}","show_present":true,"increase_good":true,"order_by":"name"}],"title":"Widget
-      Title","type":"change","time":{"live_span":"1h"}},"id":7510492339957753},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","time":{"live_span":"1h"}},"id":3745667864721328},{"definition":{"title":"Widget
-      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":8717189187634603},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"time":{"live_span":"1h"},"type":"heatmap","title":"Widget
-      Title"},"id":3189470194766778},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
+      Title","type":"change","time":{"live_span":"1h"}},"id":3786279037028240},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":4868091045450726},{"definition":{"title":"Widget
+      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":5144245788952582},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
+      Title","show_legend":false,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":603258090547376},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
       Title","node_type":"container","no_metric_hosts":true,"scope":["region:us-east-1","aws_account:727006795293"],"requests":{"size":{"q":"avg:memcache.uptime{*}
-      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":602446704727500},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
-      text","show_tick":true,"background_color":"pink"},"id":22018145864219},{"definition":{"autoscale":true,"title":"Widget
+      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":4740067701952169},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
+      text","show_tick":true,"background_color":"pink"},"id":3022225614582049},{"definition":{"autoscale":true,"title":"Widget
       Title","text_align":"right","custom_unit":"xx","precision":4,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":4337897217652900},{"definition":{"title":"Widget
+      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":8515772567511399},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"max":"2222","min":"5","scale":"log","label":"y"},"color_by_groups":["account","apm-role-group"],"xaxis":{"include_zero":true,"max":"2000","min":"1","scale":"pow","label":"x"},"time":{"live_span":"1h"},"requests":{"y":{"q":"avg:system.mem.used{*}
       by {service, account}","aggregator":"min"},"x":{"q":"avg:system.cpu.user{*}
-      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":8353938331614156},{"definition":{"title":"Widget
+      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":8463059092044388},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"scale":"log","max":"100"},"markers":[{"display_type":"error
       dashed","value":"y=4","label":" z=6 "},{"display_type":"ok solid","value":"10
       < y < 999","label":" x=8 "}],"events":[{"q":"sources:test tags:1"},{"q":"sources:test
       tags:2"}],"show_legend":true,"time":{"live_span":"1h"},"legend_size":"2","type":"timeseries","requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","style":{"line_width":"thin","palette":"warm","line_type":"dashed"},"display_type":"line","metadata":[{"expression":"avg:system.cpu.user{app:general}
-      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"}]},"id":5006685172366903},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
+      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"},{"display_type":"bars","security_query":{"index":"signal","search":{"query":"status:(high
+      OR critical)"},"group_by":[{"facet":"status"}],"compute":{"aggregation":"count"}}},{"rum_query":{"index":"rum","search":{"query":"status:info"},"group_by":[{"facet":"service"}],"compute":{"aggregation":"count"}},"display_type":"bars"}]},"id":3386652248538803},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"toplist","title":"Widget
-      Title"},"id":2720082503893472},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
-      note widget","show_tick":false,"background_color":"yellow"},"id":4338191889083278},{"definition":{"alert_id":"123","title":"Alert
-      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":7695144653164086}],"layout_type":"ordered","type":"group","title":"Group
-      Widget"},"id":7661082510522807},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
-      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":8986275005169463},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      Title"},"id":6192096461598520},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
+      note widget","show_tick":false,"background_color":"yellow"},"id":344365360506961},{"definition":{"alert_id":"123","title":"Alert
+      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":5427188636150195}],"layout_type":"ordered","type":"group","title":"Group
+      Widget"},"id":6204712051511488},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
+      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":5147590025261966},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
       by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}],"limit":10}],"title":"Widget
-      Title","type":"query_table","time":{"live_span":"1h"}},"id":8907742562879124}],"layout_type":"ordered"}'
+      Title","type":"query_table","time":{"live_span":"1h"}},"id":8738841365296731}],"layout_type":"ordered"}'
     headers:
       Cache-Control:
       - no-cache
@@ -455,13 +461,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:53:07 GMT
+      - Mon, 27 Jul 2020 15:30:53 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 22-Jun-2020 15:53:07 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 15:30:53 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -470,9 +476,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - KKQq2SiaDLpychKSp47ffvU6SRxUV+VzBWr187ESkULBuGOI+kREfb/2NCy8DAWC
+      - B/LXPck0nGNX0RSV/Gw7cnZ0oe92FUOfg1ec7WcU0kSvw/UBT+IXTFTD87Snvz2v
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -487,43 +493,44 @@ interactions:
       Dd-Operation-Id:
       - GetDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/rgg-gtv-2sx
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/7j3-9mf-ub5
     method: GET
   response:
     body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":"Nicholas Muesch","template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"rgg-gtv-2sx","title":"Acceptance
-      Test Ordered Dashboard","url":"/dashboard/rgg-gtv-2sx/acceptance-test-ordered-dashboard","created_at":"2020-06-15T15:52:55.634935+00:00","modified_at":"2020-06-15T15:52:55.634935+00:00","author_handle":"nicholas.muesch@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
-      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":7718718870866810},{"definition":{"title":"Widget
-      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":2259659517650449},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"7j3-9mf-ub5","title":"Acceptance
+      Test Ordered Dashboard","url":"/dashboard/7j3-9mf-ub5/acceptance-test-ordered-dashboard","created_at":"2020-07-27T15:30:44.779300+00:00","modified_at":"2020-07-27T15:30:44.779300+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
+      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":8703460318206405},{"definition":{"title":"Widget
+      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":4663531293783662},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
       by {account}","show_present":true,"increase_good":true,"order_by":"name"}],"title":"Widget
-      Title","type":"change","time":{"live_span":"1h"}},"id":7510492339957753},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","time":{"live_span":"1h"}},"id":3745667864721328},{"definition":{"title":"Widget
-      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":8717189187634603},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"time":{"live_span":"1h"},"type":"heatmap","title":"Widget
-      Title"},"id":3189470194766778},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
+      Title","type":"change","time":{"live_span":"1h"}},"id":3786279037028240},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":4868091045450726},{"definition":{"title":"Widget
+      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":5144245788952582},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
+      Title","show_legend":false,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":603258090547376},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
       Title","node_type":"container","no_metric_hosts":true,"scope":["region:us-east-1","aws_account:727006795293"],"requests":{"size":{"q":"avg:memcache.uptime{*}
-      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":602446704727500},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
-      text","show_tick":true,"background_color":"pink"},"id":22018145864219},{"definition":{"autoscale":true,"title":"Widget
+      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":4740067701952169},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
+      text","show_tick":true,"background_color":"pink"},"id":3022225614582049},{"definition":{"autoscale":true,"title":"Widget
       Title","text_align":"right","custom_unit":"xx","precision":4,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":4337897217652900},{"definition":{"title":"Widget
+      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":8515772567511399},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"max":"2222","min":"5","scale":"log","label":"y"},"color_by_groups":["account","apm-role-group"],"xaxis":{"include_zero":true,"max":"2000","min":"1","scale":"pow","label":"x"},"time":{"live_span":"1h"},"requests":{"y":{"q":"avg:system.mem.used{*}
       by {service, account}","aggregator":"min"},"x":{"q":"avg:system.cpu.user{*}
-      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":8353938331614156},{"definition":{"title":"Widget
+      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":8463059092044388},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"scale":"log","max":"100"},"markers":[{"display_type":"error
       dashed","value":"y=4","label":" z=6 "},{"display_type":"ok solid","value":"10
       < y < 999","label":" x=8 "}],"events":[{"q":"sources:test tags:1"},{"q":"sources:test
       tags:2"}],"show_legend":true,"time":{"live_span":"1h"},"legend_size":"2","type":"timeseries","requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","style":{"line_width":"thin","palette":"warm","line_type":"dashed"},"display_type":"line","metadata":[{"expression":"avg:system.cpu.user{app:general}
-      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"}]},"id":5006685172366903},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
+      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"},{"display_type":"bars","security_query":{"index":"signal","search":{"query":"status:(high
+      OR critical)"},"group_by":[{"facet":"status"}],"compute":{"aggregation":"count"}}},{"rum_query":{"index":"rum","search":{"query":"status:info"},"group_by":[{"facet":"service"}],"compute":{"aggregation":"count"}},"display_type":"bars"}]},"id":3386652248538803},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"toplist","title":"Widget
-      Title"},"id":2720082503893472},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
-      note widget","show_tick":false,"background_color":"yellow"},"id":4338191889083278},{"definition":{"alert_id":"123","title":"Alert
-      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":7695144653164086}],"layout_type":"ordered","type":"group","title":"Group
-      Widget"},"id":7661082510522807},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
-      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":8986275005169463},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      Title"},"id":6192096461598520},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
+      note widget","show_tick":false,"background_color":"yellow"},"id":344365360506961},{"definition":{"alert_id":"123","title":"Alert
+      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":5427188636150195}],"layout_type":"ordered","type":"group","title":"Group
+      Widget"},"id":6204712051511488},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
+      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":5147590025261966},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
       by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}],"limit":10}],"title":"Widget
-      Title","type":"query_table","time":{"live_span":"1h"}},"id":8907742562879124}],"layout_type":"ordered"}'
+      Title","type":"query_table","time":{"live_span":"1h"}},"id":8738841365296731}],"layout_type":"ordered"}'
     headers:
       Cache-Control:
       - no-cache
@@ -534,13 +541,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:53:07 GMT
+      - Mon, 27 Jul 2020 15:30:53 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 22-Jun-2020 15:53:07 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 15:30:53 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -549,9 +556,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - F2g1vP9i37Cj4rH5vEufbSNzCmriMTDVzKKqVk/JOUesbIz8psR3R2945wO0PbTf
+      - nRZqCODixwNZX0HLyT17WzYwenviVG0rmnZak57k5KsDWun3aWEsPedTsRpiFQxf
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -566,43 +573,44 @@ interactions:
       Dd-Operation-Id:
       - GetDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/rgg-gtv-2sx
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/7j3-9mf-ub5
     method: GET
   response:
     body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":"Nicholas Muesch","template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"rgg-gtv-2sx","title":"Acceptance
-      Test Ordered Dashboard","url":"/dashboard/rgg-gtv-2sx/acceptance-test-ordered-dashboard","created_at":"2020-06-15T15:52:55.634935+00:00","modified_at":"2020-06-15T15:52:55.634935+00:00","author_handle":"nicholas.muesch@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
-      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":7718718870866810},{"definition":{"title":"Widget
-      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":2259659517650449},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"7j3-9mf-ub5","title":"Acceptance
+      Test Ordered Dashboard","url":"/dashboard/7j3-9mf-ub5/acceptance-test-ordered-dashboard","created_at":"2020-07-27T15:30:44.779300+00:00","modified_at":"2020-07-27T15:30:44.779300+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
+      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":8703460318206405},{"definition":{"title":"Widget
+      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":4663531293783662},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
       by {account}","show_present":true,"increase_good":true,"order_by":"name"}],"title":"Widget
-      Title","type":"change","time":{"live_span":"1h"}},"id":7510492339957753},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","time":{"live_span":"1h"}},"id":3745667864721328},{"definition":{"title":"Widget
-      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":8717189187634603},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"time":{"live_span":"1h"},"type":"heatmap","title":"Widget
-      Title"},"id":3189470194766778},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
+      Title","type":"change","time":{"live_span":"1h"}},"id":3786279037028240},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":4868091045450726},{"definition":{"title":"Widget
+      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":5144245788952582},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
+      Title","show_legend":false,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":603258090547376},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
       Title","node_type":"container","no_metric_hosts":true,"scope":["region:us-east-1","aws_account:727006795293"],"requests":{"size":{"q":"avg:memcache.uptime{*}
-      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":602446704727500},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
-      text","show_tick":true,"background_color":"pink"},"id":22018145864219},{"definition":{"autoscale":true,"title":"Widget
+      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":4740067701952169},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
+      text","show_tick":true,"background_color":"pink"},"id":3022225614582049},{"definition":{"autoscale":true,"title":"Widget
       Title","text_align":"right","custom_unit":"xx","precision":4,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":4337897217652900},{"definition":{"title":"Widget
+      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":8515772567511399},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"max":"2222","min":"5","scale":"log","label":"y"},"color_by_groups":["account","apm-role-group"],"xaxis":{"include_zero":true,"max":"2000","min":"1","scale":"pow","label":"x"},"time":{"live_span":"1h"},"requests":{"y":{"q":"avg:system.mem.used{*}
       by {service, account}","aggregator":"min"},"x":{"q":"avg:system.cpu.user{*}
-      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":8353938331614156},{"definition":{"title":"Widget
+      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":8463059092044388},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"scale":"log","max":"100"},"markers":[{"display_type":"error
       dashed","value":"y=4","label":" z=6 "},{"display_type":"ok solid","value":"10
       < y < 999","label":" x=8 "}],"events":[{"q":"sources:test tags:1"},{"q":"sources:test
       tags:2"}],"show_legend":true,"time":{"live_span":"1h"},"legend_size":"2","type":"timeseries","requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","style":{"line_width":"thin","palette":"warm","line_type":"dashed"},"display_type":"line","metadata":[{"expression":"avg:system.cpu.user{app:general}
-      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"}]},"id":5006685172366903},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
+      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"},{"display_type":"bars","security_query":{"index":"signal","search":{"query":"status:(high
+      OR critical)"},"group_by":[{"facet":"status"}],"compute":{"aggregation":"count"}}},{"rum_query":{"index":"rum","search":{"query":"status:info"},"group_by":[{"facet":"service"}],"compute":{"aggregation":"count"}},"display_type":"bars"}]},"id":3386652248538803},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"toplist","title":"Widget
-      Title"},"id":2720082503893472},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
-      note widget","show_tick":false,"background_color":"yellow"},"id":4338191889083278},{"definition":{"alert_id":"123","title":"Alert
-      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":7695144653164086}],"layout_type":"ordered","type":"group","title":"Group
-      Widget"},"id":7661082510522807},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
-      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":8986275005169463},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      Title"},"id":6192096461598520},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
+      note widget","show_tick":false,"background_color":"yellow"},"id":344365360506961},{"definition":{"alert_id":"123","title":"Alert
+      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":5427188636150195}],"layout_type":"ordered","type":"group","title":"Group
+      Widget"},"id":6204712051511488},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
+      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":5147590025261966},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
       by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}],"limit":10}],"title":"Widget
-      Title","type":"query_table","time":{"live_span":"1h"}},"id":8907742562879124}],"layout_type":"ordered"}'
+      Title","type":"query_table","time":{"live_span":"1h"}},"id":8738841365296731}],"layout_type":"ordered"}'
     headers:
       Cache-Control:
       - no-cache
@@ -613,13 +621,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:53:12 GMT
+      - Mon, 27 Jul 2020 15:30:55 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 22-Jun-2020 15:53:11 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 15:30:55 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -628,9 +636,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - u9VEJv4YNx+Fl9tRGJNbGm0+76jyym0t+mec2t84PhoJYEedil3ajyEhP7U3EneZ
+      - Wts7Rn21w0qW4rqYtxheVW/4xeY9Y3ARkRMnLeq6etar4hXLqkvskJXcsIyQxYKB
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -645,43 +653,44 @@ interactions:
       Dd-Operation-Id:
       - GetDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/rgg-gtv-2sx
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/7j3-9mf-ub5
     method: GET
   response:
     body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":"Nicholas Muesch","template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"rgg-gtv-2sx","title":"Acceptance
-      Test Ordered Dashboard","url":"/dashboard/rgg-gtv-2sx/acceptance-test-ordered-dashboard","created_at":"2020-06-15T15:52:55.634935+00:00","modified_at":"2020-06-15T15:52:55.634935+00:00","author_handle":"nicholas.muesch@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
-      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":7718718870866810},{"definition":{"title":"Widget
-      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":2259659517650449},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"7j3-9mf-ub5","title":"Acceptance
+      Test Ordered Dashboard","url":"/dashboard/7j3-9mf-ub5/acceptance-test-ordered-dashboard","created_at":"2020-07-27T15:30:44.779300+00:00","modified_at":"2020-07-27T15:30:44.779300+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
+      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":8703460318206405},{"definition":{"title":"Widget
+      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":4663531293783662},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
       by {account}","show_present":true,"increase_good":true,"order_by":"name"}],"title":"Widget
-      Title","type":"change","time":{"live_span":"1h"}},"id":7510492339957753},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","time":{"live_span":"1h"}},"id":3745667864721328},{"definition":{"title":"Widget
-      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":8717189187634603},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"time":{"live_span":"1h"},"type":"heatmap","title":"Widget
-      Title"},"id":3189470194766778},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
+      Title","type":"change","time":{"live_span":"1h"}},"id":3786279037028240},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":4868091045450726},{"definition":{"title":"Widget
+      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":5144245788952582},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
+      Title","show_legend":false,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":603258090547376},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
       Title","node_type":"container","no_metric_hosts":true,"scope":["region:us-east-1","aws_account:727006795293"],"requests":{"size":{"q":"avg:memcache.uptime{*}
-      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":602446704727500},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
-      text","show_tick":true,"background_color":"pink"},"id":22018145864219},{"definition":{"autoscale":true,"title":"Widget
+      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":4740067701952169},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
+      text","show_tick":true,"background_color":"pink"},"id":3022225614582049},{"definition":{"autoscale":true,"title":"Widget
       Title","text_align":"right","custom_unit":"xx","precision":4,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":4337897217652900},{"definition":{"title":"Widget
+      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":8515772567511399},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"max":"2222","min":"5","scale":"log","label":"y"},"color_by_groups":["account","apm-role-group"],"xaxis":{"include_zero":true,"max":"2000","min":"1","scale":"pow","label":"x"},"time":{"live_span":"1h"},"requests":{"y":{"q":"avg:system.mem.used{*}
       by {service, account}","aggregator":"min"},"x":{"q":"avg:system.cpu.user{*}
-      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":8353938331614156},{"definition":{"title":"Widget
+      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":8463059092044388},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"scale":"log","max":"100"},"markers":[{"display_type":"error
       dashed","value":"y=4","label":" z=6 "},{"display_type":"ok solid","value":"10
       < y < 999","label":" x=8 "}],"events":[{"q":"sources:test tags:1"},{"q":"sources:test
       tags:2"}],"show_legend":true,"time":{"live_span":"1h"},"legend_size":"2","type":"timeseries","requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","style":{"line_width":"thin","palette":"warm","line_type":"dashed"},"display_type":"line","metadata":[{"expression":"avg:system.cpu.user{app:general}
-      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"}]},"id":5006685172366903},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
+      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"},{"display_type":"bars","security_query":{"index":"signal","search":{"query":"status:(high
+      OR critical)"},"group_by":[{"facet":"status"}],"compute":{"aggregation":"count"}}},{"rum_query":{"index":"rum","search":{"query":"status:info"},"group_by":[{"facet":"service"}],"compute":{"aggregation":"count"}},"display_type":"bars"}]},"id":3386652248538803},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"toplist","title":"Widget
-      Title"},"id":2720082503893472},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
-      note widget","show_tick":false,"background_color":"yellow"},"id":4338191889083278},{"definition":{"alert_id":"123","title":"Alert
-      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":7695144653164086}],"layout_type":"ordered","type":"group","title":"Group
-      Widget"},"id":7661082510522807},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
-      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":8986275005169463},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      Title"},"id":6192096461598520},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
+      note widget","show_tick":false,"background_color":"yellow"},"id":344365360506961},{"definition":{"alert_id":"123","title":"Alert
+      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":5427188636150195}],"layout_type":"ordered","type":"group","title":"Group
+      Widget"},"id":6204712051511488},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
+      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":5147590025261966},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
       by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}],"limit":10}],"title":"Widget
-      Title","type":"query_table","time":{"live_span":"1h"}},"id":8907742562879124}],"layout_type":"ordered"}'
+      Title","type":"query_table","time":{"live_span":"1h"}},"id":8738841365296731}],"layout_type":"ordered"}'
     headers:
       Cache-Control:
       - no-cache
@@ -692,13 +701,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:53:12 GMT
+      - Mon, 27 Jul 2020 15:30:55 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 22-Jun-2020 15:53:12 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 15:30:55 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -707,9 +716,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - ADT0ms9dQnbDHbbduv4c09ChngZrYY7A/Pgms/qacMOruS4mPwZ1GJWq74I7G11W
+      - QO3HutZQjgMDp/HqClcLon+qq5lEghb3LRV+gXMIQ2Jivd1m1eEGCh0RxplUQMIV
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -727,18 +736,18 @@ interactions:
       Dd-Operation-Id:
       - CreateDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
     url: https://api.datadoghq.com/api/v1/dashboard
     method: POST
   response:
     body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":"Nicholas Muesch","template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":false,"id":"xrg-4wk-z3j","title":"Acceptance
-      Test Free Dashboard","url":"/dashboard/xrg-4wk-z3j/acceptance-test-free-dashboard","created_at":"2020-06-15T15:53:18.514267+00:00","modified_at":"2020-06-15T15:53:18.514267+00:00","author_handle":"nicholas.muesch@datadoghq.com","widgets":[{"definition":{"title_size":"16","title":"Widget
-      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_stream","event_size":"l"},"layout":{"y":5,"width":32,"x":5,"height":43},"id":96703958520854},{"definition":{"title_size":"16","title":"Widget
-      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_timeline"},"layout":{"y":73,"width":65,"x":42,"height":9},"id":4107676652485735},{"definition":{"color":"#d00","text":"free
-      text content","font_size":"88","text_align":"left","type":"free_text"},"layout":{"y":5,"width":30,"x":42,"height":20},"id":6513245852972190},{"definition":{"url":"http://google.com","type":"iframe"},"layout":{"y":8,"width":39,"x":111,"height":46},"id":2127604159891238},{"definition":{"sizing":"fit","type":"image","margin":"small","url":"https://images.pexels.com/photos/67636/rose-blue-flower-rose-blooms-67636.jpeg?auto=compress&cs=tinysrgb&h=350"},"layout":{"y":7,"width":30,"x":77,"height":20},"id":5647700161189175},{"definition":{"logset":"19","sort":{"column":"time","order":"desc"},"show_message_column":true,"show_date_column":true,"message_display":"expanded-md","indexes":[],"query":"error","type":"log_stream","columns":["core_host","core_service","tag_source"]},"layout":{"y":51,"width":32,"x":5,"height":36},"id":2114422299081408},{"definition":{"count":50,"sort":"status,asc","title_size":"16","title":"Widget
-      Title","title_align":"left","hide_zero_counts":true,"start":0,"summary_type":"monitors","color_preference":"text","query":"type:metric","show_last_triggered":true,"type":"manage_status","display_format":"countsAndList"},"layout":{"y":55,"width":30,"x":112,"height":40},"id":4235645656785120},{"definition":{"span_name":"cassandra.query","title_size":"13","service":"alerting-cassandra","title":"alerting-cassandra
-      #env:datad0g.com","size_format":"large","show_hits":true,"title_align":"center","show_errors":true,"show_breakdown":true,"type":"trace_service","env":"datad0g.com","time":{"live_span":"1h"},"show_distribution":true,"display_format":"three_column","show_latency":false,"show_resource_list":false},"layout":{"y":28,"width":67,"x":40,"height":38},"id":511295784703213}],"layout_type":"free"}'
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":false,"id":"fc9-357-2c2","title":"Acceptance
+      Test Free Dashboard","url":"/dashboard/fc9-357-2c2/acceptance-test-free-dashboard","created_at":"2020-07-27T15:30:59.018418+00:00","modified_at":"2020-07-27T15:30:59.018418+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"title_size":"16","title":"Widget
+      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_stream","event_size":"l"},"layout":{"y":5,"width":32,"x":5,"height":43},"id":6853670302307275},{"definition":{"title_size":"16","title":"Widget
+      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_timeline"},"layout":{"y":73,"width":65,"x":42,"height":9},"id":3099196089769225},{"definition":{"color":"#d00","text":"free
+      text content","font_size":"88","text_align":"left","type":"free_text"},"layout":{"y":5,"width":30,"x":42,"height":20},"id":3506682701748283},{"definition":{"url":"http://google.com","type":"iframe"},"layout":{"y":8,"width":39,"x":111,"height":46},"id":5485157401580873},{"definition":{"sizing":"fit","type":"image","margin":"small","url":"https://images.pexels.com/photos/67636/rose-blue-flower-rose-blooms-67636.jpeg?auto=compress&cs=tinysrgb&h=350"},"layout":{"y":7,"width":30,"x":77,"height":20},"id":3095979551624111},{"definition":{"logset":"19","sort":{"column":"time","order":"desc"},"show_message_column":true,"show_date_column":true,"message_display":"expanded-md","indexes":[],"query":"error","type":"log_stream","columns":["core_host","core_service","tag_source"]},"layout":{"y":51,"width":32,"x":5,"height":36},"id":6224124477024345},{"definition":{"count":50,"sort":"status,asc","title_size":"16","title":"Widget
+      Title","title_align":"left","hide_zero_counts":true,"start":0,"summary_type":"monitors","color_preference":"text","query":"type:metric","show_last_triggered":true,"type":"manage_status","display_format":"countsAndList"},"layout":{"y":55,"width":30,"x":112,"height":40},"id":332452485187779},{"definition":{"span_name":"cassandra.query","title_size":"13","service":"alerting-cassandra","title":"alerting-cassandra
+      #env:datad0g.com","size_format":"large","show_hits":true,"title_align":"center","show_errors":true,"show_breakdown":true,"type":"trace_service","env":"datad0g.com","time":{"live_span":"1h"},"show_distribution":true,"display_format":"three_column","show_latency":false,"show_resource_list":false},"layout":{"y":28,"width":67,"x":40,"height":38},"id":3880165379069118}],"layout_type":"free"}'
     headers:
       Cache-Control:
       - no-cache
@@ -749,13 +758,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:53:18 GMT
+      - Mon, 27 Jul 2020 15:30:59 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 22-Jun-2020 15:53:18 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 15:30:58 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -764,9 +773,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - sg8vzlrAXfi82gDuSEBUxkn5dG85uDtr4RhaVLNn521TM8s6JdimiKDHvX2NhFjo
+      - vQYgH+orCqhRbQG/mSd6IeQSqyYBCkFVCv4Bj6PXMALQcvTK5EvxQuH7fIz3d52m
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -781,18 +790,18 @@ interactions:
       Dd-Operation-Id:
       - GetDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/xrg-4wk-z3j
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/fc9-357-2c2
     method: GET
   response:
     body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":"Nicholas Muesch","template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":false,"id":"xrg-4wk-z3j","title":"Acceptance
-      Test Free Dashboard","url":"/dashboard/xrg-4wk-z3j/acceptance-test-free-dashboard","created_at":"2020-06-15T15:53:18.514267+00:00","modified_at":"2020-06-15T15:53:18.514267+00:00","author_handle":"nicholas.muesch@datadoghq.com","widgets":[{"definition":{"title_size":"16","title":"Widget
-      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_stream","event_size":"l"},"layout":{"y":5,"width":32,"x":5,"height":43},"id":96703958520854},{"definition":{"title_size":"16","title":"Widget
-      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_timeline"},"layout":{"y":73,"width":65,"x":42,"height":9},"id":4107676652485735},{"definition":{"color":"#d00","text":"free
-      text content","font_size":"88","text_align":"left","type":"free_text"},"layout":{"y":5,"width":30,"x":42,"height":20},"id":6513245852972190},{"definition":{"url":"http://google.com","type":"iframe"},"layout":{"y":8,"width":39,"x":111,"height":46},"id":2127604159891238},{"definition":{"sizing":"fit","type":"image","margin":"small","url":"https://images.pexels.com/photos/67636/rose-blue-flower-rose-blooms-67636.jpeg?auto=compress&cs=tinysrgb&h=350"},"layout":{"y":7,"width":30,"x":77,"height":20},"id":5647700161189175},{"definition":{"logset":"19","sort":{"column":"time","order":"desc"},"show_message_column":true,"show_date_column":true,"message_display":"expanded-md","indexes":[],"query":"error","type":"log_stream","columns":["core_host","core_service","tag_source"]},"layout":{"y":51,"width":32,"x":5,"height":36},"id":2114422299081408},{"definition":{"count":50,"sort":"status,asc","title_size":"16","title":"Widget
-      Title","title_align":"left","hide_zero_counts":true,"start":0,"summary_type":"monitors","color_preference":"text","query":"type:metric","show_last_triggered":true,"type":"manage_status","display_format":"countsAndList"},"layout":{"y":55,"width":30,"x":112,"height":40},"id":4235645656785120},{"definition":{"span_name":"cassandra.query","title_size":"13","service":"alerting-cassandra","title":"alerting-cassandra
-      #env:datad0g.com","size_format":"large","show_hits":true,"title_align":"center","show_errors":true,"show_breakdown":true,"type":"trace_service","env":"datad0g.com","time":{"live_span":"1h"},"show_distribution":true,"display_format":"three_column","show_latency":false,"show_resource_list":false},"layout":{"y":28,"width":67,"x":40,"height":38},"id":511295784703213}],"layout_type":"free"}'
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":false,"id":"fc9-357-2c2","title":"Acceptance
+      Test Free Dashboard","url":"/dashboard/fc9-357-2c2/acceptance-test-free-dashboard","created_at":"2020-07-27T15:30:59.018418+00:00","modified_at":"2020-07-27T15:30:59.018418+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"title_size":"16","title":"Widget
+      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_stream","event_size":"l"},"layout":{"y":5,"width":32,"x":5,"height":43},"id":6853670302307275},{"definition":{"title_size":"16","title":"Widget
+      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_timeline"},"layout":{"y":73,"width":65,"x":42,"height":9},"id":3099196089769225},{"definition":{"color":"#d00","text":"free
+      text content","font_size":"88","text_align":"left","type":"free_text"},"layout":{"y":5,"width":30,"x":42,"height":20},"id":3506682701748283},{"definition":{"url":"http://google.com","type":"iframe"},"layout":{"y":8,"width":39,"x":111,"height":46},"id":5485157401580873},{"definition":{"sizing":"fit","type":"image","margin":"small","url":"https://images.pexels.com/photos/67636/rose-blue-flower-rose-blooms-67636.jpeg?auto=compress&cs=tinysrgb&h=350"},"layout":{"y":7,"width":30,"x":77,"height":20},"id":3095979551624111},{"definition":{"logset":"19","sort":{"column":"time","order":"desc"},"show_message_column":true,"show_date_column":true,"message_display":"expanded-md","indexes":[],"query":"error","type":"log_stream","columns":["core_host","core_service","tag_source"]},"layout":{"y":51,"width":32,"x":5,"height":36},"id":6224124477024345},{"definition":{"count":50,"sort":"status,asc","title_size":"16","title":"Widget
+      Title","title_align":"left","hide_zero_counts":true,"start":0,"summary_type":"monitors","color_preference":"text","query":"type:metric","show_last_triggered":true,"type":"manage_status","display_format":"countsAndList"},"layout":{"y":55,"width":30,"x":112,"height":40},"id":332452485187779},{"definition":{"span_name":"cassandra.query","title_size":"13","service":"alerting-cassandra","title":"alerting-cassandra
+      #env:datad0g.com","size_format":"large","show_hits":true,"title_align":"center","show_errors":true,"show_breakdown":true,"type":"trace_service","env":"datad0g.com","time":{"live_span":"1h"},"show_distribution":true,"display_format":"three_column","show_latency":false,"show_resource_list":false},"layout":{"y":28,"width":67,"x":40,"height":38},"id":3880165379069118}],"layout_type":"free"}'
     headers:
       Cache-Control:
       - no-cache
@@ -803,13 +812,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:53:18 GMT
+      - Mon, 27 Jul 2020 15:30:59 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 22-Jun-2020 15:53:18 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 15:30:59 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -818,9 +827,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - og1WGdy+2nV+rkkclmd3Cf2I26XhV3/6yjBeQCP8aHbH2k2cKwC+X9WmhIghcJ94
+      - KKQq2SiaDLpychKSp47ffvU6SRxUV+VzBWr187ESkULBuGOI+kREfb/2NCy8DAWC
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -835,11 +844,11 @@ interactions:
       Dd-Operation-Id:
       - DeleteDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/rgg-gtv-2sx
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/7j3-9mf-ub5
     method: DELETE
   response:
-    body: '{"deleted_dashboard_id":"rgg-gtv-2sx"}'
+    body: '{"deleted_dashboard_id":"7j3-9mf-ub5"}'
     headers:
       Cache-Control:
       - no-cache
@@ -850,13 +859,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:53:26 GMT
+      - Mon, 27 Jul 2020 15:31:22 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 22-Jun-2020 15:53:17 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 15:30:58 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -865,9 +874,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - cQFL4MaIw90DmTTH7z4Gqhr8PBtz47vyzddN9k7nXjUK2yrLiBjbdIgydUT8r1ut
+      - J7vOWsxZd7Grxzg2TIaQpn2nGjrOScgI4Kwzur8V2oOTYInX6xbVT4leinNkGLPk
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -882,18 +891,18 @@ interactions:
       Dd-Operation-Id:
       - GetDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/xrg-4wk-z3j
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/fc9-357-2c2
     method: GET
   response:
     body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":"Nicholas Muesch","template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":false,"id":"xrg-4wk-z3j","title":"Acceptance
-      Test Free Dashboard","url":"/dashboard/xrg-4wk-z3j/acceptance-test-free-dashboard","created_at":"2020-06-15T15:53:18.514267+00:00","modified_at":"2020-06-15T15:53:18.514267+00:00","author_handle":"nicholas.muesch@datadoghq.com","widgets":[{"definition":{"title_size":"16","title":"Widget
-      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_stream","event_size":"l"},"layout":{"y":5,"width":32,"x":5,"height":43},"id":96703958520854},{"definition":{"title_size":"16","title":"Widget
-      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_timeline"},"layout":{"y":73,"width":65,"x":42,"height":9},"id":4107676652485735},{"definition":{"color":"#d00","text":"free
-      text content","font_size":"88","text_align":"left","type":"free_text"},"layout":{"y":5,"width":30,"x":42,"height":20},"id":6513245852972190},{"definition":{"url":"http://google.com","type":"iframe"},"layout":{"y":8,"width":39,"x":111,"height":46},"id":2127604159891238},{"definition":{"sizing":"fit","type":"image","margin":"small","url":"https://images.pexels.com/photos/67636/rose-blue-flower-rose-blooms-67636.jpeg?auto=compress&cs=tinysrgb&h=350"},"layout":{"y":7,"width":30,"x":77,"height":20},"id":5647700161189175},{"definition":{"logset":"19","sort":{"column":"time","order":"desc"},"show_message_column":true,"show_date_column":true,"message_display":"expanded-md","indexes":[],"query":"error","type":"log_stream","columns":["core_host","core_service","tag_source"]},"layout":{"y":51,"width":32,"x":5,"height":36},"id":2114422299081408},{"definition":{"count":50,"sort":"status,asc","title_size":"16","title":"Widget
-      Title","title_align":"left","hide_zero_counts":true,"start":0,"summary_type":"monitors","color_preference":"text","query":"type:metric","show_last_triggered":true,"type":"manage_status","display_format":"countsAndList"},"layout":{"y":55,"width":30,"x":112,"height":40},"id":4235645656785120},{"definition":{"span_name":"cassandra.query","title_size":"13","service":"alerting-cassandra","title":"alerting-cassandra
-      #env:datad0g.com","size_format":"large","show_hits":true,"title_align":"center","show_errors":true,"show_breakdown":true,"type":"trace_service","env":"datad0g.com","time":{"live_span":"1h"},"show_distribution":true,"display_format":"three_column","show_latency":false,"show_resource_list":false},"layout":{"y":28,"width":67,"x":40,"height":38},"id":511295784703213}],"layout_type":"free"}'
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":false,"id":"fc9-357-2c2","title":"Acceptance
+      Test Free Dashboard","url":"/dashboard/fc9-357-2c2/acceptance-test-free-dashboard","created_at":"2020-07-27T15:30:59.018418+00:00","modified_at":"2020-07-27T15:30:59.018418+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"title_size":"16","title":"Widget
+      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_stream","event_size":"l"},"layout":{"y":5,"width":32,"x":5,"height":43},"id":6853670302307275},{"definition":{"title_size":"16","title":"Widget
+      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_timeline"},"layout":{"y":73,"width":65,"x":42,"height":9},"id":3099196089769225},{"definition":{"color":"#d00","text":"free
+      text content","font_size":"88","text_align":"left","type":"free_text"},"layout":{"y":5,"width":30,"x":42,"height":20},"id":3506682701748283},{"definition":{"url":"http://google.com","type":"iframe"},"layout":{"y":8,"width":39,"x":111,"height":46},"id":5485157401580873},{"definition":{"sizing":"fit","type":"image","margin":"small","url":"https://images.pexels.com/photos/67636/rose-blue-flower-rose-blooms-67636.jpeg?auto=compress&cs=tinysrgb&h=350"},"layout":{"y":7,"width":30,"x":77,"height":20},"id":3095979551624111},{"definition":{"logset":"19","sort":{"column":"time","order":"desc"},"show_message_column":true,"show_date_column":true,"message_display":"expanded-md","indexes":[],"query":"error","type":"log_stream","columns":["core_host","core_service","tag_source"]},"layout":{"y":51,"width":32,"x":5,"height":36},"id":6224124477024345},{"definition":{"count":50,"sort":"status,asc","title_size":"16","title":"Widget
+      Title","title_align":"left","hide_zero_counts":true,"start":0,"summary_type":"monitors","color_preference":"text","query":"type:metric","show_last_triggered":true,"type":"manage_status","display_format":"countsAndList"},"layout":{"y":55,"width":30,"x":112,"height":40},"id":332452485187779},{"definition":{"span_name":"cassandra.query","title_size":"13","service":"alerting-cassandra","title":"alerting-cassandra
+      #env:datad0g.com","size_format":"large","show_hits":true,"title_align":"center","show_errors":true,"show_breakdown":true,"type":"trace_service","env":"datad0g.com","time":{"live_span":"1h"},"show_distribution":true,"display_format":"three_column","show_latency":false,"show_resource_list":false},"layout":{"y":28,"width":67,"x":40,"height":38},"id":3880165379069118}],"layout_type":"free"}'
     headers:
       Cache-Control:
       - no-cache
@@ -904,13 +913,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:53:31 GMT
+      - Mon, 27 Jul 2020 15:31:25 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 22-Jun-2020 15:53:31 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 15:31:25 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -919,9 +928,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - 2VXDwI2pcuhRZeQ6xt/fJh1koMYSfGcgQg5wAzgLqeh10Zf5/W946U7T5w6SEIhy
+      - pT9LlAdgAzlrCUxMXQkBRs/Qti76jKIHng1uB0/SctAaYjB4WqOgOZYpCbOMQKll
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -936,18 +945,18 @@ interactions:
       Dd-Operation-Id:
       - GetDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/xrg-4wk-z3j
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/fc9-357-2c2
     method: GET
   response:
     body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":"Nicholas Muesch","template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":false,"id":"xrg-4wk-z3j","title":"Acceptance
-      Test Free Dashboard","url":"/dashboard/xrg-4wk-z3j/acceptance-test-free-dashboard","created_at":"2020-06-15T15:53:18.514267+00:00","modified_at":"2020-06-15T15:53:18.514267+00:00","author_handle":"nicholas.muesch@datadoghq.com","widgets":[{"definition":{"title_size":"16","title":"Widget
-      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_stream","event_size":"l"},"layout":{"y":5,"width":32,"x":5,"height":43},"id":96703958520854},{"definition":{"title_size":"16","title":"Widget
-      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_timeline"},"layout":{"y":73,"width":65,"x":42,"height":9},"id":4107676652485735},{"definition":{"color":"#d00","text":"free
-      text content","font_size":"88","text_align":"left","type":"free_text"},"layout":{"y":5,"width":30,"x":42,"height":20},"id":6513245852972190},{"definition":{"url":"http://google.com","type":"iframe"},"layout":{"y":8,"width":39,"x":111,"height":46},"id":2127604159891238},{"definition":{"sizing":"fit","type":"image","margin":"small","url":"https://images.pexels.com/photos/67636/rose-blue-flower-rose-blooms-67636.jpeg?auto=compress&cs=tinysrgb&h=350"},"layout":{"y":7,"width":30,"x":77,"height":20},"id":5647700161189175},{"definition":{"logset":"19","sort":{"column":"time","order":"desc"},"show_message_column":true,"show_date_column":true,"message_display":"expanded-md","indexes":[],"query":"error","type":"log_stream","columns":["core_host","core_service","tag_source"]},"layout":{"y":51,"width":32,"x":5,"height":36},"id":2114422299081408},{"definition":{"count":50,"sort":"status,asc","title_size":"16","title":"Widget
-      Title","title_align":"left","hide_zero_counts":true,"start":0,"summary_type":"monitors","color_preference":"text","query":"type:metric","show_last_triggered":true,"type":"manage_status","display_format":"countsAndList"},"layout":{"y":55,"width":30,"x":112,"height":40},"id":4235645656785120},{"definition":{"span_name":"cassandra.query","title_size":"13","service":"alerting-cassandra","title":"alerting-cassandra
-      #env:datad0g.com","size_format":"large","show_hits":true,"title_align":"center","show_errors":true,"show_breakdown":true,"type":"trace_service","env":"datad0g.com","time":{"live_span":"1h"},"show_distribution":true,"display_format":"three_column","show_latency":false,"show_resource_list":false},"layout":{"y":28,"width":67,"x":40,"height":38},"id":511295784703213}],"layout_type":"free"}'
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":false,"id":"fc9-357-2c2","title":"Acceptance
+      Test Free Dashboard","url":"/dashboard/fc9-357-2c2/acceptance-test-free-dashboard","created_at":"2020-07-27T15:30:59.018418+00:00","modified_at":"2020-07-27T15:30:59.018418+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"title_size":"16","title":"Widget
+      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_stream","event_size":"l"},"layout":{"y":5,"width":32,"x":5,"height":43},"id":6853670302307275},{"definition":{"title_size":"16","title":"Widget
+      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_timeline"},"layout":{"y":73,"width":65,"x":42,"height":9},"id":3099196089769225},{"definition":{"color":"#d00","text":"free
+      text content","font_size":"88","text_align":"left","type":"free_text"},"layout":{"y":5,"width":30,"x":42,"height":20},"id":3506682701748283},{"definition":{"url":"http://google.com","type":"iframe"},"layout":{"y":8,"width":39,"x":111,"height":46},"id":5485157401580873},{"definition":{"sizing":"fit","type":"image","margin":"small","url":"https://images.pexels.com/photos/67636/rose-blue-flower-rose-blooms-67636.jpeg?auto=compress&cs=tinysrgb&h=350"},"layout":{"y":7,"width":30,"x":77,"height":20},"id":3095979551624111},{"definition":{"logset":"19","sort":{"column":"time","order":"desc"},"show_message_column":true,"show_date_column":true,"message_display":"expanded-md","indexes":[],"query":"error","type":"log_stream","columns":["core_host","core_service","tag_source"]},"layout":{"y":51,"width":32,"x":5,"height":36},"id":6224124477024345},{"definition":{"count":50,"sort":"status,asc","title_size":"16","title":"Widget
+      Title","title_align":"left","hide_zero_counts":true,"start":0,"summary_type":"monitors","color_preference":"text","query":"type:metric","show_last_triggered":true,"type":"manage_status","display_format":"countsAndList"},"layout":{"y":55,"width":30,"x":112,"height":40},"id":332452485187779},{"definition":{"span_name":"cassandra.query","title_size":"13","service":"alerting-cassandra","title":"alerting-cassandra
+      #env:datad0g.com","size_format":"large","show_hits":true,"title_align":"center","show_errors":true,"show_breakdown":true,"type":"trace_service","env":"datad0g.com","time":{"live_span":"1h"},"show_distribution":true,"display_format":"three_column","show_latency":false,"show_resource_list":false},"layout":{"y":28,"width":67,"x":40,"height":38},"id":3880165379069118}],"layout_type":"free"}'
     headers:
       Cache-Control:
       - no-cache
@@ -958,13 +967,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:53:32 GMT
+      - Mon, 27 Jul 2020 15:31:25 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 22-Jun-2020 15:53:31 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 15:31:25 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -973,9 +982,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - wB7h0Rt2IYxDUBLtoJ4y0ZOq10ZaMdDZiRuFZ3d/FUUtC7gfBEZWTs0Y6dZhoLZS
+      - em3KoJu1XYdqq1w4EpLi4L54svjYBxZahEDJ8c5gcdIOxnNafHMdF5LLysPLuNcH
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -990,18 +999,18 @@ interactions:
       Dd-Operation-Id:
       - GetDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/xrg-4wk-z3j
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/fc9-357-2c2
     method: GET
   response:
     body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":"Nicholas Muesch","template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":false,"id":"xrg-4wk-z3j","title":"Acceptance
-      Test Free Dashboard","url":"/dashboard/xrg-4wk-z3j/acceptance-test-free-dashboard","created_at":"2020-06-15T15:53:18.514267+00:00","modified_at":"2020-06-15T15:53:18.514267+00:00","author_handle":"nicholas.muesch@datadoghq.com","widgets":[{"definition":{"title_size":"16","title":"Widget
-      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_stream","event_size":"l"},"layout":{"y":5,"width":32,"x":5,"height":43},"id":96703958520854},{"definition":{"title_size":"16","title":"Widget
-      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_timeline"},"layout":{"y":73,"width":65,"x":42,"height":9},"id":4107676652485735},{"definition":{"color":"#d00","text":"free
-      text content","font_size":"88","text_align":"left","type":"free_text"},"layout":{"y":5,"width":30,"x":42,"height":20},"id":6513245852972190},{"definition":{"url":"http://google.com","type":"iframe"},"layout":{"y":8,"width":39,"x":111,"height":46},"id":2127604159891238},{"definition":{"sizing":"fit","type":"image","margin":"small","url":"https://images.pexels.com/photos/67636/rose-blue-flower-rose-blooms-67636.jpeg?auto=compress&cs=tinysrgb&h=350"},"layout":{"y":7,"width":30,"x":77,"height":20},"id":5647700161189175},{"definition":{"logset":"19","sort":{"column":"time","order":"desc"},"show_message_column":true,"show_date_column":true,"message_display":"expanded-md","indexes":[],"query":"error","type":"log_stream","columns":["core_host","core_service","tag_source"]},"layout":{"y":51,"width":32,"x":5,"height":36},"id":2114422299081408},{"definition":{"count":50,"sort":"status,asc","title_size":"16","title":"Widget
-      Title","title_align":"left","hide_zero_counts":true,"start":0,"summary_type":"monitors","color_preference":"text","query":"type:metric","show_last_triggered":true,"type":"manage_status","display_format":"countsAndList"},"layout":{"y":55,"width":30,"x":112,"height":40},"id":4235645656785120},{"definition":{"span_name":"cassandra.query","title_size":"13","service":"alerting-cassandra","title":"alerting-cassandra
-      #env:datad0g.com","size_format":"large","show_hits":true,"title_align":"center","show_errors":true,"show_breakdown":true,"type":"trace_service","env":"datad0g.com","time":{"live_span":"1h"},"show_distribution":true,"display_format":"three_column","show_latency":false,"show_resource_list":false},"layout":{"y":28,"width":67,"x":40,"height":38},"id":511295784703213}],"layout_type":"free"}'
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":false,"id":"fc9-357-2c2","title":"Acceptance
+      Test Free Dashboard","url":"/dashboard/fc9-357-2c2/acceptance-test-free-dashboard","created_at":"2020-07-27T15:30:59.018418+00:00","modified_at":"2020-07-27T15:30:59.018418+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"title_size":"16","title":"Widget
+      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_stream","event_size":"l"},"layout":{"y":5,"width":32,"x":5,"height":43},"id":6853670302307275},{"definition":{"title_size":"16","title":"Widget
+      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_timeline"},"layout":{"y":73,"width":65,"x":42,"height":9},"id":3099196089769225},{"definition":{"color":"#d00","text":"free
+      text content","font_size":"88","text_align":"left","type":"free_text"},"layout":{"y":5,"width":30,"x":42,"height":20},"id":3506682701748283},{"definition":{"url":"http://google.com","type":"iframe"},"layout":{"y":8,"width":39,"x":111,"height":46},"id":5485157401580873},{"definition":{"sizing":"fit","type":"image","margin":"small","url":"https://images.pexels.com/photos/67636/rose-blue-flower-rose-blooms-67636.jpeg?auto=compress&cs=tinysrgb&h=350"},"layout":{"y":7,"width":30,"x":77,"height":20},"id":3095979551624111},{"definition":{"logset":"19","sort":{"column":"time","order":"desc"},"show_message_column":true,"show_date_column":true,"message_display":"expanded-md","indexes":[],"query":"error","type":"log_stream","columns":["core_host","core_service","tag_source"]},"layout":{"y":51,"width":32,"x":5,"height":36},"id":6224124477024345},{"definition":{"count":50,"sort":"status,asc","title_size":"16","title":"Widget
+      Title","title_align":"left","hide_zero_counts":true,"start":0,"summary_type":"monitors","color_preference":"text","query":"type:metric","show_last_triggered":true,"type":"manage_status","display_format":"countsAndList"},"layout":{"y":55,"width":30,"x":112,"height":40},"id":332452485187779},{"definition":{"span_name":"cassandra.query","title_size":"13","service":"alerting-cassandra","title":"alerting-cassandra
+      #env:datad0g.com","size_format":"large","show_hits":true,"title_align":"center","show_errors":true,"show_breakdown":true,"type":"trace_service","env":"datad0g.com","time":{"live_span":"1h"},"show_distribution":true,"display_format":"three_column","show_latency":false,"show_resource_list":false},"layout":{"y":28,"width":67,"x":40,"height":38},"id":3880165379069118}],"layout_type":"free"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1012,13 +1021,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:53:34 GMT
+      - Mon, 27 Jul 2020 15:31:27 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 22-Jun-2020 15:53:34 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 15:31:27 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -1027,9 +1036,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - AZX6w/8zD+VN3BjlP7mTxsWKLW39bs6QmKw7eyNlBdxzsMsZp5eTFn4umzElZK4n
+      - +tJ1fMj4fNxjcw2FPYtySx6EFt5bjky3JD4t0qr7zCELerxUlLnRZokC544QOi8l
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -1044,18 +1053,18 @@ interactions:
       Dd-Operation-Id:
       - GetDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/xrg-4wk-z3j
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/fc9-357-2c2
     method: GET
   response:
     body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":"Nicholas Muesch","template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":false,"id":"xrg-4wk-z3j","title":"Acceptance
-      Test Free Dashboard","url":"/dashboard/xrg-4wk-z3j/acceptance-test-free-dashboard","created_at":"2020-06-15T15:53:18.514267+00:00","modified_at":"2020-06-15T15:53:18.514267+00:00","author_handle":"nicholas.muesch@datadoghq.com","widgets":[{"definition":{"title_size":"16","title":"Widget
-      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_stream","event_size":"l"},"layout":{"y":5,"width":32,"x":5,"height":43},"id":96703958520854},{"definition":{"title_size":"16","title":"Widget
-      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_timeline"},"layout":{"y":73,"width":65,"x":42,"height":9},"id":4107676652485735},{"definition":{"color":"#d00","text":"free
-      text content","font_size":"88","text_align":"left","type":"free_text"},"layout":{"y":5,"width":30,"x":42,"height":20},"id":6513245852972190},{"definition":{"url":"http://google.com","type":"iframe"},"layout":{"y":8,"width":39,"x":111,"height":46},"id":2127604159891238},{"definition":{"sizing":"fit","type":"image","margin":"small","url":"https://images.pexels.com/photos/67636/rose-blue-flower-rose-blooms-67636.jpeg?auto=compress&cs=tinysrgb&h=350"},"layout":{"y":7,"width":30,"x":77,"height":20},"id":5647700161189175},{"definition":{"logset":"19","sort":{"column":"time","order":"desc"},"show_message_column":true,"show_date_column":true,"message_display":"expanded-md","indexes":[],"query":"error","type":"log_stream","columns":["core_host","core_service","tag_source"]},"layout":{"y":51,"width":32,"x":5,"height":36},"id":2114422299081408},{"definition":{"count":50,"sort":"status,asc","title_size":"16","title":"Widget
-      Title","title_align":"left","hide_zero_counts":true,"start":0,"summary_type":"monitors","color_preference":"text","query":"type:metric","show_last_triggered":true,"type":"manage_status","display_format":"countsAndList"},"layout":{"y":55,"width":30,"x":112,"height":40},"id":4235645656785120},{"definition":{"span_name":"cassandra.query","title_size":"13","service":"alerting-cassandra","title":"alerting-cassandra
-      #env:datad0g.com","size_format":"large","show_hits":true,"title_align":"center","show_errors":true,"show_breakdown":true,"type":"trace_service","env":"datad0g.com","time":{"live_span":"1h"},"show_distribution":true,"display_format":"three_column","show_latency":false,"show_resource_list":false},"layout":{"y":28,"width":67,"x":40,"height":38},"id":511295784703213}],"layout_type":"free"}'
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":false,"id":"fc9-357-2c2","title":"Acceptance
+      Test Free Dashboard","url":"/dashboard/fc9-357-2c2/acceptance-test-free-dashboard","created_at":"2020-07-27T15:30:59.018418+00:00","modified_at":"2020-07-27T15:30:59.018418+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"title_size":"16","title":"Widget
+      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_stream","event_size":"l"},"layout":{"y":5,"width":32,"x":5,"height":43},"id":6853670302307275},{"definition":{"title_size":"16","title":"Widget
+      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_timeline"},"layout":{"y":73,"width":65,"x":42,"height":9},"id":3099196089769225},{"definition":{"color":"#d00","text":"free
+      text content","font_size":"88","text_align":"left","type":"free_text"},"layout":{"y":5,"width":30,"x":42,"height":20},"id":3506682701748283},{"definition":{"url":"http://google.com","type":"iframe"},"layout":{"y":8,"width":39,"x":111,"height":46},"id":5485157401580873},{"definition":{"sizing":"fit","type":"image","margin":"small","url":"https://images.pexels.com/photos/67636/rose-blue-flower-rose-blooms-67636.jpeg?auto=compress&cs=tinysrgb&h=350"},"layout":{"y":7,"width":30,"x":77,"height":20},"id":3095979551624111},{"definition":{"logset":"19","sort":{"column":"time","order":"desc"},"show_message_column":true,"show_date_column":true,"message_display":"expanded-md","indexes":[],"query":"error","type":"log_stream","columns":["core_host","core_service","tag_source"]},"layout":{"y":51,"width":32,"x":5,"height":36},"id":6224124477024345},{"definition":{"count":50,"sort":"status,asc","title_size":"16","title":"Widget
+      Title","title_align":"left","hide_zero_counts":true,"start":0,"summary_type":"monitors","color_preference":"text","query":"type:metric","show_last_triggered":true,"type":"manage_status","display_format":"countsAndList"},"layout":{"y":55,"width":30,"x":112,"height":40},"id":332452485187779},{"definition":{"span_name":"cassandra.query","title_size":"13","service":"alerting-cassandra","title":"alerting-cassandra
+      #env:datad0g.com","size_format":"large","show_hits":true,"title_align":"center","show_errors":true,"show_breakdown":true,"type":"trace_service","env":"datad0g.com","time":{"live_span":"1h"},"show_distribution":true,"display_format":"three_column","show_latency":false,"show_resource_list":false},"layout":{"y":28,"width":67,"x":40,"height":38},"id":3880165379069118}],"layout_type":"free"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1066,13 +1075,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:53:35 GMT
+      - Mon, 27 Jul 2020 15:31:28 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 22-Jun-2020 15:53:35 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 15:31:28 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -1081,9 +1090,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - pEDVi2191MvoIMwusdL+COAxndBmcRhJtxAtWxDDnECWDI8Z99hIoBZbpR57tJKz
+      - xuqj9hdWDkSD9EtpcqPe+eGtJAYYHPEMbUsHJUlu4ckBMffeXAIJAOyY354PYCG0
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -1098,18 +1107,18 @@ interactions:
       Dd-Operation-Id:
       - GetDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/xrg-4wk-z3j
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/fc9-357-2c2
     method: GET
   response:
     body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":"Nicholas Muesch","template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":false,"id":"xrg-4wk-z3j","title":"Acceptance
-      Test Free Dashboard","url":"/dashboard/xrg-4wk-z3j/acceptance-test-free-dashboard","created_at":"2020-06-15T15:53:18.514267+00:00","modified_at":"2020-06-15T15:53:18.514267+00:00","author_handle":"nicholas.muesch@datadoghq.com","widgets":[{"definition":{"title_size":"16","title":"Widget
-      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_stream","event_size":"l"},"layout":{"y":5,"width":32,"x":5,"height":43},"id":96703958520854},{"definition":{"title_size":"16","title":"Widget
-      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_timeline"},"layout":{"y":73,"width":65,"x":42,"height":9},"id":4107676652485735},{"definition":{"color":"#d00","text":"free
-      text content","font_size":"88","text_align":"left","type":"free_text"},"layout":{"y":5,"width":30,"x":42,"height":20},"id":6513245852972190},{"definition":{"url":"http://google.com","type":"iframe"},"layout":{"y":8,"width":39,"x":111,"height":46},"id":2127604159891238},{"definition":{"sizing":"fit","type":"image","margin":"small","url":"https://images.pexels.com/photos/67636/rose-blue-flower-rose-blooms-67636.jpeg?auto=compress&cs=tinysrgb&h=350"},"layout":{"y":7,"width":30,"x":77,"height":20},"id":5647700161189175},{"definition":{"logset":"19","sort":{"column":"time","order":"desc"},"show_message_column":true,"show_date_column":true,"message_display":"expanded-md","indexes":[],"query":"error","type":"log_stream","columns":["core_host","core_service","tag_source"]},"layout":{"y":51,"width":32,"x":5,"height":36},"id":2114422299081408},{"definition":{"count":50,"sort":"status,asc","title_size":"16","title":"Widget
-      Title","title_align":"left","hide_zero_counts":true,"start":0,"summary_type":"monitors","color_preference":"text","query":"type:metric","show_last_triggered":true,"type":"manage_status","display_format":"countsAndList"},"layout":{"y":55,"width":30,"x":112,"height":40},"id":4235645656785120},{"definition":{"span_name":"cassandra.query","title_size":"13","service":"alerting-cassandra","title":"alerting-cassandra
-      #env:datad0g.com","size_format":"large","show_hits":true,"title_align":"center","show_errors":true,"show_breakdown":true,"type":"trace_service","env":"datad0g.com","time":{"live_span":"1h"},"show_distribution":true,"display_format":"three_column","show_latency":false,"show_resource_list":false},"layout":{"y":28,"width":67,"x":40,"height":38},"id":511295784703213}],"layout_type":"free"}'
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":false,"id":"fc9-357-2c2","title":"Acceptance
+      Test Free Dashboard","url":"/dashboard/fc9-357-2c2/acceptance-test-free-dashboard","created_at":"2020-07-27T15:30:59.018418+00:00","modified_at":"2020-07-27T15:30:59.018418+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"title_size":"16","title":"Widget
+      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_stream","event_size":"l"},"layout":{"y":5,"width":32,"x":5,"height":43},"id":6853670302307275},{"definition":{"title_size":"16","title":"Widget
+      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_timeline"},"layout":{"y":73,"width":65,"x":42,"height":9},"id":3099196089769225},{"definition":{"color":"#d00","text":"free
+      text content","font_size":"88","text_align":"left","type":"free_text"},"layout":{"y":5,"width":30,"x":42,"height":20},"id":3506682701748283},{"definition":{"url":"http://google.com","type":"iframe"},"layout":{"y":8,"width":39,"x":111,"height":46},"id":5485157401580873},{"definition":{"sizing":"fit","type":"image","margin":"small","url":"https://images.pexels.com/photos/67636/rose-blue-flower-rose-blooms-67636.jpeg?auto=compress&cs=tinysrgb&h=350"},"layout":{"y":7,"width":30,"x":77,"height":20},"id":3095979551624111},{"definition":{"logset":"19","sort":{"column":"time","order":"desc"},"show_message_column":true,"show_date_column":true,"message_display":"expanded-md","indexes":[],"query":"error","type":"log_stream","columns":["core_host","core_service","tag_source"]},"layout":{"y":51,"width":32,"x":5,"height":36},"id":6224124477024345},{"definition":{"count":50,"sort":"status,asc","title_size":"16","title":"Widget
+      Title","title_align":"left","hide_zero_counts":true,"start":0,"summary_type":"monitors","color_preference":"text","query":"type:metric","show_last_triggered":true,"type":"manage_status","display_format":"countsAndList"},"layout":{"y":55,"width":30,"x":112,"height":40},"id":332452485187779},{"definition":{"span_name":"cassandra.query","title_size":"13","service":"alerting-cassandra","title":"alerting-cassandra
+      #env:datad0g.com","size_format":"large","show_hits":true,"title_align":"center","show_errors":true,"show_breakdown":true,"type":"trace_service","env":"datad0g.com","time":{"live_span":"1h"},"show_distribution":true,"display_format":"three_column","show_latency":false,"show_resource_list":false},"layout":{"y":28,"width":67,"x":40,"height":38},"id":3880165379069118}],"layout_type":"free"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1120,13 +1129,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:53:35 GMT
+      - Mon, 27 Jul 2020 15:31:28 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 22-Jun-2020 15:53:35 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 15:31:28 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -1135,9 +1144,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - kqXz3OvR7iajEJOdRFWpzJtcDHRumYwGfjdF12Vd65Xt1uV9T6lEO/K0lkxmcRvl
+      - YCJuwY9AAFMveejFq3DmCuXNgWrXpDBQxqXi3LxQxaHO16MK3yMSWa14TOuRlDjy
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -1152,18 +1161,18 @@ interactions:
       Dd-Operation-Id:
       - GetDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/xrg-4wk-z3j
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/fc9-357-2c2
     method: GET
   response:
     body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":"Nicholas Muesch","template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":false,"id":"xrg-4wk-z3j","title":"Acceptance
-      Test Free Dashboard","url":"/dashboard/xrg-4wk-z3j/acceptance-test-free-dashboard","created_at":"2020-06-15T15:53:18.514267+00:00","modified_at":"2020-06-15T15:53:18.514267+00:00","author_handle":"nicholas.muesch@datadoghq.com","widgets":[{"definition":{"title_size":"16","title":"Widget
-      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_stream","event_size":"l"},"layout":{"y":5,"width":32,"x":5,"height":43},"id":96703958520854},{"definition":{"title_size":"16","title":"Widget
-      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_timeline"},"layout":{"y":73,"width":65,"x":42,"height":9},"id":4107676652485735},{"definition":{"color":"#d00","text":"free
-      text content","font_size":"88","text_align":"left","type":"free_text"},"layout":{"y":5,"width":30,"x":42,"height":20},"id":6513245852972190},{"definition":{"url":"http://google.com","type":"iframe"},"layout":{"y":8,"width":39,"x":111,"height":46},"id":2127604159891238},{"definition":{"sizing":"fit","type":"image","margin":"small","url":"https://images.pexels.com/photos/67636/rose-blue-flower-rose-blooms-67636.jpeg?auto=compress&cs=tinysrgb&h=350"},"layout":{"y":7,"width":30,"x":77,"height":20},"id":5647700161189175},{"definition":{"logset":"19","sort":{"column":"time","order":"desc"},"show_message_column":true,"show_date_column":true,"message_display":"expanded-md","indexes":[],"query":"error","type":"log_stream","columns":["core_host","core_service","tag_source"]},"layout":{"y":51,"width":32,"x":5,"height":36},"id":2114422299081408},{"definition":{"count":50,"sort":"status,asc","title_size":"16","title":"Widget
-      Title","title_align":"left","hide_zero_counts":true,"start":0,"summary_type":"monitors","color_preference":"text","query":"type:metric","show_last_triggered":true,"type":"manage_status","display_format":"countsAndList"},"layout":{"y":55,"width":30,"x":112,"height":40},"id":4235645656785120},{"definition":{"span_name":"cassandra.query","title_size":"13","service":"alerting-cassandra","title":"alerting-cassandra
-      #env:datad0g.com","size_format":"large","show_hits":true,"title_align":"center","show_errors":true,"show_breakdown":true,"type":"trace_service","env":"datad0g.com","time":{"live_span":"1h"},"show_distribution":true,"display_format":"three_column","show_latency":false,"show_resource_list":false},"layout":{"y":28,"width":67,"x":40,"height":38},"id":511295784703213}],"layout_type":"free"}'
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":false,"id":"fc9-357-2c2","title":"Acceptance
+      Test Free Dashboard","url":"/dashboard/fc9-357-2c2/acceptance-test-free-dashboard","created_at":"2020-07-27T15:30:59.018418+00:00","modified_at":"2020-07-27T15:30:59.018418+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"title_size":"16","title":"Widget
+      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_stream","event_size":"l"},"layout":{"y":5,"width":32,"x":5,"height":43},"id":6853670302307275},{"definition":{"title_size":"16","title":"Widget
+      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_timeline"},"layout":{"y":73,"width":65,"x":42,"height":9},"id":3099196089769225},{"definition":{"color":"#d00","text":"free
+      text content","font_size":"88","text_align":"left","type":"free_text"},"layout":{"y":5,"width":30,"x":42,"height":20},"id":3506682701748283},{"definition":{"url":"http://google.com","type":"iframe"},"layout":{"y":8,"width":39,"x":111,"height":46},"id":5485157401580873},{"definition":{"sizing":"fit","type":"image","margin":"small","url":"https://images.pexels.com/photos/67636/rose-blue-flower-rose-blooms-67636.jpeg?auto=compress&cs=tinysrgb&h=350"},"layout":{"y":7,"width":30,"x":77,"height":20},"id":3095979551624111},{"definition":{"logset":"19","sort":{"column":"time","order":"desc"},"show_message_column":true,"show_date_column":true,"message_display":"expanded-md","indexes":[],"query":"error","type":"log_stream","columns":["core_host","core_service","tag_source"]},"layout":{"y":51,"width":32,"x":5,"height":36},"id":6224124477024345},{"definition":{"count":50,"sort":"status,asc","title_size":"16","title":"Widget
+      Title","title_align":"left","hide_zero_counts":true,"start":0,"summary_type":"monitors","color_preference":"text","query":"type:metric","show_last_triggered":true,"type":"manage_status","display_format":"countsAndList"},"layout":{"y":55,"width":30,"x":112,"height":40},"id":332452485187779},{"definition":{"span_name":"cassandra.query","title_size":"13","service":"alerting-cassandra","title":"alerting-cassandra
+      #env:datad0g.com","size_format":"large","show_hits":true,"title_align":"center","show_errors":true,"show_breakdown":true,"type":"trace_service","env":"datad0g.com","time":{"live_span":"1h"},"show_distribution":true,"display_format":"three_column","show_latency":false,"show_resource_list":false},"layout":{"y":28,"width":67,"x":40,"height":38},"id":3880165379069118}],"layout_type":"free"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1174,13 +1183,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:53:37 GMT
+      - Mon, 27 Jul 2020 15:31:29 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 22-Jun-2020 15:53:37 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 15:31:29 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -1189,9 +1198,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - Xj/PwLDKe3Ll1QwGP2SdQuyUcOtG0YD60hQDJ9tPEhK9OEMHkSCPXdZRvPX0YYGO
+      - J5PL0LnJukdy69mckjXi3cjye/YJX2hkoCBkqKQi+tYjrsXYELx6DfDD11fhyjYF
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -1206,18 +1215,18 @@ interactions:
       Dd-Operation-Id:
       - GetDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/xrg-4wk-z3j
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/fc9-357-2c2
     method: GET
   response:
     body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":"Nicholas Muesch","template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":false,"id":"xrg-4wk-z3j","title":"Acceptance
-      Test Free Dashboard","url":"/dashboard/xrg-4wk-z3j/acceptance-test-free-dashboard","created_at":"2020-06-15T15:53:18.514267+00:00","modified_at":"2020-06-15T15:53:18.514267+00:00","author_handle":"nicholas.muesch@datadoghq.com","widgets":[{"definition":{"title_size":"16","title":"Widget
-      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_stream","event_size":"l"},"layout":{"y":5,"width":32,"x":5,"height":43},"id":96703958520854},{"definition":{"title_size":"16","title":"Widget
-      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_timeline"},"layout":{"y":73,"width":65,"x":42,"height":9},"id":4107676652485735},{"definition":{"color":"#d00","text":"free
-      text content","font_size":"88","text_align":"left","type":"free_text"},"layout":{"y":5,"width":30,"x":42,"height":20},"id":6513245852972190},{"definition":{"url":"http://google.com","type":"iframe"},"layout":{"y":8,"width":39,"x":111,"height":46},"id":2127604159891238},{"definition":{"sizing":"fit","type":"image","margin":"small","url":"https://images.pexels.com/photos/67636/rose-blue-flower-rose-blooms-67636.jpeg?auto=compress&cs=tinysrgb&h=350"},"layout":{"y":7,"width":30,"x":77,"height":20},"id":5647700161189175},{"definition":{"logset":"19","sort":{"column":"time","order":"desc"},"show_message_column":true,"show_date_column":true,"message_display":"expanded-md","indexes":[],"query":"error","type":"log_stream","columns":["core_host","core_service","tag_source"]},"layout":{"y":51,"width":32,"x":5,"height":36},"id":2114422299081408},{"definition":{"count":50,"sort":"status,asc","title_size":"16","title":"Widget
-      Title","title_align":"left","hide_zero_counts":true,"start":0,"summary_type":"monitors","color_preference":"text","query":"type:metric","show_last_triggered":true,"type":"manage_status","display_format":"countsAndList"},"layout":{"y":55,"width":30,"x":112,"height":40},"id":4235645656785120},{"definition":{"span_name":"cassandra.query","title_size":"13","service":"alerting-cassandra","title":"alerting-cassandra
-      #env:datad0g.com","size_format":"large","show_hits":true,"title_align":"center","show_errors":true,"show_breakdown":true,"type":"trace_service","env":"datad0g.com","time":{"live_span":"1h"},"show_distribution":true,"display_format":"three_column","show_latency":false,"show_resource_list":false},"layout":{"y":28,"width":67,"x":40,"height":38},"id":511295784703213}],"layout_type":"free"}'
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":false,"id":"fc9-357-2c2","title":"Acceptance
+      Test Free Dashboard","url":"/dashboard/fc9-357-2c2/acceptance-test-free-dashboard","created_at":"2020-07-27T15:30:59.018418+00:00","modified_at":"2020-07-27T15:30:59.018418+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"title_size":"16","title":"Widget
+      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_stream","event_size":"l"},"layout":{"y":5,"width":32,"x":5,"height":43},"id":6853670302307275},{"definition":{"title_size":"16","title":"Widget
+      Title","title_align":"left","time":{"live_span":"1h"},"query":"*","type":"event_timeline"},"layout":{"y":73,"width":65,"x":42,"height":9},"id":3099196089769225},{"definition":{"color":"#d00","text":"free
+      text content","font_size":"88","text_align":"left","type":"free_text"},"layout":{"y":5,"width":30,"x":42,"height":20},"id":3506682701748283},{"definition":{"url":"http://google.com","type":"iframe"},"layout":{"y":8,"width":39,"x":111,"height":46},"id":5485157401580873},{"definition":{"sizing":"fit","type":"image","margin":"small","url":"https://images.pexels.com/photos/67636/rose-blue-flower-rose-blooms-67636.jpeg?auto=compress&cs=tinysrgb&h=350"},"layout":{"y":7,"width":30,"x":77,"height":20},"id":3095979551624111},{"definition":{"logset":"19","sort":{"column":"time","order":"desc"},"show_message_column":true,"show_date_column":true,"message_display":"expanded-md","indexes":[],"query":"error","type":"log_stream","columns":["core_host","core_service","tag_source"]},"layout":{"y":51,"width":32,"x":5,"height":36},"id":6224124477024345},{"definition":{"count":50,"sort":"status,asc","title_size":"16","title":"Widget
+      Title","title_align":"left","hide_zero_counts":true,"start":0,"summary_type":"monitors","color_preference":"text","query":"type:metric","show_last_triggered":true,"type":"manage_status","display_format":"countsAndList"},"layout":{"y":55,"width":30,"x":112,"height":40},"id":332452485187779},{"definition":{"span_name":"cassandra.query","title_size":"13","service":"alerting-cassandra","title":"alerting-cassandra
+      #env:datad0g.com","size_format":"large","show_hits":true,"title_align":"center","show_errors":true,"show_breakdown":true,"type":"trace_service","env":"datad0g.com","time":{"live_span":"1h"},"show_distribution":true,"display_format":"three_column","show_latency":false,"show_resource_list":false},"layout":{"y":28,"width":67,"x":40,"height":38},"id":3880165379069118}],"layout_type":"free"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1228,13 +1237,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:53:39 GMT
+      - Mon, 27 Jul 2020 15:31:29 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 22-Jun-2020 15:53:38 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 15:31:29 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -1243,9 +1252,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - SxoanfhUZNcxsD3lnA3j+up2jAgZV05RpnWjR/qtgMkjy5UIlkbs0WqFT6yaBwwR
+      - rABORaCdo0eXwjiAWlD/0SR1FMrz+6a0WK3wFJ2nq/fhaAjzdUxlvh0wWPrWcMgm
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -1260,11 +1269,11 @@ interactions:
       Dd-Operation-Id:
       - DeleteDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/xrg-4wk-z3j
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/fc9-357-2c2
     method: DELETE
   response:
-    body: '{"deleted_dashboard_id":"xrg-4wk-z3j"}'
+    body: '{"deleted_dashboard_id":"fc9-357-2c2"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1275,13 +1284,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:53:52 GMT
+      - Mon, 27 Jul 2020 15:31:55 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 22-Jun-2020 15:53:40 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 15:31:31 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -1290,9 +1299,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - 1bzfAqb/6TIngEeU7r7YcGGp2+NaI+ne9J3bzgQrdB0qTrgVrMtd4iKXr1zCNOHr
+      - Uo1VdaQNhPQeC0eY/y4Ta7HXd8SNwEtwYEeUOkYIYAuiClKUSEtK3GzuFau0lMvZ
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -1307,11 +1316,11 @@ interactions:
       Dd-Operation-Id:
       - GetDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.4 (go go1.13; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/xrg-4wk-z3j
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/fc9-357-2c2
     method: GET
   response:
-    body: '{"errors": ["Dashboard with ID xrg-4wk-z3j not found"]}'
+    body: '{"errors": ["Dashboard with ID fc9-357-2c2 not found"]}'
     headers:
       Cache-Control:
       - no-cache
@@ -1322,7 +1331,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Jun 2020 15:53:52 GMT
+      - Mon, 27 Jul 2020 15:31:56 GMT
       Dd-Pool:
       - dogweb
       Pragma:
@@ -1334,7 +1343,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Version:
-      - "35.2622342"
+      - "35.2791837"
       X-Frame-Options:
       - SAMEORIGIN
     status: 404 Not Found

--- a/datadog/cassettes/TestAccDatadogDashboard_update.yaml
+++ b/datadog/cassettes/TestAccDatadogDashboard_update.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"description":"Created using the Datadog provider in Terraform","id":"","is_read_only":true,"layout_type":"ordered","notify_list":[],"template_variable_presets":[{"name":"preset_1","template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}]},{"name":"preset_2","template_variables":[{"name":"var_1","value":"var_1_value"}]}],"template_variables":[{"default":"aws","name":"var_1","prefix":"host"},{"default":"autoscaling","name":"var_2","prefix":"service_name"}],"title":"Acceptance Test Ordered Dashboard","widgets":[{"definition":{"alert_id":"895605","time":{"live_span":"1h"},"title":"Widget Title","type":"alert_graph","viz_type":"timeseries"}},{"definition":{"alert_id":"895605","precision":3,"text_align":"center","title":"Widget Title","type":"alert_value","unit":"b"}},{"definition":{"requests":[{"change_type":"absolute","compare_to":"week_before","increase_good":true,"order_by":"name","order_dir":"desc","q":"avg:system.load.1{env:staging} by {account}","show_present":true}],"time":{"live_span":"1h"},"title":"Widget Title","type":"change"}},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging} by {account}","style":{"palette":"warm"}}],"show_legend":false,"time":{"live_span":"1h"},"title":"Widget Title","type":"distribution"}},{"definition":{"check":"aws.ecs.agent_connected","group_by":["account","cluster"],"grouping":"cluster","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"time":{"live_span":"1h"},"title":"Widget Title","type":"check_status"}},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging} by {account}","style":{"palette":"warm"}}],"show_legend":false,"time":{"live_span":"1h"},"title":"Widget Title","type":"heatmap","yaxis":{"include_zero":true,"max":"2","min":"1","scale":"sqrt"}}},{"definition":{"group":["host","region"],"no_group_hosts":true,"no_metric_hosts":true,"node_type":"container","requests":{"fill":{"q":"avg:system.load.1{*} by {host}"},"size":{"q":"avg:memcache.uptime{*} by {host}"}},"scope":["region:us-east-1","aws_account:727006795293"],"style":{"fill_max":"20","fill_min":"10","palette":"yellow_to_green","palette_flip":true},"title":"Widget Title","type":"hostmap"}},{"definition":{"background_color":"pink","content":"note text","font_size":"14","show_tick":true,"text_align":"center","tick_edge":"left","tick_pos":"50%","type":"note"}},{"definition":{"autoscale":true,"custom_unit":"xx","precision":4,"requests":[{"aggregator":"sum","conditional_formats":[{"comparator":"\u003c","hide_value":false,"palette":"white_on_green","value":2},{"comparator":"\u003e","hide_value":false,"palette":"white_on_red","value":2.2}],"q":"avg:system.load.1{env:staging} by {account}"}],"text_align":"right","time":{"live_span":"1h"},"title":"Widget Title","type":"query_value"}},{"definition":{"color_by_groups":["account","apm-role-group"],"requests":{"x":{"aggregator":"max","q":"avg:system.cpu.user{*} by {service, account}"},"y":{"aggregator":"min","q":"avg:system.mem.used{*} by {service, account}"}},"time":{"live_span":"1h"},"title":"Widget Title","type":"scatterplot","xaxis":{"include_zero":true,"label":"x","max":"2000","min":"1","scale":"pow"},"yaxis":{"include_zero":false,"label":"y","max":"2222","min":"5","scale":"log"}}},{"definition":{"events":[{"q":"sources:test tags:1"},{"q":"sources:test tags:2"}],"legend_size":"2","markers":[{"display_type":"error dashed","label":" z=6 ","value":"y=4"},{"display_type":"ok solid","label":" x=8 ","value":"10 \u003c y \u003c 999"}],"requests":[{"display_type":"line","metadata":[{"alias_name":"Alpha","expression":"avg:system.cpu.user{app:general} by {env}"}],"q":"avg:system.cpu.user{app:general} by {env}","style":{"line_type":"dashed","line_width":"thin","palette":"warm"}},{"display_type":"area","log_query":{"compute":{"aggregation":"count","facet":"@duration","interval":5000},"group_by":[{"facet":"host","limit":10,"sort":{"aggregation":"avg","facet":"@duration","order":"desc"}}],"index":"mcnulty","search":{"query":"status:info"}}},{"apm_query":{"compute":{"aggregation":"count","facet":"@duration","interval":5000},"group_by":[{"facet":"resource_name","limit":50,"sort":{"aggregation":"avg","facet":"@string_query.interval","order":"desc"}}],"index":"apm-search","search":{"query":"type:web"}},"display_type":"bars"},{"display_type":"area","process_query":{"filter_by":["active"],"limit":50,"metric":"process.stat.cpu.total_pct","search_by":"error"}}],"show_legend":true,"time":{"live_span":"1h"},"title":"Widget Title","type":"timeseries","yaxis":{"include_zero":false,"max":"100","scale":"log"}}},{"definition":{"requests":[{"conditional_formats":[{"comparator":"\u003c","hide_value":false,"palette":"white_on_green","value":2},{"comparator":"\u003e","hide_value":false,"palette":"white_on_red","value":2.2}],"q":"avg:system.cpu.user{app:general} by {env}"}],"title":"Widget Title","type":"toplist"}},{"definition":{"layout_type":"ordered","title":"Group Widget","type":"group","widgets":[{"definition":{"background_color":"yellow","content":"cluster note widget","font_size":"16","show_tick":false,"text_align":"left","tick_edge":"left","tick_pos":"50%","type":"note"}},{"definition":{"alert_id":"123","time":{"live_span":"1h"},"title":"Alert Graph","type":"alert_graph","viz_type":"toplist"}}]}},{"definition":{"show_error_budget":true,"slo_id":"56789","time_windows":["7d","previous_week"],"title":"Widget Title","type":"slo","view_mode":"overall","view_type":"detail"}},{"definition":{"requests":[{"aggregator":"sum","conditional_formats":[{"comparator":"\u003c","hide_value":false,"palette":"white_on_green","value":2},{"comparator":"\u003e","hide_value":false,"palette":"white_on_red","value":2.2}],"limit":10,"q":"avg:system.load.1{env:staging} by {account}"}],"time":{"live_span":"1h"},"title":"Widget Title","type":"query_table"}}]}
+      {"description":"Created using the Datadog provider in Terraform","id":"","is_read_only":true,"layout_type":"ordered","notify_list":[],"template_variable_presets":[{"name":"preset_1","template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}]},{"name":"preset_2","template_variables":[{"name":"var_1","value":"var_1_value"}]}],"template_variables":[{"default":"aws","name":"var_1","prefix":"host"},{"default":"autoscaling","name":"var_2","prefix":"service_name"}],"title":"Acceptance Test Ordered Dashboard","widgets":[{"definition":{"alert_id":"895605","time":{"live_span":"1h"},"title":"Widget Title","type":"alert_graph","viz_type":"timeseries"}},{"definition":{"alert_id":"895605","precision":3,"text_align":"center","title":"Widget Title","type":"alert_value","unit":"b"}},{"definition":{"requests":[{"change_type":"absolute","compare_to":"week_before","increase_good":true,"order_by":"name","order_dir":"desc","q":"avg:system.load.1{env:staging} by {account}","show_present":true}],"time":{"live_span":"1h"},"title":"Widget Title","type":"change"}},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging} by {account}","style":{"palette":"warm"}}],"show_legend":false,"time":{"live_span":"1h"},"title":"Widget Title","type":"distribution"}},{"definition":{"check":"aws.ecs.agent_connected","group_by":["account","cluster"],"grouping":"cluster","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"time":{"live_span":"1h"},"title":"Widget Title","type":"check_status"}},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging} by {account}","style":{"palette":"warm"}}],"show_legend":false,"time":{"live_span":"1h"},"title":"Widget Title","type":"heatmap","yaxis":{"include_zero":true,"max":"2","min":"1","scale":"sqrt"}}},{"definition":{"group":["host","region"],"no_group_hosts":true,"no_metric_hosts":true,"node_type":"container","requests":{"fill":{"q":"avg:system.load.1{*} by {host}"},"size":{"q":"avg:memcache.uptime{*} by {host}"}},"scope":["region:us-east-1","aws_account:727006795293"],"style":{"fill_max":"20","fill_min":"10","palette":"yellow_to_green","palette_flip":true},"title":"Widget Title","type":"hostmap"}},{"definition":{"background_color":"pink","content":"note text","font_size":"14","show_tick":true,"text_align":"center","tick_edge":"left","tick_pos":"50%","type":"note"}},{"definition":{"autoscale":true,"custom_unit":"xx","precision":4,"requests":[{"aggregator":"sum","conditional_formats":[{"comparator":"\u003c","hide_value":false,"palette":"white_on_green","value":2},{"comparator":"\u003e","hide_value":false,"palette":"white_on_red","value":2.2}],"q":"avg:system.load.1{env:staging} by {account}"}],"text_align":"right","time":{"live_span":"1h"},"title":"Widget Title","type":"query_value"}},{"definition":{"color_by_groups":["account","apm-role-group"],"requests":{"x":{"aggregator":"max","q":"avg:system.cpu.user{*} by {service, account}"},"y":{"aggregator":"min","q":"avg:system.mem.used{*} by {service, account}"}},"time":{"live_span":"1h"},"title":"Widget Title","type":"scatterplot","xaxis":{"include_zero":true,"label":"x","max":"2000","min":"1","scale":"pow"},"yaxis":{"include_zero":false,"label":"y","max":"2222","min":"5","scale":"log"}}},{"definition":{"events":[{"q":"sources:test tags:1"},{"q":"sources:test tags:2"}],"legend_size":"2","markers":[{"display_type":"error dashed","label":" z=6 ","value":"y=4"},{"display_type":"ok solid","label":" x=8 ","value":"10 \u003c y \u003c 999"}],"requests":[{"display_type":"line","metadata":[{"alias_name":"Alpha","expression":"avg:system.cpu.user{app:general} by {env}"}],"q":"avg:system.cpu.user{app:general} by {env}","style":{"line_type":"dashed","line_width":"thin","palette":"warm"}},{"display_type":"area","log_query":{"compute":{"aggregation":"count","facet":"@duration","interval":5000},"group_by":[{"facet":"host","limit":10,"sort":{"aggregation":"avg","facet":"@duration","order":"desc"}}],"index":"mcnulty","search":{"query":"status:info"}}},{"apm_query":{"compute":{"aggregation":"count","facet":"@duration","interval":5000},"group_by":[{"facet":"resource_name","limit":50,"sort":{"aggregation":"avg","facet":"@string_query.interval","order":"desc"}}],"index":"apm-search","search":{"query":"type:web"}},"display_type":"bars"},{"display_type":"area","process_query":{"filter_by":["active"],"limit":50,"metric":"process.stat.cpu.total_pct","search_by":"error"}},{"display_type":"bars","security_query":{"compute":{"aggregation":"count"},"group_by":[{"facet":"status"}],"index":"signal","search":{"query":"status:(high OR critical)"}}},{"display_type":"bars","rum_query":{"compute":{"aggregation":"count"},"group_by":[{"facet":"service"}],"index":"rum","search":{"query":"status:info"}}}],"show_legend":true,"time":{"live_span":"1h"},"title":"Widget Title","type":"timeseries","yaxis":{"include_zero":false,"max":"100","scale":"log"}}},{"definition":{"requests":[{"conditional_formats":[{"comparator":"\u003c","hide_value":false,"palette":"white_on_green","value":2},{"comparator":"\u003e","hide_value":false,"palette":"white_on_red","value":2.2}],"q":"avg:system.cpu.user{app:general} by {env}"}],"title":"Widget Title","type":"toplist"}},{"definition":{"layout_type":"ordered","title":"Group Widget","type":"group","widgets":[{"definition":{"background_color":"yellow","content":"cluster note widget","font_size":"16","show_tick":false,"text_align":"left","tick_edge":"left","tick_pos":"50%","type":"note"}},{"definition":{"alert_id":"123","time":{"live_span":"1h"},"title":"Alert Graph","type":"alert_graph","viz_type":"toplist"}}]}},{"definition":{"show_error_budget":true,"slo_id":"56789","time_windows":["7d","previous_week"],"title":"Widget Title","type":"slo","view_mode":"overall","view_type":"detail"}},{"definition":{"requests":[{"aggregator":"sum","conditional_formats":[{"comparator":"\u003c","hide_value":false,"palette":"white_on_green","value":2},{"comparator":"\u003e","hide_value":false,"palette":"white_on_red","value":2.2}],"limit":10,"q":"avg:system.load.1{env:staging} by {account}"}],"time":{"live_span":"1h"},"title":"Widget Title","type":"query_table"}}]}
     form: {}
     headers:
       Accept:
@@ -13,43 +13,44 @@ interactions:
       Dd-Operation-Id:
       - CreateDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.6 (go go1.14.3; os darwin; arch amd64)
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
     url: https://api.datadoghq.com/api/v1/dashboard
     method: POST
   response:
     body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"7ez-rcs-6sw","title":"Acceptance
-      Test Ordered Dashboard","url":"/dashboard/7ez-rcs-6sw/acceptance-test-ordered-dashboard","created_at":"2020-06-26T09:04:50.250650+00:00","modified_at":"2020-06-26T09:04:50.250650+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
-      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":5482991373819465},{"definition":{"title":"Widget
-      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":7068655639347766},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"ptd-vmf-qqv","title":"Acceptance
+      Test Ordered Dashboard","url":"/dashboard/ptd-vmf-qqv/acceptance-test-ordered-dashboard","created_at":"2020-07-27T09:28:45.829652+00:00","modified_at":"2020-07-27T09:28:45.829652+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
+      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":2004439419232673},{"definition":{"title":"Widget
+      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":7950551701283055},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
       by {account}","show_present":true,"increase_good":true,"order_by":"name"}],"title":"Widget
-      Title","type":"change","time":{"live_span":"1h"}},"id":5875675526524686},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":3129835329781849},{"definition":{"title":"Widget
-      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":2617145282777},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
+      Title","type":"change","time":{"live_span":"1h"}},"id":161294403450521},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":2694686495192282},{"definition":{"title":"Widget
+      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":6145647906918396},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
       Title","show_legend":false,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":2938319160483767},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
+      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":2303253220680899},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
       Title","node_type":"container","no_metric_hosts":true,"scope":["region:us-east-1","aws_account:727006795293"],"requests":{"size":{"q":"avg:memcache.uptime{*}
-      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":7626117416951771},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
-      text","show_tick":true,"background_color":"pink"},"id":1527444943211519},{"definition":{"autoscale":true,"title":"Widget
+      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":4708965777250787},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
+      text","show_tick":true,"background_color":"pink"},"id":2051810116930768},{"definition":{"autoscale":true,"title":"Widget
       Title","text_align":"right","custom_unit":"xx","precision":4,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":6702801832330157},{"definition":{"title":"Widget
+      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":8481495082193006},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"max":"2222","min":"5","scale":"log","label":"y"},"color_by_groups":["account","apm-role-group"],"xaxis":{"include_zero":true,"max":"2000","min":"1","scale":"pow","label":"x"},"time":{"live_span":"1h"},"requests":{"y":{"q":"avg:system.mem.used{*}
       by {service, account}","aggregator":"min"},"x":{"q":"avg:system.cpu.user{*}
-      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":5916680852227051},{"definition":{"title":"Widget
+      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":4891601216198077},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"scale":"log","max":"100"},"markers":[{"display_type":"error
       dashed","value":"y=4","label":" z=6 "},{"display_type":"ok solid","value":"10
       < y < 999","label":" x=8 "}],"events":[{"q":"sources:test tags:1"},{"q":"sources:test
       tags:2"}],"show_legend":true,"time":{"live_span":"1h"},"legend_size":"2","type":"timeseries","requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","style":{"line_width":"thin","palette":"warm","line_type":"dashed"},"display_type":"line","metadata":[{"expression":"avg:system.cpu.user{app:general}
-      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"}]},"id":3692649315881749},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
+      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"},{"display_type":"bars","security_query":{"index":"signal","search":{"query":"status:(high
+      OR critical)"},"group_by":[{"facet":"status"}],"compute":{"aggregation":"count"}}},{"rum_query":{"index":"rum","search":{"query":"status:info"},"group_by":[{"facet":"service"}],"compute":{"aggregation":"count"}},"display_type":"bars"}]},"id":2971304434695583},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"toplist","title":"Widget
-      Title"},"id":5889476127695513},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
-      note widget","show_tick":false,"background_color":"yellow"},"id":831175390868293},{"definition":{"alert_id":"123","title":"Alert
-      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":993262831680574}],"layout_type":"ordered","type":"group","title":"Group
-      Widget"},"id":4252600679884569},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
-      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":520921794228166},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      Title"},"id":7859659637769425},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
+      note widget","show_tick":false,"background_color":"yellow"},"id":6933836026472965},{"definition":{"alert_id":"123","title":"Alert
+      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":3881107819734845}],"layout_type":"ordered","type":"group","title":"Group
+      Widget"},"id":7272901138747326},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
+      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":710643654763486},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
       by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}],"limit":10}],"title":"Widget
-      Title","type":"query_table","time":{"live_span":"1h"}},"id":6111791390371422}],"layout_type":"ordered"}'
+      Title","type":"query_table","time":{"live_span":"1h"}},"id":1859705441759450}],"layout_type":"ordered"}'
     headers:
       Cache-Control:
       - no-cache
@@ -60,13 +61,253 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Jun 2020 09:04:50 GMT
+      - Mon, 27 Jul 2020 09:28:45 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Fri, 03-Jul-2020 09:04:50 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:28:45 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - 5gIeAyE850e1lqVwTAgwvudewR8EzuQd3qGaXsS2D0CKQVhFOIjBoeQYiH0qPohy
+      X-Dd-Version:
+      - "35.2790462"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Dd-Operation-Id:
+      - GetDashboard
+      User-Agent:
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/ptd-vmf-qqv
+    method: GET
+  response:
+    body: '{"notify_list":[],"description":"Created using the Datadog provider in
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"ptd-vmf-qqv","title":"Acceptance
+      Test Ordered Dashboard","url":"/dashboard/ptd-vmf-qqv/acceptance-test-ordered-dashboard","created_at":"2020-07-27T09:28:45.829652+00:00","modified_at":"2020-07-27T09:28:45.829652+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
+      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":2004439419232673},{"definition":{"title":"Widget
+      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":7950551701283055},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
+      by {account}","show_present":true,"increase_good":true,"order_by":"name"}],"title":"Widget
+      Title","type":"change","time":{"live_span":"1h"}},"id":161294403450521},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":2694686495192282},{"definition":{"title":"Widget
+      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":6145647906918396},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
+      Title","show_legend":false,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":2303253220680899},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
+      Title","node_type":"container","no_metric_hosts":true,"scope":["region:us-east-1","aws_account:727006795293"],"requests":{"size":{"q":"avg:memcache.uptime{*}
+      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":4708965777250787},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
+      text","show_tick":true,"background_color":"pink"},"id":2051810116930768},{"definition":{"autoscale":true,"title":"Widget
+      Title","text_align":"right","custom_unit":"xx","precision":4,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":8481495082193006},{"definition":{"title":"Widget
+      Title","yaxis":{"include_zero":false,"max":"2222","min":"5","scale":"log","label":"y"},"color_by_groups":["account","apm-role-group"],"xaxis":{"include_zero":true,"max":"2000","min":"1","scale":"pow","label":"x"},"time":{"live_span":"1h"},"requests":{"y":{"q":"avg:system.mem.used{*}
+      by {service, account}","aggregator":"min"},"x":{"q":"avg:system.cpu.user{*}
+      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":4891601216198077},{"definition":{"title":"Widget
+      Title","yaxis":{"include_zero":false,"scale":"log","max":"100"},"markers":[{"display_type":"error
+      dashed","value":"y=4","label":" z=6 "},{"display_type":"ok solid","value":"10
+      < y < 999","label":" x=8 "}],"events":[{"q":"sources:test tags:1"},{"q":"sources:test
+      tags:2"}],"show_legend":true,"time":{"live_span":"1h"},"legend_size":"2","type":"timeseries","requests":[{"q":"avg:system.cpu.user{app:general}
+      by {env}","style":{"line_width":"thin","palette":"warm","line_type":"dashed"},"display_type":"line","metadata":[{"expression":"avg:system.cpu.user{app:general}
+      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"},{"display_type":"bars","security_query":{"index":"signal","search":{"query":"status:(high
+      OR critical)"},"group_by":[{"facet":"status"}],"compute":{"aggregation":"count"}}},{"rum_query":{"index":"rum","search":{"query":"status:info"},"group_by":[{"facet":"service"}],"compute":{"aggregation":"count"}},"display_type":"bars"}]},"id":2971304434695583},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
+      by {env}","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"toplist","title":"Widget
+      Title"},"id":7859659637769425},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
+      note widget","show_tick":false,"background_color":"yellow"},"id":6933836026472965},{"definition":{"alert_id":"123","title":"Alert
+      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":3881107819734845}],"layout_type":"ordered","type":"group","title":"Group
+      Widget"},"id":7272901138747326},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
+      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":710643654763486},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}],"limit":10}],"title":"Widget
+      Title","type":"query_table","time":{"live_span":"1h"}},"id":1859705441759450}],"layout_type":"ordered"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jul 2020 09:28:46 GMT
+      Dd-Pool:
+      - dogweb
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:28:46 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - 6qTaw+brNWWnKD6ULH8747/TVkPK0wedRsruOmMITJcYBkJ/Eac9bUO9jP1Btfl5
+      X-Dd-Version:
+      - "35.2790462"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Dd-Operation-Id:
+      - GetDashboard
+      User-Agent:
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/ptd-vmf-qqv
+    method: GET
+  response:
+    body: '{"notify_list":[],"description":"Created using the Datadog provider in
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"ptd-vmf-qqv","title":"Acceptance
+      Test Ordered Dashboard","url":"/dashboard/ptd-vmf-qqv/acceptance-test-ordered-dashboard","created_at":"2020-07-27T09:28:45.829652+00:00","modified_at":"2020-07-27T09:28:45.829652+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
+      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":2004439419232673},{"definition":{"title":"Widget
+      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":7950551701283055},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
+      by {account}","show_present":true,"increase_good":true,"order_by":"name"}],"title":"Widget
+      Title","type":"change","time":{"live_span":"1h"}},"id":161294403450521},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":2694686495192282},{"definition":{"title":"Widget
+      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":6145647906918396},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
+      Title","show_legend":false,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":2303253220680899},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
+      Title","node_type":"container","no_metric_hosts":true,"scope":["region:us-east-1","aws_account:727006795293"],"requests":{"size":{"q":"avg:memcache.uptime{*}
+      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":4708965777250787},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
+      text","show_tick":true,"background_color":"pink"},"id":2051810116930768},{"definition":{"autoscale":true,"title":"Widget
+      Title","text_align":"right","custom_unit":"xx","precision":4,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":8481495082193006},{"definition":{"title":"Widget
+      Title","yaxis":{"include_zero":false,"max":"2222","min":"5","scale":"log","label":"y"},"color_by_groups":["account","apm-role-group"],"xaxis":{"include_zero":true,"max":"2000","min":"1","scale":"pow","label":"x"},"time":{"live_span":"1h"},"requests":{"y":{"q":"avg:system.mem.used{*}
+      by {service, account}","aggregator":"min"},"x":{"q":"avg:system.cpu.user{*}
+      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":4891601216198077},{"definition":{"title":"Widget
+      Title","yaxis":{"include_zero":false,"scale":"log","max":"100"},"markers":[{"display_type":"error
+      dashed","value":"y=4","label":" z=6 "},{"display_type":"ok solid","value":"10
+      < y < 999","label":" x=8 "}],"events":[{"q":"sources:test tags:1"},{"q":"sources:test
+      tags:2"}],"show_legend":true,"time":{"live_span":"1h"},"legend_size":"2","type":"timeseries","requests":[{"q":"avg:system.cpu.user{app:general}
+      by {env}","style":{"line_width":"thin","palette":"warm","line_type":"dashed"},"display_type":"line","metadata":[{"expression":"avg:system.cpu.user{app:general}
+      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"},{"display_type":"bars","security_query":{"index":"signal","search":{"query":"status:(high
+      OR critical)"},"group_by":[{"facet":"status"}],"compute":{"aggregation":"count"}}},{"rum_query":{"index":"rum","search":{"query":"status:info"},"group_by":[{"facet":"service"}],"compute":{"aggregation":"count"}},"display_type":"bars"}]},"id":2971304434695583},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
+      by {env}","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"toplist","title":"Widget
+      Title"},"id":7859659637769425},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
+      note widget","show_tick":false,"background_color":"yellow"},"id":6933836026472965},{"definition":{"alert_id":"123","title":"Alert
+      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":3881107819734845}],"layout_type":"ordered","type":"group","title":"Group
+      Widget"},"id":7272901138747326},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
+      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":710643654763486},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}],"limit":10}],"title":"Widget
+      Title","type":"query_table","time":{"live_span":"1h"}},"id":1859705441759450}],"layout_type":"ordered"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jul 2020 09:28:46 GMT
+      Dd-Pool:
+      - dogweb
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:28:46 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - 7TxqGOOndreg52igtXLKdvEB8M2Uby8upoxCr+mzZBPLwPuOVdJ4ujutF+9TQL1R
+      X-Dd-Version:
+      - "35.2790462"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Dd-Operation-Id:
+      - GetDashboard
+      User-Agent:
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/ptd-vmf-qqv
+    method: GET
+  response:
+    body: '{"notify_list":[],"description":"Created using the Datadog provider in
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"ptd-vmf-qqv","title":"Acceptance
+      Test Ordered Dashboard","url":"/dashboard/ptd-vmf-qqv/acceptance-test-ordered-dashboard","created_at":"2020-07-27T09:28:45.829652+00:00","modified_at":"2020-07-27T09:28:45.829652+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
+      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":2004439419232673},{"definition":{"title":"Widget
+      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":7950551701283055},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
+      by {account}","show_present":true,"increase_good":true,"order_by":"name"}],"title":"Widget
+      Title","type":"change","time":{"live_span":"1h"}},"id":161294403450521},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":2694686495192282},{"definition":{"title":"Widget
+      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":6145647906918396},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
+      Title","show_legend":false,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":2303253220680899},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
+      Title","node_type":"container","no_metric_hosts":true,"scope":["region:us-east-1","aws_account:727006795293"],"requests":{"size":{"q":"avg:memcache.uptime{*}
+      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":4708965777250787},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
+      text","show_tick":true,"background_color":"pink"},"id":2051810116930768},{"definition":{"autoscale":true,"title":"Widget
+      Title","text_align":"right","custom_unit":"xx","precision":4,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":8481495082193006},{"definition":{"title":"Widget
+      Title","yaxis":{"include_zero":false,"max":"2222","min":"5","scale":"log","label":"y"},"color_by_groups":["account","apm-role-group"],"xaxis":{"include_zero":true,"max":"2000","min":"1","scale":"pow","label":"x"},"time":{"live_span":"1h"},"requests":{"y":{"q":"avg:system.mem.used{*}
+      by {service, account}","aggregator":"min"},"x":{"q":"avg:system.cpu.user{*}
+      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":4891601216198077},{"definition":{"title":"Widget
+      Title","yaxis":{"include_zero":false,"scale":"log","max":"100"},"markers":[{"display_type":"error
+      dashed","value":"y=4","label":" z=6 "},{"display_type":"ok solid","value":"10
+      < y < 999","label":" x=8 "}],"events":[{"q":"sources:test tags:1"},{"q":"sources:test
+      tags:2"}],"show_legend":true,"time":{"live_span":"1h"},"legend_size":"2","type":"timeseries","requests":[{"q":"avg:system.cpu.user{app:general}
+      by {env}","style":{"line_width":"thin","palette":"warm","line_type":"dashed"},"display_type":"line","metadata":[{"expression":"avg:system.cpu.user{app:general}
+      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"},{"display_type":"bars","security_query":{"index":"signal","search":{"query":"status:(high
+      OR critical)"},"group_by":[{"facet":"status"}],"compute":{"aggregation":"count"}}},{"rum_query":{"index":"rum","search":{"query":"status:info"},"group_by":[{"facet":"service"}],"compute":{"aggregation":"count"}},"display_type":"bars"}]},"id":2971304434695583},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
+      by {env}","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"toplist","title":"Widget
+      Title"},"id":7859659637769425},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
+      note widget","show_tick":false,"background_color":"yellow"},"id":6933836026472965},{"definition":{"alert_id":"123","title":"Alert
+      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":3881107819734845}],"layout_type":"ordered","type":"group","title":"Group
+      Widget"},"id":7272901138747326},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
+      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":710643654763486},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}],"limit":10}],"title":"Widget
+      Title","type":"query_table","time":{"live_span":"1h"}},"id":1859705441759450}],"layout_type":"ordered"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jul 2020 09:28:48 GMT
+      Dd-Pool:
+      - dogweb
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:28:48 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -77,7 +318,7 @@ interactions:
       X-Dd-Debug:
       - vQYgH+orCqhRbQG/mSd6IeQSqyYBCkFVCv4Bj6PXMALQcvTK5EvxQuH7fIz3d52m
       X-Dd-Version:
-      - "35.2668538"
+      - "35.2790462"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -92,43 +333,44 @@ interactions:
       Dd-Operation-Id:
       - GetDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.6 (go go1.14.3; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/7ez-rcs-6sw
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/ptd-vmf-qqv
     method: GET
   response:
     body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"7ez-rcs-6sw","title":"Acceptance
-      Test Ordered Dashboard","url":"/dashboard/7ez-rcs-6sw/acceptance-test-ordered-dashboard","created_at":"2020-06-26T09:04:50.250650+00:00","modified_at":"2020-06-26T09:04:50.250650+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
-      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":5482991373819465},{"definition":{"title":"Widget
-      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":7068655639347766},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
+      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"ptd-vmf-qqv","title":"Acceptance
+      Test Ordered Dashboard","url":"/dashboard/ptd-vmf-qqv/acceptance-test-ordered-dashboard","created_at":"2020-07-27T09:28:45.829652+00:00","modified_at":"2020-07-27T09:28:45.829652+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
+      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":2004439419232673},{"definition":{"title":"Widget
+      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":7950551701283055},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
       by {account}","show_present":true,"increase_good":true,"order_by":"name"}],"title":"Widget
-      Title","type":"change","time":{"live_span":"1h"}},"id":5875675526524686},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":3129835329781849},{"definition":{"title":"Widget
-      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":2617145282777},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
+      Title","type":"change","time":{"live_span":"1h"}},"id":161294403450521},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":2694686495192282},{"definition":{"title":"Widget
+      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":6145647906918396},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
       Title","show_legend":false,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":2938319160483767},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
+      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":2303253220680899},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
       Title","node_type":"container","no_metric_hosts":true,"scope":["region:us-east-1","aws_account:727006795293"],"requests":{"size":{"q":"avg:memcache.uptime{*}
-      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":7626117416951771},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
-      text","show_tick":true,"background_color":"pink"},"id":1527444943211519},{"definition":{"autoscale":true,"title":"Widget
+      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":4708965777250787},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
+      text","show_tick":true,"background_color":"pink"},"id":2051810116930768},{"definition":{"autoscale":true,"title":"Widget
       Title","text_align":"right","custom_unit":"xx","precision":4,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":6702801832330157},{"definition":{"title":"Widget
+      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":8481495082193006},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"max":"2222","min":"5","scale":"log","label":"y"},"color_by_groups":["account","apm-role-group"],"xaxis":{"include_zero":true,"max":"2000","min":"1","scale":"pow","label":"x"},"time":{"live_span":"1h"},"requests":{"y":{"q":"avg:system.mem.used{*}
       by {service, account}","aggregator":"min"},"x":{"q":"avg:system.cpu.user{*}
-      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":5916680852227051},{"definition":{"title":"Widget
+      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":4891601216198077},{"definition":{"title":"Widget
       Title","yaxis":{"include_zero":false,"scale":"log","max":"100"},"markers":[{"display_type":"error
       dashed","value":"y=4","label":" z=6 "},{"display_type":"ok solid","value":"10
       < y < 999","label":" x=8 "}],"events":[{"q":"sources:test tags:1"},{"q":"sources:test
       tags:2"}],"show_legend":true,"time":{"live_span":"1h"},"legend_size":"2","type":"timeseries","requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","style":{"line_width":"thin","palette":"warm","line_type":"dashed"},"display_type":"line","metadata":[{"expression":"avg:system.cpu.user{app:general}
-      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"}]},"id":3692649315881749},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
+      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"},{"display_type":"bars","security_query":{"index":"signal","search":{"query":"status:(high
+      OR critical)"},"group_by":[{"facet":"status"}],"compute":{"aggregation":"count"}}},{"rum_query":{"index":"rum","search":{"query":"status:info"},"group_by":[{"facet":"service"}],"compute":{"aggregation":"count"}},"display_type":"bars"}]},"id":2971304434695583},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
       by {env}","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"toplist","title":"Widget
-      Title"},"id":5889476127695513},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
-      note widget","show_tick":false,"background_color":"yellow"},"id":831175390868293},{"definition":{"alert_id":"123","title":"Alert
-      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":993262831680574}],"layout_type":"ordered","type":"group","title":"Group
-      Widget"},"id":4252600679884569},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
-      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":520921794228166},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
+      Title"},"id":7859659637769425},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
+      note widget","show_tick":false,"background_color":"yellow"},"id":6933836026472965},{"definition":{"alert_id":"123","title":"Alert
+      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":3881107819734845}],"layout_type":"ordered","type":"group","title":"Group
+      Widget"},"id":7272901138747326},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
+      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":710643654763486},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
       by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}],"limit":10}],"title":"Widget
-      Title","type":"query_table","time":{"live_span":"1h"}},"id":6111791390371422}],"layout_type":"ordered"}'
+      Title","type":"query_table","time":{"live_span":"1h"}},"id":1859705441759450}],"layout_type":"ordered"}'
     headers:
       Cache-Control:
       - no-cache
@@ -139,13 +381,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Jun 2020 09:04:50 GMT
+      - Mon, 27 Jul 2020 09:28:49 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Fri, 03-Jul-2020 09:04:50 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:28:49 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -154,404 +396,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - qA85Kiicwd/s93AfT3MSf+l6IYc5FQ6tEbp4Kft/ri41UOumJ967MPQKmz3gwejd
+      - 0pmBjL5vG2A5IkxC4OBtwgn929khTZGgUquRW20JC77zchR4jTrHgra/pB22jP66
       X-Dd-Version:
-      - "35.2668538"
-      X-Frame-Options:
-      - SAMEORIGIN
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Dd-Operation-Id:
-      - GetDashboard
-      User-Agent:
-      - datadog-api-client-go/1.0.0-beta.6 (go go1.14.3; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/7ez-rcs-6sw
-    method: GET
-  response:
-    body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"7ez-rcs-6sw","title":"Acceptance
-      Test Ordered Dashboard","url":"/dashboard/7ez-rcs-6sw/acceptance-test-ordered-dashboard","created_at":"2020-06-26T09:04:50.250650+00:00","modified_at":"2020-06-26T09:04:50.250650+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
-      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":5482991373819465},{"definition":{"title":"Widget
-      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":7068655639347766},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
-      by {account}","show_present":true,"increase_good":true,"order_by":"name"}],"title":"Widget
-      Title","type":"change","time":{"live_span":"1h"}},"id":5875675526524686},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":3129835329781849},{"definition":{"title":"Widget
-      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":2617145282777},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
-      Title","show_legend":false,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":2938319160483767},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
-      Title","node_type":"container","no_metric_hosts":true,"scope":["region:us-east-1","aws_account:727006795293"],"requests":{"size":{"q":"avg:memcache.uptime{*}
-      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":7626117416951771},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
-      text","show_tick":true,"background_color":"pink"},"id":1527444943211519},{"definition":{"autoscale":true,"title":"Widget
-      Title","text_align":"right","custom_unit":"xx","precision":4,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":6702801832330157},{"definition":{"title":"Widget
-      Title","yaxis":{"include_zero":false,"max":"2222","min":"5","scale":"log","label":"y"},"color_by_groups":["account","apm-role-group"],"xaxis":{"include_zero":true,"max":"2000","min":"1","scale":"pow","label":"x"},"time":{"live_span":"1h"},"requests":{"y":{"q":"avg:system.mem.used{*}
-      by {service, account}","aggregator":"min"},"x":{"q":"avg:system.cpu.user{*}
-      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":5916680852227051},{"definition":{"title":"Widget
-      Title","yaxis":{"include_zero":false,"scale":"log","max":"100"},"markers":[{"display_type":"error
-      dashed","value":"y=4","label":" z=6 "},{"display_type":"ok solid","value":"10
-      < y < 999","label":" x=8 "}],"events":[{"q":"sources:test tags:1"},{"q":"sources:test
-      tags:2"}],"show_legend":true,"time":{"live_span":"1h"},"legend_size":"2","type":"timeseries","requests":[{"q":"avg:system.cpu.user{app:general}
-      by {env}","style":{"line_width":"thin","palette":"warm","line_type":"dashed"},"display_type":"line","metadata":[{"expression":"avg:system.cpu.user{app:general}
-      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"}]},"id":3692649315881749},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
-      by {env}","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"toplist","title":"Widget
-      Title"},"id":5889476127695513},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
-      note widget","show_tick":false,"background_color":"yellow"},"id":831175390868293},{"definition":{"alert_id":"123","title":"Alert
-      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":993262831680574}],"layout_type":"ordered","type":"group","title":"Group
-      Widget"},"id":4252600679884569},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
-      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":520921794228166},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}],"limit":10}],"title":"Widget
-      Title","type":"query_table","time":{"live_span":"1h"}},"id":6111791390371422}],"layout_type":"ordered"}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 26 Jun 2020 09:04:50 GMT
-      Dd-Pool:
-      - dogweb
-      Pragma:
-      - no-cache
-      Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Fri, 03-Jul-2020 09:04:50 GMT;
-        secure; HttpOnly
-      Strict-Transport-Security:
-      - max-age=15724800;
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Dd-Debug:
-      - UmZMvwWLI5lgbGFBnw6J7jqO5hwyrvVF8Un8TwZ8TRQQ6jetE/6GVTSaoSUmQWRg
-      X-Dd-Version:
-      - "35.2668538"
-      X-Frame-Options:
-      - SAMEORIGIN
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Dd-Operation-Id:
-      - GetDashboard
-      User-Agent:
-      - datadog-api-client-go/1.0.0-beta.6 (go go1.14.3; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/7ez-rcs-6sw
-    method: GET
-  response:
-    body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"7ez-rcs-6sw","title":"Acceptance
-      Test Ordered Dashboard","url":"/dashboard/7ez-rcs-6sw/acceptance-test-ordered-dashboard","created_at":"2020-06-26T09:04:50.250650+00:00","modified_at":"2020-06-26T09:04:50.250650+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
-      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":5482991373819465},{"definition":{"title":"Widget
-      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":7068655639347766},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
-      by {account}","show_present":true,"increase_good":true,"order_by":"name"}],"title":"Widget
-      Title","type":"change","time":{"live_span":"1h"}},"id":5875675526524686},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":3129835329781849},{"definition":{"title":"Widget
-      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":2617145282777},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
-      Title","show_legend":false,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":2938319160483767},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
-      Title","node_type":"container","no_metric_hosts":true,"scope":["region:us-east-1","aws_account:727006795293"],"requests":{"size":{"q":"avg:memcache.uptime{*}
-      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":7626117416951771},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
-      text","show_tick":true,"background_color":"pink"},"id":1527444943211519},{"definition":{"autoscale":true,"title":"Widget
-      Title","text_align":"right","custom_unit":"xx","precision":4,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":6702801832330157},{"definition":{"title":"Widget
-      Title","yaxis":{"include_zero":false,"max":"2222","min":"5","scale":"log","label":"y"},"color_by_groups":["account","apm-role-group"],"xaxis":{"include_zero":true,"max":"2000","min":"1","scale":"pow","label":"x"},"time":{"live_span":"1h"},"requests":{"y":{"q":"avg:system.mem.used{*}
-      by {service, account}","aggregator":"min"},"x":{"q":"avg:system.cpu.user{*}
-      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":5916680852227051},{"definition":{"title":"Widget
-      Title","yaxis":{"include_zero":false,"scale":"log","max":"100"},"markers":[{"display_type":"error
-      dashed","value":"y=4","label":" z=6 "},{"display_type":"ok solid","value":"10
-      < y < 999","label":" x=8 "}],"events":[{"q":"sources:test tags:1"},{"q":"sources:test
-      tags:2"}],"show_legend":true,"time":{"live_span":"1h"},"legend_size":"2","type":"timeseries","requests":[{"q":"avg:system.cpu.user{app:general}
-      by {env}","style":{"line_width":"thin","palette":"warm","line_type":"dashed"},"display_type":"line","metadata":[{"expression":"avg:system.cpu.user{app:general}
-      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"}]},"id":3692649315881749},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
-      by {env}","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"toplist","title":"Widget
-      Title"},"id":5889476127695513},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
-      note widget","show_tick":false,"background_color":"yellow"},"id":831175390868293},{"definition":{"alert_id":"123","title":"Alert
-      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":993262831680574}],"layout_type":"ordered","type":"group","title":"Group
-      Widget"},"id":4252600679884569},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
-      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":520921794228166},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}],"limit":10}],"title":"Widget
-      Title","type":"query_table","time":{"live_span":"1h"}},"id":6111791390371422}],"layout_type":"ordered"}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 26 Jun 2020 09:04:53 GMT
-      Dd-Pool:
-      - dogweb
-      Pragma:
-      - no-cache
-      Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Fri, 03-Jul-2020 09:04:53 GMT;
-        secure; HttpOnly
-      Strict-Transport-Security:
-      - max-age=15724800;
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Dd-Debug:
-      - zDaLXgTwOglSG/+LeCisOhDwAOr7D4UzTY02i97kQg3V5W3f2nMLfChR6yLoaPN1
-      X-Dd-Version:
-      - "35.2668538"
-      X-Frame-Options:
-      - SAMEORIGIN
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Dd-Operation-Id:
-      - GetDashboard
-      User-Agent:
-      - datadog-api-client-go/1.0.0-beta.6 (go go1.14.3; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/7ez-rcs-6sw
-    method: GET
-  response:
-    body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"7ez-rcs-6sw","title":"Acceptance
-      Test Ordered Dashboard","url":"/dashboard/7ez-rcs-6sw/acceptance-test-ordered-dashboard","created_at":"2020-06-26T09:04:50.250650+00:00","modified_at":"2020-06-26T09:04:50.250650+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
-      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":5482991373819465},{"definition":{"title":"Widget
-      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":7068655639347766},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
-      by {account}","show_present":true,"increase_good":true,"order_by":"name"}],"title":"Widget
-      Title","type":"change","time":{"live_span":"1h"}},"id":5875675526524686},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":3129835329781849},{"definition":{"title":"Widget
-      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":2617145282777},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
-      Title","show_legend":false,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":2938319160483767},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
-      Title","node_type":"container","no_metric_hosts":true,"scope":["region:us-east-1","aws_account:727006795293"],"requests":{"size":{"q":"avg:memcache.uptime{*}
-      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":7626117416951771},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
-      text","show_tick":true,"background_color":"pink"},"id":1527444943211519},{"definition":{"autoscale":true,"title":"Widget
-      Title","text_align":"right","custom_unit":"xx","precision":4,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":6702801832330157},{"definition":{"title":"Widget
-      Title","yaxis":{"include_zero":false,"max":"2222","min":"5","scale":"log","label":"y"},"color_by_groups":["account","apm-role-group"],"xaxis":{"include_zero":true,"max":"2000","min":"1","scale":"pow","label":"x"},"time":{"live_span":"1h"},"requests":{"y":{"q":"avg:system.mem.used{*}
-      by {service, account}","aggregator":"min"},"x":{"q":"avg:system.cpu.user{*}
-      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":5916680852227051},{"definition":{"title":"Widget
-      Title","yaxis":{"include_zero":false,"scale":"log","max":"100"},"markers":[{"display_type":"error
-      dashed","value":"y=4","label":" z=6 "},{"display_type":"ok solid","value":"10
-      < y < 999","label":" x=8 "}],"events":[{"q":"sources:test tags:1"},{"q":"sources:test
-      tags:2"}],"show_legend":true,"time":{"live_span":"1h"},"legend_size":"2","type":"timeseries","requests":[{"q":"avg:system.cpu.user{app:general}
-      by {env}","style":{"line_width":"thin","palette":"warm","line_type":"dashed"},"display_type":"line","metadata":[{"expression":"avg:system.cpu.user{app:general}
-      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"}]},"id":3692649315881749},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
-      by {env}","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"toplist","title":"Widget
-      Title"},"id":5889476127695513},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
-      note widget","show_tick":false,"background_color":"yellow"},"id":831175390868293},{"definition":{"alert_id":"123","title":"Alert
-      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":993262831680574}],"layout_type":"ordered","type":"group","title":"Group
-      Widget"},"id":4252600679884569},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
-      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":520921794228166},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}],"limit":10}],"title":"Widget
-      Title","type":"query_table","time":{"live_span":"1h"}},"id":6111791390371422}],"layout_type":"ordered"}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 26 Jun 2020 09:04:53 GMT
-      Dd-Pool:
-      - dogweb
-      Pragma:
-      - no-cache
-      Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Fri, 03-Jul-2020 09:04:53 GMT;
-        secure; HttpOnly
-      Strict-Transport-Security:
-      - max-age=15724800;
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Dd-Debug:
-      - gH++OYwf8a2QZXnzDsHHnXqPhHbI48oqNvFjE/0p0ObpMBY4290QCI5SB0tU0MAF
-      X-Dd-Version:
-      - "35.2668538"
-      X-Frame-Options:
-      - SAMEORIGIN
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Dd-Operation-Id:
-      - GetDashboard
-      User-Agent:
-      - datadog-api-client-go/1.0.0-beta.6 (go go1.14.3; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/7ez-rcs-6sw
-    method: GET
-  response:
-    body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"7ez-rcs-6sw","title":"Acceptance
-      Test Ordered Dashboard","url":"/dashboard/7ez-rcs-6sw/acceptance-test-ordered-dashboard","created_at":"2020-06-26T09:04:50.250650+00:00","modified_at":"2020-06-26T09:04:50.250650+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
-      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":5482991373819465},{"definition":{"title":"Widget
-      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":7068655639347766},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
-      by {account}","show_present":true,"increase_good":true,"order_by":"name"}],"title":"Widget
-      Title","type":"change","time":{"live_span":"1h"}},"id":5875675526524686},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":3129835329781849},{"definition":{"title":"Widget
-      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":2617145282777},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
-      Title","show_legend":false,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":2938319160483767},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
-      Title","node_type":"container","no_metric_hosts":true,"scope":["region:us-east-1","aws_account:727006795293"],"requests":{"size":{"q":"avg:memcache.uptime{*}
-      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":7626117416951771},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
-      text","show_tick":true,"background_color":"pink"},"id":1527444943211519},{"definition":{"autoscale":true,"title":"Widget
-      Title","text_align":"right","custom_unit":"xx","precision":4,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":6702801832330157},{"definition":{"title":"Widget
-      Title","yaxis":{"include_zero":false,"max":"2222","min":"5","scale":"log","label":"y"},"color_by_groups":["account","apm-role-group"],"xaxis":{"include_zero":true,"max":"2000","min":"1","scale":"pow","label":"x"},"time":{"live_span":"1h"},"requests":{"y":{"q":"avg:system.mem.used{*}
-      by {service, account}","aggregator":"min"},"x":{"q":"avg:system.cpu.user{*}
-      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":5916680852227051},{"definition":{"title":"Widget
-      Title","yaxis":{"include_zero":false,"scale":"log","max":"100"},"markers":[{"display_type":"error
-      dashed","value":"y=4","label":" z=6 "},{"display_type":"ok solid","value":"10
-      < y < 999","label":" x=8 "}],"events":[{"q":"sources:test tags:1"},{"q":"sources:test
-      tags:2"}],"show_legend":true,"time":{"live_span":"1h"},"legend_size":"2","type":"timeseries","requests":[{"q":"avg:system.cpu.user{app:general}
-      by {env}","style":{"line_width":"thin","palette":"warm","line_type":"dashed"},"display_type":"line","metadata":[{"expression":"avg:system.cpu.user{app:general}
-      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"}]},"id":3692649315881749},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
-      by {env}","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"toplist","title":"Widget
-      Title"},"id":5889476127695513},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
-      note widget","show_tick":false,"background_color":"yellow"},"id":831175390868293},{"definition":{"alert_id":"123","title":"Alert
-      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":993262831680574}],"layout_type":"ordered","type":"group","title":"Group
-      Widget"},"id":4252600679884569},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
-      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":520921794228166},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}],"limit":10}],"title":"Widget
-      Title","type":"query_table","time":{"live_span":"1h"}},"id":6111791390371422}],"layout_type":"ordered"}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 26 Jun 2020 09:04:56 GMT
-      Dd-Pool:
-      - dogweb
-      Pragma:
-      - no-cache
-      Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Fri, 03-Jul-2020 09:04:56 GMT;
-        secure; HttpOnly
-      Strict-Transport-Security:
-      - max-age=15724800;
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Dd-Debug:
-      - u9VEJv4YNx+Fl9tRGJNbGm0+76jyym0t+mec2t84PhoJYEedil3ajyEhP7U3EneZ
-      X-Dd-Version:
-      - "35.2668538"
-      X-Frame-Options:
-      - SAMEORIGIN
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Dd-Operation-Id:
-      - GetDashboard
-      User-Agent:
-      - datadog-api-client-go/1.0.0-beta.6 (go go1.14.3; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/7ez-rcs-6sw
-    method: GET
-  response:
-    body: '{"notify_list":[],"description":"Created using the Datadog provider in
-      Terraform","author_name":null,"template_variable_presets":[{"template_variables":[{"name":"var_1","value":"var_1_value"},{"name":"var_2","value":"var_2_value"}],"name":"preset_1"},{"template_variables":[{"name":"var_1","value":"var_1_value"}],"name":"preset_2"}],"template_variables":[{"default":"aws","prefix":"host","name":"var_1"},{"default":"autoscaling","prefix":"service_name","name":"var_2"}],"is_read_only":true,"id":"7ez-rcs-6sw","title":"Acceptance
-      Test Ordered Dashboard","url":"/dashboard/7ez-rcs-6sw/acceptance-test-ordered-dashboard","created_at":"2020-06-26T09:04:50.250650+00:00","modified_at":"2020-06-26T09:04:50.250650+00:00","author_handle":"frog@datadoghq.com","widgets":[{"definition":{"alert_id":"895605","title":"Widget
-      Title","type":"alert_graph","viz_type":"timeseries","time":{"live_span":"1h"}},"id":5482991373819465},{"definition":{"title":"Widget
-      Title","text_align":"center","precision":3,"alert_id":"895605","type":"alert_value","unit":"b"},"id":7068655639347766},{"definition":{"requests":[{"change_type":"absolute","order_dir":"desc","compare_to":"week_before","q":"avg:system.load.1{env:staging}
-      by {account}","show_present":true,"increase_good":true,"order_by":"name"}],"title":"Widget
-      Title","type":"change","time":{"live_span":"1h"}},"id":5875675526524686},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"title":"Widget Title","type":"distribution","show_legend":false,"time":{"live_span":"1h"}},"id":3129835329781849},{"definition":{"title":"Widget
-      Title","tags":["account:demo","cluster:awseb-ruthebdog-env-8-dn3m6u3gvk"],"group_by":["account","cluster"],"time":{"live_span":"1h"},"type":"check_status","check":"aws.ecs.agent_connected","grouping":"cluster"},"id":2617145282777},{"definition":{"yaxis":{"include_zero":true,"scale":"sqrt","min":"1","max":"2"},"title":"Widget
-      Title","show_legend":false,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","style":{"palette":"warm"}}],"type":"heatmap"},"id":2938319160483767},{"definition":{"style":{"fill_min":"10","fill_max":"20","palette":"yellow_to_green","palette_flip":true},"group":["host","region"],"title":"Widget
-      Title","node_type":"container","no_metric_hosts":true,"scope":["region:us-east-1","aws_account:727006795293"],"requests":{"size":{"q":"avg:memcache.uptime{*}
-      by {host}"},"fill":{"q":"avg:system.load.1{*} by {host}"}},"no_group_hosts":true,"type":"hostmap"},"id":7626117416951771},{"definition":{"tick_pos":"50%","font_size":"14","type":"note","tick_edge":"left","text_align":"center","content":"note
-      text","show_tick":true,"background_color":"pink"},"id":1527444943211519},{"definition":{"autoscale":true,"title":"Widget
-      Title","text_align":"right","custom_unit":"xx","precision":4,"time":{"live_span":"1h"},"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"query_value"},"id":6702801832330157},{"definition":{"title":"Widget
-      Title","yaxis":{"include_zero":false,"max":"2222","min":"5","scale":"log","label":"y"},"color_by_groups":["account","apm-role-group"],"xaxis":{"include_zero":true,"max":"2000","min":"1","scale":"pow","label":"x"},"time":{"live_span":"1h"},"requests":{"y":{"q":"avg:system.mem.used{*}
-      by {service, account}","aggregator":"min"},"x":{"q":"avg:system.cpu.user{*}
-      by {service, account}","aggregator":"max"}},"type":"scatterplot"},"id":5916680852227051},{"definition":{"title":"Widget
-      Title","yaxis":{"include_zero":false,"scale":"log","max":"100"},"markers":[{"display_type":"error
-      dashed","value":"y=4","label":" z=6 "},{"display_type":"ok solid","value":"10
-      < y < 999","label":" x=8 "}],"events":[{"q":"sources:test tags:1"},{"q":"sources:test
-      tags:2"}],"show_legend":true,"time":{"live_span":"1h"},"legend_size":"2","type":"timeseries","requests":[{"q":"avg:system.cpu.user{app:general}
-      by {env}","style":{"line_width":"thin","palette":"warm","line_type":"dashed"},"display_type":"line","metadata":[{"expression":"avg:system.cpu.user{app:general}
-      by {env}","alias_name":"Alpha"}]},{"display_type":"area","log_query":{"index":"mcnulty","search":{"query":"status:info"},"group_by":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}}},{"apm_query":{"index":"apm-search","search":{"query":"type:web"},"group_by":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}],"compute":{"facet":"@duration","interval":5000,"aggregation":"count"}},"display_type":"bars"},{"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"display_type":"area"}]},"id":3692649315881749},{"definition":{"requests":[{"q":"avg:system.cpu.user{app:general}
-      by {env}","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}]}],"type":"toplist","title":"Widget
-      Title"},"id":5889476127695513},{"definition":{"widgets":[{"definition":{"tick_pos":"50%","font_size":"16","type":"note","tick_edge":"left","text_align":"left","content":"cluster
-      note widget","show_tick":false,"background_color":"yellow"},"id":831175390868293},{"definition":{"alert_id":"123","title":"Alert
-      Graph","type":"alert_graph","viz_type":"toplist","time":{"live_span":"1h"}},"id":993262831680574}],"layout_type":"ordered","type":"group","title":"Group
-      Widget"},"id":4252600679884569},{"definition":{"time_windows":["7d","previous_week"],"show_error_budget":true,"title":"Widget
-      Title","view_type":"detail","slo_id":"56789","view_mode":"overall","type":"slo"},"id":520921794228166},{"definition":{"requests":[{"q":"avg:system.load.1{env:staging}
-      by {account}","aggregator":"sum","conditional_formats":[{"palette":"white_on_green","hide_value":false,"value":2,"comparator":"<"},{"palette":"white_on_red","hide_value":false,"value":2.2,"comparator":">"}],"limit":10}],"title":"Widget
-      Title","type":"query_table","time":{"live_span":"1h"}},"id":6111791390371422}],"layout_type":"ordered"}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 26 Jun 2020 09:04:57 GMT
-      Dd-Pool:
-      - dogweb
-      Pragma:
-      - no-cache
-      Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Fri, 03-Jul-2020 09:04:57 GMT;
-        secure; HttpOnly
-      Strict-Transport-Security:
-      - max-age=15724800;
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Dd-Debug:
-      - Wpac2a5DsHa/eqG3DjQhOxPXeBQRcLxZ18fT3wn3gFeruJMdJwvfZxTA9hAiHLHZ
-      X-Dd-Version:
-      - "35.2668538"
+      - "35.2790462"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -566,11 +413,11 @@ interactions:
       Dd-Operation-Id:
       - DeleteDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.6 (go go1.14.3; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/7ez-rcs-6sw
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/ptd-vmf-qqv
     method: DELETE
   response:
-    body: '{"deleted_dashboard_id":"7ez-rcs-6sw"}'
+    body: '{"deleted_dashboard_id":"ptd-vmf-qqv"}'
     headers:
       Cache-Control:
       - no-cache
@@ -581,13 +428,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Jun 2020 09:05:12 GMT
+      - Mon, 27 Jul 2020 09:29:16 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Fri, 03-Jul-2020 09:04:58 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:28:51 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -596,9 +443,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - 0pmBjL5vG2A5IkxC4OBtwgn929khTZGgUquRW20JC77zchR4jTrHgra/pB22jP66
+      - kg+/Cls6zaJcT2blJLlU62BwgGePGdpqSwWrJ0xEIvzmSMWHXxGNsiyEzBPJ1a96
       X-Dd-Version:
-      - "35.2668538"
+      - "35.2790462"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -613,11 +460,11 @@ interactions:
       Dd-Operation-Id:
       - GetDashboard
       User-Agent:
-      - datadog-api-client-go/1.0.0-beta.6 (go go1.14.3; os darwin; arch amd64)
-    url: https://api.datadoghq.com/api/v1/dashboard/7ez-rcs-6sw
+      - datadog-api-client-go/1.0.0-beta.8+dev (go go1.14.4; os darwin; arch amd64)
+    url: https://api.datadoghq.com/api/v1/dashboard/ptd-vmf-qqv
     method: GET
   response:
-    body: '{"errors": ["Dashboard with ID 7ez-rcs-6sw not found"]}'
+    body: '{"errors": ["Dashboard with ID ptd-vmf-qqv not found"]}'
     headers:
       Cache-Control:
       - no-cache
@@ -628,7 +475,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Jun 2020 09:05:12 GMT
+      - Mon, 27 Jul 2020 09:29:16 GMT
       Dd-Pool:
       - dogweb
       Pragma:
@@ -640,7 +487,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Version:
-      - "35.2668538"
+      - "35.2790462"
       X-Frame-Options:
       - SAMEORIGIN
     status: 404 Not Found

--- a/datadog/cassettes/TestAccDatadogTimeboard_update.yaml
+++ b/datadog/cassettes/TestAccDatadogTimeboard_update.yaml
@@ -12,7 +12,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
+      - Datadog/dev/terraform (go1.14.4)
     url: https://api.datadoghq.com/api/v1/dash
     method: POST
   response:
@@ -21,7 +21,7 @@ interactions:
       System CPU by Docker container"},{"definition":{"style":{"paletteFlip":true},"autoscale":false,"yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"toplist","nodeType":"","requests":[{"q":"top(avg:docker.cpu.system{*}
       by {container_name}, 10, ''mean'', ''desc'')","aggregator":"","style":{},"stacked":false,"type":"line"}],"noGroupHosts":false},"title":"Top
       System CPU by Docker container, flipped"}],"template_variables":null,"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:25.404855+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:31.620797+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -32,13 +32,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:25 GMT
+      - Mon, 27 Jul 2020 09:10:31 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:25 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:31 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -47,9 +47,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - u9VEJv4YNx+Fl9tRGJNbGm0+76jyym0t+mec2t84PhoJYEedil3ajyEhP7U3EneZ
+      - e/PzE6y8JJ1tlF66uEI2h0RElcpoaXRe9TzYMeQVIADcqTHrHUqcUgRemfbYKGMv
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790462"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -60,8 +60,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
     body: '{"dash":{"read_only":true,"graphs":[{"definition":{"style":{"paletteFlip":false},"autoscale":false,"yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"toplist","nodeType":"","requests":[{"q":"top(avg:docker.cpu.system{*}
@@ -69,7 +69,7 @@ interactions:
       System CPU by Docker container"},{"definition":{"style":{"paletteFlip":true},"autoscale":false,"yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"toplist","nodeType":"","requests":[{"q":"top(avg:docker.cpu.system{*}
       by {container_name}, 10, ''mean'', ''desc'')","aggregator":"","style":{},"stacked":false,"type":"line"}],"noGroupHosts":false},"title":"Top
       System CPU by Docker container, flipped"}],"template_variables":null,"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:25.404855+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:31.620797+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -80,13 +80,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:25 GMT
+      - Mon, 27 Jul 2020 09:10:31 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:25 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:31 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -95,9 +95,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - QaEGvF++JqTbTiFomKhE21Fdnra2zinKOaCEqOgwcd7OtJatRLgvovBbCNyGqcpO
+      - AVsav2jjRGvwjNvJeRUS7kJsgTlhh9y9smyL3UJVQTMAUoPyejdL0bVSnanIQLK4
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790442"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -108,8 +108,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
     body: '{"dash":{"read_only":true,"graphs":[{"definition":{"style":{"paletteFlip":false},"autoscale":false,"yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"toplist","nodeType":"","requests":[{"q":"top(avg:docker.cpu.system{*}
@@ -117,7 +117,7 @@ interactions:
       System CPU by Docker container"},{"definition":{"style":{"paletteFlip":true},"autoscale":false,"yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"toplist","nodeType":"","requests":[{"q":"top(avg:docker.cpu.system{*}
       by {container_name}, 10, ''mean'', ''desc'')","aggregator":"","style":{},"stacked":false,"type":"line"}],"noGroupHosts":false},"title":"Top
       System CPU by Docker container, flipped"}],"template_variables":null,"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:25.404855+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:31.620797+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -128,13 +128,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:25 GMT
+      - Mon, 27 Jul 2020 09:10:32 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:25 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:32 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -143,9 +143,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - ztq+F8HwxRthTKNo0l2MCEDK5uwvgQzF00nWu49lHsBM51hGZBm/pPILDqupy+Xd
+      - RbevWUvO2oQYYDnX/G1lndTh/kTt+ebFIvajU6/3Ivb5c6aUQf49/uD1ICaXyx52
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790442"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -156,8 +156,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
     body: '{"dash":{"read_only":true,"graphs":[{"definition":{"style":{"paletteFlip":false},"autoscale":false,"yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"toplist","nodeType":"","requests":[{"q":"top(avg:docker.cpu.system{*}
@@ -165,7 +165,7 @@ interactions:
       System CPU by Docker container"},{"definition":{"style":{"paletteFlip":true},"autoscale":false,"yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"toplist","nodeType":"","requests":[{"q":"top(avg:docker.cpu.system{*}
       by {container_name}, 10, ''mean'', ''desc'')","aggregator":"","style":{},"stacked":false,"type":"line"}],"noGroupHosts":false},"title":"Top
       System CPU by Docker container, flipped"}],"template_variables":null,"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:25.404855+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:31.620797+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -176,13 +176,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:25 GMT
+      - Mon, 27 Jul 2020 09:10:32 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:25 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:32 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -191,9 +191,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - j9H0Mt41m875GBjR2i9r831ZILGOU6+Jata5+JJkOQgIsO+SrMkmgWN80SCun0Sk
+      - YNGrI7M9aLfuf6Npp7n/51e6xDtYCO9Rm/LB+HGbX4I6A/e7rnC+cgQxIZnsU+fj
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790442"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -204,8 +204,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
     body: '{"dash":{"read_only":true,"graphs":[{"definition":{"style":{"paletteFlip":false},"autoscale":false,"yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"toplist","nodeType":"","requests":[{"q":"top(avg:docker.cpu.system{*}
@@ -213,7 +213,7 @@ interactions:
       System CPU by Docker container"},{"definition":{"style":{"paletteFlip":true},"autoscale":false,"yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"toplist","nodeType":"","requests":[{"q":"top(avg:docker.cpu.system{*}
       by {container_name}, 10, ''mean'', ''desc'')","aggregator":"","style":{},"stacked":false,"type":"line"}],"noGroupHosts":false},"title":"Top
       System CPU by Docker container, flipped"}],"template_variables":null,"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:25.404855+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:31.620797+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -224,13 +224,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:26 GMT
+      - Mon, 27 Jul 2020 09:10:32 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:26 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:32 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -239,9 +239,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - IWbeot5NPPjwzkLRJwJSrhKxooUYWPiItYmeOu7MvfpEU9kI8879nM2EukYnEnom
+      - 2qCkWfddHrPF9jSCADI+4oMJC7ye/JJPxREHTFHEFILURsabvi1w9B+PDmBrh/Xk
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790462"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -252,8 +252,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
     body: '{"dash":{"read_only":true,"graphs":[{"definition":{"style":{"paletteFlip":false},"autoscale":false,"yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"toplist","nodeType":"","requests":[{"q":"top(avg:docker.cpu.system{*}
@@ -261,7 +261,7 @@ interactions:
       System CPU by Docker container"},{"definition":{"style":{"paletteFlip":true},"autoscale":false,"yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"toplist","nodeType":"","requests":[{"q":"top(avg:docker.cpu.system{*}
       by {container_name}, 10, ''mean'', ''desc'')","aggregator":"","style":{},"stacked":false,"type":"line"}],"noGroupHosts":false},"title":"Top
       System CPU by Docker container, flipped"}],"template_variables":null,"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:25.404855+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:31.620797+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -272,13 +272,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:26 GMT
+      - Mon, 27 Jul 2020 09:10:32 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:26 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:32 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -287,9 +287,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - QpzDmIoaO5Hufx014PqM5BuLw+G9k75nLqy12TEr4Iab1Fl7hIFT5DrERoBer8OF
+      - 7/pC7B9bYAY6HGz006Bg+ZrYGMZFiH1gxYQ0jMSpdzevd2r/Iy3Bkt2FGvLL5qId
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790442"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -300,8 +300,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
     body: '{"dash":{"read_only":true,"graphs":[{"definition":{"style":{"paletteFlip":false},"autoscale":false,"yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"toplist","nodeType":"","requests":[{"q":"top(avg:docker.cpu.system{*}
@@ -309,7 +309,7 @@ interactions:
       System CPU by Docker container"},{"definition":{"style":{"paletteFlip":true},"autoscale":false,"yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"toplist","nodeType":"","requests":[{"q":"top(avg:docker.cpu.system{*}
       by {container_name}, 10, ''mean'', ''desc'')","aggregator":"","style":{},"stacked":false,"type":"line"}],"noGroupHosts":false},"title":"Top
       System CPU by Docker container, flipped"}],"template_variables":null,"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:25.404855+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:31.620797+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -320,13 +320,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:26 GMT
+      - Mon, 27 Jul 2020 09:10:33 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:26 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:33 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -335,16 +335,16 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - mIWJPPM06xs5rSGFgggpdD5UbOnt6ntntAO8/8YDsVuXnSmp/k0aZ5dEUtAKB7Td
+      - fFk0sZgwwse+ZeEmqVGZPgcNG+SDXdM7Y74n6iOGuvoZenvaYEqZOvpOSMu1XDXx
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790442"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"id":1654151,"description":"Created using the Datadog provider in Terraform","title":"Acceptance
+    body: '{"id":2026623,"description":"Created using the Datadog provider in Terraform","title":"Acceptance
       Test Timeboard","graphs":[{"title":"Redis latency (ms)","definition":{"viz":"timeseries","requests":[{"stacked":false,"aggregator":"","type":"line","style":{},"change_type":"","order_dir":"","compare_to":"","increase_good":false,"order_by":"","metadata":{"avg:redis.info.latency_ms{$host}":{"alias":"Redis
       latency"}},"q":"avg:redis.info.latency_ms{$host}"}],"yaxis":{},"autoscale":false,"text_align":"","custom_unit":"","style":{},"noMetricHosts":false,"noGroupHosts":false,"nodeType":""}},{"title":"Redis
       memory usage","definition":{"viz":"timeseries","requests":[{"stacked":true,"aggregator":"sum","type":"line","style":{},"change_type":"","order_dir":"","compare_to":"","increase_good":false,"order_by":"","q":"avg:redis.mem.used{$host}
@@ -354,15 +354,15 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: PUT
   response:
     body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.info.latency_ms{$host}","type":"line","metadata":{"avg:redis.info.latency_ms{$host}":{"alias":"Redis
       latency"}}}],"noGroupHosts":false},"title":"Redis latency (ms)"},{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":true,"aggregator":"sum","q":"avg:redis.mem.used{$host}
       - avg:redis.mem.lua{$host}, avg:redis.mem.lua{$host}","type":"line"},{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.mem.rss{$host}","type":"line"},{"style":{"palette":"warm"},"stacked":false,"aggregator":"max","q":"avg:redis.mem.rss{$host}","type":"bars"}],"noGroupHosts":false},"title":"Redis
       memory usage"}],"template_variables":[{"default":"","prefix":"host","name":"host"}],"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:26.723952+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:33.531922+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -373,13 +373,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:26 GMT
+      - Mon, 27 Jul 2020 09:10:33 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:26 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:33 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -388,9 +388,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - pT9LlAdgAzlrCUxMXQkBRs/Qti76jKIHng1uB0/SctAaYjB4WqOgOZYpCbOMQKll
+      - aswcxBk1J00Iy18+kQFKF6EQfzLy4sWD4ILciesVMX5rWDYniffEYH6qbK0qwOgw
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790442"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -401,15 +401,15 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
     body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.info.latency_ms{$host}","type":"line","metadata":{"avg:redis.info.latency_ms{$host}":{"alias":"Redis
       latency"}}}],"noGroupHosts":false},"title":"Redis latency (ms)"},{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":true,"aggregator":"sum","q":"avg:redis.mem.used{$host}
       - avg:redis.mem.lua{$host}, avg:redis.mem.lua{$host}","type":"line"},{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.mem.rss{$host}","type":"line"},{"style":{"palette":"warm"},"stacked":false,"aggregator":"max","q":"avg:redis.mem.rss{$host}","type":"bars"}],"noGroupHosts":false},"title":"Redis
       memory usage"}],"template_variables":[{"default":"","prefix":"host","name":"host"}],"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:26.723952+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:33.531922+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -420,13 +420,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:26 GMT
+      - Mon, 27 Jul 2020 09:10:33 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:26 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:33 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -435,9 +435,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - QaEGvF++JqTbTiFomKhE21Fdnra2zinKOaCEqOgwcd7OtJatRLgvovBbCNyGqcpO
+      - qA85Kiicwd/s93AfT3MSf+l6IYc5FQ6tEbp4Kft/ri41UOumJ967MPQKmz3gwejd
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790442"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -448,15 +448,15 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
     body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.info.latency_ms{$host}","type":"line","metadata":{"avg:redis.info.latency_ms{$host}":{"alias":"Redis
       latency"}}}],"noGroupHosts":false},"title":"Redis latency (ms)"},{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":true,"aggregator":"sum","q":"avg:redis.mem.used{$host}
       - avg:redis.mem.lua{$host}, avg:redis.mem.lua{$host}","type":"line"},{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.mem.rss{$host}","type":"line"},{"style":{"palette":"warm"},"stacked":false,"aggregator":"max","q":"avg:redis.mem.rss{$host}","type":"bars"}],"noGroupHosts":false},"title":"Redis
       memory usage"}],"template_variables":[{"default":"","prefix":"host","name":"host"}],"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:26.723952+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:33.531922+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -467,13 +467,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:27 GMT
+      - Mon, 27 Jul 2020 09:10:34 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:27 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:34 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -482,9 +482,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - FGm8mbL/ixNS/zyX94m5xaWAxszhu9w68KL0QwTbLNqYgp2ZyX2W4rsoYLDoadr+
+      - fFk0sZgwwse+ZeEmqVGZPgcNG+SDXdM7Y74n6iOGuvoZenvaYEqZOvpOSMu1XDXx
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790462"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -495,15 +495,15 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
     body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.info.latency_ms{$host}","type":"line","metadata":{"avg:redis.info.latency_ms{$host}":{"alias":"Redis
       latency"}}}],"noGroupHosts":false},"title":"Redis latency (ms)"},{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":true,"aggregator":"sum","q":"avg:redis.mem.used{$host}
       - avg:redis.mem.lua{$host}, avg:redis.mem.lua{$host}","type":"line"},{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.mem.rss{$host}","type":"line"},{"style":{"palette":"warm"},"stacked":false,"aggregator":"max","q":"avg:redis.mem.rss{$host}","type":"bars"}],"noGroupHosts":false},"title":"Redis
       memory usage"}],"template_variables":[{"default":"","prefix":"host","name":"host"}],"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:26.723952+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:33.531922+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -514,13 +514,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:27 GMT
+      - Mon, 27 Jul 2020 09:10:34 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:27 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:34 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -529,9 +529,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - IWbeot5NPPjwzkLRJwJSrhKxooUYWPiItYmeOu7MvfpEU9kI8879nM2EukYnEnom
+      - BQaWiIhDCyK3JbvyPZudxtMuoedbvOKE6tb5GJMfo6GT4EOQ8qx9lqgA4UCxp88q
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790442"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -542,15 +542,15 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
     body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.info.latency_ms{$host}","type":"line","metadata":{"avg:redis.info.latency_ms{$host}":{"alias":"Redis
       latency"}}}],"noGroupHosts":false},"title":"Redis latency (ms)"},{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":true,"aggregator":"sum","q":"avg:redis.mem.used{$host}
       - avg:redis.mem.lua{$host}, avg:redis.mem.lua{$host}","type":"line"},{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.mem.rss{$host}","type":"line"},{"style":{"palette":"warm"},"stacked":false,"aggregator":"max","q":"avg:redis.mem.rss{$host}","type":"bars"}],"noGroupHosts":false},"title":"Redis
       memory usage"}],"template_variables":[{"default":"","prefix":"host","name":"host"}],"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:26.723952+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:33.531922+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -561,13 +561,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:27 GMT
+      - Mon, 27 Jul 2020 09:10:34 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:27 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:34 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -576,9 +576,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - mIWJPPM06xs5rSGFgggpdD5UbOnt6ntntAO8/8YDsVuXnSmp/k0aZ5dEUtAKB7Td
+      - aERr2Ftx8O/BR8oAhSymZ3bVROQEC+81YMSphOQK1me4DxXSbMIcFkB0Di4ggZ++
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790442"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -589,15 +589,15 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
     body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.info.latency_ms{$host}","type":"line","metadata":{"avg:redis.info.latency_ms{$host}":{"alias":"Redis
       latency"}}}],"noGroupHosts":false},"title":"Redis latency (ms)"},{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":true,"aggregator":"sum","q":"avg:redis.mem.used{$host}
       - avg:redis.mem.lua{$host}, avg:redis.mem.lua{$host}","type":"line"},{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.mem.rss{$host}","type":"line"},{"style":{"palette":"warm"},"stacked":false,"aggregator":"max","q":"avg:redis.mem.rss{$host}","type":"bars"}],"noGroupHosts":false},"title":"Redis
       memory usage"}],"template_variables":[{"default":"","prefix":"host","name":"host"}],"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:26.723952+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:33.531922+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -608,13 +608,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:27 GMT
+      - Mon, 27 Jul 2020 09:10:34 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:27 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:34 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -623,9 +623,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - sAPKocoLMDEnM5qY2PL6SCQ+dkENYAR/6IistAQ5iiTU/UnJHAba158nxOvVRvKJ
+      - 6TICFxDFBNq65Lw6aA0hO1z7nxUSiTzUAT0k7ln4UasEU6/emXomwtYWMJdIuxUV
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790442"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -636,15 +636,15 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
     body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.info.latency_ms{$host}","type":"line","metadata":{"avg:redis.info.latency_ms{$host}":{"alias":"Redis
       latency"}}}],"noGroupHosts":false},"title":"Redis latency (ms)"},{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":true,"aggregator":"sum","q":"avg:redis.mem.used{$host}
       - avg:redis.mem.lua{$host}, avg:redis.mem.lua{$host}","type":"line"},{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.mem.rss{$host}","type":"line"},{"style":{"palette":"warm"},"stacked":false,"aggregator":"max","q":"avg:redis.mem.rss{$host}","type":"bars"}],"noGroupHosts":false},"title":"Redis
       memory usage"}],"template_variables":[{"default":"","prefix":"host","name":"host"}],"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:26.723952+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:33.531922+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -655,13 +655,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:27 GMT
+      - Mon, 27 Jul 2020 09:10:35 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:27 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:35 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -670,16 +670,16 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - u2B27rQjtu8TuEjzrroc8ae3xeJMLmsxU6SiAszW1tH+EI3X0cOP819eGNRqlxzl
+      - YCJuwY9AAFMveejFq3DmCuXNgWrXpDBQxqXi3LxQxaHO16MK3yMSWa14TOuRlDjy
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790442"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"id":1654151,"description":"Created using the Datadog provider in Terraform","title":"Acceptance
+    body: '{"id":2026623,"description":"Created using the Datadog provider in Terraform","title":"Acceptance
       Test Timeboard","graphs":[{"title":"Redis latency (ms)","definition":{"viz":"timeseries","requests":[{"stacked":false,"aggregator":"","type":"line","style":{},"change_type":"","order_dir":"","compare_to":"","increase_good":false,"order_by":"","q":"avg:redis.info.latency_ms{$host}"}],"events":[{"q":"sources:capistrano"}],"markers":[{"type":"error
       solid","value":"y \u003e 100","label":"High Latency"}],"yaxis":{"max":50,"scale":"sqrt","includeZero":true,"units":true},"autoscale":false,"text_align":"","custom_unit":"","style":{},"noMetricHosts":false,"noGroupHosts":false,"nodeType":""}},{"title":"ELB
       Requests","definition":{"viz":"query_value","requests":[{"stacked":false,"aggregator":"min","conditional_formats":[{"palette":"white_on_red","comparator":"\u003e","custom_bg_color":"","value":1000,"custom_fg_color":""},{"palette":"white_on_green","comparator":"\u003c=","custom_bg_color":"","value":1000,"custom_fg_color":""}],"type":"line","style":{},"change_type":"","order_dir":"","compare_to":"","increase_good":false,"order_by":"","q":"sum:aws.elb.request_count{*}.as_count()"}],"yaxis":{},"autoscale":false,"text_align":"left","precision":"*","custom_unit":"hits","style":{},"noMetricHosts":false,"noGroupHosts":false,"nodeType":""}}],"template_variables":[{"name":"host","prefix":"host","default":""}],"read_only":false}'
@@ -688,15 +688,15 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: PUT
   response:
     body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{"scale":"sqrt","max":"50","units":true,"includeZero":true},"text_align":"","markers":[{"type":"error
       solid","value":"y > 100","label":"High Latency"}],"custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.info.latency_ms{$host}","type":"line"}],"events":[{"q":"sources:capistrano"}],"noGroupHosts":false},"title":"Redis
       latency (ms)"},{"definition":{"style":{},"autoscale":false,"yaxis":{},"text_align":"left","custom_unit":"hits","noMetricHosts":false,"precision":"*","viz":"query_value","nodeType":"","requests":[{"style":{},"stacked":false,"aggregator":"min","conditional_formats":[{"custom_fg_color":"","custom_bg_color":"","palette":"white_on_red","value":1000,"comparator":">"},{"custom_fg_color":"","custom_bg_color":"","palette":"white_on_green","value":1000,"comparator":"<="}],"q":"sum:aws.elb.request_count{*}.as_count()","type":"line"}],"noGroupHosts":false},"title":"ELB
       Requests"}],"template_variables":[{"default":"","prefix":"host","name":"host"}],"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:28.298459+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:35.390813+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -707,13 +707,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:28 GMT
+      - Mon, 27 Jul 2020 09:10:35 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:28 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:35 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -722,9 +722,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - IRAJ1mQ+c3epm0CLGtZoe/y8O4TCss3jYw+fwQOm7+eSKRCE+p3OtawVnIQ5ts76
+      - UmZMvwWLI5lgbGFBnw6J7jqO5hwyrvVF8Un8TwZ8TRQQ6jetE/6GVTSaoSUmQWRg
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790442"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -735,15 +735,15 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
     body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{"scale":"sqrt","max":"50","units":true,"includeZero":true},"text_align":"","markers":[{"type":"error
       solid","value":"y > 100","label":"High Latency"}],"custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.info.latency_ms{$host}","type":"line"}],"events":[{"q":"sources:capistrano"}],"noGroupHosts":false},"title":"Redis
       latency (ms)"},{"definition":{"style":{},"autoscale":false,"yaxis":{},"text_align":"left","custom_unit":"hits","noMetricHosts":false,"precision":"*","viz":"query_value","nodeType":"","requests":[{"style":{},"stacked":false,"aggregator":"min","conditional_formats":[{"custom_fg_color":"","custom_bg_color":"","palette":"white_on_red","value":1000,"comparator":">"},{"custom_fg_color":"","custom_bg_color":"","palette":"white_on_green","value":1000,"comparator":"<="}],"q":"sum:aws.elb.request_count{*}.as_count()","type":"line"}],"noGroupHosts":false},"title":"ELB
       Requests"}],"template_variables":[{"default":"","prefix":"host","name":"host"}],"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:28.298459+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:35.390813+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -754,13 +754,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:28 GMT
+      - Mon, 27 Jul 2020 09:10:35 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:28 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:35 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -769,9 +769,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - FB5oGxuL9E/cplxahdQnU5Nw5E7KX0Smq18it9qYKIt8BXsSloE0IpDRA39tfQwn
+      - aq7EAvMMXGdldXT5eVhOcqdveqp5VDY6MoO0A/xKTuSa7v4Cc6HWT9iWUnYD+m1F
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790442"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -782,15 +782,15 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
     body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{"scale":"sqrt","max":"50","units":true,"includeZero":true},"text_align":"","markers":[{"type":"error
       solid","value":"y > 100","label":"High Latency"}],"custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.info.latency_ms{$host}","type":"line"}],"events":[{"q":"sources:capistrano"}],"noGroupHosts":false},"title":"Redis
       latency (ms)"},{"definition":{"style":{},"autoscale":false,"yaxis":{},"text_align":"left","custom_unit":"hits","noMetricHosts":false,"precision":"*","viz":"query_value","nodeType":"","requests":[{"style":{},"stacked":false,"aggregator":"min","conditional_formats":[{"custom_fg_color":"","custom_bg_color":"","palette":"white_on_red","value":1000,"comparator":">"},{"custom_fg_color":"","custom_bg_color":"","palette":"white_on_green","value":1000,"comparator":"<="}],"q":"sum:aws.elb.request_count{*}.as_count()","type":"line"}],"noGroupHosts":false},"title":"ELB
       Requests"}],"template_variables":[{"default":"","prefix":"host","name":"host"}],"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:28.298459+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:35.390813+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -801,13 +801,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:28 GMT
+      - Mon, 27 Jul 2020 09:10:35 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:28 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:35 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -816,9 +816,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - 3GTZ6ImnvkiMOuKTP2ILv/2CbQJLb5wTjyX1KOTCD/aaxDS+HyYye1EH1uVK9Ajh
+      - cYNsy3QDuOaYo2clO/PharSNtCykS9KtUfiNevH3xDbHJlRyddWkNpuDhMgHWZ43
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790462"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -829,15 +829,15 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
     body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{"scale":"sqrt","max":"50","units":true,"includeZero":true},"text_align":"","markers":[{"type":"error
       solid","value":"y > 100","label":"High Latency"}],"custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.info.latency_ms{$host}","type":"line"}],"events":[{"q":"sources:capistrano"}],"noGroupHosts":false},"title":"Redis
       latency (ms)"},{"definition":{"style":{},"autoscale":false,"yaxis":{},"text_align":"left","custom_unit":"hits","noMetricHosts":false,"precision":"*","viz":"query_value","nodeType":"","requests":[{"style":{},"stacked":false,"aggregator":"min","conditional_formats":[{"custom_fg_color":"","custom_bg_color":"","palette":"white_on_red","value":1000,"comparator":">"},{"custom_fg_color":"","custom_bg_color":"","palette":"white_on_green","value":1000,"comparator":"<="}],"q":"sum:aws.elb.request_count{*}.as_count()","type":"line"}],"noGroupHosts":false},"title":"ELB
       Requests"}],"template_variables":[{"default":"","prefix":"host","name":"host"}],"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:28.298459+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:35.390813+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -848,13 +848,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:28 GMT
+      - Mon, 27 Jul 2020 09:10:36 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:28 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:35 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -863,9 +863,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - o1rjyOSbDnvYaQgtO33vwWSNsIwHafzLqam2amG/PbTP69SVY965ZpWutdoYJB30
+      - XrVF9iGOfdATIczLJsCTqr1ORVJWAydZm12oLZRyDN+lGe5bU8VekbcSMjJ2fj90
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790462"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -876,15 +876,15 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
     body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{"scale":"sqrt","max":"50","units":true,"includeZero":true},"text_align":"","markers":[{"type":"error
       solid","value":"y > 100","label":"High Latency"}],"custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.info.latency_ms{$host}","type":"line"}],"events":[{"q":"sources:capistrano"}],"noGroupHosts":false},"title":"Redis
       latency (ms)"},{"definition":{"style":{},"autoscale":false,"yaxis":{},"text_align":"left","custom_unit":"hits","noMetricHosts":false,"precision":"*","viz":"query_value","nodeType":"","requests":[{"style":{},"stacked":false,"aggregator":"min","conditional_formats":[{"custom_fg_color":"","custom_bg_color":"","palette":"white_on_red","value":1000,"comparator":">"},{"custom_fg_color":"","custom_bg_color":"","palette":"white_on_green","value":1000,"comparator":"<="}],"q":"sum:aws.elb.request_count{*}.as_count()","type":"line"}],"noGroupHosts":false},"title":"ELB
       Requests"}],"template_variables":[{"default":"","prefix":"host","name":"host"}],"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:28.298459+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:35.390813+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -895,203 +895,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:28 GMT
+      - Mon, 27 Jul 2020 09:10:36 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:28 GMT;
-        secure; HttpOnly
-      Strict-Transport-Security:
-      - max-age=15724800;
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Dd-Debug:
-      - P2v7RkLoCWSKqMAo7HF484UAAT2/cQHsvX2DV8G10CAxYBcO25Cq9ZgfwOWpYGFP
-      X-Dd-Version:
-      - "35.2282030"
-      X-Frame-Options:
-      - SAMEORIGIN
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
-    method: GET
-  response:
-    body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{"scale":"sqrt","max":"50","units":true,"includeZero":true},"text_align":"","markers":[{"type":"error
-      solid","value":"y > 100","label":"High Latency"}],"custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.info.latency_ms{$host}","type":"line"}],"events":[{"q":"sources:capistrano"}],"noGroupHosts":false},"title":"Redis
-      latency (ms)"},{"definition":{"style":{},"autoscale":false,"yaxis":{},"text_align":"left","custom_unit":"hits","noMetricHosts":false,"precision":"*","viz":"query_value","nodeType":"","requests":[{"style":{},"stacked":false,"aggregator":"min","conditional_formats":[{"custom_fg_color":"","custom_bg_color":"","palette":"white_on_red","value":1000,"comparator":">"},{"custom_fg_color":"","custom_bg_color":"","palette":"white_on_green","value":1000,"comparator":"<="}],"q":"sum:aws.elb.request_count{*}.as_count()","type":"line"}],"noGroupHosts":false},"title":"ELB
-      Requests"}],"template_variables":[{"default":"","prefix":"host","name":"host"}],"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:28.298459+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 16 Mar 2020 13:06:29 GMT
-      Dd-Pool:
-      - dogweb
-      Pragma:
-      - no-cache
-      Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:29 GMT;
-        secure; HttpOnly
-      Strict-Transport-Security:
-      - max-age=15724800;
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Dd-Debug:
-      - hlZGwPPL87Cire+2SDWJrcKtg5ChXKBaVFmtHdrZS+BoDfdo10256wfXrEDRUv8c
-      X-Dd-Version:
-      - "35.2282030"
-      X-Frame-Options:
-      - SAMEORIGIN
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
-    method: GET
-  response:
-    body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{"scale":"sqrt","max":"50","units":true,"includeZero":true},"text_align":"","markers":[{"type":"error
-      solid","value":"y > 100","label":"High Latency"}],"custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.info.latency_ms{$host}","type":"line"}],"events":[{"q":"sources:capistrano"}],"noGroupHosts":false},"title":"Redis
-      latency (ms)"},{"definition":{"style":{},"autoscale":false,"yaxis":{},"text_align":"left","custom_unit":"hits","noMetricHosts":false,"precision":"*","viz":"query_value","nodeType":"","requests":[{"style":{},"stacked":false,"aggregator":"min","conditional_formats":[{"custom_fg_color":"","custom_bg_color":"","palette":"white_on_red","value":1000,"comparator":">"},{"custom_fg_color":"","custom_bg_color":"","palette":"white_on_green","value":1000,"comparator":"<="}],"q":"sum:aws.elb.request_count{*}.as_count()","type":"line"}],"noGroupHosts":false},"title":"ELB
-      Requests"}],"template_variables":[{"default":"","prefix":"host","name":"host"}],"description":"Created
-      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:28.298459+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 16 Mar 2020 13:06:29 GMT
-      Dd-Pool:
-      - dogweb
-      Pragma:
-      - no-cache
-      Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:29 GMT;
-        secure; HttpOnly
-      Strict-Transport-Security:
-      - max-age=15724800;
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Dd-Debug:
-      - 5gIeAyE850e1lqVwTAgwvudewR8EzuQd3qGaXsS2D0CKQVhFOIjBoeQYiH0qPohy
-      X-Dd-Version:
-      - "35.2282030"
-      X-Frame-Options:
-      - SAMEORIGIN
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"id":1654151,"description":"Created using the Datadog provider in Terraform","title":"Acceptance
-      Test Timeboard","graphs":[{"title":"Widget with Multiple Queries","definition":{"viz":"timeseries","requests":[{"stacked":false,"aggregator":"","type":"line","style":{"palette":"purple","width":"thin","type":"dashed"},"change_type":"","order_dir":"","compare_to":"","increase_good":false,"order_by":"","metadata":{"avg:system.cpu.user{*}":{"alias":"Avg
-      CPU user"}},"q":"avg:system.cpu.user{*}"},{"stacked":false,"aggregator":"","type":"area","style":{},"change_type":"","order_dir":"","compare_to":"","increase_good":false,"order_by":"","log_query":{"index":"mcnulty","compute":{"aggregation":"avg","facet":"@duration","interval":5000},"search":{"query":"status:info"},"groupBy":[{"facet":"host","limit":10,"sort":{"aggregation":"avg","order":"desc","facet":"@duration"}}]}},{"stacked":false,"aggregator":"","type":"bars","style":{},"change_type":"","order_dir":"","compare_to":"","increase_good":false,"order_by":"","apm_query":{"index":"apm-search","compute":{"aggregation":"avg","facet":"@duration","interval":5000},"search":{"query":"type:web"},"groupBy":[{"facet":"resource_name","limit":50,"sort":{"aggregation":"avg","order":"desc","facet":"@string_query.interval"}}]}},{"stacked":false,"aggregator":"","type":"area","style":{},"change_type":"","order_dir":"","compare_to":"","increase_good":false,"order_by":"","process_query":{"metric":"process.stat.cpu.total_pct","search_by":"error","filter_by":["active"],"limit":50}}],"yaxis":{},"autoscale":false,"text_align":"","custom_unit":"","style":{},"noMetricHosts":false,"noGroupHosts":false,"nodeType":""}}],"read_only":false}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
-    method: PUT
-  response:
-    body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{"palette":"purple","width":"thin","type":"dashed"},"stacked":false,"aggregator":"","q":"avg:system.cpu.user{*}","type":"line","metadata":{"avg:system.cpu.user{*}":{"alias":"Avg
-      CPU user"}}},{"style":{},"stacked":false,"log_query":{"index":"mcnulty","search":{"query":"status:info"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}]},"aggregator":"","type":"area"},{"style":{},"stacked":false,"aggregator":"","type":"bars","apm_query":{"index":"apm-search","search":{"query":"type:web"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}]}},{"style":{},"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"stacked":false,"aggregator":"","type":"area"}],"noGroupHosts":false},"title":"Widget
-      with Multiple Queries"}],"template_variables":null,"description":"Created using
-      the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:29.665899+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 16 Mar 2020 13:06:29 GMT
-      Dd-Pool:
-      - dogweb
-      Pragma:
-      - no-cache
-      Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:29 GMT;
-        secure; HttpOnly
-      Strict-Transport-Security:
-      - max-age=15724800;
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Dd-Debug:
-      - PmDXJXCpOnq24qtagNCLPTUoILSRgi3DGaXUca70kUEAM8DZBLYkwSVilYSYEHCG
-      X-Dd-Version:
-      - "35.2282030"
-      X-Frame-Options:
-      - SAMEORIGIN
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
-    method: GET
-  response:
-    body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{"palette":"purple","width":"thin","type":"dashed"},"stacked":false,"aggregator":"","q":"avg:system.cpu.user{*}","type":"line","metadata":{"avg:system.cpu.user{*}":{"alias":"Avg
-      CPU user"}}},{"style":{},"stacked":false,"log_query":{"index":"mcnulty","search":{"query":"status:info"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}]},"aggregator":"","type":"area"},{"style":{},"stacked":false,"aggregator":"","type":"bars","apm_query":{"index":"apm-search","search":{"query":"type:web"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}]}},{"style":{},"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"stacked":false,"aggregator":"","type":"area"}],"noGroupHosts":false},"title":"Widget
-      with Multiple Queries"}],"template_variables":null,"description":"Created using
-      the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:29.665899+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 16 Mar 2020 13:06:29 GMT
-      Dd-Pool:
-      - dogweb
-      Pragma:
-      - no-cache
-      Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:29 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:36 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -1102,7 +912,7 @@ interactions:
       X-Dd-Debug:
       - nSRgqrrNNmPPT6VSGZq0R9QdtdJF1qxzho2//eboP+tsIQDRgfSx3bSVb1t6QyYb
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790442"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -1113,14 +923,15 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
-    body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{"palette":"purple","width":"thin","type":"dashed"},"stacked":false,"aggregator":"","q":"avg:system.cpu.user{*}","type":"line","metadata":{"avg:system.cpu.user{*}":{"alias":"Avg
-      CPU user"}}},{"style":{},"stacked":false,"log_query":{"index":"mcnulty","search":{"query":"status:info"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}]},"aggregator":"","type":"area"},{"style":{},"stacked":false,"aggregator":"","type":"bars","apm_query":{"index":"apm-search","search":{"query":"type:web"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}]}},{"style":{},"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"stacked":false,"aggregator":"","type":"area"}],"noGroupHosts":false},"title":"Widget
-      with Multiple Queries"}],"template_variables":null,"description":"Created using
-      the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:29.665899+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+    body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{"scale":"sqrt","max":"50","units":true,"includeZero":true},"text_align":"","markers":[{"type":"error
+      solid","value":"y > 100","label":"High Latency"}],"custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.info.latency_ms{$host}","type":"line"}],"events":[{"q":"sources:capistrano"}],"noGroupHosts":false},"title":"Redis
+      latency (ms)"},{"definition":{"style":{},"autoscale":false,"yaxis":{},"text_align":"left","custom_unit":"hits","noMetricHosts":false,"precision":"*","viz":"query_value","nodeType":"","requests":[{"style":{},"stacked":false,"aggregator":"min","conditional_formats":[{"custom_fg_color":"","custom_bg_color":"","palette":"white_on_red","value":1000,"comparator":">"},{"custom_fg_color":"","custom_bg_color":"","palette":"white_on_green","value":1000,"comparator":"<="}],"q":"sum:aws.elb.request_count{*}.as_count()","type":"line"}],"noGroupHosts":false},"title":"ELB
+      Requests"}],"template_variables":[{"default":"","prefix":"host","name":"host"}],"description":"Created
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:35.390813+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1131,13 +942,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:30 GMT
+      - Mon, 27 Jul 2020 09:10:36 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:30 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:36 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -1146,9 +957,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - +0e88dcOoH2a7qrZ5zz4PnubdrAKvSl+k8YKr4bhBQyArPBFiYg3oXWqeVKLPB1I
+      - J7vOWsxZd7Grxzg2TIaQpn2nGjrOScgI4Kwzur8V2oOTYInX6xbVT4leinNkGLPk
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790442"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -1159,14 +970,15 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
-    body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{"palette":"purple","width":"thin","type":"dashed"},"stacked":false,"aggregator":"","q":"avg:system.cpu.user{*}","type":"line","metadata":{"avg:system.cpu.user{*}":{"alias":"Avg
-      CPU user"}}},{"style":{},"stacked":false,"log_query":{"index":"mcnulty","search":{"query":"status:info"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}]},"aggregator":"","type":"area"},{"style":{},"stacked":false,"aggregator":"","type":"bars","apm_query":{"index":"apm-search","search":{"query":"type:web"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}]}},{"style":{},"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"stacked":false,"aggregator":"","type":"area"}],"noGroupHosts":false},"title":"Widget
-      with Multiple Queries"}],"template_variables":null,"description":"Created using
-      the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:29.665899+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+    body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{"scale":"sqrt","max":"50","units":true,"includeZero":true},"text_align":"","markers":[{"type":"error
+      solid","value":"y > 100","label":"High Latency"}],"custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{},"stacked":false,"aggregator":"","q":"avg:redis.info.latency_ms{$host}","type":"line"}],"events":[{"q":"sources:capistrano"}],"noGroupHosts":false},"title":"Redis
+      latency (ms)"},{"definition":{"style":{},"autoscale":false,"yaxis":{},"text_align":"left","custom_unit":"hits","noMetricHosts":false,"precision":"*","viz":"query_value","nodeType":"","requests":[{"style":{},"stacked":false,"aggregator":"min","conditional_formats":[{"custom_fg_color":"","custom_bg_color":"","palette":"white_on_red","value":1000,"comparator":">"},{"custom_fg_color":"","custom_bg_color":"","palette":"white_on_green","value":1000,"comparator":"<="}],"q":"sum:aws.elb.request_count{*}.as_count()","type":"line"}],"noGroupHosts":false},"title":"ELB
+      Requests"}],"template_variables":[{"default":"","prefix":"host","name":"host"}],"description":"Created
+      using the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:35.390813+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1177,13 +989,109 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:30 GMT
+      - Mon, 27 Jul 2020 09:10:36 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:30 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:36 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - XsUcj00kgZUn78/yrMgBc2B4U9QizwFFNtN2OKmtTvmSRTdL165j4Ltg6xvjCzDU
+      X-Dd-Version:
+      - "35.2790442"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":2026623,"description":"Created using the Datadog provider in Terraform","title":"Acceptance
+      Test Timeboard","graphs":[{"title":"Widget with Multiple Queries","definition":{"viz":"timeseries","requests":[{"stacked":false,"aggregator":"","type":"line","style":{"palette":"purple","width":"thin","type":"dashed"},"change_type":"","order_dir":"","compare_to":"","increase_good":false,"order_by":"","metadata":{"avg:system.cpu.user{*}":{"alias":"Avg
+      CPU user"}},"q":"avg:system.cpu.user{*}"},{"stacked":false,"aggregator":"","type":"area","style":{},"change_type":"","order_dir":"","compare_to":"","increase_good":false,"order_by":"","log_query":{"index":"mcnulty","compute":{"aggregation":"avg","facet":"@duration","interval":5000},"search":{"query":"status:info"},"groupBy":[{"facet":"host","limit":10,"sort":{"aggregation":"avg","order":"desc","facet":"@duration"}}]}},{"stacked":false,"aggregator":"","type":"bars","style":{},"change_type":"","order_dir":"","compare_to":"","increase_good":false,"order_by":"","apm_query":{"index":"apm-search","compute":{"aggregation":"avg","facet":"@duration","interval":5000},"search":{"query":"type:web"},"groupBy":[{"facet":"resource_name","limit":50,"sort":{"aggregation":"avg","order":"desc","facet":"@string_query.interval"}}]}},{"stacked":false,"aggregator":"","type":"area","style":{},"change_type":"","order_dir":"","compare_to":"","increase_good":false,"order_by":"","process_query":{"metric":"process.stat.cpu.total_pct","search_by":"error","filter_by":["active"],"limit":50}}],"yaxis":{},"autoscale":false,"text_align":"","custom_unit":"","style":{},"noMetricHosts":false,"noGroupHosts":false,"nodeType":""}}],"read_only":false}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
+    method: PUT
+  response:
+    body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{"palette":"purple","width":"thin","type":"dashed"},"stacked":false,"aggregator":"","q":"avg:system.cpu.user{*}","type":"line","metadata":{"avg:system.cpu.user{*}":{"alias":"Avg
+      CPU user"}}},{"style":{},"stacked":false,"log_query":{"index":"mcnulty","search":{"query":"status:info"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}]},"aggregator":"","type":"area"},{"style":{},"stacked":false,"aggregator":"","type":"bars","apm_query":{"index":"apm-search","search":{"query":"type:web"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}]}},{"style":{},"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"stacked":false,"aggregator":"","type":"area"}],"noGroupHosts":false},"title":"Widget
+      with Multiple Queries"}],"template_variables":null,"description":"Created using
+      the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:36.984087+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jul 2020 09:10:37 GMT
+      Dd-Pool:
+      - dogweb
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:36 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - 9KqlMq3gTLpkJSVJyvAwXe8+x8jjzLiadKiJ+urXt2iPIG7RDD8GegNJYYpRqZOo
+      X-Dd-Version:
+      - "35.2790442"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
+    method: GET
+  response:
+    body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{"palette":"purple","width":"thin","type":"dashed"},"stacked":false,"aggregator":"","q":"avg:system.cpu.user{*}","type":"line","metadata":{"avg:system.cpu.user{*}":{"alias":"Avg
+      CPU user"}}},{"style":{},"stacked":false,"log_query":{"index":"mcnulty","search":{"query":"status:info"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}]},"aggregator":"","type":"area"},{"style":{},"stacked":false,"aggregator":"","type":"bars","apm_query":{"index":"apm-search","search":{"query":"type:web"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}]}},{"style":{},"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"stacked":false,"aggregator":"","type":"area"}],"noGroupHosts":false},"title":"Widget
+      with Multiple Queries"}],"template_variables":null,"description":"Created using
+      the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:36.984087+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jul 2020 09:10:37 GMT
+      Dd-Pool:
+      - dogweb
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:37 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -1194,7 +1102,7 @@ interactions:
       X-Dd-Debug:
       - 7vC9CD2UnUYbC7cu05B95RgDyGt2vcRq8GQJgBahx4BAPKzA8OvLqEF8NdaLccla
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790442"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -1205,14 +1113,14 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
     body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{"palette":"purple","width":"thin","type":"dashed"},"stacked":false,"aggregator":"","q":"avg:system.cpu.user{*}","type":"line","metadata":{"avg:system.cpu.user{*}":{"alias":"Avg
       CPU user"}}},{"style":{},"stacked":false,"log_query":{"index":"mcnulty","search":{"query":"status:info"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}]},"aggregator":"","type":"area"},{"style":{},"stacked":false,"aggregator":"","type":"bars","apm_query":{"index":"apm-search","search":{"query":"type:web"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}]}},{"style":{},"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"stacked":false,"aggregator":"","type":"area"}],"noGroupHosts":false},"title":"Widget
       with Multiple Queries"}],"template_variables":null,"description":"Created using
-      the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:29.665899+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:36.984087+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1223,13 +1131,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:30 GMT
+      - Mon, 27 Jul 2020 09:10:37 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:30 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:37 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -1238,9 +1146,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - x4pYHtiOW9rUeREgXmH2iIgBaXVGD7x1RIZUg56H0ghPppdtz0ZBEK6nMs8tuoqc
+      - dPTJBBDv5jeY1gnH1FisDpda5Hi0boOGbsHxIOi4qkMt+QLOH7F7P7MeSr40vXZ0
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790442"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -1251,14 +1159,14 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
     body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{"palette":"purple","width":"thin","type":"dashed"},"stacked":false,"aggregator":"","q":"avg:system.cpu.user{*}","type":"line","metadata":{"avg:system.cpu.user{*}":{"alias":"Avg
       CPU user"}}},{"style":{},"stacked":false,"log_query":{"index":"mcnulty","search":{"query":"status:info"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}]},"aggregator":"","type":"area"},{"style":{},"stacked":false,"aggregator":"","type":"bars","apm_query":{"index":"apm-search","search":{"query":"type:web"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}]}},{"style":{},"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"stacked":false,"aggregator":"","type":"area"}],"noGroupHosts":false},"title":"Widget
       with Multiple Queries"}],"template_variables":null,"description":"Created using
-      the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:29.665899+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:36.984087+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1269,13 +1177,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:30 GMT
+      - Mon, 27 Jul 2020 09:10:37 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:30 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:37 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -1284,9 +1192,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - EE74ncTR989SomsonUvABJWdGDkXBs7Emqj3HVDpp6NYddpvHp95kXsnHux1Es9E
+      - /Ib6MMQTHlX0/jTb6tlEMzSZs2crLqjkGjYkoQ/zb0RHtMaXT744DZRFpy23W0oi
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790442"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -1297,14 +1205,14 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
     body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{"palette":"purple","width":"thin","type":"dashed"},"stacked":false,"aggregator":"","q":"avg:system.cpu.user{*}","type":"line","metadata":{"avg:system.cpu.user{*}":{"alias":"Avg
       CPU user"}}},{"style":{},"stacked":false,"log_query":{"index":"mcnulty","search":{"query":"status:info"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}]},"aggregator":"","type":"area"},{"style":{},"stacked":false,"aggregator":"","type":"bars","apm_query":{"index":"apm-search","search":{"query":"type:web"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}]}},{"style":{},"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"stacked":false,"aggregator":"","type":"area"}],"noGroupHosts":false},"title":"Widget
       with Multiple Queries"}],"template_variables":null,"description":"Created using
-      the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-03-16T13:06:25.404855+00:00","new_id":"mwf-wvc-y2b","id":1654151,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-03-16T13:06:29.665899+00:00"},"url":"/dash/1654151/acceptance-test-timeboard","resource":"/api/v1/dash/1654151"}'
+      the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:36.984087+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1315,13 +1223,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:30 GMT
+      - Mon, 27 Jul 2020 09:10:37 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:30 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:37 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
@@ -1330,9 +1238,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - QpzDmIoaO5Hufx014PqM5BuLw+G9k75nLqy12TEr4Iab1Fl7hIFT5DrERoBer8OF
+      - og1WGdy+2nV+rkkclmd3Cf2I26XhV3/6yjBeQCP8aHbH2k2cKwC+X9WmhIghcJ94
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790462"
       X-Frame-Options:
       - SAMEORIGIN
     status: 200 OK
@@ -1343,8 +1251,100 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
+    method: GET
+  response:
+    body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{"palette":"purple","width":"thin","type":"dashed"},"stacked":false,"aggregator":"","q":"avg:system.cpu.user{*}","type":"line","metadata":{"avg:system.cpu.user{*}":{"alias":"Avg
+      CPU user"}}},{"style":{},"stacked":false,"log_query":{"index":"mcnulty","search":{"query":"status:info"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}]},"aggregator":"","type":"area"},{"style":{},"stacked":false,"aggregator":"","type":"bars","apm_query":{"index":"apm-search","search":{"query":"type:web"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}]}},{"style":{},"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"stacked":false,"aggregator":"","type":"area"}],"noGroupHosts":false},"title":"Widget
+      with Multiple Queries"}],"template_variables":null,"description":"Created using
+      the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:36.984087+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jul 2020 09:10:38 GMT
+      Dd-Pool:
+      - dogweb
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:38 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - 7vC9CD2UnUYbC7cu05B95RgDyGt2vcRq8GQJgBahx4BAPKzA8OvLqEF8NdaLccla
+      X-Dd-Version:
+      - "35.2790442"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
+    method: GET
+  response:
+    body: '{"dash":{"read_only":false,"graphs":[{"definition":{"style":{},"nodeType":"","yaxis":{},"text_align":"","custom_unit":"","noMetricHosts":false,"viz":"timeseries","autoscale":false,"requests":[{"style":{"palette":"purple","width":"thin","type":"dashed"},"stacked":false,"aggregator":"","q":"avg:system.cpu.user{*}","type":"line","metadata":{"avg:system.cpu.user{*}":{"alias":"Avg
+      CPU user"}}},{"style":{},"stacked":false,"log_query":{"index":"mcnulty","search":{"query":"status:info"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"host","sort":{"facet":"@duration","aggregation":"avg","order":"desc"},"limit":10}]},"aggregator":"","type":"area"},{"style":{},"stacked":false,"aggregator":"","type":"bars","apm_query":{"index":"apm-search","search":{"query":"type:web"},"compute":{"facet":"@duration","interval":5000,"aggregation":"avg"},"groupBy":[{"facet":"resource_name","sort":{"facet":"@string_query.interval","aggregation":"avg","order":"desc"},"limit":50}]}},{"style":{},"process_query":{"search_by":"error","metric":"process.stat.cpu.total_pct","limit":50,"filter_by":["active"]},"stacked":false,"aggregator":"","type":"area"}],"noGroupHosts":false},"title":"Widget
+      with Multiple Queries"}],"template_variables":null,"description":"Created using
+      the Datadog provider in Terraform","title":"Acceptance Test Timeboard","created":"2020-07-27T09:10:31.620797+00:00","new_id":"fv7-kuf-d66","id":2026623,"created_by":{"disabled":false,"handle":"frog@datadoghq.com","name":null,"title":null,"is_admin":true,"role":null,"access_role":"adm","verified":true,"email":"frog@datadoghq.com","icon":"https://secure.gravatar.com/avatar/28a16dfe36e73b60c1d55872cb0f1172?s=48&d=retro"},"modified":"2020-07-27T09:10:36.984087+00:00"},"url":"/dash/2026623/acceptance-test-timeboard","resource":"/api/v1/dash/2026623"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jul 2020 09:10:38 GMT
+      Dd-Pool:
+      - dogweb
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:38 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Debug:
+      - YKF8+1vTI0wiWlB3VWhiMVnZ1RLtV3h2yAW6/TGe9qIMWdYXxsNpy3J4QxfrJoDD
+      X-Dd-Version:
+      - "35.2790442"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: DELETE
   response:
     body: ""
@@ -1360,22 +1360,22 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:33 GMT
+      - Mon, 27 Jul 2020 09:11:06 GMT
       Dd-Pool:
       - dogweb
       Pragma:
       - no-cache
       Set-Cookie:
-      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 23-Mar-2020 13:06:31 GMT;
+      - DD-PSHARD=233; Max-Age=604800; Path=/; expires=Mon, 03-Aug-2020 09:10:38 GMT;
         secure; HttpOnly
       Strict-Transport-Security:
       - max-age=15724800;
       X-Content-Type-Options:
       - nosniff
       X-Dd-Debug:
-      - ztq+F8HwxRthTKNo0l2MCEDK5uwvgQzF00nWu49lHsBM51hGZBm/pPILDqupy+Xd
+      - nRZqCODixwNZX0HLyT17WzYwenviVG0rmnZak57k5KsDWun3aWEsPedTsRpiFQxf
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790442"
       X-Frame-Options:
       - SAMEORIGIN
     status: 204 No Content
@@ -1386,8 +1386,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Datadog/dev/terraform (go1.13)
-    url: https://api.datadoghq.com/api/v1/dash/1654151
+      - Datadog/dev/terraform (go1.14.4)
+    url: https://api.datadoghq.com/api/v1/dash/2026623
     method: GET
   response:
     body: '{"errors": ["No dashboard matches that dash_id."]}'
@@ -1401,7 +1401,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Mar 2020 13:06:33 GMT
+      - Mon, 27 Jul 2020 09:11:06 GMT
       Dd-Pool:
       - dogweb
       Pragma:
@@ -1413,7 +1413,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Dd-Version:
-      - "35.2282030"
+      - "35.2790442"
       X-Frame-Options:
       - SAMEORIGIN
     status: 404 Not Found

--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -1516,10 +1516,12 @@ func buildTerraformDistributionDefinition(datadogDefinition datadogV1.Distributi
 func getDistributionRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement exactly one of the following type of query
-		"q":             getMetricQuerySchema(),
-		"apm_query":     getApmLogNetworkOrRumQuerySchema(),
-		"log_query":     getApmLogNetworkOrRumQuerySchema(),
-		"process_query": getProcessQuerySchema(),
+		"q":              getMetricQuerySchema(),
+		"apm_query":      getApmOrLogQuerySchema(),
+		"log_query":      getApmOrLogQuerySchema(),
+		"process_query":  getProcessQuerySchema(),
+		"rum_query":      getApmOrLogQuerySchema(),
+		"security_query": getApmOrLogQuerySchema(),
 		// Settings specific to Distribution requests
 		"style": {
 			Type:     schema.TypeList,
@@ -1548,6 +1550,12 @@ func buildDatadogDistributionRequests(terraformRequests *[]interface{}) *[]datad
 		} else if v, ok := terraformRequest["process_query"].([]interface{}); ok && len(v) > 0 {
 			processQuery := v[0].(map[string]interface{})
 			datadogDistributionRequest.ProcessQuery = buildDatadogProcessQuery(processQuery)
+		} else if v, ok := terraformRequest["rum_query"].([]interface{}); ok && len(v) > 0 {
+			rumQuery := v[0].(map[string]interface{})
+			datadogDistributionRequest.RumQuery = buildDatadogApmOrLogQuery(rumQuery)
+		} else if v, ok := terraformRequest["security_query"].([]interface{}); ok && len(v) > 0 {
+			securityQuery := v[0].(map[string]interface{})
+			datadogDistributionRequest.SecurityQuery = buildDatadogApmOrLogQuery(securityQuery)
 		}
 		if style, ok := terraformRequest["style"].([]interface{}); ok && len(style) > 0 {
 			if v, ok := style[0].(map[string]interface{}); ok && len(v) > 0 {
@@ -1574,6 +1582,12 @@ func buildTerraformDistributionRequests(datadogDistributionRequests *[]datadogV1
 		} else if v, ok := datadogRequest.GetProcessQueryOk(); ok {
 			terraformQuery := buildTerraformProcessQuery(*v)
 			terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
+		} else if datadogRequest.RumQuery != nil {
+			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.RumQuery)
+			terraformRequest["rum_query"] = []map[string]interface{}{terraformQuery}
+		} else if datadogRequest.SecurityQuery != nil {
+			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.SecurityQuery)
+			terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
 		}
 		if datadogRequest.Style != nil {
 			style := buildTerraformWidgetStyle(*datadogRequest.Style)
@@ -2071,10 +2085,19 @@ func buildTerraformHeatmapDefinition(datadogDefinition datadogV1.HeatMapWidgetDe
 func getHeatmapRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement exactly one of the following type of query
+<<<<<<< HEAD
 		"q":             getMetricQuerySchema(),
 		"apm_query":     getApmLogNetworkOrRumQuerySchema(),
 		"log_query":     getApmLogNetworkOrRumQuerySchema(),
 		"process_query": getProcessQuerySchema(),
+=======
+		"q":              getMetricQuerySchema(),
+		"apm_query":      getApmOrLogQuerySchema(),
+		"log_query":      getApmOrLogQuerySchema(),
+		"process_query":  getProcessQuerySchema(),
+		"rum_query":      getApmOrLogQuerySchema(),
+		"security_query": getApmOrLogQuerySchema(),
+>>>>>>> c36107a... [k9] Add support for ScatterPlot,  HeatMap, Distribution and HostMap widgets
 		// Settings specific to Heatmap requests
 		"style": {
 			Type:     schema.TypeList,
@@ -2103,6 +2126,12 @@ func buildDatadogHeatmapRequests(terraformRequests *[]interface{}) *[]datadogV1.
 		} else if v, ok := terraformRequest["process_query"].([]interface{}); ok && len(v) > 0 {
 			processQuery := v[0].(map[string]interface{})
 			datadogHeatmapRequest.ProcessQuery = buildDatadogProcessQuery(processQuery)
+		} else if v, ok := terraformRequest["rum_query"].([]interface{}); ok && len(v) > 0 {
+			rumQuery := v[0].(map[string]interface{})
+			datadogHeatmapRequest.RumQuery = buildDatadogApmOrLogQuery(rumQuery)
+		} else if v, ok := terraformRequest["security_query"].([]interface{}); ok && len(v) > 0 {
+			securityQuery := v[0].(map[string]interface{})
+			datadogHeatmapRequest.SecurityQuery = buildDatadogApmOrLogQuery(securityQuery)
 		}
 		if style, ok := terraformRequest["style"].([]interface{}); ok && len(style) > 0 {
 			if v, ok := style[0].(map[string]interface{}); ok && len(v) > 0 {
@@ -2128,6 +2157,12 @@ func buildTerraformHeatmapRequests(datadogHeatmapRequests *[]datadogV1.HeatMapWi
 		} else if v, ok := datadogRequest.GetProcessQueryOk(); ok {
 			terraformQuery := buildTerraformProcessQuery(*v)
 			terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
+		} else if datadogRequest.RumQuery != nil {
+			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.RumQuery)
+			terraformRequest["rum_query"] = []map[string]interface{}{terraformQuery}
+		} else if datadogRequest.SecurityQuery != nil {
+			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.SecurityQuery)
+			terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
 		}
 		if v, ok := datadogRequest.GetStyleOk(); ok {
 			style := buildTerraformWidgetStyle(*v)
@@ -2343,10 +2378,19 @@ func buildTerraformHostmapDefinition(datadogDefinition datadogV1.HostMapWidgetDe
 func getHostmapRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement at least one of the following type of query
+<<<<<<< HEAD
 		"q":             getMetricQuerySchema(),
 		"apm_query":     getApmLogNetworkOrRumQuerySchema(),
 		"log_query":     getApmLogNetworkOrRumQuerySchema(),
 		"process_query": getProcessQuerySchema(),
+=======
+		"q":              getMetricQuerySchema(),
+		"apm_query":      getApmOrLogQuerySchema(),
+		"log_query":      getApmOrLogQuerySchema(),
+		"process_query":  getProcessQuerySchema(),
+		"rum_query":      getApmOrLogQuerySchema(),
+		"security_query": getApmOrLogQuerySchema(),
+>>>>>>> c36107a... [k9] Add support for ScatterPlot,  HeatMap, Distribution and HostMap widgets
 	}
 }
 func buildDatadogHostmapRequest(terraformRequest map[string]interface{}) *datadogV1.HostMapRequest {
@@ -2363,6 +2407,12 @@ func buildDatadogHostmapRequest(terraformRequest map[string]interface{}) *datado
 	} else if v, ok := terraformRequest["process_query"].([]interface{}); ok && len(v) > 0 {
 		processQuery := v[0].(map[string]interface{})
 		datadogHostmapRequest.ProcessQuery = buildDatadogProcessQuery(processQuery)
+	} else if v, ok := terraformRequest["rum_query"].([]interface{}); ok && len(v) > 0 {
+		rumQuery := v[0].(map[string]interface{})
+		datadogHostmapRequest.RumQuery = buildDatadogApmOrLogQuery(rumQuery)
+	} else if v, ok := terraformRequest["security_query"].([]interface{}); ok && len(v) > 0 {
+		securityQuery := v[0].(map[string]interface{})
+		datadogHostmapRequest.SecurityQuery = buildDatadogApmOrLogQuery(securityQuery)
 	}
 
 	return datadogHostmapRequest
@@ -2380,6 +2430,12 @@ func buildTerraformHostmapRequest(datadogHostmapRequest *datadogV1.HostMapReques
 	} else if v, ok := datadogHostmapRequest.GetProcessQueryOk(); ok {
 		terraformQuery := buildTerraformProcessQuery(*v)
 		terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
+	} else if datadogHostmapRequest.RumQuery != nil {
+		terraformQuery := buildTerraformApmOrLogQuery(*datadogHostmapRequest.RumQuery)
+		terraformRequest["rum_query"] = []map[string]interface{}{terraformQuery}
+	} else if datadogHostmapRequest.SecurityQuery != nil {
+		terraformQuery := buildTerraformApmOrLogQuery(*datadogHostmapRequest.SecurityQuery)
+		terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
 	}
 	return &terraformRequest
 }
@@ -3507,10 +3563,19 @@ func buildTerraformScatterplotDefinition(datadogDefinition datadogV1.ScatterPlot
 func getScatterplotRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement exactly one of the following type of query
+<<<<<<< HEAD
 		"q":             getMetricQuerySchema(),
 		"apm_query":     getApmLogNetworkOrRumQuerySchema(),
 		"log_query":     getApmLogNetworkOrRumQuerySchema(),
 		"process_query": getProcessQuerySchema(),
+=======
+		"q":              getMetricQuerySchema(),
+		"apm_query":      getApmOrLogQuerySchema(),
+		"log_query":      getApmOrLogQuerySchema(),
+		"process_query":  getProcessQuerySchema(),
+		"rum_query":      getApmOrLogQuerySchema(),
+		"security_query": getApmOrLogQuerySchema(),
+>>>>>>> c36107a... [k9] Add support for ScatterPlot,  HeatMap, Distribution and HostMap widgets
 		// Settings specific to Scatterplot requests
 		"aggregator": {
 			Type:     schema.TypeString,
@@ -3532,6 +3597,12 @@ func buildDatadogScatterplotRequest(terraformRequest map[string]interface{}) *da
 	} else if v, ok := terraformRequest["process_query"].([]interface{}); ok && len(v) > 0 {
 		processQuery := v[0].(map[string]interface{})
 		datadogScatterplotRequest.ProcessQuery = buildDatadogProcessQuery(processQuery)
+	} else if v, ok := terraformRequest["rum_query"].([]interface{}); ok && len(v) > 0 {
+		rumQuery := v[0].(map[string]interface{})
+		datadogScatterplotRequest.RumQuery = buildDatadogApmOrLogQuery(rumQuery)
+	} else if v, ok := terraformRequest["security_query"].([]interface{}); ok && len(v) > 0 {
+		securityQuery := v[0].(map[string]interface{})
+		datadogScatterplotRequest.SecurityQuery = buildDatadogApmOrLogQuery(securityQuery)
 	}
 
 	if v, ok := terraformRequest["aggregator"].(string); ok && len(v) != 0 {
@@ -3553,6 +3624,12 @@ func buildTerraformScatterplotRequest(datadogScatterplotRequest *datadogV1.Scatt
 	} else if datadogScatterplotRequest.ProcessQuery != nil {
 		terraformQuery := buildTerraformProcessQuery(*datadogScatterplotRequest.ProcessQuery)
 		terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
+	} else if datadogScatterplotRequest.RumQuery != nil {
+		terraformQuery := buildTerraformApmOrLogQuery(*datadogScatterplotRequest.RumQuery)
+		terraformRequest["rum_query"] = []map[string]interface{}{terraformQuery}
+	} else if datadogScatterplotRequest.SecurityQuery != nil {
+		terraformQuery := buildTerraformApmOrLogQuery(*datadogScatterplotRequest.SecurityQuery)
+		terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
 	}
 
 	if datadogScatterplotRequest.Aggregator != nil {
@@ -4174,7 +4251,7 @@ func buildDatadogToplistRequests(terraformRequests *[]interface{}) *[]datadogV1.
 			datadogToplistRequest.ProcessQuery = buildDatadogProcessQuery(processQuery)
 		} else if v, ok := terraformRequest["rum_query"].([]interface{}); ok && len(v) > 0 {
 			rumQuery := v[0].(map[string]interface{})
-			datadogChangeRequest.RumQuery = buildDatadogApmOrLogQuery(rumQuery)
+			datadogToplistRequest.RumQuery = buildDatadogApmOrLogQuery(rumQuery)
 		} else if v, ok := terraformRequest["security_query"].([]interface{}); ok && len(v) > 0 {
 			securityQuery := v[0].(map[string]interface{})
 			datadogToplistRequest.SecurityQuery = buildDatadogApmOrLogQuery(securityQuery)

--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -2085,19 +2085,12 @@ func buildTerraformHeatmapDefinition(datadogDefinition datadogV1.HeatMapWidgetDe
 func getHeatmapRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement exactly one of the following type of query
-<<<<<<< HEAD
-		"q":             getMetricQuerySchema(),
-		"apm_query":     getApmLogNetworkOrRumQuerySchema(),
-		"log_query":     getApmLogNetworkOrRumQuerySchema(),
-		"process_query": getProcessQuerySchema(),
-=======
 		"q":              getMetricQuerySchema(),
 		"apm_query":      getApmOrLogQuerySchema(),
 		"log_query":      getApmOrLogQuerySchema(),
 		"process_query":  getProcessQuerySchema(),
 		"rum_query":      getApmOrLogQuerySchema(),
 		"security_query": getApmOrLogQuerySchema(),
->>>>>>> c36107a... [k9] Add support for ScatterPlot,  HeatMap, Distribution and HostMap widgets
 		// Settings specific to Heatmap requests
 		"style": {
 			Type:     schema.TypeList,
@@ -2378,19 +2371,12 @@ func buildTerraformHostmapDefinition(datadogDefinition datadogV1.HostMapWidgetDe
 func getHostmapRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement at least one of the following type of query
-<<<<<<< HEAD
-		"q":             getMetricQuerySchema(),
-		"apm_query":     getApmLogNetworkOrRumQuerySchema(),
-		"log_query":     getApmLogNetworkOrRumQuerySchema(),
-		"process_query": getProcessQuerySchema(),
-=======
 		"q":              getMetricQuerySchema(),
 		"apm_query":      getApmOrLogQuerySchema(),
 		"log_query":      getApmOrLogQuerySchema(),
 		"process_query":  getProcessQuerySchema(),
 		"rum_query":      getApmOrLogQuerySchema(),
 		"security_query": getApmOrLogQuerySchema(),
->>>>>>> c36107a... [k9] Add support for ScatterPlot,  HeatMap, Distribution and HostMap widgets
 	}
 }
 func buildDatadogHostmapRequest(terraformRequest map[string]interface{}) *datadogV1.HostMapRequest {
@@ -3563,19 +3549,12 @@ func buildTerraformScatterplotDefinition(datadogDefinition datadogV1.ScatterPlot
 func getScatterplotRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement exactly one of the following type of query
-<<<<<<< HEAD
-		"q":             getMetricQuerySchema(),
-		"apm_query":     getApmLogNetworkOrRumQuerySchema(),
-		"log_query":     getApmLogNetworkOrRumQuerySchema(),
-		"process_query": getProcessQuerySchema(),
-=======
 		"q":              getMetricQuerySchema(),
 		"apm_query":      getApmOrLogQuerySchema(),
 		"log_query":      getApmOrLogQuerySchema(),
 		"process_query":  getProcessQuerySchema(),
 		"rum_query":      getApmOrLogQuerySchema(),
 		"security_query": getApmOrLogQuerySchema(),
->>>>>>> c36107a... [k9] Add support for ScatterPlot,  HeatMap, Distribution and HostMap widgets
 		// Settings specific to Scatterplot requests
 		"aggregator": {
 			Type:     schema.TypeString,
@@ -3971,8 +3950,8 @@ func getTimeseriesRequestSchema() map[string]*schema.Schema {
 		"q":              getMetricQuerySchema(),
 		"apm_query":      getApmOrLogQuerySchema(),
 		"log_query":      getApmOrLogQuerySchema(),
-		"rum_query":     getApmLogNetworkOrRumQuerySchema(),
-		"network_query": getApmLogNetworkOrRumQuerySchema(),
+		"rum_query":      getApmLogNetworkOrRumQuerySchema(),
+		"network_query":  getApmLogNetworkOrRumQuerySchema(),
 		"process_query":  getProcessQuerySchema(),
 		"rum_query":      getApmOrLogQuerySchema(),
 		"security_query": getApmOrLogQuerySchema(),

--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -1387,11 +1387,11 @@ func buildTerraformChangeRequests(datadogChangeRequests *[]datadogV1.ChangeWidge
 		} else if v, ok := datadogRequest.GetProcessQueryOk(); ok {
 			terraformQuery := buildTerraformProcessQuery(*v)
 			terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
-		} else if datadogRequest.RumQuery != nil {
-			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.RumQuery)
+		} else if v, ok := datadogRequest.GetRumQueryOk(); ok {
+			terraformQuery := buildTerraformApmOrLogQuery(*v)
 			terraformRequest["rum_query"] = []map[string]interface{}{terraformQuery}
-		} else if datadogRequest.SecurityQuery != nil {
-			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.SecurityQuery)
+		} else if v, ok := datadogRequest.GetSecurityQueryOk(); ok {
+			terraformQuery := buildTerraformApmOrLogQuery(*v)
 			terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
 		}
 
@@ -1582,11 +1582,11 @@ func buildTerraformDistributionRequests(datadogDistributionRequests *[]datadogV1
 		} else if v, ok := datadogRequest.GetProcessQueryOk(); ok {
 			terraformQuery := buildTerraformProcessQuery(*v)
 			terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
-		} else if datadogRequest.RumQuery != nil {
-			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.RumQuery)
+		} else if v, ok := datadogRequest.GetRumQueryOk(); ok {
+			terraformQuery := buildTerraformApmOrLogQuery(*v)
 			terraformRequest["rum_query"] = []map[string]interface{}{terraformQuery}
-		} else if datadogRequest.SecurityQuery != nil {
-			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.SecurityQuery)
+		} else if v, ok := datadogRequest.GetSecurityQueryOk(); ok {
+			terraformQuery := buildTerraformApmOrLogQuery(*v)
 			terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
 		}
 		if datadogRequest.Style != nil {
@@ -2150,11 +2150,11 @@ func buildTerraformHeatmapRequests(datadogHeatmapRequests *[]datadogV1.HeatMapWi
 		} else if v, ok := datadogRequest.GetProcessQueryOk(); ok {
 			terraformQuery := buildTerraformProcessQuery(*v)
 			terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
-		} else if datadogRequest.RumQuery != nil {
-			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.RumQuery)
+		} else if v, ok := datadogRequest.GetRumQueryOk(); ok {
+			terraformQuery := buildTerraformApmOrLogQuery(*v)
 			terraformRequest["rum_query"] = []map[string]interface{}{terraformQuery}
-		} else if datadogRequest.SecurityQuery != nil {
-			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.SecurityQuery)
+		} else if v, ok := datadogRequest.GetSecurityQueryOk(); ok {
+			terraformQuery := buildTerraformApmOrLogQuery(*v)
 			terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
 		}
 		if v, ok := datadogRequest.GetStyleOk(); ok {
@@ -2416,11 +2416,11 @@ func buildTerraformHostmapRequest(datadogHostmapRequest *datadogV1.HostMapReques
 	} else if v, ok := datadogHostmapRequest.GetProcessQueryOk(); ok {
 		terraformQuery := buildTerraformProcessQuery(*v)
 		terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
-	} else if datadogHostmapRequest.RumQuery != nil {
-		terraformQuery := buildTerraformApmOrLogQuery(*datadogHostmapRequest.RumQuery)
+	} else if v, ok := datadogHostmapRequest.GetRumQueryOk(); ok {
+		terraformQuery := buildTerraformApmOrLogQuery(*v)
 		terraformRequest["rum_query"] = []map[string]interface{}{terraformQuery}
-	} else if datadogHostmapRequest.SecurityQuery != nil {
-		terraformQuery := buildTerraformApmOrLogQuery(*datadogHostmapRequest.SecurityQuery)
+	} else if v, ok := datadogHostmapRequest.GetSecurityQueryOk(); ok {
+		terraformQuery := buildTerraformApmOrLogQuery(*v)
 		terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
 	}
 	return &terraformRequest
@@ -3160,11 +3160,11 @@ func buildTerraformQueryValueRequests(datadogQueryValueRequests *[]datadogV1.Que
 		} else if datadogRequest.ProcessQuery != nil {
 			terraformQuery := buildTerraformProcessQuery(*datadogRequest.ProcessQuery)
 			terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
-		} else if datadogRequest.RumQuery != nil {
-			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.RumQuery)
+		} else if v, ok := datadogRequest.GetRumQueryOk(); ok {
+			terraformQuery := buildTerraformApmOrLogQuery(*v)
 			terraformRequest["rum_query"] = []map[string]interface{}{terraformQuery}
-		} else if datadogRequest.SecurityQuery != nil {
-			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.SecurityQuery)
+		} else if v, ok := datadogRequest.GetSecurityQueryOk(); ok {
+			terraformQuery := buildTerraformApmOrLogQuery(*v)
 			terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
 		}
 
@@ -3349,11 +3349,11 @@ func buildTerraformQueryTableRequests(datadogQueryTableRequests *[]datadogV1.Tab
 		} else if v, ok := datadogRequest.GetProcessQueryOk(); ok {
 			terraformQuery := buildTerraformProcessQuery(*v)
 			terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
-		} else if datadogRequest.RumQuery != nil {
-			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.RumQuery)
+		} else if v, ok := datadogRequest.GetRumQueryOk(); ok {
+			terraformQuery := buildTerraformApmOrLogQuery(*v)
 			terraformRequest["rum_query"] = []map[string]interface{}{terraformQuery}
-		} else if datadogRequest.SecurityQuery != nil {
-			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.SecurityQuery)
+		} else if v, ok := datadogRequest.GetSecurityQueryOk(); ok {
+			terraformQuery := buildTerraformApmOrLogQuery(*v)
 			terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
 		}
 
@@ -3603,11 +3603,11 @@ func buildTerraformScatterplotRequest(datadogScatterplotRequest *datadogV1.Scatt
 	} else if datadogScatterplotRequest.ProcessQuery != nil {
 		terraformQuery := buildTerraformProcessQuery(*datadogScatterplotRequest.ProcessQuery)
 		terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
-	} else if datadogScatterplotRequest.RumQuery != nil {
-		terraformQuery := buildTerraformApmOrLogQuery(*datadogScatterplotRequest.RumQuery)
+	} else if v, ok := datadogScatterplotRequest.GetRumQueryOk(); ok {
+		terraformQuery := buildTerraformApmOrLogQuery(*v)
 		terraformRequest["rum_query"] = []map[string]interface{}{terraformQuery}
-	} else if datadogScatterplotRequest.SecurityQuery != nil {
-		terraformQuery := buildTerraformApmOrLogQuery(*datadogScatterplotRequest.SecurityQuery)
+	} else if v, ok := datadogScatterplotRequest.GetSecurityQueryOk(); ok {
+		terraformQuery := buildTerraformApmOrLogQuery(*v)
 		terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
 	}
 
@@ -4073,11 +4073,11 @@ func buildTerraformTimeseriesRequests(datadogTimeseriesRequests *[]datadogV1.Tim
 		} else if v, ok := datadogRequest.GetProcessQueryOk(); ok {
 			terraformQuery := buildTerraformProcessQuery(*v)
 			terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
-		} else if datadogRequest.RumQuery != nil {
-			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.RumQuery)
+		} else if v, ok := datadogRequest.GetRumQueryOk(); ok {
+			terraformQuery := buildTerraformApmOrLogQuery(*v)
 			terraformRequest["rum_query"] = []map[string]interface{}{terraformQuery}
-		} else if datadogRequest.SecurityQuery != nil {
-			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.SecurityQuery)
+		} else if v, ok := datadogRequest.GetSecurityQueryOk(); ok {
+			terraformQuery := buildTerraformApmOrLogQuery(*v)
 			terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
 		}
 		if v, ok := datadogRequest.GetStyleOk(); ok {
@@ -4261,11 +4261,11 @@ func buildTerraformToplistRequests(datadogToplistRequests *[]datadogV1.ToplistWi
 		} else if v, ok := datadogRequest.GetProcessQueryOk(); ok {
 			terraformQuery := buildTerraformProcessQuery(*v)
 			terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
-		} else if datadogRequest.RumQuery != nil {
-			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.RumQuery)
+		} else if v, ok := datadogRequest.GetRumQueryOk(); ok {
+			terraformQuery := buildTerraformApmOrLogQuery(*v)
 			terraformRequest["rum_query"] = []map[string]interface{}{terraformQuery}
-		} else if datadogRequest.SecurityQuery != nil {
-			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.SecurityQuery)
+		} else if v, ok := datadogRequest.GetSecurityQueryOk(); ok {
+			terraformQuery := buildTerraformApmOrLogQuery(*v)
 			terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
 		}
 

--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -1292,10 +1292,10 @@ func getChangeRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement exactly one of the following type of query
 		"q":              getMetricQuerySchema(),
-		"apm_query":      getApmOrLogQuerySchema(),
-		"log_query":      getApmOrLogQuerySchema(),
-		"rum_query":      getApmOrLogQuerySchema(),
-		"security_query": getApmOrLogQuerySchema(),
+		"apm_query":      getApmLogNetworkRumSecurityQuerySchema(),
+		"log_query":      getApmLogNetworkRumSecurityQuerySchema(),
+		"rum_query":      getApmLogNetworkRumSecurityQuerySchema(),
+		"security_query": getApmLogNetworkRumSecurityQuerySchema(),
 		"process_query":  getProcessQuerySchema(),
 		// Settings specific to Change requests
 		"change_type": {
@@ -1517,11 +1517,11 @@ func getDistributionRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement exactly one of the following type of query
 		"q":              getMetricQuerySchema(),
-		"apm_query":      getApmOrLogQuerySchema(),
-		"log_query":      getApmOrLogQuerySchema(),
+		"apm_query":      getApmLogNetworkRumSecurityQuerySchema(),
+		"log_query":      getApmLogNetworkRumSecurityQuerySchema(),
 		"process_query":  getProcessQuerySchema(),
-		"rum_query":      getApmOrLogQuerySchema(),
-		"security_query": getApmOrLogQuerySchema(),
+		"rum_query":      getApmLogNetworkRumSecurityQuerySchema(),
+		"security_query": getApmLogNetworkRumSecurityQuerySchema(),
 		// Settings specific to Distribution requests
 		"style": {
 			Type:     schema.TypeList,
@@ -2086,11 +2086,11 @@ func getHeatmapRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement exactly one of the following type of query
 		"q":              getMetricQuerySchema(),
-		"apm_query":      getApmOrLogQuerySchema(),
-		"log_query":      getApmOrLogQuerySchema(),
+		"apm_query":      getApmLogNetworkRumSecurityQuerySchema(),
+		"log_query":      getApmLogNetworkRumSecurityQuerySchema(),
 		"process_query":  getProcessQuerySchema(),
-		"rum_query":      getApmOrLogQuerySchema(),
-		"security_query": getApmOrLogQuerySchema(),
+		"rum_query":      getApmLogNetworkRumSecurityQuerySchema(),
+		"security_query": getApmLogNetworkRumSecurityQuerySchema(),
 		// Settings specific to Heatmap requests
 		"style": {
 			Type:     schema.TypeList,
@@ -2372,11 +2372,11 @@ func getHostmapRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement at least one of the following type of query
 		"q":              getMetricQuerySchema(),
-		"apm_query":      getApmOrLogQuerySchema(),
-		"log_query":      getApmOrLogQuerySchema(),
+		"apm_query":      getApmLogNetworkRumSecurityQuerySchema(),
+		"log_query":      getApmLogNetworkRumSecurityQuerySchema(),
 		"process_query":  getProcessQuerySchema(),
-		"rum_query":      getApmOrLogQuerySchema(),
-		"security_query": getApmOrLogQuerySchema(),
+		"rum_query":      getApmLogNetworkRumSecurityQuerySchema(),
+		"security_query": getApmLogNetworkRumSecurityQuerySchema(),
 	}
 }
 func buildDatadogHostmapRequest(terraformRequest map[string]interface{}) *datadogV1.HostMapRequest {
@@ -3090,11 +3090,11 @@ func getQueryValueRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement exactly one of the following type of query
 		"q":              getMetricQuerySchema(),
-		"apm_query":      getApmOrLogQuerySchema(),
-		"log_query":      getApmOrLogQuerySchema(),
+		"apm_query":      getApmLogNetworkRumSecurityQuerySchema(),
+		"log_query":      getApmLogNetworkRumSecurityQuerySchema(),
 		"process_query":  getProcessQuerySchema(),
-		"rum_query":      getApmOrLogQuerySchema(),
-		"security_query": getApmOrLogQuerySchema(),
+		"rum_query":      getApmLogNetworkRumSecurityQuerySchema(),
+		"security_query": getApmLogNetworkRumSecurityQuerySchema(),
 		// Settings specific to QueryValue requests
 		"conditional_formats": {
 			Type:     schema.TypeList,
@@ -3258,11 +3258,11 @@ func getQueryTableRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement exactly one of the following type of query
 		"q":              getMetricQuerySchema(),
-		"apm_query":      getApmOrLogQuerySchema(),
-		"log_query":      getApmOrLogQuerySchema(),
+		"apm_query":      getApmLogNetworkRumSecurityQuerySchema(),
+		"log_query":      getApmLogNetworkRumSecurityQuerySchema(),
 		"process_query":  getProcessQuerySchema(),
-		"rum_query":      getApmOrLogQuerySchema(),
-		"security_query": getApmOrLogQuerySchema(),
+		"rum_query":      getApmLogNetworkRumSecurityQuerySchema(),
+		"security_query": getApmLogNetworkRumSecurityQuerySchema(),
 		// Settings specific to QueryTable requests
 		"conditional_formats": {
 			Type:     schema.TypeList,
@@ -3550,11 +3550,11 @@ func getScatterplotRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement exactly one of the following type of query
 		"q":              getMetricQuerySchema(),
-		"apm_query":      getApmOrLogQuerySchema(),
-		"log_query":      getApmOrLogQuerySchema(),
+		"apm_query":      getApmLogNetworkRumSecurityQuerySchema(),
+		"log_query":      getApmLogNetworkRumSecurityQuerySchema(),
 		"process_query":  getProcessQuerySchema(),
-		"rum_query":      getApmOrLogQuerySchema(),
-		"security_query": getApmOrLogQuerySchema(),
+		"rum_query":      getApmLogNetworkRumSecurityQuerySchema(),
+		"security_query": getApmLogNetworkRumSecurityQuerySchema(),
 		// Settings specific to Scatterplot requests
 		"aggregator": {
 			Type:     schema.TypeString,
@@ -3948,13 +3948,13 @@ func getTimeseriesRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement exactly one of the following type of query
 		"q":              getMetricQuerySchema(),
-		"apm_query":      getApmOrLogQuerySchema(),
-		"log_query":      getApmOrLogQuerySchema(),
+		"apm_query":      getApmLogNetworkRumSecurityQuerySchema(),
+		"log_query":      getApmLogNetworkRumSecurityQuerySchema(),
 		"rum_query":      getApmLogNetworkOrRumQuerySchema(),
 		"network_query":  getApmLogNetworkOrRumQuerySchema(),
 		"process_query":  getProcessQuerySchema(),
-		"rum_query":      getApmOrLogQuerySchema(),
-		"security_query": getApmOrLogQuerySchema(),
+		"rum_query":      getApmLogNetworkRumSecurityQuerySchema(),
+		"security_query": getApmLogNetworkRumSecurityQuerySchema(),
 		// Settings specific to Timeseries requests
 		"style": {
 			Type:     schema.TypeList,
@@ -4188,11 +4188,11 @@ func getToplistRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement exactly one of the following type of query
 		"q":              getMetricQuerySchema(),
-		"apm_query":      getApmOrLogQuerySchema(),
-		"log_query":      getApmOrLogQuerySchema(),
+		"apm_query":      getApmLogNetworkRumSecurityQuerySchema(),
+		"log_query":      getApmLogNetworkRumSecurityQuerySchema(),
 		"process_query":  getProcessQuerySchema(),
-		"rum_query":      getApmOrLogQuerySchema(),
-		"security_query": getApmOrLogQuerySchema(),
+		"rum_query":      getApmLogNetworkRumSecurityQuerySchema(),
+		"security_query": getApmLogNetworkRumSecurityQuerySchema(),
 		// Settings specific to Toplist requests
 		"conditional_formats": {
 			Type:     schema.TypeList,
@@ -4674,7 +4674,7 @@ func getMetricQuerySchema() *schema.Schema {
 }
 
 // APM, Log, Network or RUM Query
-func getApmLogNetworkOrRumQuerySchema() *schema.Schema {
+func getApmLogNetworkRumSecurityQuerySchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,

--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -3950,10 +3950,9 @@ func getTimeseriesRequestSchema() map[string]*schema.Schema {
 		"q":              getMetricQuerySchema(),
 		"apm_query":      getApmLogNetworkRumSecurityQuerySchema(),
 		"log_query":      getApmLogNetworkRumSecurityQuerySchema(),
-		"rum_query":      getApmLogNetworkOrRumQuerySchema(),
-		"network_query":  getApmLogNetworkOrRumQuerySchema(),
-		"process_query":  getProcessQuerySchema(),
 		"rum_query":      getApmLogNetworkRumSecurityQuerySchema(),
+		"network_query":  getApmLogNetworkRumSecurityQuerySchema(),
+		"process_query":  getProcessQuerySchema(),
 		"security_query": getApmLogNetworkRumSecurityQuerySchema(),
 		// Settings specific to Timeseries requests
 		"style": {

--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -1291,10 +1291,11 @@ func buildTerraformChangeDefinition(datadogDefinition datadogV1.ChangeWidgetDefi
 func getChangeRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement exactly one of the following type of query
-		"q":             getMetricQuerySchema(),
-		"apm_query":     getApmLogNetworkOrRumQuerySchema(),
-		"log_query":     getApmLogNetworkOrRumQuerySchema(),
-		"process_query": getProcessQuerySchema(),
+		"q":              getMetricQuerySchema(),
+		"apm_query":      getApmOrLogQuerySchema(),
+		"log_query":      getApmOrLogQuerySchema(),
+		"security_query": getApmOrLogQuerySchema(),
+		"process_query":  getProcessQuerySchema(),
 		// Settings specific to Change requests
 		"change_type": {
 			Type:     schema.TypeString,
@@ -1336,6 +1337,9 @@ func buildDatadogChangeRequests(terraformRequests *[]interface{}) *[]datadogV1.C
 		} else if v, ok := terraformRequest["log_query"].([]interface{}); ok && len(v) > 0 {
 			logQuery := v[0].(map[string]interface{})
 			datadogChangeRequest.LogQuery = buildDatadogApmOrLogQuery(logQuery)
+		} else if v, ok := terraformRequest["security_query"].([]interface{}); ok && len(v) > 0 {
+			securityQuery := v[0].(map[string]interface{})
+			datadogChangeRequest.SecurityQuery = buildDatadogApmOrLogQuery(securityQuery)
 		} else if v, ok := terraformRequest["process_query"].([]interface{}); ok && len(v) > 0 {
 			processQuery := v[0].(map[string]interface{})
 			datadogChangeRequest.ProcessQuery = buildDatadogProcessQuery(processQuery)
@@ -1379,6 +1383,9 @@ func buildTerraformChangeRequests(datadogChangeRequests *[]datadogV1.ChangeWidge
 		} else if v, ok := datadogRequest.GetProcessQueryOk(); ok {
 			terraformQuery := buildTerraformProcessQuery(*v)
 			terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
+		} else if datadogRequest.SecurityQuery != nil {
+			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.SecurityQuery)
+			terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
 		}
 
 		if v, ok := datadogRequest.GetChangeTypeOk(); ok {
@@ -3033,10 +3040,11 @@ func buildTerraformQueryValueDefinition(datadogDefinition datadogV1.QueryValueWi
 func getQueryValueRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement exactly one of the following type of query
-		"q":             getMetricQuerySchema(),
-		"apm_query":     getApmLogNetworkOrRumQuerySchema(),
-		"log_query":     getApmLogNetworkOrRumQuerySchema(),
-		"process_query": getProcessQuerySchema(),
+		"q":              getMetricQuerySchema(),
+		"apm_query":      getApmOrLogQuerySchema(),
+		"log_query":      getApmOrLogQuerySchema(),
+		"process_query":  getProcessQuerySchema(),
+		"security_query": getApmOrLogQuerySchema(),
 		// Settings specific to QueryValue requests
 		"conditional_formats": {
 			Type:     schema.TypeList,
@@ -3068,6 +3076,9 @@ func buildDatadogQueryValueRequests(terraformRequests *[]interface{}) *[]datadog
 		} else if v, ok := terraformRequest["process_query"].([]interface{}); ok && len(v) > 0 {
 			processQuery := v[0].(map[string]interface{})
 			datadogQueryValueRequest.ProcessQuery = buildDatadogProcessQuery(processQuery)
+		} else if v, ok := terraformRequest["security_query"].([]interface{}); ok && len(v) > 0 {
+			securityQuery := v[0].(map[string]interface{})
+			datadogQueryValueRequest.SecurityQuery = buildDatadogApmOrLogQuery(securityQuery)
 		}
 
 		if v, ok := terraformRequest["conditional_formats"].([]interface{}); ok && len(v) != 0 {
@@ -3096,6 +3107,9 @@ func buildTerraformQueryValueRequests(datadogQueryValueRequests *[]datadogV1.Que
 		} else if datadogRequest.ProcessQuery != nil {
 			terraformQuery := buildTerraformProcessQuery(*datadogRequest.ProcessQuery)
 			terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
+		} else if datadogRequest.SecurityQuery != nil {
+			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.SecurityQuery)
+			terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
 		}
 
 		if datadogRequest.ConditionalFormats != nil {
@@ -3187,10 +3201,11 @@ func buildTerraformQueryTableDefinition(datadogDefinition datadogV1.TableWidgetD
 func getQueryTableRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement exactly one of the following type of query
-		"q":             getMetricQuerySchema(),
-		"apm_query":     getApmLogNetworkOrRumQuerySchema(),
-		"log_query":     getApmLogNetworkOrRumQuerySchema(),
-		"process_query": getProcessQuerySchema(),
+		"q":              getMetricQuerySchema(),
+		"apm_query":      getApmOrLogQuerySchema(),
+		"log_query":      getApmOrLogQuerySchema(),
+		"process_query":  getProcessQuerySchema(),
+		"security_query": getApmOrLogQuerySchema(),
 		// Settings specific to QueryTable requests
 		"conditional_formats": {
 			Type:     schema.TypeList,
@@ -3234,6 +3249,9 @@ func buildDatadogQueryTableRequests(terraformRequests *[]interface{}) *[]datadog
 		} else if v, ok := terraformRequest["process_query"].([]interface{}); ok && len(v) > 0 {
 			processQuery := v[0].(map[string]interface{})
 			datadogQueryTableRequest.ProcessQuery = buildDatadogProcessQuery(processQuery)
+		} else if v, ok := terraformRequest["security_query"].([]interface{}); ok && len(v) > 0 {
+			securityQuery := v[0].(map[string]interface{})
+			datadogQueryTableRequest.SecurityQuery = buildDatadogApmOrLogQuery(securityQuery)
 		}
 
 		if v, ok := terraformRequest["conditional_formats"].([]interface{}); ok && len(v) != 0 {
@@ -3271,6 +3289,9 @@ func buildTerraformQueryTableRequests(datadogQueryTableRequests *[]datadogV1.Tab
 		} else if v, ok := datadogRequest.GetProcessQueryOk(); ok {
 			terraformQuery := buildTerraformProcessQuery(*v)
 			terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
+		} else if datadogRequest.SecurityQuery != nil {
+			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.SecurityQuery)
+			terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
 		}
 
 		if v, ok := datadogRequest.GetConditionalFormatsOk(); ok {
@@ -3849,12 +3870,13 @@ func buildTerraformTimeseriesDefinition(datadogDefinition datadogV1.TimeseriesWi
 func getTimeseriesRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement exactly one of the following type of query
-		"q":             getMetricQuerySchema(),
-		"apm_query":     getApmLogNetworkOrRumQuerySchema(),
-		"log_query":     getApmLogNetworkOrRumQuerySchema(),
+		"q":              getMetricQuerySchema(),
+		"apm_query":      getApmOrLogQuerySchema(),
+		"log_query":      getApmOrLogQuerySchema(),
 		"rum_query":     getApmLogNetworkOrRumQuerySchema(),
 		"network_query": getApmLogNetworkOrRumQuerySchema(),
-		"process_query": getProcessQuerySchema(),
+		"process_query":  getProcessQuerySchema(),
+		"security_query": getApmOrLogQuerySchema(),
 		// Settings specific to Timeseries requests
 		"style": {
 			Type:     schema.TypeList,
@@ -3919,6 +3941,9 @@ func buildDatadogTimeseriesRequests(terraformRequests *[]interface{}) *[]datadog
 		} else if v, ok := terraformRequest["rum_query"].([]interface{}); ok && len(v) > 0 {
 			rumQuery := v[0].(map[string]interface{})
 			datadogTimeseriesRequest.RumQuery = buildDatadogApmOrLogQuery(rumQuery)
+		} else if v, ok := terraformRequest["security_query"].([]interface{}); ok && len(v) > 0 {
+			securityQuery := v[0].(map[string]interface{})
+			datadogTimeseriesRequest.SecurityQuery = buildDatadogApmOrLogQuery(securityQuery)
 		} else if v, ok := terraformRequest["process_query"].([]interface{}); ok && len(v) > 0 {
 			processQuery := v[0].(map[string]interface{})
 			datadogTimeseriesRequest.ProcessQuery = buildDatadogProcessQuery(processQuery)
@@ -3971,6 +3996,9 @@ func buildTerraformTimeseriesRequests(datadogTimeseriesRequests *[]datadogV1.Tim
 		} else if v, ok := datadogRequest.GetProcessQueryOk(); ok {
 			terraformQuery := buildTerraformProcessQuery(*v)
 			terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
+		} else if datadogRequest.SecurityQuery != nil {
+			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.SecurityQuery)
+			terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
 		}
 		if v, ok := datadogRequest.GetStyleOk(); ok {
 			style := buildTerraformWidgetRequestStyle(*v)
@@ -4078,10 +4106,11 @@ func buildTerraformToplistDefinition(datadogDefinition datadogV1.ToplistWidgetDe
 func getToplistRequestSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		// A request should implement exactly one of the following type of query
-		"q":             getMetricQuerySchema(),
-		"apm_query":     getApmLogNetworkOrRumQuerySchema(),
-		"log_query":     getApmLogNetworkOrRumQuerySchema(),
-		"process_query": getProcessQuerySchema(),
+		"q":              getMetricQuerySchema(),
+		"apm_query":      getApmOrLogQuerySchema(),
+		"log_query":      getApmOrLogQuerySchema(),
+		"process_query":  getProcessQuerySchema(),
+		"security_query": getApmOrLogQuerySchema(),
 		// Settings specific to Toplist requests
 		"conditional_formats": {
 			Type:     schema.TypeList,
@@ -4117,6 +4146,9 @@ func buildDatadogToplistRequests(terraformRequests *[]interface{}) *[]datadogV1.
 		} else if v, ok := terraformRequest["process_query"].([]interface{}); ok && len(v) > 0 {
 			processQuery := v[0].(map[string]interface{})
 			datadogToplistRequest.ProcessQuery = buildDatadogProcessQuery(processQuery)
+		} else if v, ok := terraformRequest["security_query"].([]interface{}); ok && len(v) > 0 {
+			securityQuery := v[0].(map[string]interface{})
+			datadogToplistRequest.SecurityQuery = buildDatadogApmOrLogQuery(securityQuery)
 		}
 		if v, ok := terraformRequest["conditional_formats"].([]interface{}); ok && len(v) != 0 {
 			datadogToplistRequest.ConditionalFormats = buildDatadogWidgetConditionalFormat(&v)
@@ -4145,6 +4177,9 @@ func buildTerraformToplistRequests(datadogToplistRequests *[]datadogV1.ToplistWi
 		} else if v, ok := datadogRequest.GetProcessQueryOk(); ok {
 			terraformQuery := buildTerraformProcessQuery(*v)
 			terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
+		} else if datadogRequest.SecurityQuery != nil {
+			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.SecurityQuery)
+			terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
 		}
 
 		if v, ok := datadogRequest.GetConditionalFormatsOk(); ok {

--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -1294,6 +1294,7 @@ func getChangeRequestSchema() map[string]*schema.Schema {
 		"q":              getMetricQuerySchema(),
 		"apm_query":      getApmOrLogQuerySchema(),
 		"log_query":      getApmOrLogQuerySchema(),
+		"rum_query":      getApmOrLogQuerySchema(),
 		"security_query": getApmOrLogQuerySchema(),
 		"process_query":  getProcessQuerySchema(),
 		// Settings specific to Change requests
@@ -1337,6 +1338,9 @@ func buildDatadogChangeRequests(terraformRequests *[]interface{}) *[]datadogV1.C
 		} else if v, ok := terraformRequest["log_query"].([]interface{}); ok && len(v) > 0 {
 			logQuery := v[0].(map[string]interface{})
 			datadogChangeRequest.LogQuery = buildDatadogApmOrLogQuery(logQuery)
+		} else if v, ok := terraformRequest["rum_query"].([]interface{}); ok && len(v) > 0 {
+			rumQuery := v[0].(map[string]interface{})
+			datadogChangeRequest.RumQuery = buildDatadogApmOrLogQuery(rumQuery)
 		} else if v, ok := terraformRequest["security_query"].([]interface{}); ok && len(v) > 0 {
 			securityQuery := v[0].(map[string]interface{})
 			datadogChangeRequest.SecurityQuery = buildDatadogApmOrLogQuery(securityQuery)
@@ -1383,6 +1387,9 @@ func buildTerraformChangeRequests(datadogChangeRequests *[]datadogV1.ChangeWidge
 		} else if v, ok := datadogRequest.GetProcessQueryOk(); ok {
 			terraformQuery := buildTerraformProcessQuery(*v)
 			terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
+		} else if datadogRequest.RumQuery != nil {
+			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.RumQuery)
+			terraformRequest["rum_query"] = []map[string]interface{}{terraformQuery}
 		} else if datadogRequest.SecurityQuery != nil {
 			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.SecurityQuery)
 			terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
@@ -3044,6 +3051,7 @@ func getQueryValueRequestSchema() map[string]*schema.Schema {
 		"apm_query":      getApmOrLogQuerySchema(),
 		"log_query":      getApmOrLogQuerySchema(),
 		"process_query":  getProcessQuerySchema(),
+		"rum_query":      getApmOrLogQuerySchema(),
 		"security_query": getApmOrLogQuerySchema(),
 		// Settings specific to QueryValue requests
 		"conditional_formats": {
@@ -3076,6 +3084,9 @@ func buildDatadogQueryValueRequests(terraformRequests *[]interface{}) *[]datadog
 		} else if v, ok := terraformRequest["process_query"].([]interface{}); ok && len(v) > 0 {
 			processQuery := v[0].(map[string]interface{})
 			datadogQueryValueRequest.ProcessQuery = buildDatadogProcessQuery(processQuery)
+		} else if v, ok := terraformRequest["rum_query"].([]interface{}); ok && len(v) > 0 {
+			rumQuery := v[0].(map[string]interface{})
+			datadogQueryValueRequest.RumQuery = buildDatadogApmOrLogQuery(rumQuery)
 		} else if v, ok := terraformRequest["security_query"].([]interface{}); ok && len(v) > 0 {
 			securityQuery := v[0].(map[string]interface{})
 			datadogQueryValueRequest.SecurityQuery = buildDatadogApmOrLogQuery(securityQuery)
@@ -3107,6 +3118,9 @@ func buildTerraformQueryValueRequests(datadogQueryValueRequests *[]datadogV1.Que
 		} else if datadogRequest.ProcessQuery != nil {
 			terraformQuery := buildTerraformProcessQuery(*datadogRequest.ProcessQuery)
 			terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
+		} else if datadogRequest.RumQuery != nil {
+			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.RumQuery)
+			terraformRequest["rum_query"] = []map[string]interface{}{terraformQuery}
 		} else if datadogRequest.SecurityQuery != nil {
 			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.SecurityQuery)
 			terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
@@ -3205,6 +3219,7 @@ func getQueryTableRequestSchema() map[string]*schema.Schema {
 		"apm_query":      getApmOrLogQuerySchema(),
 		"log_query":      getApmOrLogQuerySchema(),
 		"process_query":  getProcessQuerySchema(),
+		"rum_query":      getApmOrLogQuerySchema(),
 		"security_query": getApmOrLogQuerySchema(),
 		// Settings specific to QueryTable requests
 		"conditional_formats": {
@@ -3249,6 +3264,9 @@ func buildDatadogQueryTableRequests(terraformRequests *[]interface{}) *[]datadog
 		} else if v, ok := terraformRequest["process_query"].([]interface{}); ok && len(v) > 0 {
 			processQuery := v[0].(map[string]interface{})
 			datadogQueryTableRequest.ProcessQuery = buildDatadogProcessQuery(processQuery)
+		} else if v, ok := terraformRequest["rum_query"].([]interface{}); ok && len(v) > 0 {
+			rumQuery := v[0].(map[string]interface{})
+			datadogQueryTableRequest.RumQuery = buildDatadogApmOrLogQuery(rumQuery)
 		} else if v, ok := terraformRequest["security_query"].([]interface{}); ok && len(v) > 0 {
 			securityQuery := v[0].(map[string]interface{})
 			datadogQueryTableRequest.SecurityQuery = buildDatadogApmOrLogQuery(securityQuery)
@@ -3289,6 +3307,9 @@ func buildTerraformQueryTableRequests(datadogQueryTableRequests *[]datadogV1.Tab
 		} else if v, ok := datadogRequest.GetProcessQueryOk(); ok {
 			terraformQuery := buildTerraformProcessQuery(*v)
 			terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
+		} else if datadogRequest.RumQuery != nil {
+			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.RumQuery)
+			terraformRequest["rum_query"] = []map[string]interface{}{terraformQuery}
 		} else if datadogRequest.SecurityQuery != nil {
 			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.SecurityQuery)
 			terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
@@ -3876,6 +3897,7 @@ func getTimeseriesRequestSchema() map[string]*schema.Schema {
 		"rum_query":     getApmLogNetworkOrRumQuerySchema(),
 		"network_query": getApmLogNetworkOrRumQuerySchema(),
 		"process_query":  getProcessQuerySchema(),
+		"rum_query":      getApmOrLogQuerySchema(),
 		"security_query": getApmOrLogQuerySchema(),
 		// Settings specific to Timeseries requests
 		"style": {
@@ -3996,6 +4018,9 @@ func buildTerraformTimeseriesRequests(datadogTimeseriesRequests *[]datadogV1.Tim
 		} else if v, ok := datadogRequest.GetProcessQueryOk(); ok {
 			terraformQuery := buildTerraformProcessQuery(*v)
 			terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
+		} else if datadogRequest.RumQuery != nil {
+			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.RumQuery)
+			terraformRequest["rum_query"] = []map[string]interface{}{terraformQuery}
 		} else if datadogRequest.SecurityQuery != nil {
 			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.SecurityQuery)
 			terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}
@@ -4110,6 +4135,7 @@ func getToplistRequestSchema() map[string]*schema.Schema {
 		"apm_query":      getApmOrLogQuerySchema(),
 		"log_query":      getApmOrLogQuerySchema(),
 		"process_query":  getProcessQuerySchema(),
+		"rum_query":      getApmOrLogQuerySchema(),
 		"security_query": getApmOrLogQuerySchema(),
 		// Settings specific to Toplist requests
 		"conditional_formats": {
@@ -4146,6 +4172,9 @@ func buildDatadogToplistRequests(terraformRequests *[]interface{}) *[]datadogV1.
 		} else if v, ok := terraformRequest["process_query"].([]interface{}); ok && len(v) > 0 {
 			processQuery := v[0].(map[string]interface{})
 			datadogToplistRequest.ProcessQuery = buildDatadogProcessQuery(processQuery)
+		} else if v, ok := terraformRequest["rum_query"].([]interface{}); ok && len(v) > 0 {
+			rumQuery := v[0].(map[string]interface{})
+			datadogChangeRequest.RumQuery = buildDatadogApmOrLogQuery(rumQuery)
 		} else if v, ok := terraformRequest["security_query"].([]interface{}); ok && len(v) > 0 {
 			securityQuery := v[0].(map[string]interface{})
 			datadogToplistRequest.SecurityQuery = buildDatadogApmOrLogQuery(securityQuery)
@@ -4177,6 +4206,9 @@ func buildTerraformToplistRequests(datadogToplistRequests *[]datadogV1.ToplistWi
 		} else if v, ok := datadogRequest.GetProcessQueryOk(); ok {
 			terraformQuery := buildTerraformProcessQuery(*v)
 			terraformRequest["process_query"] = []map[string]interface{}{terraformQuery}
+		} else if datadogRequest.RumQuery != nil {
+			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.RumQuery)
+			terraformRequest["rum_query"] = []map[string]interface{}{terraformQuery}
 		} else if datadogRequest.SecurityQuery != nil {
 			terraformQuery := buildTerraformApmOrLogQuery(*datadogRequest.SecurityQuery)
 			terraformRequest["security_query"] = []map[string]interface{}{terraformQuery}

--- a/datadog/resource_datadog_dashboard_test.go
+++ b/datadog/resource_datadog_dashboard_test.go
@@ -12,10 +12,10 @@ import (
 
 const datadogOrderedDashboardConfig = `
 resource "datadog_dashboard" "ordered_dashboard" {
-  title         = "Acceptance Test Ordered Dashboard"
-  description   = "Created using the Datadog provider in Terraform"
-  layout_type   = "ordered"
-  is_read_only  = true
+	title         = "Acceptance Test Ordered Dashboard"
+	description   = "Created using the Datadog provider in Terraform"
+	layout_type   = "ordered"
+	is_read_only  = true
 	widget {
 		alert_graph_definition {
 			alert_id = "895605"
@@ -135,28 +135,28 @@ resource "datadog_dashboard" "ordered_dashboard" {
 	}
 	widget {
 		query_value_definition {
-		  request {
-			q = "avg:system.load.1{env:staging} by {account}"
-			aggregator = "sum"
-			conditional_formats {
-				comparator = "<"
-				value = "2"
-				palette = "white_on_green"
+			request {
+				q = "avg:system.load.1{env:staging} by {account}"
+				aggregator = "sum"
+				conditional_formats {
+					comparator = "<"
+					value = "2"
+					palette = "white_on_green"
+				}
+				conditional_formats {
+					comparator = ">"
+					value = "2.2"
+					palette = "white_on_red"
+				}
 			}
-			conditional_formats {
-				comparator = ">"
-				value = "2.2"
-				palette = "white_on_red"
+			autoscale = true
+			custom_unit = "xx"
+			precision = "4"
+			text_align = "right"
+			title = "Widget Title"
+			time = {
+				live_span = "1h"
 			}
-		  }
-		  autoscale = true
-		  custom_unit = "xx"
-		  precision = "4"
-		  text_align = "right"
-		  title = "Widget Title"
-		  time = {
-			live_span = "1h"
-		  }
 		}
 	}
 	widget {
@@ -262,6 +262,36 @@ resource "datadog_dashboard" "ordered_dashboard" {
 				}
 				display_type = "area"
 			}
+			request {
+				security_query {
+					index = "signal"
+					compute = {
+						aggregation = "count"
+					}
+					search = {
+						query = "status:(high OR critical)"
+					}
+					group_by {
+						facet = "status"
+					}
+				}
+				display_type = "bars"
+			}
+			request {
+				rum_query {
+					index = "rum"
+					compute = {
+						aggregation = "count"
+					}
+					search = {
+						query = "status:info"
+					}
+					group_by {
+						facet = "service"
+					}
+				}
+				display_type = "bars"
+			}
 			marker {
 				display_type = "error dashed"
 				label = " z=6 "
@@ -288,7 +318,7 @@ resource "datadog_dashboard" "ordered_dashboard" {
 				scale = "log"
 				include_zero = false
 				max = 100
-			  }
+			}
 		}
 	}
 	widget {
@@ -305,7 +335,7 @@ resource "datadog_dashboard" "ordered_dashboard" {
 					value = "2.2"
 					palette = "white_on_red"
 				}
-		  	}
+			}
 			title = "Widget Title"
 		}
 	}
@@ -349,25 +379,25 @@ resource "datadog_dashboard" "ordered_dashboard" {
 	}
 	widget {
 		query_table_definition {
-		  request {
-			q = "avg:system.load.1{env:staging} by {account}"
-			aggregator = "sum"
-			limit = "10"
-			conditional_formats {
-				comparator = "<"
-				value = "2"
-				palette = "white_on_green"
+			request {
+				q = "avg:system.load.1{env:staging} by {account}"
+				aggregator = "sum"
+				limit = "10"
+				conditional_formats {
+					comparator = "<"
+					value = "2"
+					palette = "white_on_green"
+				}
+				conditional_formats {
+					comparator = ">"
+					value = "2.2"
+					palette = "white_on_red"
+				}
 			}
-			conditional_formats {
-				comparator = ">"
-				value = "2.2"
-				palette = "white_on_red"
+			title = "Widget Title"
+			time = {
+				live_span = "1h"
 			}
-		  }
-		  title = "Widget Title"
-		  time = {
-		    live_span = "1h"
-		  }
 		}
 	}
 	template_variable {
@@ -409,7 +439,7 @@ resource "datadog_dashboard" "free_dashboard" {
 	description   = "Created using the Datadog provider in Terraform"
 	layout_type   = "free"
 	is_read_only  = false
-  	widget {
+	widget {
 		event_stream_definition {
 			query = "*"
 			event_size = "l"
@@ -426,7 +456,7 @@ resource "datadog_dashboard" "free_dashboard" {
 			x = 5
 			y = 5
 		}
-  	}
+	}
 	widget {
 		event_timeline_definition {
 			query = "*"
@@ -491,7 +521,7 @@ resource "datadog_dashboard" "free_dashboard" {
 			show_message_column = true
 			message_display = "expanded-md"
 			sort {
-				column = "time" 
+				column = "time"
 				order = "desc"
 			}
 		}
@@ -733,6 +763,16 @@ var datadogOrderedDashboardAsserts = []string{
 	"widget.10.timeseries_definition.0.request.3.process_query.0.filter_by.0 = active",
 	"widget.10.timeseries_definition.0.request.3.process_query.0.limit = 50",
 	"widget.10.timeseries_definition.0.request.3.display_type = area",
+	"widget.10.timeseries_definition.0.request.4.security_query.0.index = signal",
+	"widget.10.timeseries_definition.0.request.4.security_query.0.compute.aggregation = count",
+	"widget.10.timeseries_definition.0.request.4.security_query.0.search.query = status:(high OR critical)",
+	"widget.10.timeseries_definition.0.request.4.security_query.0.group_by.0.facet = status",
+	"widget.10.timeseries_definition.0.request.4.display_type = bars",
+	"widget.10.timeseries_definition.0.request.5.rum_query.0.index = rum",
+	"widget.10.timeseries_definition.0.request.5.rum_query.0.compute.aggregation = count",
+	"widget.10.timeseries_definition.0.request.5.rum_query.0.search.query = status:info",
+	"widget.10.timeseries_definition.0.request.5.rum_query.0.group_by.0.facet = service",
+	"widget.10.timeseries_definition.0.request.5.display_type = bars",
 	"widget.10.timeseries_definition.0.marker.# = 2",
 	"widget.10.timeseries_definition.0.marker.0.display_type = error dashed",
 	"widget.10.timeseries_definition.0.marker.0.label =  z=6 ",

--- a/datadog/resource_datadog_timeboard.go
+++ b/datadog/resource_datadog_timeboard.go
@@ -134,9 +134,10 @@ func resourceDatadogTimeboard() *schema.Resource {
 					Type:     schema.TypeString,
 					Optional: true,
 				},
-				"log_query":     apmOrLogQuery,
-				"apm_query":     apmOrLogQuery,
-				"process_query": processQuery,
+				"log_query":      apmOrLogQuery,
+				"apm_query":      apmOrLogQuery,
+				"process_query":  processQuery,
+				"security_query": apmOrLogQuery,
 				"stacked": {
 					Type:     schema.TypeBool,
 					Optional: true,
@@ -590,6 +591,9 @@ func appendRequests(datadogGraph *datadog.Graph, terraformRequests *[]interface{
 		} else if v, ok := t["process_query"].([]interface{}); ok && len(v) > 0 {
 			processQuery := v[0].(map[string]interface{})
 			d.ProcessQuery = buildDatadogGraphProcessQuery(processQuery)
+		} else if v, ok := t["security_query"].([]interface{}); ok && len(v) > 0 {
+			securityQuery := v[0].(map[string]interface{})
+			d.SecurityQuery = buildDatadogGraphApmOrLogQuery(securityQuery)
 		}
 
 		if stacked, ok := t["stacked"]; ok {
@@ -938,6 +942,9 @@ func appendTerraformGraphRequests(datadogRequests []datadog.GraphDefinitionReque
 		} else if datadogRequest.ProcessQuery != nil {
 			terraformQuery := buildTFGraphProcessQuery(*datadogRequest.ProcessQuery)
 			request["process_query"] = []map[string]interface{}{terraformQuery}
+		} else if datadogRequest.SecurityQuery != nil {
+			terraformQuery := buildTFGraphApmOrLogQuery(*datadogRequest.SecurityQuery)
+			request["security_query"] = []map[string]interface{}{terraformQuery}
 		}
 		if v, ok := datadogRequest.GetStackedOk(); ok {
 			request["stacked"] = v

--- a/datadog/resource_datadog_timeboard.go
+++ b/datadog/resource_datadog_timeboard.go
@@ -134,11 +134,9 @@ func resourceDatadogTimeboard() *schema.Resource {
 					Type:     schema.TypeString,
 					Optional: true,
 				},
-				"log_query":      apmOrLogQuery,
-				"apm_query":      apmOrLogQuery,
-				"process_query":  processQuery,
-				"rum_query":      apmOrLogQuery,
-				"security_query": apmOrLogQuery,
+				"log_query":     apmOrLogQuery,
+				"apm_query":     apmOrLogQuery,
+				"process_query": processQuery,
 				"stacked": {
 					Type:     schema.TypeBool,
 					Optional: true,
@@ -592,12 +590,6 @@ func appendRequests(datadogGraph *datadog.Graph, terraformRequests *[]interface{
 		} else if v, ok := t["process_query"].([]interface{}); ok && len(v) > 0 {
 			processQuery := v[0].(map[string]interface{})
 			d.ProcessQuery = buildDatadogGraphProcessQuery(processQuery)
-		} else if v, ok := t["rum_query"].([]interface{}); ok && len(v) > 0 {
-			rumQuery := v[0].(map[string]interface{})
-			d.RumQuery = buildDatadogGraphApmOrLogQuery(rumQuery)
-		} else if v, ok := t["security_query"].([]interface{}); ok && len(v) > 0 {
-			securityQuery := v[0].(map[string]interface{})
-			d.SecurityQuery = buildDatadogGraphApmOrLogQuery(securityQuery)
 		}
 
 		if stacked, ok := t["stacked"]; ok {
@@ -946,12 +938,6 @@ func appendTerraformGraphRequests(datadogRequests []datadog.GraphDefinitionReque
 		} else if datadogRequest.ProcessQuery != nil {
 			terraformQuery := buildTFGraphProcessQuery(*datadogRequest.ProcessQuery)
 			request["process_query"] = []map[string]interface{}{terraformQuery}
-		} else if datadogRequest.RumQuery != nil {
-			terraformQuery := buildTFGraphApmOrLogQuery(*datadogRequest.RumQuery)
-			request["rum_query"] = []map[string]interface{}{terraformQuery}
-		} else if datadogRequest.SecurityQuery != nil {
-			terraformQuery := buildTFGraphApmOrLogQuery(*datadogRequest.SecurityQuery)
-			request["security_query"] = []map[string]interface{}{terraformQuery}
 		}
 		if v, ok := datadogRequest.GetStackedOk(); ok {
 			request["stacked"] = v

--- a/datadog/resource_datadog_timeboard.go
+++ b/datadog/resource_datadog_timeboard.go
@@ -137,6 +137,7 @@ func resourceDatadogTimeboard() *schema.Resource {
 				"log_query":      apmOrLogQuery,
 				"apm_query":      apmOrLogQuery,
 				"process_query":  processQuery,
+				"rum_query":      apmOrLogQuery,
 				"security_query": apmOrLogQuery,
 				"stacked": {
 					Type:     schema.TypeBool,
@@ -591,6 +592,9 @@ func appendRequests(datadogGraph *datadog.Graph, terraformRequests *[]interface{
 		} else if v, ok := t["process_query"].([]interface{}); ok && len(v) > 0 {
 			processQuery := v[0].(map[string]interface{})
 			d.ProcessQuery = buildDatadogGraphProcessQuery(processQuery)
+		} else if v, ok := t["rum_query"].([]interface{}); ok && len(v) > 0 {
+			rumQuery := v[0].(map[string]interface{})
+			d.RumQuery = buildDatadogGraphApmOrLogQuery(rumQuery)
 		} else if v, ok := t["security_query"].([]interface{}); ok && len(v) > 0 {
 			securityQuery := v[0].(map[string]interface{})
 			d.SecurityQuery = buildDatadogGraphApmOrLogQuery(securityQuery)
@@ -942,6 +946,9 @@ func appendTerraformGraphRequests(datadogRequests []datadog.GraphDefinitionReque
 		} else if datadogRequest.ProcessQuery != nil {
 			terraformQuery := buildTFGraphProcessQuery(*datadogRequest.ProcessQuery)
 			request["process_query"] = []map[string]interface{}{terraformQuery}
+		} else if datadogRequest.RumQuery != nil {
+			terraformQuery := buildTFGraphApmOrLogQuery(*datadogRequest.RumQuery)
+			request["rum_query"] = []map[string]interface{}{terraformQuery}
 		} else if datadogRequest.SecurityQuery != nil {
 			terraformQuery := buildTFGraphApmOrLogQuery(*datadogRequest.SecurityQuery)
 			request["security_query"] = []map[string]interface{}{terraformQuery}

--- a/datadog/resource_datadog_timeboard_test.go
+++ b/datadog/resource_datadog_timeboard_test.go
@@ -212,36 +212,6 @@ resource "datadog_timeboard" "acceptance_test" {
       }
       type = "area"
     }
-    request {
-      security_query {
-        index = "signal"
-        compute {
-          aggregation = "count"
-        }
-        search {
-          query = "status:(high OR critical)"
-        }
-        group_by {
-          facet = "status"
-        }
-      }
-      type = "bars"
-    }
-    request {
-      rum_query {
-        index = "rum"
-        compute {
-          aggregation = "count"
-        }
-        search {
-          query = "status:info"
-        }
-        group_by {
-          facet = "service"
-        }
-      }
-      type = "bars"
-    }
   }
 }
 `
@@ -373,16 +343,6 @@ func TestAccDatadogTimeboard_update(t *testing.T) {
 			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.3.process_query.0.filter_by.#", "1"),
 			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.3.process_query.0.filter_by.0", "active"),
 			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.3.process_query.0.limit", "50"),
-			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.4.security_query.0.index", "signal"),
-			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.4.security_query.0.compute.0.aggregation", "count"),
-			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.4.security_query.0.search.0.query", "status:(high OR critical)"),
-			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.4.security_query.0.group_by.0.facet", "status"),
-			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.4.type", "bars"),
-			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.5.rum_query.0.index", "rum"),
-			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.5.rum_query.0.compute.0.aggregation", "count"),
-			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.5.rum_query.0.search.0.query", "status:info"),
-			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.5.rum_query.0.group_by.0.facet", "service"),
-			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.5.type", "bars"),
 		),
 	}
 

--- a/datadog/resource_datadog_timeboard_test.go
+++ b/datadog/resource_datadog_timeboard_test.go
@@ -212,6 +212,36 @@ resource "datadog_timeboard" "acceptance_test" {
       }
       type = "area"
     }
+    request {
+      security_query {
+        index = "signal"
+        compute {
+          aggregation = "count"
+        }
+        search {
+          query = "status:(high OR critical)"
+        }
+        group_by {
+          facet = "status"
+        }
+      }
+      type = "bars"
+    }
+    request {
+      rum_query {
+        index = "rum"
+        compute {
+          aggregation = "count"
+        }
+        search {
+          query = "status:info"
+        }
+        group_by {
+          facet = "service"
+        }
+      }
+      type = "bars"
+    }
   }
 }
 `
@@ -343,6 +373,16 @@ func TestAccDatadogTimeboard_update(t *testing.T) {
 			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.3.process_query.0.filter_by.#", "1"),
 			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.3.process_query.0.filter_by.0", "active"),
 			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.3.process_query.0.limit", "50"),
+			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.4.security_query.0.index", "signal"),
+			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.4.security_query.0.compute.0.aggregation", "count"),
+			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.4.security_query.0.search.0.query", "status:(high OR critical)"),
+			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.4.security_query.0.group_by.0.facet", "status"),
+			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.4.type", "bars"),
+			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.5.rum_query.0.index", "rum"),
+			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.5.rum_query.0.compute.0.aggregation", "count"),
+			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.5.rum_query.0.search.0.query", "status:info"),
+			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.5.rum_query.0.group_by.0.facet", "service"),
+			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.request.5.type", "bars"),
 		),
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/terraform-providers/terraform-provider-datadog
 
 require (
 	4d63.com/tz v1.1.0
-	github.com/DataDog/datadog-api-client-go v1.0.0-beta.7.0.20200724115206-de170dad4ec5
+	github.com/DataDog/datadog-api-client-go v1.0.0-beta.7.0.20200724163653-3a86da699532
 	github.com/cenkalti/backoff v2.1.1+incompatible // indirect
 	github.com/dnaeon/go-vcr v1.0.1
 	github.com/hashicorp/go-cleanhttp v0.5.1

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/terraform-providers/terraform-provider-datadog
 
 require (
 	4d63.com/tz v1.1.0
-	github.com/DataDog/datadog-api-client-go v1.0.0-beta.7
+	github.com/DataDog/datadog-api-client-go v1.0.0-beta.7.0.20200724115206-de170dad4ec5
 	github.com/cenkalti/backoff v2.1.1+incompatible // indirect
 	github.com/dnaeon/go-vcr v1.0.1
 	github.com/hashicorp/go-cleanhttp v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbf
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DataDog/datadog-api-client-go v1.0.0-beta.7 h1:GGF2JsBg6MTu5nRLKF2NKrxgQl9g0SGjR6Wo7Z5yRwI=
-github.com/DataDog/datadog-api-client-go v1.0.0-beta.7/go.mod h1:RQvzywj9rwl11tiGxX84pe3hZlU9f3Wd/8435jr7M3s=
+github.com/DataDog/datadog-api-client-go v1.0.0-beta.7.0.20200724115206-de170dad4ec5 h1:Tix8DdN9j/XPAKtMuGhgvkFk4xOZa5vxswso0Xi2Xvc=
+github.com/DataDog/datadog-api-client-go v1.0.0-beta.7.0.20200724115206-de170dad4ec5/go.mod h1:RQvzywj9rwl11tiGxX84pe3hZlU9f3Wd/8435jr7M3s=
 github.com/DataDog/datadog-go v3.6.0+incompatible h1:ILg7c5Y1KvZFDOaVS0higGmJ5Fal5O1KQrkrT9j6dSM=
 github.com/DataDog/datadog-go v3.6.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbf
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DataDog/datadog-api-client-go v1.0.0-beta.7.0.20200724115206-de170dad4ec5 h1:Tix8DdN9j/XPAKtMuGhgvkFk4xOZa5vxswso0Xi2Xvc=
-github.com/DataDog/datadog-api-client-go v1.0.0-beta.7.0.20200724115206-de170dad4ec5/go.mod h1:RQvzywj9rwl11tiGxX84pe3hZlU9f3Wd/8435jr7M3s=
+github.com/DataDog/datadog-api-client-go v1.0.0-beta.7.0.20200724163653-3a86da699532 h1:rJmsPbfmLznuLPtZRM2VzCePG9K9ab9clVVL2w9NXuM=
+github.com/DataDog/datadog-api-client-go v1.0.0-beta.7.0.20200724163653-3a86da699532/go.mod h1:RQvzywj9rwl11tiGxX84pe3hZlU9f3Wd/8435jr7M3s=
 github.com/DataDog/datadog-go v3.6.0+incompatible h1:ILg7c5Y1KvZFDOaVS0higGmJ5Fal5O1KQrkrT9j6dSM=
 github.com/DataDog/datadog-go v3.6.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/vendor/github.com/DataDog/datadog-api-client-go/.apigentools-info
+++ b/vendor/github.com/DataDog/datadog-api-client-go/.apigentools-info
@@ -4,13 +4,13 @@
     "spec_versions": {
         "v1": {
             "apigentools_version": "1.2.0",
-            "regenerated": "2020-07-23 12:04:18.350338",
-            "spec_repo_commit": "37e359d"
+            "regenerated": "2020-07-24 15:03:03.374180",
+            "spec_repo_commit": "1189f44"
         },
         "v2": {
             "apigentools_version": "1.2.0",
-            "regenerated": "2020-07-23 12:04:24.308927",
-            "spec_repo_commit": "37e359d"
+            "regenerated": "2020-07-24 15:03:10.936059",
+            "spec_repo_commit": "1189f44"
         }
     }
 }

--- a/vendor/github.com/DataDog/datadog-api-client-go/.apigentools-info
+++ b/vendor/github.com/DataDog/datadog-api-client-go/.apigentools-info
@@ -4,13 +4,13 @@
     "spec_versions": {
         "v1": {
             "apigentools_version": "1.2.0",
-            "regenerated": "2020-07-21 20:48:17.105796",
-            "spec_repo_commit": "e726177"
+            "regenerated": "2020-07-23 12:04:18.350338",
+            "spec_repo_commit": "37e359d"
         },
         "v2": {
             "apigentools_version": "1.2.0",
-            "regenerated": "2020-07-21 20:48:22.812696",
-            "spec_repo_commit": "e726177"
+            "regenerated": "2020-07-23 12:04:24.308927",
+            "spec_repo_commit": "37e359d"
         }
     }
 }

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_change_widget_request.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_change_widget_request.go
@@ -26,8 +26,9 @@ type ChangeWidgetRequest struct {
 	OrderDir     *WidgetSort             `json:"order_dir,omitempty"`
 	ProcessQuery *ProcessQueryDefinition `json:"process_query,omitempty"`
 	// Query definition.
-	Q        *string             `json:"q,omitempty"`
-	RumQuery *LogQueryDefinition `json:"rum_query,omitempty"`
+	Q             *string             `json:"q,omitempty"`
+	RumQuery      *LogQueryDefinition `json:"rum_query,omitempty"`
+	SecurityQuery *LogQueryDefinition `json:"security_query,omitempty"`
 	// Whether to show the present value.
 	ShowPresent *bool `json:"show_present,omitempty"`
 }
@@ -433,6 +434,38 @@ func (o *ChangeWidgetRequest) SetRumQuery(v LogQueryDefinition) {
 	o.RumQuery = &v
 }
 
+// GetSecurityQuery returns the SecurityQuery field value if set, zero value otherwise.
+func (o *ChangeWidgetRequest) GetSecurityQuery() LogQueryDefinition {
+	if o == nil || o.SecurityQuery == nil {
+		var ret LogQueryDefinition
+		return ret
+	}
+	return *o.SecurityQuery
+}
+
+// GetSecurityQueryOk returns a tuple with the SecurityQuery field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ChangeWidgetRequest) GetSecurityQueryOk() (*LogQueryDefinition, bool) {
+	if o == nil || o.SecurityQuery == nil {
+		return nil, false
+	}
+	return o.SecurityQuery, true
+}
+
+// HasSecurityQuery returns a boolean if a field has been set.
+func (o *ChangeWidgetRequest) HasSecurityQuery() bool {
+	if o != nil && o.SecurityQuery != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSecurityQuery gets a reference to the given LogQueryDefinition and assigns it to the SecurityQuery field.
+func (o *ChangeWidgetRequest) SetSecurityQuery(v LogQueryDefinition) {
+	o.SecurityQuery = &v
+}
+
 // GetShowPresent returns the ShowPresent field value if set, zero value otherwise.
 func (o *ChangeWidgetRequest) GetShowPresent() bool {
 	if o == nil || o.ShowPresent == nil {
@@ -502,6 +535,9 @@ func (o ChangeWidgetRequest) MarshalJSON() ([]byte, error) {
 	}
 	if o.RumQuery != nil {
 		toSerialize["rum_query"] = o.RumQuery
+	}
+	if o.SecurityQuery != nil {
+		toSerialize["security_query"] = o.SecurityQuery
 	}
 	if o.ShowPresent != nil {
 		toSerialize["show_present"] = o.ShowPresent

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_distribution_widget_request.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_distribution_widget_request.go
@@ -20,9 +20,10 @@ type DistributionWidgetRequest struct {
 	NetworkQuery *LogQueryDefinition     `json:"network_query,omitempty"`
 	ProcessQuery *ProcessQueryDefinition `json:"process_query,omitempty"`
 	// Widget query.
-	Q        *string             `json:"q,omitempty"`
-	RumQuery *LogQueryDefinition `json:"rum_query,omitempty"`
-	Style    *WidgetStyle        `json:"style,omitempty"`
+	Q             *string             `json:"q,omitempty"`
+	RumQuery      *LogQueryDefinition `json:"rum_query,omitempty"`
+	SecurityQuery *LogQueryDefinition `json:"security_query,omitempty"`
+	Style         *WidgetStyle        `json:"style,omitempty"`
 }
 
 // NewDistributionWidgetRequest instantiates a new DistributionWidgetRequest object
@@ -266,6 +267,38 @@ func (o *DistributionWidgetRequest) SetRumQuery(v LogQueryDefinition) {
 	o.RumQuery = &v
 }
 
+// GetSecurityQuery returns the SecurityQuery field value if set, zero value otherwise.
+func (o *DistributionWidgetRequest) GetSecurityQuery() LogQueryDefinition {
+	if o == nil || o.SecurityQuery == nil {
+		var ret LogQueryDefinition
+		return ret
+	}
+	return *o.SecurityQuery
+}
+
+// GetSecurityQueryOk returns a tuple with the SecurityQuery field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *DistributionWidgetRequest) GetSecurityQueryOk() (*LogQueryDefinition, bool) {
+	if o == nil || o.SecurityQuery == nil {
+		return nil, false
+	}
+	return o.SecurityQuery, true
+}
+
+// HasSecurityQuery returns a boolean if a field has been set.
+func (o *DistributionWidgetRequest) HasSecurityQuery() bool {
+	if o != nil && o.SecurityQuery != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSecurityQuery gets a reference to the given LogQueryDefinition and assigns it to the SecurityQuery field.
+func (o *DistributionWidgetRequest) SetSecurityQuery(v LogQueryDefinition) {
+	o.SecurityQuery = &v
+}
+
 // GetStyle returns the Style field value if set, zero value otherwise.
 func (o *DistributionWidgetRequest) GetStyle() WidgetStyle {
 	if o == nil || o.Style == nil {
@@ -320,6 +353,9 @@ func (o DistributionWidgetRequest) MarshalJSON() ([]byte, error) {
 	}
 	if o.RumQuery != nil {
 		toSerialize["rum_query"] = o.RumQuery
+	}
+	if o.SecurityQuery != nil {
+		toSerialize["security_query"] = o.SecurityQuery
 	}
 	if o.Style != nil {
 		toSerialize["style"] = o.Style

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_heat_map_widget_request.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_heat_map_widget_request.go
@@ -20,9 +20,10 @@ type HeatMapWidgetRequest struct {
 	NetworkQuery *LogQueryDefinition     `json:"network_query,omitempty"`
 	ProcessQuery *ProcessQueryDefinition `json:"process_query,omitempty"`
 	// Widget query.
-	Q        *string             `json:"q,omitempty"`
-	RumQuery *LogQueryDefinition `json:"rum_query,omitempty"`
-	Style    *WidgetStyle        `json:"style,omitempty"`
+	Q             *string             `json:"q,omitempty"`
+	RumQuery      *LogQueryDefinition `json:"rum_query,omitempty"`
+	SecurityQuery *LogQueryDefinition `json:"security_query,omitempty"`
+	Style         *WidgetStyle        `json:"style,omitempty"`
 }
 
 // NewHeatMapWidgetRequest instantiates a new HeatMapWidgetRequest object
@@ -266,6 +267,38 @@ func (o *HeatMapWidgetRequest) SetRumQuery(v LogQueryDefinition) {
 	o.RumQuery = &v
 }
 
+// GetSecurityQuery returns the SecurityQuery field value if set, zero value otherwise.
+func (o *HeatMapWidgetRequest) GetSecurityQuery() LogQueryDefinition {
+	if o == nil || o.SecurityQuery == nil {
+		var ret LogQueryDefinition
+		return ret
+	}
+	return *o.SecurityQuery
+}
+
+// GetSecurityQueryOk returns a tuple with the SecurityQuery field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *HeatMapWidgetRequest) GetSecurityQueryOk() (*LogQueryDefinition, bool) {
+	if o == nil || o.SecurityQuery == nil {
+		return nil, false
+	}
+	return o.SecurityQuery, true
+}
+
+// HasSecurityQuery returns a boolean if a field has been set.
+func (o *HeatMapWidgetRequest) HasSecurityQuery() bool {
+	if o != nil && o.SecurityQuery != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSecurityQuery gets a reference to the given LogQueryDefinition and assigns it to the SecurityQuery field.
+func (o *HeatMapWidgetRequest) SetSecurityQuery(v LogQueryDefinition) {
+	o.SecurityQuery = &v
+}
+
 // GetStyle returns the Style field value if set, zero value otherwise.
 func (o *HeatMapWidgetRequest) GetStyle() WidgetStyle {
 	if o == nil || o.Style == nil {
@@ -320,6 +353,9 @@ func (o HeatMapWidgetRequest) MarshalJSON() ([]byte, error) {
 	}
 	if o.RumQuery != nil {
 		toSerialize["rum_query"] = o.RumQuery
+	}
+	if o.SecurityQuery != nil {
+		toSerialize["security_query"] = o.SecurityQuery
 	}
 	if o.Style != nil {
 		toSerialize["style"] = o.Style

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_host_map_request.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_host_map_request.go
@@ -20,8 +20,9 @@ type HostMapRequest struct {
 	NetworkQuery *LogQueryDefinition     `json:"network_query,omitempty"`
 	ProcessQuery *ProcessQueryDefinition `json:"process_query,omitempty"`
 	// Query definition.
-	Q        *string             `json:"q,omitempty"`
-	RumQuery *LogQueryDefinition `json:"rum_query,omitempty"`
+	Q             *string             `json:"q,omitempty"`
+	RumQuery      *LogQueryDefinition `json:"rum_query,omitempty"`
+	SecurityQuery *LogQueryDefinition `json:"security_query,omitempty"`
 }
 
 // NewHostMapRequest instantiates a new HostMapRequest object
@@ -265,6 +266,38 @@ func (o *HostMapRequest) SetRumQuery(v LogQueryDefinition) {
 	o.RumQuery = &v
 }
 
+// GetSecurityQuery returns the SecurityQuery field value if set, zero value otherwise.
+func (o *HostMapRequest) GetSecurityQuery() LogQueryDefinition {
+	if o == nil || o.SecurityQuery == nil {
+		var ret LogQueryDefinition
+		return ret
+	}
+	return *o.SecurityQuery
+}
+
+// GetSecurityQueryOk returns a tuple with the SecurityQuery field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *HostMapRequest) GetSecurityQueryOk() (*LogQueryDefinition, bool) {
+	if o == nil || o.SecurityQuery == nil {
+		return nil, false
+	}
+	return o.SecurityQuery, true
+}
+
+// HasSecurityQuery returns a boolean if a field has been set.
+func (o *HostMapRequest) HasSecurityQuery() bool {
+	if o != nil && o.SecurityQuery != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSecurityQuery gets a reference to the given LogQueryDefinition and assigns it to the SecurityQuery field.
+func (o *HostMapRequest) SetSecurityQuery(v LogQueryDefinition) {
+	o.SecurityQuery = &v
+}
+
 func (o HostMapRequest) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.ApmQuery != nil {
@@ -287,6 +320,9 @@ func (o HostMapRequest) MarshalJSON() ([]byte, error) {
 	}
 	if o.RumQuery != nil {
 		toSerialize["rum_query"] = o.RumQuery
+	}
+	if o.SecurityQuery != nil {
+		toSerialize["security_query"] = o.SecurityQuery
 	}
 	return json.Marshal(toSerialize)
 }

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_monitor_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_monitor_type.go
@@ -28,6 +28,7 @@ const (
 	MONITORTYPE_SERVICE_CHECK         MonitorType = "service check"
 	MONITORTYPE_SYNTHETICS_ALERT      MonitorType = "synthetics alert"
 	MONITORTYPE_TRACE_ANALYTICS_ALERT MonitorType = "trace-analytics alert"
+	MONITORTYPE_SLO_ALERT             MonitorType = "slo alert"
 )
 
 func (v *MonitorType) UnmarshalJSON(src []byte) error {
@@ -37,7 +38,7 @@ func (v *MonitorType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := MonitorType(value)
-	for _, existing := range []MonitorType{"composite", "event alert", "log alert", "metric alert", "process alert", "query alert", "rum alert", "service check", "synthetics alert", "trace-analytics alert"} {
+	for _, existing := range []MonitorType{"composite", "event alert", "log alert", "metric alert", "process alert", "query alert", "rum alert", "service check", "synthetics alert", "trace-analytics alert", "slo alert"} {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_query_value_widget_request.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_query_value_widget_request.go
@@ -23,8 +23,9 @@ type QueryValueWidgetRequest struct {
 	NetworkQuery       *LogQueryDefinition        `json:"network_query,omitempty"`
 	ProcessQuery       *ProcessQueryDefinition    `json:"process_query,omitempty"`
 	// TODO.
-	Q        *string             `json:"q,omitempty"`
-	RumQuery *LogQueryDefinition `json:"rum_query,omitempty"`
+	Q             *string             `json:"q,omitempty"`
+	RumQuery      *LogQueryDefinition `json:"rum_query,omitempty"`
+	SecurityQuery *LogQueryDefinition `json:"security_query,omitempty"`
 }
 
 // NewQueryValueWidgetRequest instantiates a new QueryValueWidgetRequest object
@@ -332,6 +333,38 @@ func (o *QueryValueWidgetRequest) SetRumQuery(v LogQueryDefinition) {
 	o.RumQuery = &v
 }
 
+// GetSecurityQuery returns the SecurityQuery field value if set, zero value otherwise.
+func (o *QueryValueWidgetRequest) GetSecurityQuery() LogQueryDefinition {
+	if o == nil || o.SecurityQuery == nil {
+		var ret LogQueryDefinition
+		return ret
+	}
+	return *o.SecurityQuery
+}
+
+// GetSecurityQueryOk returns a tuple with the SecurityQuery field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *QueryValueWidgetRequest) GetSecurityQueryOk() (*LogQueryDefinition, bool) {
+	if o == nil || o.SecurityQuery == nil {
+		return nil, false
+	}
+	return o.SecurityQuery, true
+}
+
+// HasSecurityQuery returns a boolean if a field has been set.
+func (o *QueryValueWidgetRequest) HasSecurityQuery() bool {
+	if o != nil && o.SecurityQuery != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSecurityQuery gets a reference to the given LogQueryDefinition and assigns it to the SecurityQuery field.
+func (o *QueryValueWidgetRequest) SetSecurityQuery(v LogQueryDefinition) {
+	o.SecurityQuery = &v
+}
+
 func (o QueryValueWidgetRequest) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.Aggregator != nil {
@@ -360,6 +393,9 @@ func (o QueryValueWidgetRequest) MarshalJSON() ([]byte, error) {
 	}
 	if o.RumQuery != nil {
 		toSerialize["rum_query"] = o.RumQuery
+	}
+	if o.SecurityQuery != nil {
+		toSerialize["security_query"] = o.SecurityQuery
 	}
 	return json.Marshal(toSerialize)
 }

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_scatter_plot_request.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_scatter_plot_request.go
@@ -21,8 +21,9 @@ type ScatterPlotRequest struct {
 	NetworkQuery *LogQueryDefinition     `json:"network_query,omitempty"`
 	ProcessQuery *ProcessQueryDefinition `json:"process_query,omitempty"`
 	// Query definition.
-	Q        *string             `json:"q,omitempty"`
-	RumQuery *LogQueryDefinition `json:"rum_query,omitempty"`
+	Q             *string             `json:"q,omitempty"`
+	RumQuery      *LogQueryDefinition `json:"rum_query,omitempty"`
+	SecurityQuery *LogQueryDefinition `json:"security_query,omitempty"`
 }
 
 // NewScatterPlotRequest instantiates a new ScatterPlotRequest object
@@ -298,6 +299,38 @@ func (o *ScatterPlotRequest) SetRumQuery(v LogQueryDefinition) {
 	o.RumQuery = &v
 }
 
+// GetSecurityQuery returns the SecurityQuery field value if set, zero value otherwise.
+func (o *ScatterPlotRequest) GetSecurityQuery() LogQueryDefinition {
+	if o == nil || o.SecurityQuery == nil {
+		var ret LogQueryDefinition
+		return ret
+	}
+	return *o.SecurityQuery
+}
+
+// GetSecurityQueryOk returns a tuple with the SecurityQuery field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ScatterPlotRequest) GetSecurityQueryOk() (*LogQueryDefinition, bool) {
+	if o == nil || o.SecurityQuery == nil {
+		return nil, false
+	}
+	return o.SecurityQuery, true
+}
+
+// HasSecurityQuery returns a boolean if a field has been set.
+func (o *ScatterPlotRequest) HasSecurityQuery() bool {
+	if o != nil && o.SecurityQuery != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSecurityQuery gets a reference to the given LogQueryDefinition and assigns it to the SecurityQuery field.
+func (o *ScatterPlotRequest) SetSecurityQuery(v LogQueryDefinition) {
+	o.SecurityQuery = &v
+}
+
 func (o ScatterPlotRequest) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.Aggregator != nil {
@@ -323,6 +356,9 @@ func (o ScatterPlotRequest) MarshalJSON() ([]byte, error) {
 	}
 	if o.RumQuery != nil {
 		toSerialize["rum_query"] = o.RumQuery
+	}
+	if o.SecurityQuery != nil {
+		toSerialize["security_query"] = o.SecurityQuery
 	}
 	return json.Marshal(toSerialize)
 }

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_table_widget_request.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_table_widget_request.go
@@ -28,8 +28,9 @@ type TableWidgetRequest struct {
 	Order        *WidgetSort             `json:"order,omitempty"`
 	ProcessQuery *ProcessQueryDefinition `json:"process_query,omitempty"`
 	// Query definition.
-	Q        *string             `json:"q,omitempty"`
-	RumQuery *LogQueryDefinition `json:"rum_query,omitempty"`
+	Q             *string             `json:"q,omitempty"`
+	RumQuery      *LogQueryDefinition `json:"rum_query,omitempty"`
+	SecurityQuery *LogQueryDefinition `json:"security_query,omitempty"`
 }
 
 // NewTableWidgetRequest instantiates a new TableWidgetRequest object
@@ -433,6 +434,38 @@ func (o *TableWidgetRequest) SetRumQuery(v LogQueryDefinition) {
 	o.RumQuery = &v
 }
 
+// GetSecurityQuery returns the SecurityQuery field value if set, zero value otherwise.
+func (o *TableWidgetRequest) GetSecurityQuery() LogQueryDefinition {
+	if o == nil || o.SecurityQuery == nil {
+		var ret LogQueryDefinition
+		return ret
+	}
+	return *o.SecurityQuery
+}
+
+// GetSecurityQueryOk returns a tuple with the SecurityQuery field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TableWidgetRequest) GetSecurityQueryOk() (*LogQueryDefinition, bool) {
+	if o == nil || o.SecurityQuery == nil {
+		return nil, false
+	}
+	return o.SecurityQuery, true
+}
+
+// HasSecurityQuery returns a boolean if a field has been set.
+func (o *TableWidgetRequest) HasSecurityQuery() bool {
+	if o != nil && o.SecurityQuery != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSecurityQuery gets a reference to the given LogQueryDefinition and assigns it to the SecurityQuery field.
+func (o *TableWidgetRequest) SetSecurityQuery(v LogQueryDefinition) {
+	o.SecurityQuery = &v
+}
+
 func (o TableWidgetRequest) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.Aggregator != nil {
@@ -470,6 +503,9 @@ func (o TableWidgetRequest) MarshalJSON() ([]byte, error) {
 	}
 	if o.RumQuery != nil {
 		toSerialize["rum_query"] = o.RumQuery
+	}
+	if o.SecurityQuery != nil {
+		toSerialize["security_query"] = o.SecurityQuery
 	}
 	return json.Marshal(toSerialize)
 }

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_timeseries_widget_request.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_timeseries_widget_request.go
@@ -23,9 +23,10 @@ type TimeseriesWidgetRequest struct {
 	NetworkQuery *LogQueryDefinition                `json:"network_query,omitempty"`
 	ProcessQuery *ProcessQueryDefinition            `json:"process_query,omitempty"`
 	// Widget query.
-	Q        *string             `json:"q,omitempty"`
-	RumQuery *LogQueryDefinition `json:"rum_query,omitempty"`
-	Style    *WidgetRequestStyle `json:"style,omitempty"`
+	Q             *string             `json:"q,omitempty"`
+	RumQuery      *LogQueryDefinition `json:"rum_query,omitempty"`
+	SecurityQuery *LogQueryDefinition `json:"security_query,omitempty"`
+	Style         *WidgetRequestStyle `json:"style,omitempty"`
 }
 
 // NewTimeseriesWidgetRequest instantiates a new TimeseriesWidgetRequest object
@@ -333,6 +334,38 @@ func (o *TimeseriesWidgetRequest) SetRumQuery(v LogQueryDefinition) {
 	o.RumQuery = &v
 }
 
+// GetSecurityQuery returns the SecurityQuery field value if set, zero value otherwise.
+func (o *TimeseriesWidgetRequest) GetSecurityQuery() LogQueryDefinition {
+	if o == nil || o.SecurityQuery == nil {
+		var ret LogQueryDefinition
+		return ret
+	}
+	return *o.SecurityQuery
+}
+
+// GetSecurityQueryOk returns a tuple with the SecurityQuery field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TimeseriesWidgetRequest) GetSecurityQueryOk() (*LogQueryDefinition, bool) {
+	if o == nil || o.SecurityQuery == nil {
+		return nil, false
+	}
+	return o.SecurityQuery, true
+}
+
+// HasSecurityQuery returns a boolean if a field has been set.
+func (o *TimeseriesWidgetRequest) HasSecurityQuery() bool {
+	if o != nil && o.SecurityQuery != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSecurityQuery gets a reference to the given LogQueryDefinition and assigns it to the SecurityQuery field.
+func (o *TimeseriesWidgetRequest) SetSecurityQuery(v LogQueryDefinition) {
+	o.SecurityQuery = &v
+}
+
 // GetStyle returns the Style field value if set, zero value otherwise.
 func (o *TimeseriesWidgetRequest) GetStyle() WidgetRequestStyle {
 	if o == nil || o.Style == nil {
@@ -393,6 +426,9 @@ func (o TimeseriesWidgetRequest) MarshalJSON() ([]byte, error) {
 	}
 	if o.RumQuery != nil {
 		toSerialize["rum_query"] = o.RumQuery
+	}
+	if o.SecurityQuery != nil {
+		toSerialize["security_query"] = o.SecurityQuery
 	}
 	if o.Style != nil {
 		toSerialize["style"] = o.Style

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_toplist_widget_request.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_toplist_widget_request.go
@@ -22,9 +22,10 @@ type ToplistWidgetRequest struct {
 	NetworkQuery       *LogQueryDefinition        `json:"network_query,omitempty"`
 	ProcessQuery       *ProcessQueryDefinition    `json:"process_query,omitempty"`
 	// Widget query.
-	Q        *string             `json:"q,omitempty"`
-	RumQuery *LogQueryDefinition `json:"rum_query,omitempty"`
-	Style    *WidgetRequestStyle `json:"style,omitempty"`
+	Q             *string             `json:"q,omitempty"`
+	RumQuery      *LogQueryDefinition `json:"rum_query,omitempty"`
+	SecurityQuery *LogQueryDefinition `json:"security_query,omitempty"`
+	Style         *WidgetRequestStyle `json:"style,omitempty"`
 }
 
 // NewToplistWidgetRequest instantiates a new ToplistWidgetRequest object
@@ -300,6 +301,38 @@ func (o *ToplistWidgetRequest) SetRumQuery(v LogQueryDefinition) {
 	o.RumQuery = &v
 }
 
+// GetSecurityQuery returns the SecurityQuery field value if set, zero value otherwise.
+func (o *ToplistWidgetRequest) GetSecurityQuery() LogQueryDefinition {
+	if o == nil || o.SecurityQuery == nil {
+		var ret LogQueryDefinition
+		return ret
+	}
+	return *o.SecurityQuery
+}
+
+// GetSecurityQueryOk returns a tuple with the SecurityQuery field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ToplistWidgetRequest) GetSecurityQueryOk() (*LogQueryDefinition, bool) {
+	if o == nil || o.SecurityQuery == nil {
+		return nil, false
+	}
+	return o.SecurityQuery, true
+}
+
+// HasSecurityQuery returns a boolean if a field has been set.
+func (o *ToplistWidgetRequest) HasSecurityQuery() bool {
+	if o != nil && o.SecurityQuery != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSecurityQuery gets a reference to the given LogQueryDefinition and assigns it to the SecurityQuery field.
+func (o *ToplistWidgetRequest) SetSecurityQuery(v LogQueryDefinition) {
+	o.SecurityQuery = &v
+}
+
 // GetStyle returns the Style field value if set, zero value otherwise.
 func (o *ToplistWidgetRequest) GetStyle() WidgetRequestStyle {
 	if o == nil || o.Style == nil {
@@ -357,6 +390,9 @@ func (o ToplistWidgetRequest) MarshalJSON() ([]byte, error) {
 	}
 	if o.RumQuery != nil {
 		toSerialize["rum_query"] = o.RumQuery
+	}
+	if o.SecurityQuery != nil {
+		toSerialize["security_query"] = o.SecurityQuery
 	}
 	if o.Style != nil {
 		toSerialize["style"] = o.Style

--- a/vendor/github.com/DataDog/datadog-api-client-go/run-go-tests.sh
+++ b/vendor/github.com/DataDog/datadog-api-client-go/run-go-tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+CMD=( go test -coverpkg=$(go list ./... | grep -v /test | paste -sd "," -) -coverprofile=coverage.txt -covermode=atomic $(go list ./...) -json )
+
+if [ "$#" -ne 2 ]; then
+	"${CMD[@]}"
+else
+	if [ "$RERECORD_FAILED_TESTS" == "true" ]; then
+		RECORD=true "${CMD[@]}" $1 $2
+	else
+		"${CMD[@]}" $1 $2
+	fi
+fi

--- a/vendor/github.com/DataDog/datadog-api-client-go/run-tests.sh
+++ b/vendor/github.com/DataDog/datadog-api-client-go/run-tests.sh
@@ -21,36 +21,11 @@ fi
 # this might get solved in Go 1.14: https://github.com/golang/go/issues/30515
 cd `mktemp -d`
 GO111MODULE=on go get -u golang.org/x/lint/golint
-GO111MODULE=on go get -u gotest.tools/gotestsum@v0.4.2
+GO111MODULE=on go get -u gotest.tools/gotestsum
 cd -
 
 golint ./...
-declare -i RESULT=0
-set -o pipefail # ensure that `tee` doesn't eat up test return code
-gotestsum --debug --jsonfile gotestsum.json --format testname -- -coverpkg=$(go list ./... | grep -v /test | paste -sd "," -) -coverprofile=coverage.txt -covermode=atomic -v $(go list ./...) | tee gotestsum.out
+gotestsum --format short-verbose --rerun-fails --raw-command -- ./run-go-tests.sh
 RESULT+=$?
-set +o pipefail
-if [ "$CI" == "true" -a "$RESULT" -ne 0 ]; then
-    RESULT=0
-    FAILED_TESTS=`cat gotestsum.json | ${JQ:-jq} -s -r -c '.[] | select(.Action=="fail") | select (.Test!=null) | "\(.Package) -run ^\(.Test)$"'`
-    if [ $? -ne 0 ]; then
-        echo "Error while getting failed tests"
-        exit 1
-    fi
-    echo -e "\n============= Rerunning failed tests =============\n"
-    # NOTE: since `go test` (and `gotestsum`) don't allow specifying multiple different test cases
-    # from different test modules with `-run`, we run them one by one in form of:
-    # gotestsum <arguments> github.com/DataDog/datadog-api-client-go/tests/api/v<version>/datadog -run ^TestCaseName$
-    while read -r i ; do
-        gotestsum --format testname -- -v $i
-        RESULT+=$?
-    done <<<$FAILED_TESTS
-    # because of https://github.com/gotestyourself/gotestsum/issues/16, gotestsum doesn't tell us if there were issues
-    # with *compiling* a test module, so we do manual inspection of the output
-    cat gotestsum.out | grep -q "^=== Errors$"
-    if [ $? -eq 0 ]; then
-        RESULT+=1
-    fi
-fi
 go mod tidy
 exit $RESULT

--- a/vendor/github.com/DataDog/datadog-api-client-go/version.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/version.go
@@ -1,4 +1,4 @@
 package client
 
 // Version used in User-Agent header.
-const Version = "1.0.0-beta.7"
+const Version = "1.0.0-beta.8+dev"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ cloud.google.com/go/internal/optional
 cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 cloud.google.com/go/storage
-# github.com/DataDog/datadog-api-client-go v1.0.0-beta.7.0.20200724115206-de170dad4ec5
+# github.com/DataDog/datadog-api-client-go v1.0.0-beta.7.0.20200724163653-3a86da699532
 github.com/DataDog/datadog-api-client-go
 github.com/DataDog/datadog-api-client-go/api/v1/datadog
 github.com/DataDog/datadog-api-client-go/api/v2/datadog

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ cloud.google.com/go/internal/optional
 cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 cloud.google.com/go/storage
-# github.com/DataDog/datadog-api-client-go v1.0.0-beta.7
+# github.com/DataDog/datadog-api-client-go v1.0.0-beta.7.0.20200724115206-de170dad4ec5
 github.com/DataDog/datadog-api-client-go
 github.com/DataDog/datadog-api-client-go/api/v1/datadog
 github.com/DataDog/datadog-api-client-go/api/v2/datadog


### PR DESCRIPTION
Add security signals and RUM events as data sources for Timeseries, Query Value, Table and Top List dashboard widgets.

This PR is related to this [go api PR](https://github.com/zorkian/go-datadog-api/pull/304). It will be merged with the version bump after go api PR is merged and a new version is released.