### PR TITLE
[Synthetics] Set client certificate content as sensitive

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -259,8 +259,9 @@ func syntheticsTestRequestClientCertificateItem() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"content": {
-					Type:     schema.TypeString,
-					Required: true,
+					Type:      schema.TypeString,
+					Required:  true,
+					Sensitive: true,
 				},
 				"filename": {
 					Type:     schema.TypeString,


### PR DESCRIPTION
Set the client certificate content in synthetics config to prevent leaking content in CLI.