### PR TITLE
Decrease flakiness of metric metadata tests by not running in parallel

### DIFF
--- a/datadog/resource_datadog_metric_metadata_test.go
+++ b/datadog/resource_datadog_metric_metadata_test.go
@@ -16,7 +16,7 @@ func TestAccDatadogMetricMetadata_Basic(t *testing.T) {
 	defer cleanup(t)
 	accProvider := testAccProvider(t, accProviders)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: accProviders,
 		Steps: []resource.TestStep{
@@ -48,7 +48,7 @@ func TestAccDatadogMetricMetadata_Updated(t *testing.T) {
 	defer cleanup(t)
 	accProvider := testAccProvider(t, accProviders)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: accProviders,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
Because these two tests operate on the same metric, we can't run them in parallel. The "proper" fix for this test case that would protect it from even two concurrent runs of the test suite will involve a bit more work, but this should help considerably in the meanwhile.