### PR TITLE
Fix build error with go 1.15

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -545,7 +545,7 @@ func resourceDatadogMonitorUpdate(d *schema.ResourceData, meta interface{}) erro
 		silencedList := m.Options.GetSilenced()
 		for _, scope := range unmutedScopes {
 			if _, ok := silencedList[scope]; ok {
-				delete(silencedList, string(silencedList[scope]))
+				delete(silencedList, scope)
 			}
 		}
 		if _, _, err = datadogClientV1.MonitorsApi.UpdateMonitor(authV1, i).Body(*m).Execute(); err != nil {


### PR DESCRIPTION
This fixes a build error happening with the new go release, which seems
to be an actual bug.