### PR TITLE
Bump prettier version to 2.1.1 to match the existing config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,4 +15,4 @@
         additional_dependencies:
             # When updating the version of prettier, make sure to check the  pre-commit file
             # And keep the `entry` here up to date https://github.com/prettier/prettier/blob/master/.pre-commit-hooks.yaml
-            - prettier@2.0.5
+            - prettier@2.1.1


### PR DESCRIPTION
Bump the version of prettier to match the revision used in the pre-commit hook. 
This mismatch was causing CI failures as we were using an out of date version that didn't include CLI flags we needed. Example of failure run - https://github.com/DataDog/terraform-provider-datadog/pull/729/checks?check_run_id=1329277125