### PR TITLE
Completely skip creds validation when validate is false

### DIFF
--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -102,10 +102,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		return nil, errors.New("api_key and app_key must be set unless validate = false")
 	}
 
-	if !validate && (apiKey != "" || appKey != "") {
-		return nil, errors.New("api_key and app_key must not be set when validate = false")
-	}
-
 	// Initialize the community client
 	communityClient := datadogCommunity.NewClient(apiKey, appKey)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,4 +37,4 @@ The following arguments are supported:
 * `api_key` - (Required unless `validate` is false) Datadog API key. This can also be set via the `DD_API_KEY` environment variable.
 * `app_key` - (Required unless `validate` is false) Datadog APP key. This can also be set via the `DD_APP_KEY` environment variable.
 * `api_url` - (Optional) The API Url. This can be also be set via the `DD_HOST` environment variable. Note that this URL must not end with the `/api/` path. For example, `https://api.datadoghq.com/` is a correct value, while `https://api.datadoghq.com/api/` is not. And if you're working with  "EU" version of Datadog, use `https://api.datadoghq.eu/`.
-* `validate` - (Optional) Enables validation of the provided API and APP keys during provider initialization. Default is true. When false, `api_key` and `app_key` may only be set to empty strings.
+* `validate` - (Optional) Enables validation of the provided API and APP keys during provider initialization. Default is true. When false, `api_key` and `app_key`won't be checked.


### PR DESCRIPTION
The current approach was checking that the creds where not set, but it
doesn't make much sense to have such a restriction. Let's skip
validation altogether when `validate` is set to `false`.

Closee #640