### PR TITLE
Update documentation for synthetic retry syntax

### DIFF
--- a/docs/resources/synthetics.md
+++ b/docs/resources/synthetics.md
@@ -31,7 +31,7 @@ resource "datadog_synthetics_test" "test_api" {
   options_list {
     tick_every = 900
 
-    retry = {
+    retry {
       count = 2
       interval = 300
     }


### PR DESCRIPTION
Threw me off for a good bit.

`Retry` is of type `TypeList`