### PR TITLE
Fix DiffSuppressFunc for downtime start

### DIFF
--- a/datadog/resource_datadog_downtime.go
+++ b/datadog/resource_datadog_downtime.go
@@ -47,8 +47,8 @@ func resourceDatadogDowntime() *schema.Resource {
 				DiffSuppressFunc: func(k, oldVal, newVal string, d *schema.ResourceData) bool {
 					_, startDatePresent := d.GetOk("start_date")
 					now := time.Now().Unix()
-					// If "start_date" is set, ignore diff for "start". If "start" isn't set, ignore diff if start is in the past
-					return startDatePresent || (newVal == "0" && oldVal != "0" && int64(d.Get("start").(int)) < now)
+					// If "start_date" is set, ignore diff for "start". If "start" isn't set, ignore diff if start is now or in the past
+					return startDatePresent || (newVal == "0" && oldVal != "0" && int64(d.Get("start").(int)) <= now)
 				},
 				Description: "Specify when this downtime should start",
 			},


### PR DESCRIPTION
We want to ignore the diff even if start is set "right now". This fixes a test flake like [this](https://dev.azure.com/datadoghq/terraform-provider-datadog/_build/results?buildId=20841&view=logs&j=abc39910-4c32-5be0-0b39-6d3f303c7218&t=632788a2-3bb3-5d1a-83fe-bfd285143df8&l=573).