### PR TITLE
Update minimum version go 1.15 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Requirements
 
 -   [Terraform](https://www.terraform.io/downloads.html) 0.10.x
--   [Go](https://golang.org/doc/install) 1.11 (to build the provider plugin)
+-   [Go](https://golang.org/doc/install) 1.15 (to build the provider plugin)
 
 ## Building The Provider
 


### PR DESCRIPTION
The package `time/tzdata` is used as a dependency.