### PR TITLE
[Synthetics] Update go client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/terraform-providers/terraform-provider-datadog
 
 require (
 	4d63.com/tz v1.1.0
-	github.com/DataDog/datadog-api-client-go v1.0.0-beta.8.0.20201022082941-ff8771119740
+	github.com/DataDog/datadog-api-client-go v1.0.0-beta.8.0.20201023093342-c6c000a7e284
 	github.com/cenkalti/backoff v2.1.1+incompatible // indirect
 	github.com/dnaeon/go-vcr v1.0.1
 	github.com/fatih/color v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbf
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DataDog/datadog-api-client-go v1.0.0-beta.8.0.20201022082941-ff8771119740 h1:WGuvFzN2X48nPBuLtusOI1aKGevAflhRRMpdp0ziMIQ=
-github.com/DataDog/datadog-api-client-go v1.0.0-beta.8.0.20201022082941-ff8771119740/go.mod h1:/bMeu+q33QzX2JuO5PkGkhU1VYOXIXKEPF6Ck4yR06M=
+github.com/DataDog/datadog-api-client-go v1.0.0-beta.8.0.20201023093342-c6c000a7e284 h1:eIzdPix66KYT17HU4fxD/oFu+a4AKKJ15iYQjyKjtSU=
+github.com/DataDog/datadog-api-client-go v1.0.0-beta.8.0.20201023093342-c6c000a7e284/go.mod h1:/bMeu+q33QzX2JuO5PkGkhU1VYOXIXKEPF6Ck4yR06M=
 github.com/DataDog/datadog-go v3.6.0+incompatible h1:ILg7c5Y1KvZFDOaVS0higGmJ5Fal5O1KQrkrT9j6dSM=
 github.com/DataDog/datadog-go v3.6.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/vendor/github.com/DataDog/datadog-api-client-go/.apigentools-info
+++ b/vendor/github.com/DataDog/datadog-api-client-go/.apigentools-info
@@ -4,13 +4,13 @@
     "spec_versions": {
         "v1": {
             "apigentools_version": "1.2.0",
-            "regenerated": "2020-10-22 08:07:54.914688",
-            "spec_repo_commit": "f53311d"
+            "regenerated": "2020-10-23 09:15:18.991131",
+            "spec_repo_commit": "787c299"
         },
         "v2": {
             "apigentools_version": "1.2.0",
-            "regenerated": "2020-10-22 08:08:01.110787",
-            "spec_repo_commit": "f53311d"
+            "regenerated": "2020-10-23 09:15:24.930743",
+            "spec_repo_commit": "787c299"
         }
     }
 }

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_step_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_step_type.go
@@ -19,12 +19,16 @@ type SyntheticsStepType string
 // List of SyntheticsStepType
 const (
 	SYNTHETICSSTEPTYPE_ASSERT_CURRENT_URL        SyntheticsStepType = "assertCurrentUrl"
+	SYNTHETICSSTEPTYPE_ASSERT_ELEMENT_ATTRIBUTE  SyntheticsStepType = "assertElementAttribute"
 	SYNTHETICSSTEPTYPE_ASSERT_ELEMENT_CONTENT    SyntheticsStepType = "assertElementContent"
 	SYNTHETICSSTEPTYPE_ASSERT_ELEMENT_PRESENT    SyntheticsStepType = "assertElementPresent"
 	SYNTHETICSSTEPTYPE_ASSERT_EMAIL              SyntheticsStepType = "assertEmail"
+	SYNTHETICSSTEPTYPE_ASSERT_FILE_DOWNLOAD      SyntheticsStepType = "assertFileDownload"
+	SYNTHETICSSTEPTYPE_ASSERT_FROM_JAVASCRIPT    SyntheticsStepType = "assertFromJavascript"
 	SYNTHETICSSTEPTYPE_ASSERT_PAGE_CONTAINS      SyntheticsStepType = "assertPageContains"
 	SYNTHETICSSTEPTYPE_ASSERT_PAGE_LACKS         SyntheticsStepType = "assertPageLacks"
 	SYNTHETICSSTEPTYPE_CLICK                     SyntheticsStepType = "click"
+	SYNTHETICSSTEPTYPE_EXTRACT_FROM_JAVASCRIPT   SyntheticsStepType = "extractFromJavascript"
 	SYNTHETICSSTEPTYPE_EXTRACT_VARIABLE          SyntheticsStepType = "extractVariable"
 	SYNTHETICSSTEPTYPE_GO_TO_EMAIL_LINK          SyntheticsStepType = "goToEmailLink"
 	SYNTHETICSSTEPTYPE_GO_TO_URL                 SyntheticsStepType = "goToUrl"
@@ -33,6 +37,8 @@ const (
 	SYNTHETICSSTEPTYPE_PLAY_SUB_TEST             SyntheticsStepType = "playSubTest"
 	SYNTHETICSSTEPTYPE_PRESS_KEY                 SyntheticsStepType = "pressKey"
 	SYNTHETICSSTEPTYPE_REFRESH                   SyntheticsStepType = "refresh"
+	SYNTHETICSSTEPTYPE_RUN_API_TEST              SyntheticsStepType = "runApiTest"
+	SYNTHETICSSTEPTYPE_SCROLL                    SyntheticsStepType = "scroll"
 	SYNTHETICSSTEPTYPE_SELECT_OPTION             SyntheticsStepType = "selectOption"
 	SYNTHETICSSTEPTYPE_TYPE_TEXT                 SyntheticsStepType = "typeText"
 	SYNTHETICSSTEPTYPE_UPLOAD_FILES              SyntheticsStepType = "uploadFiles"
@@ -46,7 +52,7 @@ func (v *SyntheticsStepType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SyntheticsStepType(value)
-	for _, existing := range []SyntheticsStepType{"assertCurrentUrl", "assertElementContent", "assertElementPresent", "assertEmail", "assertPageContains", "assertPageLacks", "click", "extractVariable", "goToEmailLink", "goToUrl", "goToUrlAndMeasureTti", "hover", "playSubTest", "pressKey", "refresh", "selectOption", "typeText", "uploadFiles", "wait"} {
+	for _, existing := range []SyntheticsStepType{"assertCurrentUrl", "assertElementAttribute", "assertElementContent", "assertElementPresent", "assertEmail", "assertFileDownload", "assertFromJavascript", "assertPageContains", "assertPageLacks", "click", "extractFromJavascript", "extractVariable", "goToEmailLink", "goToUrl", "goToUrlAndMeasureTti", "hover", "playSubTest", "pressKey", "refresh", "runApiTest", "scroll", "selectOption", "typeText", "uploadFiles", "wait"} {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ cloud.google.com/go/internal/optional
 cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 cloud.google.com/go/storage
-# github.com/DataDog/datadog-api-client-go v1.0.0-beta.8.0.20201022082941-ff8771119740
+# github.com/DataDog/datadog-api-client-go v1.0.0-beta.8.0.20201023093342-c6c000a7e284
 github.com/DataDog/datadog-api-client-go
 github.com/DataDog/datadog-api-client-go/api/v1/datadog
 github.com/DataDog/datadog-api-client-go/api/v2/datadog


### PR DESCRIPTION
Update go client to fix https://github.com/DataDog/terraform-provider-datadog/issues/706
The client update includes the missing step types. 