### PR TITLE
Allow retry logic in synthetics tests

### DIFF
--- a/datadog/datadog_synthetics_test_structure.go
+++ b/datadog/datadog_synthetics_test_structure.go
@@ -1,0 +1,56 @@
+package datadog
+
+import (
+	datadog "github.com/zorkian/go-datadog-api"
+)
+
+func flattenOptions(options datadog.SyntheticsOptions) []interface{} {
+	localOptions := make(map[string]interface{})
+	if options.HasFollowRedirects() {
+		localOptions["follow_redirects"] = options.GetFollowRedirects()
+	}
+	if options.HasMinFailureDuration() {
+		localOptions["min_failure_duration"] = options.GetMinFailureDuration()
+	}
+	if options.HasMinLocationFailed() {
+		localOptions["min_location_failed"] = options.GetMinLocationFailed()
+	}
+	if options.HasTickEvery() {
+		localOptions["tick_every"] = options.GetTickEvery()
+	}
+	if options.HasAcceptSelfSigned() {
+		localOptions["accept_self_signed"] = options.GetAcceptSelfSigned()
+	}
+	if options.HasRetry() {
+		localOptions["retry"] = flattenRetry(options.GetRetry())
+	}
+	return []interface{}{localOptions}
+}
+
+func flattenRetry(r datadog.Retry) []interface{} {
+	m := make(map[string]interface{})
+	m["interval"] = r.Interval
+	m["count"] = r.Count
+	return []interface{}{m}
+}
+
+func expandOptions(m map[string]interface{}) *datadog.SyntheticsOptions {
+	d := &datadog.SyntheticsOptions{
+		TickEvery:          datadog.Int(m["tick_every"].(int)),
+		FollowRedirects:    datadog.Bool(m["follow_redirects"].(bool)),
+		MinFailureDuration: datadog.Int(m["min_failure_duration"].(int)),
+		MinLocationFailed:  datadog.Int(m["min_location_failed"].(int)),
+		AcceptSelfSigned:   datadog.Bool(m["accept_self_signed"].(bool)),
+	}
+	if v, ok := m["retry"]; ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		d.Retry = expandRetry(m["retry"].([]interface{})[0].(map[string]interface{}))
+	}
+	return d
+}
+
+func expandRetry(m map[string]interface{}) *datadog.Retry {
+	return &datadog.Retry{
+		Count:    datadog.Int(m["count"].(int)),
+		Interval: datadog.Int(m["interval"].(int)),
+	}
+}

--- a/datadog/resource_datadog_monitor_test.go
+++ b/datadog/resource_datadog_monitor_test.go
@@ -1267,7 +1267,7 @@ resource "datadog_synthetics_test" "foo" {
 
 	locations = [ "aws:eu-central-1" ]
 
-	options = {
+	options {
 		tick_every = 900
 		min_failure_duration = 10
 		min_location_failed = 1

--- a/datadog/resource_datadog_synthetics_test_migrate.go
+++ b/datadog/resource_datadog_synthetics_test_migrate.go
@@ -1,0 +1,11 @@
+package datadog
+
+import "log"
+
+func resourceDatadogSyntheticsTestStateUpgradeV0(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	log.Printf("[DEBUG] rawState before Migration: %#v", rawState)
+	options := rawState["options"].(map[string]interface{})
+	rawState["options"] = []interface{}{options}
+	log.Printf("[DEBUG] rawState after Migration: %#v", rawState)
+	return rawState, nil
+}

--- a/datadog/resource_datadog_synthetics_test_test.go
+++ b/datadog/resource_datadog_synthetics_test_test.go
@@ -216,13 +216,20 @@ func createSyntheticsAPITestStep(accProvider *schema.Provider) resource.TestStep
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.foo", "locations.0", "aws:eu-central-1"),
 			resource.TestCheckResourceAttr(
-				"datadog_synthetics_test.foo", "options.tick_every", "60"),
+				"datadog_synthetics_test.foo", "options.0.tick_every", "60"),
 			resource.TestCheckResourceAttr(
-				"datadog_synthetics_test.foo", "options.follow_redirects", "true"),
+				"datadog_synthetics_test.foo", "options.0.follow_redirects", "true"),
 			resource.TestCheckResourceAttr(
-				"datadog_synthetics_test.foo", "options.min_failure_duration", "0"),
+				"datadog_synthetics_test.foo", "options.0.min_failure_duration", "0"),
 			resource.TestCheckResourceAttr(
-				"datadog_synthetics_test.foo", "options.min_location_failed", "1"),
+				"datadog_synthetics_test.foo", "options.0.min_location_failed", "1"),
+			resource.TestCheckResourceAttr(
+				"datadog_synthetics_test.foo", "options.0.retry.#", "1"),
+			resource.TestCheckResourceAttr(
+				"datadog_synthetics_test.foo", "options.0.retry.0.interval", "10"),
+			resource.TestCheckResourceAttr(
+				"datadog_synthetics_test.foo", "options.0.retry.0.count", "1"),
+
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.foo", "name", "name for synthetics test foo"),
 			resource.TestCheckResourceAttr(
@@ -282,11 +289,15 @@ resource "datadog_synthetics_test" "foo" {
 	]
 
 	locations = [ "aws:eu-central-1" ]
-	options = {
+	options {
 		tick_every = 60
 		follow_redirects = true
 		min_failure_duration = 0
 		min_location_failed = 1
+		retry {
+			interval = 10
+			count = 1
+		}
 	}
 
 	name = "name for synthetics test foo"
@@ -325,13 +336,21 @@ func updateSyntheticsAPITestStep(accProvider *schema.Provider) resource.TestStep
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.foo", "locations.0", "aws:eu-central-1"),
 			resource.TestCheckResourceAttr(
-				"datadog_synthetics_test.foo", "options.tick_every", "900"),
+				"datadog_synthetics_test.foo", "options.#", "1"),
 			resource.TestCheckResourceAttr(
-				"datadog_synthetics_test.foo", "options.follow_redirects", "false"),
+				"datadog_synthetics_test.foo", "options.0.tick_every", "900"),
 			resource.TestCheckResourceAttr(
-				"datadog_synthetics_test.foo", "options.min_failure_duration", "10"),
+				"datadog_synthetics_test.foo", "options.0.follow_redirects", "false"),
 			resource.TestCheckResourceAttr(
-				"datadog_synthetics_test.foo", "options.min_location_failed", "1"),
+				"datadog_synthetics_test.foo", "options.0.min_failure_duration", "10"),
+			resource.TestCheckResourceAttr(
+				"datadog_synthetics_test.foo", "options.0.min_location_failed", "1"),
+			resource.TestCheckResourceAttr(
+				"datadog_synthetics_test.foo", "options.0.retry.#", "1"),
+			resource.TestCheckResourceAttr(
+				"datadog_synthetics_test.foo", "options.0.retry.0.interval", "10"),
+			resource.TestCheckResourceAttr(
+				"datadog_synthetics_test.foo", "options.0.retry.0.count", "1"),
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.foo", "name", "updated name"),
 			resource.TestCheckResourceAttr(
@@ -350,6 +369,7 @@ func updateSyntheticsAPITestStep(accProvider *schema.Provider) resource.TestStep
 				"datadog_synthetics_test.foo", "monitor_id"),
 		),
 	}
+
 }
 
 const updateSyntheticsAPITestConfig = `
@@ -373,11 +393,15 @@ resource "datadog_synthetics_test" "foo" {
 
 	locations = [ "aws:eu-central-1" ]
 
-	options = {
+	options {
 		tick_every = 900
 		follow_redirects = false
 		min_failure_duration = 10
 		min_location_failed = 1
+		retry {
+			interval = 10
+			count = 1
+		}
 	}
 
 	name = "updated name"
@@ -414,9 +438,11 @@ func createSyntheticsSSLTestStep(accProvider *schema.Provider) resource.TestStep
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.ssl", "locations.0", "aws:eu-central-1"),
 			resource.TestCheckResourceAttr(
-				"datadog_synthetics_test.ssl", "options.tick_every", "60"),
+				"datadog_synthetics_test.ssl", "options.#", "1"),
 			resource.TestCheckResourceAttr(
-				"datadog_synthetics_test.ssl", "options.accept_self_signed", "true"),
+				"datadog_synthetics_test.ssl", "options.0.tick_every", "60"),
+			resource.TestCheckResourceAttr(
+				"datadog_synthetics_test.ssl", "options.0.accept_self_signed", "true"),
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.ssl", "name", "name for synthetics test ssl"),
 			resource.TestCheckResourceAttr(
@@ -433,6 +459,7 @@ func createSyntheticsSSLTestStep(accProvider *schema.Provider) resource.TestStep
 				"datadog_synthetics_test.ssl", "monitor_id"),
 		),
 	}
+
 }
 
 const createSyntheticsSSLTestConfig = `
@@ -454,7 +481,7 @@ resource "datadog_synthetics_test" "ssl" {
 	]
 
 	locations = [ "aws:eu-central-1" ]
-	options = {
+	options {
 		tick_every = 60
 		accept_self_signed = true
 	}
@@ -493,9 +520,11 @@ func updateSyntheticsSSLTestStep(accProvider *schema.Provider) resource.TestStep
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.ssl", "locations.0", "aws:eu-central-1"),
 			resource.TestCheckResourceAttr(
-				"datadog_synthetics_test.ssl", "options.tick_every", "60"),
+				"datadog_synthetics_test.ssl", "options.#", "1"),
 			resource.TestCheckResourceAttr(
-				"datadog_synthetics_test.ssl", "options.accept_self_signed", "false"),
+				"datadog_synthetics_test.ssl", "options.0.tick_every", "60"),
+			resource.TestCheckResourceAttr(
+				"datadog_synthetics_test.ssl", "options.0.accept_self_signed", "false"),
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.ssl", "name", "updated name"),
 			resource.TestCheckResourceAttr(
@@ -514,6 +543,7 @@ func updateSyntheticsSSLTestStep(accProvider *schema.Provider) resource.TestStep
 				"datadog_synthetics_test.ssl", "monitor_id"),
 		),
 	}
+
 }
 
 const updateSyntheticsSSLTestConfig = `
@@ -536,7 +566,7 @@ resource "datadog_synthetics_test" "ssl" {
 
 	locations = [ "aws:eu-central-1" ]
 
-	options = {
+	options {
 		tick_every = 60
 		accept_self_signed = false
 	}
@@ -583,11 +613,13 @@ func createSyntheticsBrowserTestStep(accProvider *schema.Provider) resource.Test
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.bar", "locations.0", "aws:eu-central-1"),
 			resource.TestCheckResourceAttr(
-				"datadog_synthetics_test.bar", "options.tick_every", "900"),
+				"datadog_synthetics_test.bar", "options.#", "1"),
 			resource.TestCheckResourceAttr(
-				"datadog_synthetics_test.bar", "options.min_failure_duration", "0"),
+				"datadog_synthetics_test.bar", "options.0.tick_every", "900"),
 			resource.TestCheckResourceAttr(
-				"datadog_synthetics_test.bar", "options.min_location_failed", "1"),
+				"datadog_synthetics_test.bar", "options.0.min_failure_duration", "0"),
+			resource.TestCheckResourceAttr(
+				"datadog_synthetics_test.bar", "options.0.min_location_failed", "1"),
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.bar", "name", "name for synthetics browser test bar"),
 			resource.TestCheckResourceAttr(
@@ -602,6 +634,7 @@ func createSyntheticsBrowserTestStep(accProvider *schema.Provider) resource.Test
 				"datadog_synthetics_test.bar", "monitor_id"),
 		),
 	}
+
 }
 
 const createSyntheticsBrowserTestConfig = `
@@ -621,7 +654,7 @@ resource "datadog_synthetics_test" "bar" {
 
 	device_ids = [ "laptop_large", "mobile_small" ]
 	locations = [ "aws:eu-central-1" ]
-	options = {
+	options {
 		tick_every = 900
 		min_failure_duration = 0
 		min_location_failed = 1
@@ -669,11 +702,13 @@ func updateSyntheticsBrowserTestStep(accProvider *schema.Provider) resource.Test
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.bar", "locations.0", "aws:eu-central-1"),
 			resource.TestCheckResourceAttr(
-				"datadog_synthetics_test.bar", "options.tick_every", "1800"),
+				"datadog_synthetics_test.bar", "options.#", "1"),
 			resource.TestCheckResourceAttr(
-				"datadog_synthetics_test.bar", "options.min_failure_duration", "10"),
+				"datadog_synthetics_test.bar", "options.0.tick_every", "1800"),
 			resource.TestCheckResourceAttr(
-				"datadog_synthetics_test.bar", "options.min_location_failed", "1"),
+				"datadog_synthetics_test.bar", "options.0.min_failure_duration", "10"),
+			resource.TestCheckResourceAttr(
+				"datadog_synthetics_test.bar", "options.0.min_location_failed", "1"),
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.bar", "name", "updated name for synthetics browser test bar"),
 			resource.TestCheckResourceAttr(
@@ -688,6 +723,7 @@ func updateSyntheticsBrowserTestStep(accProvider *schema.Provider) resource.Test
 				"datadog_synthetics_test.bar", "monitor_id"),
 		),
 	}
+
 }
 
 const updateSyntheticsBrowserTestConfig = `
@@ -705,7 +741,7 @@ resource "datadog_synthetics_test" "bar" {
 	}
 	device_ids = [ "laptop_large", "tablet" ]
 	locations = [ "aws:eu-central-1" ]
-	options = {
+	options {
 		tick_every = 1800
 		min_failure_duration = 10
 		min_location_failed = 1


### PR DESCRIPTION
This is a bit of a dupe of https://github.com/terraform-providers/terraform-provider-datadog/pull/425.
Allows for retry logic in synthetics checks.

However, this uses the terraform migration pattern as suggested here https://www.terraform.io/docs/extend/resources/state-migration.html

This way we can keep options without deprecating and/or breaking those upgrading.