### PR TITLE
Reflect synthetics type in resource name example

### DIFF
--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -112,7 +112,7 @@ resource "datadog_synthetics_test" "test_tcp" {
 Create a new Datadog Synthetics API/DNS test on example.org
 
 ```hcl
-resource "datadog_synthetics_test" "test_tcp" {
+resource "datadog_synthetics_test" "test_dns" {
   type = "api"
   subtype = "dns"
   request = {


### PR DESCRIPTION
I know it's minor and kinda nit-picky, but I have just noticed this minor inconsistency in the docs.