### PR TITLE
[Synthetics] Fix min_location_failed parameter description

### DIFF
--- a/docs/resources/synthetics.md
+++ b/docs/resources/synthetics.md
@@ -138,7 +138,7 @@ The following arguments are supported:
   - `tick_every` - (Required)  How often the test should run (in seconds). Current possible values are 900, 1800, 3600, 21600, 43200, 86400, 604800 plus 60 if type=api or 300 if type=browser
   - `follow_redirects` - (Optional) For type=api, true or false
   - `min_failure_duration` - (Optional) How long the test should be in failure before alerting (integer, number of seconds, max 7200). Default is 0.
-  - `min_location_failed` - (Optional) Threshold below which a synthetics test is allowed to fail before sending notifications
+  - `min_location_failed` - (Optional) Minimum number of locations in failure required to trigger an alert.
   - `accept_self_signed` - (Optional) For type=ssl, true or false
   - `allow_insecure` - (Optional) For type=api, true or false. Allow your HTTP test go on with connection even if there is an error when validating the certificate.
   - `retry_count` - (Optional) Number of retries needed to consider a location as failed before sending a notification alert.


### PR DESCRIPTION
This PR updates the documentation for the `datadog_synthetics_test` resource, parameter `min_location_failed` to match the [Datadog API docs](https://docs.datadoghq.com/api/v1/synthetics/) in order to provide more clarity.