### PR TITLE
[Synthetics] Fix documentation format for nested arguments

### DIFF
--- a/docs/resources/synthetics.md
+++ b/docs/resources/synthetics.md
@@ -172,15 +172,7 @@ The following arguments are supported:
 - `request_basicauth` - (Optional) Array of 1 item containing HTTP basic authentication credentials
   - `username` - (Required) Username for authentication
   - `password` - (Required) Password for authentication
-- `assertion` - (Required) Array of 1 to 10 items, only some combinations of type/operator are valid (please refer to Datadog documentation)
-  - `type` - (Required) body, header, responseTime, statusCode
-  - `operator` - (Required) Please refer to [Datadog documentation](https://docs.datadoghq.com/synthetics/api_test/#validation) as operator depend on assertion type
-  - `target` - (Optional) Expected value, please refer to [Datadog documentation](https://docs.datadoghq.com/synthetics/api_test/#validation) as target depend on assertion type
-  - `targetjsonpath` - (Optional) Expected structure if `operator` is `validatesJSONPath`
-    - `operator` - (Required) The specific operator to use on the path
-    - `targetvalue` - (Required) Expected matching value
-    - `jsonpath` - (Required) The JSON path to assert
-  - `property` - (Optional) if assertion type is "header", this is a the header name
+- `assertion` - (Required) Array of 1 to 10 items, only some combinations of type/operator are valid (please refer to Datadog documentation). [See the assertion format below](#assertion)
 - `options` - (Required) **Deprecated**
   - `tick_every` - (Required)  How often the test should run (in seconds). Current possible values are 900, 1800, 3600, 21600, 43200, 86400, 604800 plus 60 if type=api or 300 if type=browser
   - `follow_redirects` - (Optional) For type=api, true or false
@@ -190,18 +182,7 @@ The following arguments are supported:
   - `allow_insecure` - (Optional) For type=api, true or false. Allow your HTTP test go on with connection even if there is an error when validating the certificate.
   - `retry_count` - (Optional) Number of retries needed to consider a location as failed before sending a notification alert.
   - `retry_interval` - (Optional) Interval between a failed test and the next retry in milliseconds.
-- `options_list` - (Optional)
-  - `tick_every` - (Optional)  How often the test should run (in seconds). Current possible values are 900, 1800, 3600, 21600, 43200, 86400, 604800 plus 60 if type=api or 300 if type=browser
-  - `follow_redirects` - (Optional) For type=api, true or false
-  - `min_failure_duration` - (Optional) How long the test should be in failure before alerting (integer, number of seconds, max 7200). Default is 0.
-  - `min_location_failed` - (Optional) Threshold below which a synthetics test is allowed to fail before sending notifications. Default is 1.
-  - `accept_self_signed` - (Optional) For type=ssl, true or false
-  - `allow_insecure` - (Optional) For type=api, true or false. Allow your HTTP test go on with connection even if there is an error when validating the certificate.
-  - `retry` - (Optional)
-    - `count` - (Optional) Number of retries needed to consider a location as failed before sending a notification alert.
-    - `interval` - (Optional) Interval between a failed test and the next retry in milliseconds.
-  - `monitor_options` - (Optional)
-    - `renotification_interval` - (Optional) Specify a renotification frequency.
+- `options_list` - (Optional) Options for the test [See the options list format below](#options-list)
 - `locations` - (Required) Please refer to [Datadog documentation](https://docs.datadoghq.com/synthetics/api_test/#request) for available locations (e.g. "aws:eu-central-1")
 - `device_ids` - (Optional) "laptop_large", "tablet" or "mobile_small" (only available if type=browser)
 - `status` - (Required) "live", "paused"
@@ -211,6 +192,31 @@ The following arguments are supported:
   - `params` - (Required) Parameters for the step as JSON string.
   - `allow_failure` - (Optional) Determines if the step should be allowed to fail.
   - `timeout` - (Optional) Used to override the default timeout of a step.
+
+### Assertion
+
+- `type` - (Required) body, header, responseTime, statusCode
+- `operator` - (Required) Please refer to [Datadog documentation](https://docs.datadoghq.com/synthetics/api_test/#validation) as operator depend on assertion type
+- `target` - (Optional) Expected value, please refer to [Datadog documentation](https://docs.datadoghq.com/synthetics/api_test/#validation) as target depend on assertion type
+- `targetjsonpath` - (Optional) Expected structure if `operator` is `validatesJSONPath`
+  - `operator` - (Required) The specific operator to use on the path
+  - `targetvalue` - (Required) Expected matching value
+  - `jsonpath` - (Required) The JSON path to assert
+- `property` - (Optional) if assertion type is "header", this is a the header name
+
+### Options List
+
+- `tick_every` - (Optional)  How often the test should run (in seconds). Current possible values are 900, 1800, 3600, 21600, 43200, 86400, 604800 plus 60 if type=api or 300 if type=browser
+- `follow_redirects` - (Optional) For type=api, true or false
+- `min_failure_duration` - (Optional) How long the test should be in failure before alerting (integer, number of seconds, max 7200). Default is 0.
+- `min_location_failed` - (Optional) Threshold below which a synthetics test is allowed to fail before sending notifications. Default is 1.
+- `accept_self_signed` - (Optional) For type=ssl, true or false
+- `allow_insecure` - (Optional) For type=api, true or false. Allow your HTTP test go on with connection even if there is an error when validating the certificate.
+- `retry` - (Optional)
+  - `count` - (Optional) Number of retries needed to consider a location as failed before sending a notification alert.
+  - `interval` - (Optional) Interval between a failed test and the next retry in milliseconds.
+- `monitor_options` - (Optional)
+  - `renotification_interval` - (Optional) Specify a renotification frequency.
 
 ## Attributes Reference
 

--- a/docs/resources/synthetics.md
+++ b/docs/resources/synthetics.md
@@ -172,7 +172,15 @@ The following arguments are supported:
 - `request_basicauth` - (Optional) Array of 1 item containing HTTP basic authentication credentials
   - `username` - (Required) Username for authentication
   - `password` - (Required) Password for authentication
-- `assertion` - (Required) Array of 1 to 10 items, only some combinations of type/operator are valid (please refer to Datadog documentation). [See the assertion format below](#assertion)
+- `assertion` - (Required) Array of 1 to 10 items, only some combinations of type/operator are valid (please refer to Datadog documentation).
+  - `type` - (Required) body, header, responseTime, statusCode
+  - `operator` - (Required) Please refer to [Datadog documentation](https://docs.datadoghq.com/synthetics/api_test/#validation) as operator depend on assertion type
+  - `target` - (Optional) Expected value, please refer to [Datadog documentation](https://docs.datadoghq.com/synthetics/api_test/#validation) as target depend on assertion type
+  - `targetjsonpath` - (Optional) Expected structure if `operator` is `validatesJSONPath`
+      - `operator` - (Required) The specific operator to use on the path
+      - `targetvalue` - (Required) Expected matching value
+      - `jsonpath` - (Required) The JSON path to assert
+  - `property` - (Optional) if assertion type is "header", this is a the header name
 - `options` - (Required) **Deprecated**
   - `tick_every` - (Required)  How often the test should run (in seconds). Current possible values are 900, 1800, 3600, 21600, 43200, 86400, 604800 plus 60 if type=api or 300 if type=browser
   - `follow_redirects` - (Optional) For type=api, true or false
@@ -182,7 +190,18 @@ The following arguments are supported:
   - `allow_insecure` - (Optional) For type=api, true or false. Allow your HTTP test go on with connection even if there is an error when validating the certificate.
   - `retry_count` - (Optional) Number of retries needed to consider a location as failed before sending a notification alert.
   - `retry_interval` - (Optional) Interval between a failed test and the next retry in milliseconds.
-- `options_list` - (Optional) Options for the test [See the options list format below](#options-list)
+- `options_list` - (Optional)
+  - `tick_every` - (Optional)  How often the test should run (in seconds). Current possible values are 900, 1800, 3600, 21600, 43200, 86400, 604800 plus 60 if type=api or 300 if type=browser
+  - `follow_redirects` - (Optional) For type=api, true or false
+  - `min_failure_duration` - (Optional) How long the test should be in failure before alerting (integer, number of seconds, max 7200). Default is 0.
+  - `min_location_failed` - (Optional) Threshold below which a synthetics test is allowed to fail before sending notifications. Default is 1.
+  - `accept_self_signed` - (Optional) For type=ssl, true or false
+  - `allow_insecure` - (Optional) For type=api, true or false. Allow your HTTP test go on with connection even if there is an error when validating the certificate.
+  - `retry` - (Optional)
+      - `count` - (Optional) Number of retries needed to consider a location as failed before sending a notification alert.
+      - `interval` - (Optional) Interval between a failed test and the next retry in milliseconds.
+  - `monitor_options` - (Optional)
+      - `renotification_interval` - (Optional) Specify a renotification frequency.
 - `locations` - (Required) Please refer to [Datadog documentation](https://docs.datadoghq.com/synthetics/api_test/#request) for available locations (e.g. "aws:eu-central-1")
 - `device_ids` - (Optional) "laptop_large", "tablet" or "mobile_small" (only available if type=browser)
 - `status` - (Required) "live", "paused"
@@ -192,31 +211,6 @@ The following arguments are supported:
   - `params` - (Required) Parameters for the step as JSON string.
   - `allow_failure` - (Optional) Determines if the step should be allowed to fail.
   - `timeout` - (Optional) Used to override the default timeout of a step.
-
-### Assertion
-
-- `type` - (Required) body, header, responseTime, statusCode
-- `operator` - (Required) Please refer to [Datadog documentation](https://docs.datadoghq.com/synthetics/api_test/#validation) as operator depend on assertion type
-- `target` - (Optional) Expected value, please refer to [Datadog documentation](https://docs.datadoghq.com/synthetics/api_test/#validation) as target depend on assertion type
-- `targetjsonpath` - (Optional) Expected structure if `operator` is `validatesJSONPath`
-  - `operator` - (Required) The specific operator to use on the path
-  - `targetvalue` - (Required) Expected matching value
-  - `jsonpath` - (Required) The JSON path to assert
-- `property` - (Optional) if assertion type is "header", this is a the header name
-
-### Options List
-
-- `tick_every` - (Optional)  How often the test should run (in seconds). Current possible values are 900, 1800, 3600, 21600, 43200, 86400, 604800 plus 60 if type=api or 300 if type=browser
-- `follow_redirects` - (Optional) For type=api, true or false
-- `min_failure_duration` - (Optional) How long the test should be in failure before alerting (integer, number of seconds, max 7200). Default is 0.
-- `min_location_failed` - (Optional) Threshold below which a synthetics test is allowed to fail before sending notifications. Default is 1.
-- `accept_self_signed` - (Optional) For type=ssl, true or false
-- `allow_insecure` - (Optional) For type=api, true or false. Allow your HTTP test go on with connection even if there is an error when validating the certificate.
-- `retry` - (Optional)
-  - `count` - (Optional) Number of retries needed to consider a location as failed before sending a notification alert.
-  - `interval` - (Optional) Interval between a failed test and the next retry in milliseconds.
-- `monitor_options` - (Optional)
-  - `renotification_interval` - (Optional) Specify a renotification frequency.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fix the formatting in the [terraform documentation website for nested arguments](https://www.terraform.io/docs/providers/datadog/r/synthetics.html#argument-reference). I suppose their website does not support more than one level of nesting in objects, and we have arguments that have two levels.