### PR TITLE
Add force_delete to SLO resource

### DIFF
--- a/datadog/resource_datadog_service_level_objective.go
+++ b/datadog/resource_datadog_service_level_objective.go
@@ -80,6 +80,10 @@ func resourceDatadogServiceLevelObjective() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: ValidateServiceLevelObjectiveTypeString,
 			},
+			"force_delete": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 
 			// Metric-Based SLO
 			"query": {
@@ -429,8 +433,13 @@ func resourceDatadogServiceLevelObjectiveDelete(d *schema.ResourceData, meta int
 	providerConf := meta.(*ProviderConfiguration)
 	datadogClientV1 := providerConf.DatadogClientV1
 	authV1 := providerConf.AuthV1
+	var err error
 
-	_, _, err := datadogClientV1.ServiceLevelObjectivesApi.DeleteSLO(authV1, d.Id()).Execute()
+	if d.Get("force_delete").(bool) {
+		_, _, err = datadogClientV1.ServiceLevelObjectivesApi.DeleteSLO(authV1, d.Id()).Force("true").Execute()
+	} else {
+		_, _, err = datadogClientV1.ServiceLevelObjectivesApi.DeleteSLO(authV1, d.Id()).Execute()
+	}
 	if err != nil {
 		return translateClientError(err, "error deleting service level objective")
 	}

--- a/docs/resources/service_level_objective.md
+++ b/docs/resources/service_level_objective.md
@@ -77,6 +77,7 @@ The following arguments are supported:
 -   `name`: (Required) Name of Datadog service level objective
 -   `description`: (Optional) A description of this service level objective.
 -   `tags` (Optional) A list of tags to associate with your service level objective. This can help you categorize and filter service level objectives in the service level objectives page of the UI. Note: it's not currently possible to filter by these tags when querying via the API
+-   `force_delete` (Optional) A boolean indicating whether this monitor can be deleted even if it’s referenced by other resources (e.g. dashboards).
 -   `thresholds`: (Required) - A list of thresholds and targets that define the service level objectives from the provided SLIs.
     -   `timeframe` (Required) - the time frame for the objective. The mapping from these types to the types found in the Datadog Web UI can be found in the Datadog API [documentation](https://docs.datadoghq.com/api/v1/service-level-objectives/#create-a-slo-object) page. Available options to choose from are:
         -   `7d`


### PR DESCRIPTION
Add `force_delete` to the SLO resource schema in the same way we have it for the monitor resource. 

This already exists in the API layer, so this brings TF up to date. 