### PR TITLE
Upgrade docs according to the latest recommendations

### DIFF
--- a/docs/data-sources/ip_ranges.md
+++ b/docs/data-sources/ip_ranges.md
@@ -1,14 +1,11 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_ip_ranges"
-sidebar_current: "docs-datadog-datasource-ip-ranges"
-description: |-
-  Get information on Datadog's IP addresses.
+page_title: "datadog_ip_ranges"
 ---
 
-# datadog_ip_ranges
+# datadog_ip_ranges Data Source
 
 Use this data source to retrieve information about Datadog's IP addresses.
+
 ## Example Usage
 
 ```

--- a/docs/data-sources/monitor.md
+++ b/docs/data-sources/monitor.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_monitor"
-sidebar_current: "docs-datadog-datasource-monitor"
-description: |-
-  Retrieve information about an existing monitor.
+page_title: "datadog_monitor"
 ---
 
-# datadog_monitor
+# datadog_monitor Data Source
 
 Use this data source to retrieve information about an existing monitor for use in other resources.
 

--- a/docs/guides/monitors.md
+++ b/docs/guides/monitors.md
@@ -1,12 +1,9 @@
 ---
-layout: "datadog"
-page_title: "Datadog: monitor_examples"
-sidebar_current: "docs-datadog-monitor-examples"
-description: |-
-  Provides examples for the different types of Datadog monitors. This list isn't exhaustive but serves as a reference for some examples.
+page_title: "datadog_monitor Resource Examples"
 ---
 
-## Monitor Examples
+## Monitor Resource Examples
+
 This page lists examples of how to create different Datadog monitor types within Terraform. This list is non exhaustive and will be updated over time to provide more examples.
 
 ## Watchdog Monitors

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,5 @@
 ---
-layout: "datadog"
 page_title: "Provider: Datadog"
-sidebar_current: "docs-datadog-index"
-description: |-
-  The Datadog provider is used to interact with the resources supported by Datadog. The provider needs to be configured with the proper credentials before it can be used.
 ---
 
 # Datadog Provider

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_dashboard"
-sidebar_current: "docs-datadog-resource-dashboard"
-description: |-
-  Provides a Datadog dashboard resource. This can be used to create and manage dashboards.
+page_title: " datadog_dashboard"
 ---
 
-# datadog_dashboard
+# datadog_dashboard Resource
 
 Provides a Datadog dashboard resource. This can be used to create and manage Datadog dashboards.
 

--- a/docs/resources/dashboard_list.md
+++ b/docs/resources/dashboard_list.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_dashboard_list"
-sidebar_current: "docs-datadog-resource-dashboard-list"
-description: |-
-  Provides a Datadog dashboard list resource. This can be used to create and manage dashboard lists and their sub elements.
+page_title: "datadog_dashboard_list"
 ---
 
-# datadog_dashboard_list
+# datadog_dashboard_list Resource
 
 Provides a Datadog dashboard_list resource. This can be used to create and manage Datadog Dashboard Lists and the individual dashboards within them.
 

--- a/docs/resources/downtime.md
+++ b/docs/resources/downtime.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_downtime"
-sidebar_current: "docs-datadog-resource-downtime"
-description: |-
-  Provides a Datadog downtime resource. This can be used to create and manage downtimes.
+page_title: "datadog_downtime"
 ---
 
-# datadog_downtime
+# datadog_downtime Resource
 
 Provides a Datadog downtime resource. This can be used to create and manage Datadog downtimes.
 

--- a/docs/resources/integration_aws.md
+++ b/docs/resources/integration_aws.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_integration_aws"
-sidebar_current: "docs-datadog-resource-integration_aws"
-description: |-
-  Provides a Datadog - Amazon Web Services integration resource. This can be used to create and manage the integrations.
+page_title: "datadog_integration_aws"
 ---
 
-# datadog_integration_aws
+# datadog_integration_aws Resource
 
 Provides a Datadog - Amazon Web Services integration resource. This can be used to create and manage Datadog - Amazon Web Services integration.
 

--- a/docs/resources/integration_aws_lambda_arn.md
+++ b/docs/resources/integration_aws_lambda_arn.md
@@ -1,13 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_integration_aws_lambda_arn"
-sidebar_current: "docs-datadog-resource-integration_aws_lambda_arn"
-description: |-
-  Provides a Datadog - Amazon Web Services integration Lambda ARN resource. This can be used to create and manage the
-  log collection Lambdas for an account.
+page_title: "datadog_integration_aws_lambda_arn"
 ---
 
-# datadog_integration_aws_lambda_arn
+# datadog_integration_aws_lambda_arn Resource
 
 Provides a Datadog - Amazon Web Services integration Lambda ARN resource. This can be used to create and manage the
 log collection Lambdas for an account.

--- a/docs/resources/integration_aws_log_collection.md
+++ b/docs/resources/integration_aws_log_collection.md
@@ -1,13 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_integration_aws_log_collection"
-sidebar_current: "docs-datadog-resource-integration_aws_log_collection"
-description: |-
-  Provides a Datadog - Amazon Web Services integration log collection resource. This can be used to manage which
-  AWS services logs are collected from for an account.
+page_title: "datadog_integration_aws_log_collection"
 ---
 
-# datadog_integration_aws_log_collection
+# datadog_integration_aws_log_collection Resource
 
 Provides a Datadog - Amazon Web Services integration log collection resource. This can be used to manage which
 AWS services logs are collected from for an account.

--- a/docs/resources/integration_azure.md
+++ b/docs/resources/integration_azure.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_integration_azure"
-sidebar_current: "docs-datadog-resource-integration_azure"
-description: |-
-  Provides a Datadog - Microsoft Azure integration resource. This can be used to create and manage the integrations.
+page_title: "datadog_integration_azure"
 ---
 
-# datadog_integration_azure
+# datadog_integration_azure Resource
 
 Provides a Datadog - Microsoft Azure integration resource. This can be used to create and manage the integrations.
 

--- a/docs/resources/integration_gcp.md
+++ b/docs/resources/integration_gcp.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_integration_gcp"
-sidebar_current: "docs-datadog-resource-integration_gcp"
-description: |-
-  Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage the integrations.
+page_title: "datadog_integration_gcp"
 ---
 
-# datadog_integration_gcp
+# datadog_integration_gcp Resource
 
 Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.
 

--- a/docs/resources/integration_pagerduty.md
+++ b/docs/resources/integration_pagerduty.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_integration_pagerduty"
-sidebar_current: "docs-datadog-resource-integration_pagerduty"
-description: |-
-  Provides a Datadog - PagerDuty integration resource. This can be used to create and manage the integration.
+page_title: "datadog_integration_pagerduty"
 ---
 
-# datadog_integration_pagerduty
+# datadog_integration_pagerduty Resource
 
 Provides a Datadog - PagerDuty resource. This can be used to create and manage Datadog - PagerDuty integration. This resource is deprecated and should only be used for legacy purposes.
 

--- a/docs/resources/integration_pagerduty_service_object.md
+++ b/docs/resources/integration_pagerduty_service_object.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_integration_pagerduty_service_object"
-sidebar_current: "docs-datadog-resource-integration_pagerduty_service_object"
-description: |-
-  Provides a Datadog - PagerDuty integration resource. This can be used to create and manage the integration.
+page_title: "datadog_integration_pagerduty_service_object"
 ---
 
-# datadog_integration_pagerduty_service_object
+# datadog_integration_pagerduty_service_object Resource
 
 Provides access to individual Service Objects of Datadog - PagerDuty integrations. Note that the Datadog - PagerDuty integration must be activated in the Datadog UI in order for this resource to be usable.
 

--- a/docs/resources/logs_archive.md
+++ b/docs/resources/logs_archive.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_logs_archive"
-sidebar_current: "docs-datadog-resource-logs-archive"
-description: |-
-  Provides a Datadog logs archive resource, which is used to create and manage logs archives.
+page_title: "datadog_logs_archive"
 ---
 
-# datadog_logs_archive
+# datadog_logs_archive Resource
 
 Provides a Datadog [Logs Archive API](https://docs.datadoghq.com/api/v2/logs-archives/) resource, which is used to create and manage Datadog logs archives.
 

--- a/docs/resources/logs_custom_pipeline.md
+++ b/docs/resources/logs_custom_pipeline.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_logs_custom_pipeline"
-sidebar_current: "docs-datadog-resource-logs-custom-pipeline"
-description: |-
-  Provides a Datadog logs custom pipeline resource, which is used to create and manage logs custom pipelines.
+page_title: "datadog_logs_custom_pipeline"
 ---
 
-# datadog_logs_custom_pipeline
+# datadog_logs_custom_pipeline Resource
 
 Provides a Datadog [Logs Pipeline API](https://docs.datadoghq.com/api/v1/logs-pipelines/) resource, which is used to create and manage Datadog logs custom pipelines.
 

--- a/docs/resources/logs_index.md
+++ b/docs/resources/logs_index.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_logs_index"
-sidebar_current: "docs-datadog-resource-logs-index"
-description: |-
-  Provides a Datadog logs index resource. This can be used to create and manage logs indexes.
+page_title: "datadog_logs_index"
 ---
 
-# datadog_logs_index
+# datadog_logs_index Resource
 
 Provides a Datadog [Logs Index API](https://docs.datadoghq.com/api/v1/logs-indexes/) resource. This can be used to create and manage Datadog logs indexes.
 

--- a/docs/resources/logs_index_order.md
+++ b/docs/resources/logs_index_order.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_logs_index_order"
-sidebar_current: "docs-datadog-resource-logs-index-order"
-description: |-
-  Provides a Datadog logs index order resource. This can be used to manage the order of logs indexes.
+page_title: "datadog_logs_index_order"
 ---
 
-# datadog_logs_index_order
+# datadog_logs_index_order Resource
 
 Provides a Datadog [Logs Index API](https://docs.datadoghq.com/api/v1/logs-indexes/) resource. This can be used to manage the order of Datadog logs indexes.
 

--- a/docs/resources/logs_integration_pipeline.md
+++ b/docs/resources/logs_integration_pipeline.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_logs_integration_pipeline"
-sidebar_current: "docs-datadog-resource-logs-integration-pipeline"
-description: |-
-  Provides a Datadog logs integration pipeline resource, which is used to create and manage logs integration pipelines.
+page_title: "datadog_logs_integration_pipeline"
 ---
 
-# datadog_logs_integration_pipeline
+# datadog_logs_integration_pipeline Resource
 
 Provides a Datadog [Logs Pipeline API](https://docs.datadoghq.com/api/v1/logs-pipelines/) resource to manage
 the [integrations](https://docs.datadoghq.com/logs/log_collection/?tab=tcpussite).

--- a/docs/resources/logs_pipeline_order.md
+++ b/docs/resources/logs_pipeline_order.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_logs_pipeline_order"
-sidebar_current: "docs-datadog-resource-logs-pipeline-order"
-description: |-
-  Provides a Datadog logs pipeline order resource, which is used to manage the order of log pipelines.
+page_title: "datadog_logs_pipeline_order"
 ---
 
-# datadog_logs_pipeline_order
+# datadog_logs_pipeline_order Resource
 
 Provides a Datadog [Logs Pipeline API](https://docs.datadoghq.com/api/v1/logs-pipelines/) resource, which is used to manage Datadog log pipelines order.
 

--- a/docs/resources/metric_metadata.md
+++ b/docs/resources/metric_metadata.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_metric_metadata"
-sidebar_current: "docs-datadog-resource-metric_metadata"
-description: |-
-  Provides a Datadog metric metadata resource. This can be used to manage a metric's metadata.
+page_title: "datadog_metric_metadata"
 ---
 
-# datadog_metric_metadata
+# datadog_metric_metadata Resource
 
 Provides a Datadog metric_metadata resource. This can be used to manage a metric's metadata.
 

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_monitor"
-sidebar_current: "docs-datadog-resource-monitor"
-description: |-
-  Provides a Datadog monitor resource. This can be used to create and manage monitors.
+page_title: "datadog_monitor"
 ---
 
-# datadog_monitor
+# datadog_monitor Resource
 
 Provides a Datadog monitor resource. This can be used to create and manage Datadog monitors.
 

--- a/docs/resources/screenboard.md
+++ b/docs/resources/screenboard.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_screenboard"
-sidebar_current: "docs-datadog-resource-screenboard"
-description: |-
-  Provides a Datadog screenboard resource. This can be used to create and manage screenboards.
+page_title: "datadog_screenboard"
 ---
 
-# datadog_screenboard
+# datadog_screenboard Resource
 
 Provides a Datadog screenboard resource. This can be used to create and manage Datadog screenboards.
 

--- a/docs/resources/service_level_objective.md
+++ b/docs/resources/service_level_objective.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_service_level_objective"
-sidebar_current: "docs-datadog-resource-service_level_objective"
-description: |-
-  Provides a Datadog service level objective resource. This can be used to create and manage service level objectives.
+page_title: "datadog_service_level_objective"
 ---
 
-# datadog_service_level_objective
+# datadog_service_level_objective Resource
 
 Provides a Datadog service level objective resource. This can be used to create and manage Datadog service level objectives.
 

--- a/docs/resources/synthetics.md
+++ b/docs/resources/synthetics.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_synthetics_test"
-sidebar_current: "docs-datadog-resource-synthetics_test"
-description: |-
-  Provides a Datadog synthetics resource. This can be used to create and manage synthetics.
+page_title: "datadog_synthetics_test"
 ---
 
-# datadog_synthetics_test
+# datadog_synthetics_test Resource
 
 Provides a Datadog synthetics test resource. This can be used to create and manage Datadog synthetics test.
 

--- a/docs/resources/timeboard.md
+++ b/docs/resources/timeboard.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_timeboard"
-sidebar_current: "docs-datadog-resource-timeboard"
-description: |-
-  Provides a Datadog timeboard resource. This can be used to create and manage timeboards.
+page_title: "datadog_timeboard"
 ---
 
-# datadog_timeboard
+# datadog_timeboard Resource
 
 Provides a Datadog timeboard resource. This can be used to create and manage Datadog timeboards.
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -1,12 +1,8 @@
 ---
-layout: "datadog"
-page_title: "Datadog: datadog_user"
-sidebar_current: "docs-datadog-resource-user"
-description: |-
-  Provides a Datadog user resource. This can be used to create and manage users.
+page_title: "datadog_user"
 ---
 
-# datadog_user
+# datadog_user Resource
 
 Provides a Datadog user resource. This can be used to create and manage Datadog users.
 


### PR DESCRIPTION
More upgrades to docs as recommended by the official docs at [1]:

* Remove unused frontmatter values, adapt `page_title` attributes
* Use `Data Source` resp. `Resource` after the name of the data source resp. resource in the title. 

[1] https://www.terraform.io/docs/registry/providers/docs.html