### PR TITLE
Clear dashboard_list_removed diff

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -26,7 +26,10 @@ func resourceDatadogDashboard() *schema.Resource {
 				// Only calculate removed when the list change, to no create useless diffs
 				removed := old.(*schema.Set).Difference(new.(*schema.Set))
 				diff.SetNew("dashboard_lists_removed", removed)
+			} else {
+				diff.Clear("dashboard_lists_removed")
 			}
+
 			return nil
 		},
 		Importer: &schema.ResourceImporter{


### PR DESCRIPTION
When upgrading from a version with the dashboard_list attribute on
dashboard, it would generate a diff for dashboard_list_removed on first
apply. Let's clear it to remove that diff.