### PR TITLE
Use gotestsum

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -76,6 +76,6 @@ update-go-client:
 	go mod tidy
 
 get-test-deps:
-	cd `mktemp -d`;	GO111MODULE=on GOFLAGS='' go get -u gotest.tools/gotestsum@v0.4.1; cd -
+	cd `mktemp -d`;	GO111MODULE=auto GOFLAGS='' go get -u gotest.tools/gotestsum; cd -
 
 .PHONY: build test testacc cassettes vet fmt fmtcheck errcheck test-compile website website-test get-test-deps

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,17 +17,17 @@ install: fmtcheck
 uninstall:
 	@rm -vf $(DIR)/terraform-provider-datadog
 
-test: fmtcheck
-	go test -i $(TEST) || exit 1
+test: get-test-deps fmtcheck
+	gotestsum --format testname -- -i $(TEST) || exit 1
 	echo $(TEST) | \
-		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
-	DATADOG_API_KEY=fake DATADOG_APP_KEY=fake RECORD=false TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout=120s
+		xargs -t -n4 gotestsum --format testname -- $(TESTARGS) -timeout=30s -parallel=4
+	DATADOG_API_KEY=fake DATADOG_APP_KEY=fake RECORD=false TF_ACC=1 gotestsum --format testname -- $(TEST) -v $(TESTARGS) -timeout=120s
 
-testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+testacc: get-test-deps fmtcheck
+	TF_ACC=1 gotestsum --format testname -- $(TEST) -v $(TESTARGS) -timeout 120m
 
-cassettes: fmtcheck
-	RECORD=true TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+cassettes: get-test-deps fmtcheck
+	RECORD=true TF_ACC=1 gotestsum --format testname -- $(TEST) -v $(TESTARGS) -timeout 120m
 
 vet:
 	@echo "go vet ."
@@ -48,13 +48,13 @@ errcheck:
 	@sh -c "'$(CURDIR)/scripts/errcheck.sh'"
 
 
-test-compile:
+test-compile: get-test-deps
 	@if [ "$(TEST)" = "./..." ]; then \
 		echo "ERROR: Set TEST to a specific package. For example,"; \
 		echo "  make test-compile TEST=./$(PKG_NAME)"; \
 		exit 1; \
 	fi
-	go test -c $(TEST) $(TESTARGS)
+	gotestsum --format testname -- -c $(TEST) $(TESTARGS)
 
 website:
 ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
@@ -75,4 +75,7 @@ update-go-client:
 	go mod vendor
 	go mod tidy
 
-.PHONY: build test testacc cassettes vet fmt fmtcheck errcheck test-compile website website-test
+get-test-deps:
+	cd `mktemp -d`;	GO111MODULE=on go get -u gotest.tools/gotestsum@v0.4.1; cd -
+
+.PHONY: build test testacc cassettes vet fmt fmtcheck errcheck test-compile website website-test get-test-deps

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,7 +18,7 @@ uninstall:
 	@rm -vf $(DIR)/terraform-provider-datadog
 
 test: get-test-deps fmtcheck
-	gotestsum --format testname -- -i $(TEST) || exit 1
+	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
 		xargs -t -n4 gotestsum --format testname -- $(TESTARGS) -timeout=30s -parallel=4
 	DATADOG_API_KEY=fake DATADOG_APP_KEY=fake RECORD=false TF_ACC=1 gotestsum --format testname -- $(TEST) -v $(TESTARGS) -timeout=120s

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -76,6 +76,6 @@ update-go-client:
 	go mod tidy
 
 get-test-deps:
-	cd `mktemp -d`;	GO111MODULE=on go get -u gotest.tools/gotestsum@v0.4.1; cd -
+	cd `mktemp -d`;	GO111MODULE=on GOFLAGS='' go get -u gotest.tools/gotestsum@v0.4.1; cd -
 
 .PHONY: build test testacc cassettes vet fmt fmtcheck errcheck test-compile website website-test get-test-deps


### PR DESCRIPTION
Use gotestsum for the test execution https://github.com/gotestyourself/gotestsum to get a nice summary at the end. 

Updates the Makefile to use this wherever `go test` was being executed. Also adds a get-test-deps step so that we can ensure we get gotestsum without modifying the go.mod we ship with the provider. 