### PR TITLE
Correct the spelling of dashboard in a private function

### DIFF
--- a/datadog/data_source_datadog_dashboard_list.go
+++ b/datadog/data_source_datadog_dashboard_list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
-func dataSourceDatadogDashboarList() *schema.Resource {
+func dataSourceDatadogDashboardList() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceDatadogDashboardListRead,
 

--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -75,7 +75,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"datadog_dashboard_list":       dataSourceDatadogDashboarList(),
+			"datadog_dashboard_list":       dataSourceDatadogDashboardList(),
 			"datadog_ip_ranges":            dataSourceDatadogIpRanges(),
 			"datadog_monitor":              dataSourceDatadogMonitor(),
 			"datadog_synthetics_locations": dataSourceDatadogSyntheticsLocations(),


### PR DESCRIPTION
While reading through the code I happened to notice a function had a small misspelling

- `s/boar/board/`

...unless Datadog plans to change the dog 🐶  to a boar 🐗 in an upcoming marketing rebranding.