### PR TITLE
Prevent nil pointer dereference in dashboard import

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -308,8 +308,8 @@ func buildTerraformTemplateVariables(datadogTemplateVariables *[]datadogV1.Dashb
 		if v, ok := templateVariable.GetNameOk(); ok {
 			terraformTemplateVariable["name"] = *v
 		}
-		if v, ok := templateVariable.GetPrefixOk(); ok {
-			terraformTemplateVariable["prefix"] = *v
+		if v := templateVariable.GetPrefix(); len(v) > 0 {
+			terraformTemplateVariable["prefix"] = v
 		}
 		if v, ok := templateVariable.GetDefaultOk(); ok {
 			terraformTemplateVariable["default"] = *v


### PR DESCRIPTION
When importing a dashboard with a template variable with no prefix, the
provider panics with the following error message:

```
panic: runtime error: invalid memory address or nil pointer dereference
2020-08-10T13:42:16.345+0200 [DEBUG] plugin.terraform-provider-datadog_v2.12.1: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1bddcf1]
2020-08-10T13:42:16.345+0200 [DEBUG] plugin.terraform-provider-datadog_v2.12.1:
2020-08-10T13:42:16.345+0200 [DEBUG] plugin.terraform-provider-datadog_v2.12.1: goroutine 81 [running]:                                                                                                     2020-08-10T13:42:16.345+0200 [DEBUG] plugin.terraform-provider-datadog_v2.12.1: github.com/terraform-providers/terraform-provider-datadog/datadog.buildTerraformTemplateVariables(0xc0004a1a18, 0x1fa2ab9)
2020-08-10T13:42:16.345+0200 [DEBUG] plugin.terraform-provider-datadog_v2.12.1:         github.com/terraform-providers/terraform-provider-datadog/datadog/resource_datadog_dashboard.go:296 +0x291
```

This commit prevents by first checking if the pointer that we're going
to dereference is nil. If that's the case, we assume that the template
variable doesn't have a name, prefix or default, as appropriate.