### PR TITLE
Bump datadog-api-client-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-datadog
 
 require (
-	github.com/DataDog/datadog-api-client-go v1.0.0-beta.12
+	github.com/DataDog/datadog-api-client-go v1.0.0-beta.12.0.20201217225655-87ccef56e74b
 	github.com/cenkalti/backoff v2.1.1+incompatible // indirect
 	github.com/dnaeon/go-vcr v1.0.1
 	github.com/fatih/color v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbf
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DataDog/datadog-api-client-go v1.0.0-beta.12 h1:qWUzuaQlPp2PhTqV3I5SFSTy8Bo2rubfZtmrlGyvyew=
-github.com/DataDog/datadog-api-client-go v1.0.0-beta.12/go.mod h1:/bMeu+q33QzX2JuO5PkGkhU1VYOXIXKEPF6Ck4yR06M=
+github.com/DataDog/datadog-api-client-go v1.0.0-beta.12.0.20201217225655-87ccef56e74b h1:MC1aRngMETjfQSh4WmkKNdyTvV/y0mFXYQ6lgyy6m2g=
+github.com/DataDog/datadog-api-client-go v1.0.0-beta.12.0.20201217225655-87ccef56e74b/go.mod h1:/bMeu+q33QzX2JuO5PkGkhU1VYOXIXKEPF6Ck4yR06M=
 github.com/DataDog/datadog-go v3.6.0+incompatible h1:ILg7c5Y1KvZFDOaVS0higGmJ5Fal5O1KQrkrT9j6dSM=
 github.com/DataDog/datadog-go v3.6.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/vendor/github.com/DataDog/datadog-api-client-go/.apigentools-info
+++ b/vendor/github.com/DataDog/datadog-api-client-go/.apigentools-info
@@ -3,14 +3,14 @@
     "info_version": "2",
     "spec_versions": {
         "v1": {
-            "apigentools_version": "1.3.0",
-            "regenerated": "2020-12-02 08:54:48.109093",
-            "spec_repo_commit": "cdc8c0b"
+            "apigentools_version": "1.4.0",
+            "regenerated": "2020-12-17 22:40:53.135588",
+            "spec_repo_commit": "d5e0016"
         },
         "v2": {
-            "apigentools_version": "1.3.0",
-            "regenerated": "2020-12-02 08:54:54.780188",
-            "spec_repo_commit": "cdc8c0b"
+            "apigentools_version": "1.4.0",
+            "regenerated": "2020-12-17 22:40:58.449239",
+            "spec_repo_commit": "d5e0016"
         }
     }
 }

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/README.md
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/README.md
@@ -216,7 +216,7 @@ Class | Method | HTTP request | Description
 *UsageMeteringApi* | [**GetTracingWithoutLimits**](docs/UsageMeteringApi.md#gettracingwithoutlimits) | **Get** /api/v1/usage/tracing-without-limits | Get hourly usage for tracing without limits
 *UsageMeteringApi* | [**GetUsageAnalyzedLogs**](docs/UsageMeteringApi.md#getusageanalyzedlogs) | **Get** /api/v1/usage/analyzed_logs | Get hourly usage for analyzed logs
 *UsageMeteringApi* | [**GetUsageAttribution**](docs/UsageMeteringApi.md#getusageattribution) | **Get** /api/v1/usage/attribution | Get Usage Attribution
-*UsageMeteringApi* | [**GetUsageBillableSummary**](docs/UsageMeteringApi.md#getusagebillablesummary) | **Get** /api/v1/usage/billable-summary | Get billable usage across your multi-org account
+*UsageMeteringApi* | [**GetUsageBillableSummary**](docs/UsageMeteringApi.md#getusagebillablesummary) | **Get** /api/v1/usage/billable-summary | Get billable usage across your account
 *UsageMeteringApi* | [**GetUsageFargate**](docs/UsageMeteringApi.md#getusagefargate) | **Get** /api/v1/usage/fargate | Get hourly usage for Fargate
 *UsageMeteringApi* | [**GetUsageHosts**](docs/UsageMeteringApi.md#getusagehosts) | **Get** /api/v1/usage/hosts | Get hourly usage for hosts and containers
 *UsageMeteringApi* | [**GetUsageIndexedSpans**](docs/UsageMeteringApi.md#getusageindexedspans) | **Get** /api/v1/usage/indexed-spans | Get hourly usage for indexed spans

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/api_dashboards.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/api_dashboards.go
@@ -41,10 +41,11 @@ func (r ApiCreateDashboardRequest) Execute() (Dashboard, *_nethttp.Response, err
 
 /*
  * CreateDashboard Create a new dashboard
- * Create a dashboard using the specified options.
+ * Create a dashboard using the specified options. When defining queries in your widgets, take note of which queries should have the `as_count()` or `as_rate()` modifiers appended.
+Refer to the following [documentation](https://docs.datadoghq.com/developers/metrics/type_modifiers/?tab=count#in-application-modifiers) for more information on these modifiers.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @return ApiCreateDashboardRequest
- */
+*/
 func (a *DashboardsApiService) CreateDashboard(ctx _context.Context) ApiCreateDashboardRequest {
 	return ApiCreateDashboardRequest{
 		ApiService: a,

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/api_usage_metering.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/api_usage_metering.go
@@ -1609,8 +1609,8 @@ func (r ApiGetUsageBillableSummaryRequest) Execute() (UsageBillableSummaryRespon
 }
 
 /*
- * GetUsageBillableSummary Get billable usage across your multi-org account
- * Get billable usage across your multi-org account.
+ * GetUsageBillableSummary Get billable usage across your account
+ * Get billable usage across your account.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @return ApiGetUsageBillableSummaryRequest
  */
@@ -3663,7 +3663,7 @@ func (r ApiGetUsageSummaryRequest) Execute() (UsageSummaryResponse, *_nethttp.Re
 
 /*
  * GetUsageSummary Get usage across your multi-org account
- * Get usage across your multi-org account.
+ * Get usage across your multi-org account. You must have the multi-org feature enabled.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @return ApiGetUsageSummaryRequest
  */

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/client.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/client.go
@@ -234,6 +234,14 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 		if err != nil {
 			return nil, err
 		}
+		// Strip any api keys from the response being logged
+		keys, ok := request.Context().Value(ContextAPIKeys).(map[string]APIKey)
+		if keys != nil && ok {
+			for _, apiKey := range keys {
+				valueRegex := regexp.MustCompile(fmt.Sprintf("(?m)%s", apiKey.Key))
+				dump = valueRegex.ReplaceAll(dump, []byte("REDACTED"))
+			}
+		}
 		log.Printf("\n%s\n", string(dump))
 	}
 
@@ -442,7 +450,7 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 					return err
 				}
 			} else {
-				errors.New("Unknown type with GetActualInstance but no unmarshalObj.UnmarshalJSON defined")
+				return errors.New("Unknown type with GetActualInstance but no unmarshalObj.UnmarshalJSON defined")
 			}
 		} else if err = json.Unmarshal(b, v); err != nil { // simple model
 			return err

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_access_role.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_access_role.go
@@ -24,6 +24,13 @@ const (
 	ACCESSROLE_ERROR     AccessRole = "ERROR"
 )
 
+var allowedAccessRoleEnumValues = []AccessRole{
+	"st",
+	"adm",
+	"ro",
+	"ERROR",
+}
+
 func (v *AccessRole) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -31,7 +38,7 @@ func (v *AccessRole) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := AccessRole(value)
-	for _, existing := range []AccessRole{"st", "adm", "ro", "ERROR"} {
+	for _, existing := range allowedAccessRoleEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -39,6 +46,27 @@ func (v *AccessRole) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid AccessRole", value)
+}
+
+// NewAccessRoleFromValue returns a pointer to a valid AccessRole
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewAccessRoleFromValue(v string) (*AccessRole, error) {
+	ev := AccessRole(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for AccessRole: valid values are %v", v, allowedAccessRoleEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v AccessRole) IsValid() bool {
+	for _, existing := range allowedAccessRoleEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to AccessRole value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_alert_graph_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_alert_graph_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	ALERTGRAPHWIDGETDEFINITIONTYPE_ALERT_GRAPH AlertGraphWidgetDefinitionType = "alert_graph"
 )
 
+var allowedAlertGraphWidgetDefinitionTypeEnumValues = []AlertGraphWidgetDefinitionType{
+	"alert_graph",
+}
+
 func (v *AlertGraphWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *AlertGraphWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := AlertGraphWidgetDefinitionType(value)
-	for _, existing := range []AlertGraphWidgetDefinitionType{"alert_graph"} {
+	for _, existing := range allowedAlertGraphWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *AlertGraphWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid AlertGraphWidgetDefinitionType", value)
+}
+
+// NewAlertGraphWidgetDefinitionTypeFromValue returns a pointer to a valid AlertGraphWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewAlertGraphWidgetDefinitionTypeFromValue(v string) (*AlertGraphWidgetDefinitionType, error) {
+	ev := AlertGraphWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for AlertGraphWidgetDefinitionType: valid values are %v", v, allowedAlertGraphWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v AlertGraphWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedAlertGraphWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to AlertGraphWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_alert_value_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_alert_value_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	ALERTVALUEWIDGETDEFINITIONTYPE_ALERT_VALUE AlertValueWidgetDefinitionType = "alert_value"
 )
 
+var allowedAlertValueWidgetDefinitionTypeEnumValues = []AlertValueWidgetDefinitionType{
+	"alert_value",
+}
+
 func (v *AlertValueWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *AlertValueWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := AlertValueWidgetDefinitionType(value)
-	for _, existing := range []AlertValueWidgetDefinitionType{"alert_value"} {
+	for _, existing := range allowedAlertValueWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *AlertValueWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid AlertValueWidgetDefinitionType", value)
+}
+
+// NewAlertValueWidgetDefinitionTypeFromValue returns a pointer to a valid AlertValueWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewAlertValueWidgetDefinitionTypeFromValue(v string) (*AlertValueWidgetDefinitionType, error) {
+	ev := AlertValueWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for AlertValueWidgetDefinitionType: valid values are %v", v, allowedAlertValueWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v AlertValueWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedAlertValueWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to AlertValueWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_apm_stats_query_row_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_apm_stats_query_row_type.go
@@ -23,6 +23,12 @@ const (
 	APMSTATSQUERYROWTYPE_SPAN     ApmStatsQueryRowType = "span"
 )
 
+var allowedApmStatsQueryRowTypeEnumValues = []ApmStatsQueryRowType{
+	"service",
+	"resource",
+	"span",
+}
+
 func (v *ApmStatsQueryRowType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -30,7 +36,7 @@ func (v *ApmStatsQueryRowType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := ApmStatsQueryRowType(value)
-	for _, existing := range []ApmStatsQueryRowType{"service", "resource", "span"} {
+	for _, existing := range allowedApmStatsQueryRowTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -38,6 +44,27 @@ func (v *ApmStatsQueryRowType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid ApmStatsQueryRowType", value)
+}
+
+// NewApmStatsQueryRowTypeFromValue returns a pointer to a valid ApmStatsQueryRowType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewApmStatsQueryRowTypeFromValue(v string) (*ApmStatsQueryRowType, error) {
+	ev := ApmStatsQueryRowType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for ApmStatsQueryRowType: valid values are %v", v, allowedApmStatsQueryRowTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v ApmStatsQueryRowType) IsValid() bool {
+	for _, existing := range allowedApmStatsQueryRowTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to ApmStatsQueryRowType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_aws_namespace.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_aws_namespace.go
@@ -27,6 +27,16 @@ const (
 	AWSNAMESPACE_LAMBDA          AWSNamespace = "lambda"
 )
 
+var allowedAWSNamespaceEnumValues = []AWSNamespace{
+	"elb",
+	"application_elb",
+	"sqs",
+	"rds",
+	"custom",
+	"network_elb",
+	"lambda",
+}
+
 func (v *AWSNamespace) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -34,7 +44,7 @@ func (v *AWSNamespace) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := AWSNamespace(value)
-	for _, existing := range []AWSNamespace{"elb", "application_elb", "sqs", "rds", "custom", "network_elb", "lambda"} {
+	for _, existing := range allowedAWSNamespaceEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -42,6 +52,27 @@ func (v *AWSNamespace) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid AWSNamespace", value)
+}
+
+// NewAWSNamespaceFromValue returns a pointer to a valid AWSNamespace
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewAWSNamespaceFromValue(v string) (*AWSNamespace, error) {
+	ev := AWSNamespace(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for AWSNamespace: valid values are %v", v, allowedAWSNamespaceEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v AWSNamespace) IsValid() bool {
+	for _, existing := range allowedAWSNamespaceEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to AWSNamespace value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_change_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_change_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	CHANGEWIDGETDEFINITIONTYPE_CHANGE ChangeWidgetDefinitionType = "change"
 )
 
+var allowedChangeWidgetDefinitionTypeEnumValues = []ChangeWidgetDefinitionType{
+	"change",
+}
+
 func (v *ChangeWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *ChangeWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := ChangeWidgetDefinitionType(value)
-	for _, existing := range []ChangeWidgetDefinitionType{"change"} {
+	for _, existing := range allowedChangeWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *ChangeWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid ChangeWidgetDefinitionType", value)
+}
+
+// NewChangeWidgetDefinitionTypeFromValue returns a pointer to a valid ChangeWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewChangeWidgetDefinitionTypeFromValue(v string) (*ChangeWidgetDefinitionType, error) {
+	ev := ChangeWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for ChangeWidgetDefinitionType: valid values are %v", v, allowedChangeWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v ChangeWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedChangeWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to ChangeWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_check_status_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_check_status_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	CHECKSTATUSWIDGETDEFINITIONTYPE_CHECK_STATUS CheckStatusWidgetDefinitionType = "check_status"
 )
 
+var allowedCheckStatusWidgetDefinitionTypeEnumValues = []CheckStatusWidgetDefinitionType{
+	"check_status",
+}
+
 func (v *CheckStatusWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *CheckStatusWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := CheckStatusWidgetDefinitionType(value)
-	for _, existing := range []CheckStatusWidgetDefinitionType{"check_status"} {
+	for _, existing := range allowedCheckStatusWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *CheckStatusWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid CheckStatusWidgetDefinitionType", value)
+}
+
+// NewCheckStatusWidgetDefinitionTypeFromValue returns a pointer to a valid CheckStatusWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewCheckStatusWidgetDefinitionTypeFromValue(v string) (*CheckStatusWidgetDefinitionType, error) {
+	ev := CheckStatusWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for CheckStatusWidgetDefinitionType: valid values are %v", v, allowedCheckStatusWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v CheckStatusWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedCheckStatusWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to CheckStatusWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_dashboard_layout_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_dashboard_layout_type.go
@@ -22,6 +22,11 @@ const (
 	DASHBOARDLAYOUTTYPE_FREE    DashboardLayoutType = "free"
 )
 
+var allowedDashboardLayoutTypeEnumValues = []DashboardLayoutType{
+	"ordered",
+	"free",
+}
+
 func (v *DashboardLayoutType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *DashboardLayoutType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := DashboardLayoutType(value)
-	for _, existing := range []DashboardLayoutType{"ordered", "free"} {
+	for _, existing := range allowedDashboardLayoutTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *DashboardLayoutType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid DashboardLayoutType", value)
+}
+
+// NewDashboardLayoutTypeFromValue returns a pointer to a valid DashboardLayoutType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewDashboardLayoutTypeFromValue(v string) (*DashboardLayoutType, error) {
+	ev := DashboardLayoutType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for DashboardLayoutType: valid values are %v", v, allowedDashboardLayoutTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v DashboardLayoutType) IsValid() bool {
+	for _, existing := range allowedDashboardLayoutTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to DashboardLayoutType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_distribution_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_distribution_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	DISTRIBUTIONWIDGETDEFINITIONTYPE_DISTRIBUTION DistributionWidgetDefinitionType = "distribution"
 )
 
+var allowedDistributionWidgetDefinitionTypeEnumValues = []DistributionWidgetDefinitionType{
+	"distribution",
+}
+
 func (v *DistributionWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *DistributionWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := DistributionWidgetDefinitionType(value)
-	for _, existing := range []DistributionWidgetDefinitionType{"distribution"} {
+	for _, existing := range allowedDistributionWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *DistributionWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid DistributionWidgetDefinitionType", value)
+}
+
+// NewDistributionWidgetDefinitionTypeFromValue returns a pointer to a valid DistributionWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewDistributionWidgetDefinitionTypeFromValue(v string) (*DistributionWidgetDefinitionType, error) {
+	ev := DistributionWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for DistributionWidgetDefinitionType: valid values are %v", v, allowedDistributionWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v DistributionWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedDistributionWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to DistributionWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_downtime.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_downtime.go
@@ -41,7 +41,7 @@ type Downtime struct {
 	Scope *[]string `json:"scope,omitempty"`
 	// POSIX timestamp to start the downtime. If not provided, the downtime starts the moment it is created.
 	Start *int64 `json:"start,omitempty"`
-	// The timezone for the downtime.
+	// The timezone in which to display the downtime's start and end times in Datadog applications.
 	Timezone *string `json:"timezone,omitempty"`
 	// ID of the last user that updated the downtime.
 	UpdaterId NullableInt32 `json:"updater_id,omitempty"`

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_event_alert_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_event_alert_type.go
@@ -27,6 +27,16 @@ const (
 	EVENTALERTTYPE_SNAPSHOT       EventAlertType = "snapshot"
 )
 
+var allowedEventAlertTypeEnumValues = []EventAlertType{
+	"error",
+	"warning",
+	"info",
+	"success",
+	"user_update",
+	"recommendation",
+	"snapshot",
+}
+
 func (v *EventAlertType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -34,7 +44,7 @@ func (v *EventAlertType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := EventAlertType(value)
-	for _, existing := range []EventAlertType{"error", "warning", "info", "success", "user_update", "recommendation", "snapshot"} {
+	for _, existing := range allowedEventAlertTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -42,6 +52,27 @@ func (v *EventAlertType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid EventAlertType", value)
+}
+
+// NewEventAlertTypeFromValue returns a pointer to a valid EventAlertType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewEventAlertTypeFromValue(v string) (*EventAlertType, error) {
+	ev := EventAlertType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for EventAlertType: valid values are %v", v, allowedEventAlertTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v EventAlertType) IsValid() bool {
+	for _, existing := range allowedEventAlertTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to EventAlertType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_event_priority.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_event_priority.go
@@ -22,6 +22,11 @@ const (
 	EVENTPRIORITY_LOW    EventPriority = "low"
 )
 
+var allowedEventPriorityEnumValues = []EventPriority{
+	"normal",
+	"low",
+}
+
 func (v *EventPriority) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *EventPriority) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := EventPriority(value)
-	for _, existing := range []EventPriority{"normal", "low"} {
+	for _, existing := range allowedEventPriorityEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *EventPriority) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid EventPriority", value)
+}
+
+// NewEventPriorityFromValue returns a pointer to a valid EventPriority
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewEventPriorityFromValue(v string) (*EventPriority, error) {
+	ev := EventPriority(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for EventPriority: valid values are %v", v, allowedEventPriorityEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v EventPriority) IsValid() bool {
+	for _, existing := range allowedEventPriorityEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to EventPriority value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_event_stream_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_event_stream_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	EVENTSTREAMWIDGETDEFINITIONTYPE_EVENT_STREAM EventStreamWidgetDefinitionType = "event_stream"
 )
 
+var allowedEventStreamWidgetDefinitionTypeEnumValues = []EventStreamWidgetDefinitionType{
+	"event_stream",
+}
+
 func (v *EventStreamWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *EventStreamWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := EventStreamWidgetDefinitionType(value)
-	for _, existing := range []EventStreamWidgetDefinitionType{"event_stream"} {
+	for _, existing := range allowedEventStreamWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *EventStreamWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid EventStreamWidgetDefinitionType", value)
+}
+
+// NewEventStreamWidgetDefinitionTypeFromValue returns a pointer to a valid EventStreamWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewEventStreamWidgetDefinitionTypeFromValue(v string) (*EventStreamWidgetDefinitionType, error) {
+	ev := EventStreamWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for EventStreamWidgetDefinitionType: valid values are %v", v, allowedEventStreamWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v EventStreamWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedEventStreamWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to EventStreamWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_event_timeline_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_event_timeline_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	EVENTTIMELINEWIDGETDEFINITIONTYPE_EVENT_TIMELINE EventTimelineWidgetDefinitionType = "event_timeline"
 )
 
+var allowedEventTimelineWidgetDefinitionTypeEnumValues = []EventTimelineWidgetDefinitionType{
+	"event_timeline",
+}
+
 func (v *EventTimelineWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *EventTimelineWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := EventTimelineWidgetDefinitionType(value)
-	for _, existing := range []EventTimelineWidgetDefinitionType{"event_timeline"} {
+	for _, existing := range allowedEventTimelineWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *EventTimelineWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid EventTimelineWidgetDefinitionType", value)
+}
+
+// NewEventTimelineWidgetDefinitionTypeFromValue returns a pointer to a valid EventTimelineWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewEventTimelineWidgetDefinitionTypeFromValue(v string) (*EventTimelineWidgetDefinitionType, error) {
+	ev := EventTimelineWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for EventTimelineWidgetDefinitionType: valid values are %v", v, allowedEventTimelineWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v EventTimelineWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedEventTimelineWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to EventTimelineWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_free_text_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_free_text_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	FREETEXTWIDGETDEFINITIONTYPE_FREE_TEXT FreeTextWidgetDefinitionType = "free_text"
 )
 
+var allowedFreeTextWidgetDefinitionTypeEnumValues = []FreeTextWidgetDefinitionType{
+	"free_text",
+}
+
 func (v *FreeTextWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *FreeTextWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := FreeTextWidgetDefinitionType(value)
-	for _, existing := range []FreeTextWidgetDefinitionType{"free_text"} {
+	for _, existing := range allowedFreeTextWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *FreeTextWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid FreeTextWidgetDefinitionType", value)
+}
+
+// NewFreeTextWidgetDefinitionTypeFromValue returns a pointer to a valid FreeTextWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewFreeTextWidgetDefinitionTypeFromValue(v string) (*FreeTextWidgetDefinitionType, error) {
+	ev := FreeTextWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for FreeTextWidgetDefinitionType: valid values are %v", v, allowedFreeTextWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v FreeTextWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedFreeTextWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to FreeTextWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_group_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_group_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	GROUPWIDGETDEFINITIONTYPE_GROUP GroupWidgetDefinitionType = "group"
 )
 
+var allowedGroupWidgetDefinitionTypeEnumValues = []GroupWidgetDefinitionType{
+	"group",
+}
+
 func (v *GroupWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *GroupWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := GroupWidgetDefinitionType(value)
-	for _, existing := range []GroupWidgetDefinitionType{"group"} {
+	for _, existing := range allowedGroupWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *GroupWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid GroupWidgetDefinitionType", value)
+}
+
+// NewGroupWidgetDefinitionTypeFromValue returns a pointer to a valid GroupWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewGroupWidgetDefinitionTypeFromValue(v string) (*GroupWidgetDefinitionType, error) {
+	ev := GroupWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for GroupWidgetDefinitionType: valid values are %v", v, allowedGroupWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v GroupWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedGroupWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to GroupWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_heat_map_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_heat_map_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	HEATMAPWIDGETDEFINITIONTYPE_HEATMAP HeatMapWidgetDefinitionType = "heatmap"
 )
 
+var allowedHeatMapWidgetDefinitionTypeEnumValues = []HeatMapWidgetDefinitionType{
+	"heatmap",
+}
+
 func (v *HeatMapWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *HeatMapWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := HeatMapWidgetDefinitionType(value)
-	for _, existing := range []HeatMapWidgetDefinitionType{"heatmap"} {
+	for _, existing := range allowedHeatMapWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *HeatMapWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid HeatMapWidgetDefinitionType", value)
+}
+
+// NewHeatMapWidgetDefinitionTypeFromValue returns a pointer to a valid HeatMapWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewHeatMapWidgetDefinitionTypeFromValue(v string) (*HeatMapWidgetDefinitionType, error) {
+	ev := HeatMapWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for HeatMapWidgetDefinitionType: valid values are %v", v, allowedHeatMapWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v HeatMapWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedHeatMapWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to HeatMapWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_host_map_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_host_map_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	HOSTMAPWIDGETDEFINITIONTYPE_HOSTMAP HostMapWidgetDefinitionType = "hostmap"
 )
 
+var allowedHostMapWidgetDefinitionTypeEnumValues = []HostMapWidgetDefinitionType{
+	"hostmap",
+}
+
 func (v *HostMapWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *HostMapWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := HostMapWidgetDefinitionType(value)
-	for _, existing := range []HostMapWidgetDefinitionType{"hostmap"} {
+	for _, existing := range allowedHostMapWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *HostMapWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid HostMapWidgetDefinitionType", value)
+}
+
+// NewHostMapWidgetDefinitionTypeFromValue returns a pointer to a valid HostMapWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewHostMapWidgetDefinitionTypeFromValue(v string) (*HostMapWidgetDefinitionType, error) {
+	ev := HostMapWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for HostMapWidgetDefinitionType: valid values are %v", v, allowedHostMapWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v HostMapWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedHostMapWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to HostMapWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_http_method.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_http_method.go
@@ -27,6 +27,16 @@ const (
 	HTTPMETHOD_OPTIONS HTTPMethod = "OPTIONS"
 )
 
+var allowedHTTPMethodEnumValues = []HTTPMethod{
+	"GET",
+	"POST",
+	"PATCH",
+	"PUT",
+	"DELETE",
+	"HEAD",
+	"OPTIONS",
+}
+
 func (v *HTTPMethod) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -34,7 +44,7 @@ func (v *HTTPMethod) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := HTTPMethod(value)
-	for _, existing := range []HTTPMethod{"GET", "POST", "PATCH", "PUT", "DELETE", "HEAD", "OPTIONS"} {
+	for _, existing := range allowedHTTPMethodEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -42,6 +52,27 @@ func (v *HTTPMethod) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid HTTPMethod", value)
+}
+
+// NewHTTPMethodFromValue returns a pointer to a valid HTTPMethod
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewHTTPMethodFromValue(v string) (*HTTPMethod, error) {
+	ev := HTTPMethod(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for HTTPMethod: valid values are %v", v, allowedHTTPMethodEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v HTTPMethod) IsValid() bool {
+	for _, existing := range allowedHTTPMethodEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to HTTPMethod value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_i_frame_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_i_frame_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	IFRAMEWIDGETDEFINITIONTYPE_IFRAME IFrameWidgetDefinitionType = "iframe"
 )
 
+var allowedIFrameWidgetDefinitionTypeEnumValues = []IFrameWidgetDefinitionType{
+	"iframe",
+}
+
 func (v *IFrameWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *IFrameWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := IFrameWidgetDefinitionType(value)
-	for _, existing := range []IFrameWidgetDefinitionType{"iframe"} {
+	for _, existing := range allowedIFrameWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *IFrameWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid IFrameWidgetDefinitionType", value)
+}
+
+// NewIFrameWidgetDefinitionTypeFromValue returns a pointer to a valid IFrameWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewIFrameWidgetDefinitionTypeFromValue(v string) (*IFrameWidgetDefinitionType, error) {
+	ev := IFrameWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for IFrameWidgetDefinitionType: valid values are %v", v, allowedIFrameWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v IFrameWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedIFrameWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to IFrameWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_image_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_image_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	IMAGEWIDGETDEFINITIONTYPE_IMAGE ImageWidgetDefinitionType = "image"
 )
 
+var allowedImageWidgetDefinitionTypeEnumValues = []ImageWidgetDefinitionType{
+	"image",
+}
+
 func (v *ImageWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *ImageWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := ImageWidgetDefinitionType(value)
-	for _, existing := range []ImageWidgetDefinitionType{"image"} {
+	for _, existing := range allowedImageWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *ImageWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid ImageWidgetDefinitionType", value)
+}
+
+// NewImageWidgetDefinitionTypeFromValue returns a pointer to a valid ImageWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewImageWidgetDefinitionTypeFromValue(v string) (*ImageWidgetDefinitionType, error) {
+	ev := ImageWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for ImageWidgetDefinitionType: valid values are %v", v, allowedImageWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v ImageWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedImageWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to ImageWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_log_stream_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_log_stream_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	LOGSTREAMWIDGETDEFINITIONTYPE_LOG_STREAM LogStreamWidgetDefinitionType = "log_stream"
 )
 
+var allowedLogStreamWidgetDefinitionTypeEnumValues = []LogStreamWidgetDefinitionType{
+	"log_stream",
+}
+
 func (v *LogStreamWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogStreamWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogStreamWidgetDefinitionType(value)
-	for _, existing := range []LogStreamWidgetDefinitionType{"log_stream"} {
+	for _, existing := range allowedLogStreamWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogStreamWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogStreamWidgetDefinitionType", value)
+}
+
+// NewLogStreamWidgetDefinitionTypeFromValue returns a pointer to a valid LogStreamWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogStreamWidgetDefinitionTypeFromValue(v string) (*LogStreamWidgetDefinitionType, error) {
+	ev := LogStreamWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogStreamWidgetDefinitionType: valid values are %v", v, allowedLogStreamWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogStreamWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedLogStreamWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogStreamWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_arithmetic_processor_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_arithmetic_processor_type.go
@@ -21,6 +21,10 @@ const (
 	LOGSARITHMETICPROCESSORTYPE_ARITHMETIC_PROCESSOR LogsArithmeticProcessorType = "arithmetic-processor"
 )
 
+var allowedLogsArithmeticProcessorTypeEnumValues = []LogsArithmeticProcessorType{
+	"arithmetic-processor",
+}
+
 func (v *LogsArithmeticProcessorType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogsArithmeticProcessorType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsArithmeticProcessorType(value)
-	for _, existing := range []LogsArithmeticProcessorType{"arithmetic-processor"} {
+	for _, existing := range allowedLogsArithmeticProcessorTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogsArithmeticProcessorType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsArithmeticProcessorType", value)
+}
+
+// NewLogsArithmeticProcessorTypeFromValue returns a pointer to a valid LogsArithmeticProcessorType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsArithmeticProcessorTypeFromValue(v string) (*LogsArithmeticProcessorType, error) {
+	ev := LogsArithmeticProcessorType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsArithmeticProcessorType: valid values are %v", v, allowedLogsArithmeticProcessorTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsArithmeticProcessorType) IsValid() bool {
+	for _, existing := range allowedLogsArithmeticProcessorTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsArithmeticProcessorType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_attribute_remapper_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_attribute_remapper_type.go
@@ -21,6 +21,10 @@ const (
 	LOGSATTRIBUTEREMAPPERTYPE_ATTRIBUTE_REMAPPER LogsAttributeRemapperType = "attribute-remapper"
 )
 
+var allowedLogsAttributeRemapperTypeEnumValues = []LogsAttributeRemapperType{
+	"attribute-remapper",
+}
+
 func (v *LogsAttributeRemapperType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogsAttributeRemapperType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsAttributeRemapperType(value)
-	for _, existing := range []LogsAttributeRemapperType{"attribute-remapper"} {
+	for _, existing := range allowedLogsAttributeRemapperTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogsAttributeRemapperType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsAttributeRemapperType", value)
+}
+
+// NewLogsAttributeRemapperTypeFromValue returns a pointer to a valid LogsAttributeRemapperType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsAttributeRemapperTypeFromValue(v string) (*LogsAttributeRemapperType, error) {
+	ev := LogsAttributeRemapperType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsAttributeRemapperType: valid values are %v", v, allowedLogsAttributeRemapperTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsAttributeRemapperType) IsValid() bool {
+	for _, existing := range allowedLogsAttributeRemapperTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsAttributeRemapperType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_category_processor_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_category_processor_type.go
@@ -21,6 +21,10 @@ const (
 	LOGSCATEGORYPROCESSORTYPE_CATEGORY_PROCESSOR LogsCategoryProcessorType = "category-processor"
 )
 
+var allowedLogsCategoryProcessorTypeEnumValues = []LogsCategoryProcessorType{
+	"category-processor",
+}
+
 func (v *LogsCategoryProcessorType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogsCategoryProcessorType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsCategoryProcessorType(value)
-	for _, existing := range []LogsCategoryProcessorType{"category-processor"} {
+	for _, existing := range allowedLogsCategoryProcessorTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogsCategoryProcessorType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsCategoryProcessorType", value)
+}
+
+// NewLogsCategoryProcessorTypeFromValue returns a pointer to a valid LogsCategoryProcessorType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsCategoryProcessorTypeFromValue(v string) (*LogsCategoryProcessorType, error) {
+	ev := LogsCategoryProcessorType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsCategoryProcessorType: valid values are %v", v, allowedLogsCategoryProcessorTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsCategoryProcessorType) IsValid() bool {
+	for _, existing := range allowedLogsCategoryProcessorTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsCategoryProcessorType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_date_remapper_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_date_remapper_type.go
@@ -21,6 +21,10 @@ const (
 	LOGSDATEREMAPPERTYPE_DATE_REMAPPER LogsDateRemapperType = "date-remapper"
 )
 
+var allowedLogsDateRemapperTypeEnumValues = []LogsDateRemapperType{
+	"date-remapper",
+}
+
 func (v *LogsDateRemapperType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogsDateRemapperType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsDateRemapperType(value)
-	for _, existing := range []LogsDateRemapperType{"date-remapper"} {
+	for _, existing := range allowedLogsDateRemapperTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogsDateRemapperType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsDateRemapperType", value)
+}
+
+// NewLogsDateRemapperTypeFromValue returns a pointer to a valid LogsDateRemapperType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsDateRemapperTypeFromValue(v string) (*LogsDateRemapperType, error) {
+	ev := LogsDateRemapperType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsDateRemapperType: valid values are %v", v, allowedLogsDateRemapperTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsDateRemapperType) IsValid() bool {
+	for _, existing := range allowedLogsDateRemapperTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsDateRemapperType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_geo_ip_parser_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_geo_ip_parser_type.go
@@ -21,6 +21,10 @@ const (
 	LOGSGEOIPPARSERTYPE_GEO_IP_PARSER LogsGeoIPParserType = "geo-ip-parser"
 )
 
+var allowedLogsGeoIPParserTypeEnumValues = []LogsGeoIPParserType{
+	"geo-ip-parser",
+}
+
 func (v *LogsGeoIPParserType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogsGeoIPParserType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsGeoIPParserType(value)
-	for _, existing := range []LogsGeoIPParserType{"geo-ip-parser"} {
+	for _, existing := range allowedLogsGeoIPParserTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogsGeoIPParserType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsGeoIPParserType", value)
+}
+
+// NewLogsGeoIPParserTypeFromValue returns a pointer to a valid LogsGeoIPParserType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsGeoIPParserTypeFromValue(v string) (*LogsGeoIPParserType, error) {
+	ev := LogsGeoIPParserType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsGeoIPParserType: valid values are %v", v, allowedLogsGeoIPParserTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsGeoIPParserType) IsValid() bool {
+	for _, existing := range allowedLogsGeoIPParserTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsGeoIPParserType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_grok_parser_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_grok_parser_type.go
@@ -21,6 +21,10 @@ const (
 	LOGSGROKPARSERTYPE_GROK_PARSER LogsGrokParserType = "grok-parser"
 )
 
+var allowedLogsGrokParserTypeEnumValues = []LogsGrokParserType{
+	"grok-parser",
+}
+
 func (v *LogsGrokParserType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogsGrokParserType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsGrokParserType(value)
-	for _, existing := range []LogsGrokParserType{"grok-parser"} {
+	for _, existing := range allowedLogsGrokParserTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogsGrokParserType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsGrokParserType", value)
+}
+
+// NewLogsGrokParserTypeFromValue returns a pointer to a valid LogsGrokParserType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsGrokParserTypeFromValue(v string) (*LogsGrokParserType, error) {
+	ev := LogsGrokParserType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsGrokParserType: valid values are %v", v, allowedLogsGrokParserTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsGrokParserType) IsValid() bool {
+	for _, existing := range allowedLogsGrokParserTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsGrokParserType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_lookup_processor_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_lookup_processor_type.go
@@ -21,6 +21,10 @@ const (
 	LOGSLOOKUPPROCESSORTYPE_LOOKUP_PROCESSOR LogsLookupProcessorType = "lookup-processor"
 )
 
+var allowedLogsLookupProcessorTypeEnumValues = []LogsLookupProcessorType{
+	"lookup-processor",
+}
+
 func (v *LogsLookupProcessorType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogsLookupProcessorType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsLookupProcessorType(value)
-	for _, existing := range []LogsLookupProcessorType{"lookup-processor"} {
+	for _, existing := range allowedLogsLookupProcessorTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogsLookupProcessorType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsLookupProcessorType", value)
+}
+
+// NewLogsLookupProcessorTypeFromValue returns a pointer to a valid LogsLookupProcessorType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsLookupProcessorTypeFromValue(v string) (*LogsLookupProcessorType, error) {
+	ev := LogsLookupProcessorType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsLookupProcessorType: valid values are %v", v, allowedLogsLookupProcessorTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsLookupProcessorType) IsValid() bool {
+	for _, existing := range allowedLogsLookupProcessorTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsLookupProcessorType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_message_remapper_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_message_remapper_type.go
@@ -21,6 +21,10 @@ const (
 	LOGSMESSAGEREMAPPERTYPE_MESSAGE_REMAPPER LogsMessageRemapperType = "message-remapper"
 )
 
+var allowedLogsMessageRemapperTypeEnumValues = []LogsMessageRemapperType{
+	"message-remapper",
+}
+
 func (v *LogsMessageRemapperType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogsMessageRemapperType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsMessageRemapperType(value)
-	for _, existing := range []LogsMessageRemapperType{"message-remapper"} {
+	for _, existing := range allowedLogsMessageRemapperTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogsMessageRemapperType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsMessageRemapperType", value)
+}
+
+// NewLogsMessageRemapperTypeFromValue returns a pointer to a valid LogsMessageRemapperType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsMessageRemapperTypeFromValue(v string) (*LogsMessageRemapperType, error) {
+	ev := LogsMessageRemapperType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsMessageRemapperType: valid values are %v", v, allowedLogsMessageRemapperTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsMessageRemapperType) IsValid() bool {
+	for _, existing := range allowedLogsMessageRemapperTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsMessageRemapperType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_pipeline_processor_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_pipeline_processor_type.go
@@ -21,6 +21,10 @@ const (
 	LOGSPIPELINEPROCESSORTYPE_PIPELINE LogsPipelineProcessorType = "pipeline"
 )
 
+var allowedLogsPipelineProcessorTypeEnumValues = []LogsPipelineProcessorType{
+	"pipeline",
+}
+
 func (v *LogsPipelineProcessorType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogsPipelineProcessorType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsPipelineProcessorType(value)
-	for _, existing := range []LogsPipelineProcessorType{"pipeline"} {
+	for _, existing := range allowedLogsPipelineProcessorTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogsPipelineProcessorType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsPipelineProcessorType", value)
+}
+
+// NewLogsPipelineProcessorTypeFromValue returns a pointer to a valid LogsPipelineProcessorType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsPipelineProcessorTypeFromValue(v string) (*LogsPipelineProcessorType, error) {
+	ev := LogsPipelineProcessorType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsPipelineProcessorType: valid values are %v", v, allowedLogsPipelineProcessorTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsPipelineProcessorType) IsValid() bool {
+	for _, existing := range allowedLogsPipelineProcessorTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsPipelineProcessorType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_service_remapper_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_service_remapper_type.go
@@ -21,6 +21,10 @@ const (
 	LOGSSERVICEREMAPPERTYPE_SERVICE_REMAPPER LogsServiceRemapperType = "service-remapper"
 )
 
+var allowedLogsServiceRemapperTypeEnumValues = []LogsServiceRemapperType{
+	"service-remapper",
+}
+
 func (v *LogsServiceRemapperType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogsServiceRemapperType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsServiceRemapperType(value)
-	for _, existing := range []LogsServiceRemapperType{"service-remapper"} {
+	for _, existing := range allowedLogsServiceRemapperTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogsServiceRemapperType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsServiceRemapperType", value)
+}
+
+// NewLogsServiceRemapperTypeFromValue returns a pointer to a valid LogsServiceRemapperType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsServiceRemapperTypeFromValue(v string) (*LogsServiceRemapperType, error) {
+	ev := LogsServiceRemapperType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsServiceRemapperType: valid values are %v", v, allowedLogsServiceRemapperTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsServiceRemapperType) IsValid() bool {
+	for _, existing := range allowedLogsServiceRemapperTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsServiceRemapperType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_sort.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_sort.go
@@ -22,6 +22,11 @@ const (
 	LOGSSORT_TIME_DESCENDING LogsSort = "desc"
 )
 
+var allowedLogsSortEnumValues = []LogsSort{
+	"asc",
+	"desc",
+}
+
 func (v *LogsSort) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *LogsSort) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsSort(value)
-	for _, existing := range []LogsSort{"asc", "desc"} {
+	for _, existing := range allowedLogsSortEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *LogsSort) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsSort", value)
+}
+
+// NewLogsSortFromValue returns a pointer to a valid LogsSort
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsSortFromValue(v string) (*LogsSort, error) {
+	ev := LogsSort(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsSort: valid values are %v", v, allowedLogsSortEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsSort) IsValid() bool {
+	for _, existing := range allowedLogsSortEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsSort value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_status_remapper_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_status_remapper_type.go
@@ -21,6 +21,10 @@ const (
 	LOGSSTATUSREMAPPERTYPE_STATUS_REMAPPER LogsStatusRemapperType = "status-remapper"
 )
 
+var allowedLogsStatusRemapperTypeEnumValues = []LogsStatusRemapperType{
+	"status-remapper",
+}
+
 func (v *LogsStatusRemapperType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogsStatusRemapperType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsStatusRemapperType(value)
-	for _, existing := range []LogsStatusRemapperType{"status-remapper"} {
+	for _, existing := range allowedLogsStatusRemapperTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogsStatusRemapperType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsStatusRemapperType", value)
+}
+
+// NewLogsStatusRemapperTypeFromValue returns a pointer to a valid LogsStatusRemapperType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsStatusRemapperTypeFromValue(v string) (*LogsStatusRemapperType, error) {
+	ev := LogsStatusRemapperType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsStatusRemapperType: valid values are %v", v, allowedLogsStatusRemapperTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsStatusRemapperType) IsValid() bool {
+	for _, existing := range allowedLogsStatusRemapperTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsStatusRemapperType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_string_builder_processor_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_string_builder_processor_type.go
@@ -21,6 +21,10 @@ const (
 	LOGSSTRINGBUILDERPROCESSORTYPE_STRING_BUILDER_PROCESSOR LogsStringBuilderProcessorType = "string-builder-processor"
 )
 
+var allowedLogsStringBuilderProcessorTypeEnumValues = []LogsStringBuilderProcessorType{
+	"string-builder-processor",
+}
+
 func (v *LogsStringBuilderProcessorType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogsStringBuilderProcessorType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsStringBuilderProcessorType(value)
-	for _, existing := range []LogsStringBuilderProcessorType{"string-builder-processor"} {
+	for _, existing := range allowedLogsStringBuilderProcessorTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogsStringBuilderProcessorType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsStringBuilderProcessorType", value)
+}
+
+// NewLogsStringBuilderProcessorTypeFromValue returns a pointer to a valid LogsStringBuilderProcessorType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsStringBuilderProcessorTypeFromValue(v string) (*LogsStringBuilderProcessorType, error) {
+	ev := LogsStringBuilderProcessorType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsStringBuilderProcessorType: valid values are %v", v, allowedLogsStringBuilderProcessorTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsStringBuilderProcessorType) IsValid() bool {
+	for _, existing := range allowedLogsStringBuilderProcessorTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsStringBuilderProcessorType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_trace_remapper_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_trace_remapper_type.go
@@ -21,6 +21,10 @@ const (
 	LOGSTRACEREMAPPERTYPE_TRACE_ID_REMAPPER LogsTraceRemapperType = "trace-id-remapper"
 )
 
+var allowedLogsTraceRemapperTypeEnumValues = []LogsTraceRemapperType{
+	"trace-id-remapper",
+}
+
 func (v *LogsTraceRemapperType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogsTraceRemapperType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsTraceRemapperType(value)
-	for _, existing := range []LogsTraceRemapperType{"trace-id-remapper"} {
+	for _, existing := range allowedLogsTraceRemapperTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogsTraceRemapperType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsTraceRemapperType", value)
+}
+
+// NewLogsTraceRemapperTypeFromValue returns a pointer to a valid LogsTraceRemapperType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsTraceRemapperTypeFromValue(v string) (*LogsTraceRemapperType, error) {
+	ev := LogsTraceRemapperType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsTraceRemapperType: valid values are %v", v, allowedLogsTraceRemapperTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsTraceRemapperType) IsValid() bool {
+	for _, existing := range allowedLogsTraceRemapperTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsTraceRemapperType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_url_parser_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_url_parser_type.go
@@ -21,6 +21,10 @@ const (
 	LOGSURLPARSERTYPE_URL_PARSER LogsURLParserType = "url-parser"
 )
 
+var allowedLogsURLParserTypeEnumValues = []LogsURLParserType{
+	"url-parser",
+}
+
 func (v *LogsURLParserType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogsURLParserType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsURLParserType(value)
-	for _, existing := range []LogsURLParserType{"url-parser"} {
+	for _, existing := range allowedLogsURLParserTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogsURLParserType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsURLParserType", value)
+}
+
+// NewLogsURLParserTypeFromValue returns a pointer to a valid LogsURLParserType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsURLParserTypeFromValue(v string) (*LogsURLParserType, error) {
+	ev := LogsURLParserType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsURLParserType: valid values are %v", v, allowedLogsURLParserTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsURLParserType) IsValid() bool {
+	for _, existing := range allowedLogsURLParserTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsURLParserType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_user_agent_parser_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_logs_user_agent_parser_type.go
@@ -21,6 +21,10 @@ const (
 	LOGSUSERAGENTPARSERTYPE_USER_AGENT_PARSER LogsUserAgentParserType = "user-agent-parser"
 )
 
+var allowedLogsUserAgentParserTypeEnumValues = []LogsUserAgentParserType{
+	"user-agent-parser",
+}
+
 func (v *LogsUserAgentParserType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogsUserAgentParserType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsUserAgentParserType(value)
-	for _, existing := range []LogsUserAgentParserType{"user-agent-parser"} {
+	for _, existing := range allowedLogsUserAgentParserTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogsUserAgentParserType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsUserAgentParserType", value)
+}
+
+// NewLogsUserAgentParserTypeFromValue returns a pointer to a valid LogsUserAgentParserType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsUserAgentParserTypeFromValue(v string) (*LogsUserAgentParserType, error) {
+	ev := LogsUserAgentParserType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsUserAgentParserType: valid values are %v", v, allowedLogsUserAgentParserTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsUserAgentParserType) IsValid() bool {
+	for _, existing := range allowedLogsUserAgentParserTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsUserAgentParserType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_monitor_device_id.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_monitor_device_id.go
@@ -29,6 +29,18 @@ const (
 	MONITORDEVICEID_FIREFOX_MOBILE_SMALL MonitorDeviceID = "firefox.mobile_small"
 )
 
+var allowedMonitorDeviceIDEnumValues = []MonitorDeviceID{
+	"laptop_large",
+	"tablet",
+	"mobile_small",
+	"chrome.laptop_large",
+	"chrome.tablet",
+	"chrome.mobile_small",
+	"firefox.laptop_large",
+	"firefox.tablet",
+	"firefox.mobile_small",
+}
+
 func (v *MonitorDeviceID) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -36,7 +48,7 @@ func (v *MonitorDeviceID) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := MonitorDeviceID(value)
-	for _, existing := range []MonitorDeviceID{"laptop_large", "tablet", "mobile_small", "chrome.laptop_large", "chrome.tablet", "chrome.mobile_small", "firefox.laptop_large", "firefox.tablet", "firefox.mobile_small"} {
+	for _, existing := range allowedMonitorDeviceIDEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -44,6 +56,27 @@ func (v *MonitorDeviceID) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid MonitorDeviceID", value)
+}
+
+// NewMonitorDeviceIDFromValue returns a pointer to a valid MonitorDeviceID
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewMonitorDeviceIDFromValue(v string) (*MonitorDeviceID, error) {
+	ev := MonitorDeviceID(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for MonitorDeviceID: valid values are %v", v, allowedMonitorDeviceIDEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v MonitorDeviceID) IsValid() bool {
+	for _, existing := range allowedMonitorDeviceIDEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to MonitorDeviceID value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_monitor_overall_states.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_monitor_overall_states.go
@@ -27,6 +27,16 @@ const (
 	MONITOROVERALLSTATES_WARN    MonitorOverallStates = "Warn"
 )
 
+var allowedMonitorOverallStatesEnumValues = []MonitorOverallStates{
+	"Alert",
+	"Ignored",
+	"No Data",
+	"OK",
+	"Skipped",
+	"Unknown",
+	"Warn",
+}
+
 func (v *MonitorOverallStates) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -34,7 +44,7 @@ func (v *MonitorOverallStates) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := MonitorOverallStates(value)
-	for _, existing := range []MonitorOverallStates{"Alert", "Ignored", "No Data", "OK", "Skipped", "Unknown", "Warn"} {
+	for _, existing := range allowedMonitorOverallStatesEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -42,6 +52,27 @@ func (v *MonitorOverallStates) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid MonitorOverallStates", value)
+}
+
+// NewMonitorOverallStatesFromValue returns a pointer to a valid MonitorOverallStates
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewMonitorOverallStatesFromValue(v string) (*MonitorOverallStates, error) {
+	ev := MonitorOverallStates(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for MonitorOverallStates: valid values are %v", v, allowedMonitorOverallStatesEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v MonitorOverallStates) IsValid() bool {
+	for _, existing := range allowedMonitorOverallStatesEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to MonitorOverallStates value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_monitor_summary_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_monitor_summary_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	MONITORSUMMARYWIDGETDEFINITIONTYPE_MANAGE_STATUS MonitorSummaryWidgetDefinitionType = "manage_status"
 )
 
+var allowedMonitorSummaryWidgetDefinitionTypeEnumValues = []MonitorSummaryWidgetDefinitionType{
+	"manage_status",
+}
+
 func (v *MonitorSummaryWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *MonitorSummaryWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := MonitorSummaryWidgetDefinitionType(value)
-	for _, existing := range []MonitorSummaryWidgetDefinitionType{"manage_status"} {
+	for _, existing := range allowedMonitorSummaryWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *MonitorSummaryWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid MonitorSummaryWidgetDefinitionType", value)
+}
+
+// NewMonitorSummaryWidgetDefinitionTypeFromValue returns a pointer to a valid MonitorSummaryWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewMonitorSummaryWidgetDefinitionTypeFromValue(v string) (*MonitorSummaryWidgetDefinitionType, error) {
+	ev := MonitorSummaryWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for MonitorSummaryWidgetDefinitionType: valid values are %v", v, allowedMonitorSummaryWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v MonitorSummaryWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedMonitorSummaryWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to MonitorSummaryWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_monitor_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_monitor_type.go
@@ -31,6 +31,20 @@ const (
 	MONITORTYPE_SLO_ALERT             MonitorType = "slo alert"
 )
 
+var allowedMonitorTypeEnumValues = []MonitorType{
+	"composite",
+	"event alert",
+	"log alert",
+	"metric alert",
+	"process alert",
+	"query alert",
+	"rum alert",
+	"service check",
+	"synthetics alert",
+	"trace-analytics alert",
+	"slo alert",
+}
+
 func (v *MonitorType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -38,7 +52,7 @@ func (v *MonitorType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := MonitorType(value)
-	for _, existing := range []MonitorType{"composite", "event alert", "log alert", "metric alert", "process alert", "query alert", "rum alert", "service check", "synthetics alert", "trace-analytics alert", "slo alert"} {
+	for _, existing := range allowedMonitorTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -46,6 +60,27 @@ func (v *MonitorType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid MonitorType", value)
+}
+
+// NewMonitorTypeFromValue returns a pointer to a valid MonitorType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewMonitorTypeFromValue(v string) (*MonitorType, error) {
+	ev := MonitorType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for MonitorType: valid values are %v", v, allowedMonitorTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v MonitorType) IsValid() bool {
+	for _, existing := range allowedMonitorTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to MonitorType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_note_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_note_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	NOTEWIDGETDEFINITIONTYPE_NOTE NoteWidgetDefinitionType = "note"
 )
 
+var allowedNoteWidgetDefinitionTypeEnumValues = []NoteWidgetDefinitionType{
+	"note",
+}
+
 func (v *NoteWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *NoteWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := NoteWidgetDefinitionType(value)
-	for _, existing := range []NoteWidgetDefinitionType{"note"} {
+	for _, existing := range allowedNoteWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *NoteWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid NoteWidgetDefinitionType", value)
+}
+
+// NewNoteWidgetDefinitionTypeFromValue returns a pointer to a valid NoteWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewNoteWidgetDefinitionTypeFromValue(v string) (*NoteWidgetDefinitionType, error) {
+	ev := NoteWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for NoteWidgetDefinitionType: valid values are %v", v, allowedNoteWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v NoteWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedNoteWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to NoteWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_query_value_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_query_value_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	QUERYVALUEWIDGETDEFINITIONTYPE_QUERY_VALUE QueryValueWidgetDefinitionType = "query_value"
 )
 
+var allowedQueryValueWidgetDefinitionTypeEnumValues = []QueryValueWidgetDefinitionType{
+	"query_value",
+}
+
 func (v *QueryValueWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *QueryValueWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := QueryValueWidgetDefinitionType(value)
-	for _, existing := range []QueryValueWidgetDefinitionType{"query_value"} {
+	for _, existing := range allowedQueryValueWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *QueryValueWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid QueryValueWidgetDefinitionType", value)
+}
+
+// NewQueryValueWidgetDefinitionTypeFromValue returns a pointer to a valid QueryValueWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewQueryValueWidgetDefinitionTypeFromValue(v string) (*QueryValueWidgetDefinitionType, error) {
+	ev := QueryValueWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for QueryValueWidgetDefinitionType: valid values are %v", v, allowedQueryValueWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v QueryValueWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedQueryValueWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to QueryValueWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_scatter_plot_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_scatter_plot_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	SCATTERPLOTWIDGETDEFINITIONTYPE_SCATTERPLOT ScatterPlotWidgetDefinitionType = "scatterplot"
 )
 
+var allowedScatterPlotWidgetDefinitionTypeEnumValues = []ScatterPlotWidgetDefinitionType{
+	"scatterplot",
+}
+
 func (v *ScatterPlotWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *ScatterPlotWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := ScatterPlotWidgetDefinitionType(value)
-	for _, existing := range []ScatterPlotWidgetDefinitionType{"scatterplot"} {
+	for _, existing := range allowedScatterPlotWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *ScatterPlotWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid ScatterPlotWidgetDefinitionType", value)
+}
+
+// NewScatterPlotWidgetDefinitionTypeFromValue returns a pointer to a valid ScatterPlotWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewScatterPlotWidgetDefinitionTypeFromValue(v string) (*ScatterPlotWidgetDefinitionType, error) {
+	ev := ScatterPlotWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for ScatterPlotWidgetDefinitionType: valid values are %v", v, allowedScatterPlotWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v ScatterPlotWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedScatterPlotWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to ScatterPlotWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_service_map_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_service_map_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	SERVICEMAPWIDGETDEFINITIONTYPE_SERVICEMAP ServiceMapWidgetDefinitionType = "servicemap"
 )
 
+var allowedServiceMapWidgetDefinitionTypeEnumValues = []ServiceMapWidgetDefinitionType{
+	"servicemap",
+}
+
 func (v *ServiceMapWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *ServiceMapWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := ServiceMapWidgetDefinitionType(value)
-	for _, existing := range []ServiceMapWidgetDefinitionType{"servicemap"} {
+	for _, existing := range allowedServiceMapWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *ServiceMapWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid ServiceMapWidgetDefinitionType", value)
+}
+
+// NewServiceMapWidgetDefinitionTypeFromValue returns a pointer to a valid ServiceMapWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewServiceMapWidgetDefinitionTypeFromValue(v string) (*ServiceMapWidgetDefinitionType, error) {
+	ev := ServiceMapWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for ServiceMapWidgetDefinitionType: valid values are %v", v, allowedServiceMapWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v ServiceMapWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedServiceMapWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to ServiceMapWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_service_summary_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_service_summary_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	SERVICESUMMARYWIDGETDEFINITIONTYPE_TRACE_SERVICE ServiceSummaryWidgetDefinitionType = "trace_service"
 )
 
+var allowedServiceSummaryWidgetDefinitionTypeEnumValues = []ServiceSummaryWidgetDefinitionType{
+	"trace_service",
+}
+
 func (v *ServiceSummaryWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *ServiceSummaryWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := ServiceSummaryWidgetDefinitionType(value)
-	for _, existing := range []ServiceSummaryWidgetDefinitionType{"trace_service"} {
+	for _, existing := range allowedServiceSummaryWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *ServiceSummaryWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid ServiceSummaryWidgetDefinitionType", value)
+}
+
+// NewServiceSummaryWidgetDefinitionTypeFromValue returns a pointer to a valid ServiceSummaryWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewServiceSummaryWidgetDefinitionTypeFromValue(v string) (*ServiceSummaryWidgetDefinitionType, error) {
+	ev := ServiceSummaryWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for ServiceSummaryWidgetDefinitionType: valid values are %v", v, allowedServiceSummaryWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v ServiceSummaryWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedServiceSummaryWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to ServiceSummaryWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_slo_error_timeframe.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_slo_error_timeframe.go
@@ -24,6 +24,13 @@ const (
 	SLOERRORTIMEFRAME_ALL         SLOErrorTimeframe = "all"
 )
 
+var allowedSLOErrorTimeframeEnumValues = []SLOErrorTimeframe{
+	"7d",
+	"30d",
+	"90d",
+	"all",
+}
+
 func (v *SLOErrorTimeframe) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -31,7 +38,7 @@ func (v *SLOErrorTimeframe) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SLOErrorTimeframe(value)
-	for _, existing := range []SLOErrorTimeframe{"7d", "30d", "90d", "all"} {
+	for _, existing := range allowedSLOErrorTimeframeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -39,6 +46,27 @@ func (v *SLOErrorTimeframe) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SLOErrorTimeframe", value)
+}
+
+// NewSLOErrorTimeframeFromValue returns a pointer to a valid SLOErrorTimeframe
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSLOErrorTimeframeFromValue(v string) (*SLOErrorTimeframe, error) {
+	ev := SLOErrorTimeframe(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SLOErrorTimeframe: valid values are %v", v, allowedSLOErrorTimeframeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SLOErrorTimeframe) IsValid() bool {
+	for _, existing := range allowedSLOErrorTimeframeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SLOErrorTimeframe value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_slo_timeframe.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_slo_timeframe.go
@@ -23,6 +23,12 @@ const (
 	SLOTIMEFRAME_NINETY_DAYS SLOTimeframe = "90d"
 )
 
+var allowedSLOTimeframeEnumValues = []SLOTimeframe{
+	"7d",
+	"30d",
+	"90d",
+}
+
 func (v *SLOTimeframe) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -30,7 +36,7 @@ func (v *SLOTimeframe) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SLOTimeframe(value)
-	for _, existing := range []SLOTimeframe{"7d", "30d", "90d"} {
+	for _, existing := range allowedSLOTimeframeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -38,6 +44,27 @@ func (v *SLOTimeframe) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SLOTimeframe", value)
+}
+
+// NewSLOTimeframeFromValue returns a pointer to a valid SLOTimeframe
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSLOTimeframeFromValue(v string) (*SLOTimeframe, error) {
+	ev := SLOTimeframe(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SLOTimeframe: valid values are %v", v, allowedSLOTimeframeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SLOTimeframe) IsValid() bool {
+	for _, existing := range allowedSLOTimeframeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SLOTimeframe value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_slo_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_slo_type.go
@@ -22,6 +22,11 @@ const (
 	SLOTYPE_MONITOR SLOType = "monitor"
 )
 
+var allowedSLOTypeEnumValues = []SLOType{
+	"metric",
+	"monitor",
+}
+
 func (v *SLOType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *SLOType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SLOType(value)
-	for _, existing := range []SLOType{"metric", "monitor"} {
+	for _, existing := range allowedSLOTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *SLOType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SLOType", value)
+}
+
+// NewSLOTypeFromValue returns a pointer to a valid SLOType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSLOTypeFromValue(v string) (*SLOType, error) {
+	ev := SLOType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SLOType: valid values are %v", v, allowedSLOTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SLOType) IsValid() bool {
+	for _, existing := range allowedSLOTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SLOType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_slo_type_numeric.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_slo_type_numeric.go
@@ -22,6 +22,11 @@ const (
 	SLOTYPENUMERIC_METRIC  SLOTypeNumeric = 1
 )
 
+var allowedSLOTypeNumericEnumValues = []SLOTypeNumeric{
+	0,
+	1,
+}
+
 func (v *SLOTypeNumeric) UnmarshalJSON(src []byte) error {
 	var value int32
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *SLOTypeNumeric) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SLOTypeNumeric(value)
-	for _, existing := range []SLOTypeNumeric{0, 1} {
+	for _, existing := range allowedSLOTypeNumericEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *SLOTypeNumeric) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SLOTypeNumeric", value)
+}
+
+// NewSLOTypeNumericFromValue returns a pointer to a valid SLOTypeNumeric
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSLOTypeNumericFromValue(v int32) (*SLOTypeNumeric, error) {
+	ev := SLOTypeNumeric(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SLOTypeNumeric: valid values are %v", v, allowedSLOTypeNumericEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SLOTypeNumeric) IsValid() bool {
+	for _, existing := range allowedSLOTypeNumericEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SLOTypeNumeric value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_slo_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_slo_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	SLOWIDGETDEFINITIONTYPE_SLO SLOWidgetDefinitionType = "slo"
 )
 
+var allowedSLOWidgetDefinitionTypeEnumValues = []SLOWidgetDefinitionType{
+	"slo",
+}
+
 func (v *SLOWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *SLOWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SLOWidgetDefinitionType(value)
-	for _, existing := range []SLOWidgetDefinitionType{"slo"} {
+	for _, existing := range allowedSLOWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *SLOWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SLOWidgetDefinitionType", value)
+}
+
+// NewSLOWidgetDefinitionTypeFromValue returns a pointer to a valid SLOWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSLOWidgetDefinitionTypeFromValue(v string) (*SLOWidgetDefinitionType, error) {
+	ev := SLOWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SLOWidgetDefinitionType: valid values are %v", v, allowedSLOWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SLOWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedSLOWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SLOWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_assertion_json_path_operator.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_assertion_json_path_operator.go
@@ -21,6 +21,10 @@ const (
 	SYNTHETICSASSERTIONJSONPATHOPERATOR_VALIDATES_JSON_PATH SyntheticsAssertionJSONPathOperator = "validatesJSONPath"
 )
 
+var allowedSyntheticsAssertionJSONPathOperatorEnumValues = []SyntheticsAssertionJSONPathOperator{
+	"validatesJSONPath",
+}
+
 func (v *SyntheticsAssertionJSONPathOperator) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *SyntheticsAssertionJSONPathOperator) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SyntheticsAssertionJSONPathOperator(value)
-	for _, existing := range []SyntheticsAssertionJSONPathOperator{"validatesJSONPath"} {
+	for _, existing := range allowedSyntheticsAssertionJSONPathOperatorEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *SyntheticsAssertionJSONPathOperator) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SyntheticsAssertionJSONPathOperator", value)
+}
+
+// NewSyntheticsAssertionJSONPathOperatorFromValue returns a pointer to a valid SyntheticsAssertionJSONPathOperator
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSyntheticsAssertionJSONPathOperatorFromValue(v string) (*SyntheticsAssertionJSONPathOperator, error) {
+	ev := SyntheticsAssertionJSONPathOperator(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SyntheticsAssertionJSONPathOperator: valid values are %v", v, allowedSyntheticsAssertionJSONPathOperatorEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SyntheticsAssertionJSONPathOperator) IsValid() bool {
+	for _, existing := range allowedSyntheticsAssertionJSONPathOperatorEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SyntheticsAssertionJSONPathOperator value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_assertion_operator.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_assertion_operator.go
@@ -23,13 +23,31 @@ const (
 	SYNTHETICSASSERTIONOPERATOR_IS                   SyntheticsAssertionOperator = "is"
 	SYNTHETICSASSERTIONOPERATOR_IS_NOT               SyntheticsAssertionOperator = "isNot"
 	SYNTHETICSASSERTIONOPERATOR_LESS_THAN            SyntheticsAssertionOperator = "lessThan"
+	SYNTHETICSASSERTIONOPERATOR_LESS_THAN_OR_EQUAL   SyntheticsAssertionOperator = "lessThanOrEqual"
 	SYNTHETICSASSERTIONOPERATOR_MORE_THAN            SyntheticsAssertionOperator = "moreThan"
+	SYNTHETICSASSERTIONOPERATOR_MORE_THAN_OR_EQUAL   SyntheticsAssertionOperator = "moreThanOrEqual"
 	SYNTHETICSASSERTIONOPERATOR_MATCHES              SyntheticsAssertionOperator = "matches"
 	SYNTHETICSASSERTIONOPERATOR_DOES_NOT_MATCH       SyntheticsAssertionOperator = "doesNotMatch"
 	SYNTHETICSASSERTIONOPERATOR_VALIDATES            SyntheticsAssertionOperator = "validates"
 	SYNTHETICSASSERTIONOPERATOR_IS_IN_MORE_DAYS_THAN SyntheticsAssertionOperator = "isInMoreThan"
 	SYNTHETICSASSERTIONOPERATOR_IS_IN_LESS_DAYS_THAN SyntheticsAssertionOperator = "isInLessThan"
 )
+
+var allowedSyntheticsAssertionOperatorEnumValues = []SyntheticsAssertionOperator{
+	"contains",
+	"doesNotContain",
+	"is",
+	"isNot",
+	"lessThan",
+	"lessThanOrEqual",
+	"moreThan",
+	"moreThanOrEqual",
+	"matches",
+	"doesNotMatch",
+	"validates",
+	"isInMoreThan",
+	"isInLessThan",
+}
 
 func (v *SyntheticsAssertionOperator) UnmarshalJSON(src []byte) error {
 	var value string
@@ -38,7 +56,7 @@ func (v *SyntheticsAssertionOperator) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SyntheticsAssertionOperator(value)
-	for _, existing := range []SyntheticsAssertionOperator{"contains", "doesNotContain", "is", "isNot", "lessThan", "moreThan", "matches", "doesNotMatch", "validates", "isInMoreThan", "isInLessThan"} {
+	for _, existing := range allowedSyntheticsAssertionOperatorEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -46,6 +64,27 @@ func (v *SyntheticsAssertionOperator) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SyntheticsAssertionOperator", value)
+}
+
+// NewSyntheticsAssertionOperatorFromValue returns a pointer to a valid SyntheticsAssertionOperator
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSyntheticsAssertionOperatorFromValue(v string) (*SyntheticsAssertionOperator, error) {
+	ev := SyntheticsAssertionOperator(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SyntheticsAssertionOperator: valid values are %v", v, allowedSyntheticsAssertionOperatorEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SyntheticsAssertionOperator) IsValid() bool {
+	for _, existing := range allowedSyntheticsAssertionOperatorEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SyntheticsAssertionOperator value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_assertion_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_assertion_type.go
@@ -28,6 +28,17 @@ const (
 	SYNTHETICSASSERTIONTYPE_RECORD_SOME   SyntheticsAssertionType = "recordSome"
 )
 
+var allowedSyntheticsAssertionTypeEnumValues = []SyntheticsAssertionType{
+	"body",
+	"header",
+	"statusCode",
+	"certificate",
+	"responseTime",
+	"property",
+	"recordEvery",
+	"recordSome",
+}
+
 func (v *SyntheticsAssertionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -35,7 +46,7 @@ func (v *SyntheticsAssertionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SyntheticsAssertionType(value)
-	for _, existing := range []SyntheticsAssertionType{"body", "header", "statusCode", "certificate", "responseTime", "property", "recordEvery", "recordSome"} {
+	for _, existing := range allowedSyntheticsAssertionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -43,6 +54,27 @@ func (v *SyntheticsAssertionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SyntheticsAssertionType", value)
+}
+
+// NewSyntheticsAssertionTypeFromValue returns a pointer to a valid SyntheticsAssertionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSyntheticsAssertionTypeFromValue(v string) (*SyntheticsAssertionType, error) {
+	ev := SyntheticsAssertionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SyntheticsAssertionType: valid values are %v", v, allowedSyntheticsAssertionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SyntheticsAssertionType) IsValid() bool {
+	for _, existing := range allowedSyntheticsAssertionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SyntheticsAssertionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_browser_error_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_browser_error_type.go
@@ -22,6 +22,11 @@ const (
 	SYNTHETICSBROWSERERRORTYPE_JS      SyntheticsBrowserErrorType = "js"
 )
 
+var allowedSyntheticsBrowserErrorTypeEnumValues = []SyntheticsBrowserErrorType{
+	"network",
+	"js",
+}
+
 func (v *SyntheticsBrowserErrorType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *SyntheticsBrowserErrorType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SyntheticsBrowserErrorType(value)
-	for _, existing := range []SyntheticsBrowserErrorType{"network", "js"} {
+	for _, existing := range allowedSyntheticsBrowserErrorTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *SyntheticsBrowserErrorType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SyntheticsBrowserErrorType", value)
+}
+
+// NewSyntheticsBrowserErrorTypeFromValue returns a pointer to a valid SyntheticsBrowserErrorType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSyntheticsBrowserErrorTypeFromValue(v string) (*SyntheticsBrowserErrorType, error) {
+	ev := SyntheticsBrowserErrorType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SyntheticsBrowserErrorType: valid values are %v", v, allowedSyntheticsBrowserErrorTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SyntheticsBrowserErrorType) IsValid() bool {
+	for _, existing := range allowedSyntheticsBrowserErrorTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SyntheticsBrowserErrorType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_browser_variable_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_browser_variable_type.go
@@ -18,11 +18,20 @@ type SyntheticsBrowserVariableType string
 
 // List of SyntheticsBrowserVariableType
 const (
-	SYNTHETICSBROWSERVARIABLETYPE_ELEMENT SyntheticsBrowserVariableType = "element"
-	SYNTHETICSBROWSERVARIABLETYPE_EMAIL   SyntheticsBrowserVariableType = "email"
-	SYNTHETICSBROWSERVARIABLETYPE_GLOBAL  SyntheticsBrowserVariableType = "global"
-	SYNTHETICSBROWSERVARIABLETYPE_TEXT    SyntheticsBrowserVariableType = "text"
+	SYNTHETICSBROWSERVARIABLETYPE_ELEMENT    SyntheticsBrowserVariableType = "element"
+	SYNTHETICSBROWSERVARIABLETYPE_EMAIL      SyntheticsBrowserVariableType = "email"
+	SYNTHETICSBROWSERVARIABLETYPE_GLOBAL     SyntheticsBrowserVariableType = "global"
+	SYNTHETICSBROWSERVARIABLETYPE_JAVASCRIPT SyntheticsBrowserVariableType = "javascript"
+	SYNTHETICSBROWSERVARIABLETYPE_TEXT       SyntheticsBrowserVariableType = "text"
 )
+
+var allowedSyntheticsBrowserVariableTypeEnumValues = []SyntheticsBrowserVariableType{
+	"element",
+	"email",
+	"global",
+	"javascript",
+	"text",
+}
 
 func (v *SyntheticsBrowserVariableType) UnmarshalJSON(src []byte) error {
 	var value string
@@ -31,7 +40,7 @@ func (v *SyntheticsBrowserVariableType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SyntheticsBrowserVariableType(value)
-	for _, existing := range []SyntheticsBrowserVariableType{"element", "email", "global", "text"} {
+	for _, existing := range allowedSyntheticsBrowserVariableTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -39,6 +48,27 @@ func (v *SyntheticsBrowserVariableType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SyntheticsBrowserVariableType", value)
+}
+
+// NewSyntheticsBrowserVariableTypeFromValue returns a pointer to a valid SyntheticsBrowserVariableType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSyntheticsBrowserVariableTypeFromValue(v string) (*SyntheticsBrowserVariableType, error) {
+	ev := SyntheticsBrowserVariableType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SyntheticsBrowserVariableType: valid values are %v", v, allowedSyntheticsBrowserVariableTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SyntheticsBrowserVariableType) IsValid() bool {
+	for _, existing := range allowedSyntheticsBrowserVariableTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SyntheticsBrowserVariableType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_check_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_check_type.go
@@ -31,6 +31,20 @@ const (
 	SYNTHETICSCHECKTYPE_MATCH_REGEX     SyntheticsCheckType = "matchRegex"
 )
 
+var allowedSyntheticsCheckTypeEnumValues = []SyntheticsCheckType{
+	"equals",
+	"notEquals",
+	"contains",
+	"notContains",
+	"startsWith",
+	"notStartsWith",
+	"greater",
+	"lower",
+	"greaterEquals",
+	"lowerEquals",
+	"matchRegex",
+}
+
 func (v *SyntheticsCheckType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -38,7 +52,7 @@ func (v *SyntheticsCheckType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SyntheticsCheckType(value)
-	for _, existing := range []SyntheticsCheckType{"equals", "notEquals", "contains", "notContains", "startsWith", "notStartsWith", "greater", "lower", "greaterEquals", "lowerEquals", "matchRegex"} {
+	for _, existing := range allowedSyntheticsCheckTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -46,6 +60,27 @@ func (v *SyntheticsCheckType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SyntheticsCheckType", value)
+}
+
+// NewSyntheticsCheckTypeFromValue returns a pointer to a valid SyntheticsCheckType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSyntheticsCheckTypeFromValue(v string) (*SyntheticsCheckType, error) {
+	ev := SyntheticsCheckType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SyntheticsCheckType: valid values are %v", v, allowedSyntheticsCheckTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SyntheticsCheckType) IsValid() bool {
+	for _, existing := range allowedSyntheticsCheckTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SyntheticsCheckType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_device_id.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_device_id.go
@@ -29,6 +29,18 @@ const (
 	SYNTHETICSDEVICEID_FIREFOX_MOBILE_SMALL SyntheticsDeviceID = "firefox.mobile_small"
 )
 
+var allowedSyntheticsDeviceIDEnumValues = []SyntheticsDeviceID{
+	"laptop_large",
+	"tablet",
+	"mobile_small",
+	"chrome.laptop_large",
+	"chrome.tablet",
+	"chrome.mobile_small",
+	"firefox.laptop_large",
+	"firefox.tablet",
+	"firefox.mobile_small",
+}
+
 func (v *SyntheticsDeviceID) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -36,7 +48,7 @@ func (v *SyntheticsDeviceID) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SyntheticsDeviceID(value)
-	for _, existing := range []SyntheticsDeviceID{"laptop_large", "tablet", "mobile_small", "chrome.laptop_large", "chrome.tablet", "chrome.mobile_small", "firefox.laptop_large", "firefox.tablet", "firefox.mobile_small"} {
+	for _, existing := range allowedSyntheticsDeviceIDEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -44,6 +56,27 @@ func (v *SyntheticsDeviceID) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SyntheticsDeviceID", value)
+}
+
+// NewSyntheticsDeviceIDFromValue returns a pointer to a valid SyntheticsDeviceID
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSyntheticsDeviceIDFromValue(v string) (*SyntheticsDeviceID, error) {
+	ev := SyntheticsDeviceID(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SyntheticsDeviceID: valid values are %v", v, allowedSyntheticsDeviceIDEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SyntheticsDeviceID) IsValid() bool {
+	for _, existing := range allowedSyntheticsDeviceIDEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SyntheticsDeviceID value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_error_code.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_error_code.go
@@ -27,6 +27,16 @@ const (
 	SYNTHETICSERRORCODE_INCORRECT_ASSERTION SyntheticsErrorCode = "INCORRECT_ASSERTION"
 )
 
+var allowedSyntheticsErrorCodeEnumValues = []SyntheticsErrorCode{
+	"NO_ERROR",
+	"UNKNOWN",
+	"DNS",
+	"SSL",
+	"TIMEOUT",
+	"DENIED",
+	"INCORRECT_ASSERTION",
+}
+
 func (v *SyntheticsErrorCode) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -34,7 +44,7 @@ func (v *SyntheticsErrorCode) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SyntheticsErrorCode(value)
-	for _, existing := range []SyntheticsErrorCode{"NO_ERROR", "UNKNOWN", "DNS", "SSL", "TIMEOUT", "DENIED", "INCORRECT_ASSERTION"} {
+	for _, existing := range allowedSyntheticsErrorCodeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -42,6 +52,27 @@ func (v *SyntheticsErrorCode) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SyntheticsErrorCode", value)
+}
+
+// NewSyntheticsErrorCodeFromValue returns a pointer to a valid SyntheticsErrorCode
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSyntheticsErrorCodeFromValue(v string) (*SyntheticsErrorCode, error) {
+	ev := SyntheticsErrorCode(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SyntheticsErrorCode: valid values are %v", v, allowedSyntheticsErrorCodeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SyntheticsErrorCode) IsValid() bool {
+	for _, existing := range allowedSyntheticsErrorCodeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SyntheticsErrorCode value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_playing_tab.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_playing_tab.go
@@ -25,6 +25,14 @@ const (
 	SYNTHETICSPLAYINGTAB_TAB_3    SyntheticsPlayingTab = 3
 )
 
+var allowedSyntheticsPlayingTabEnumValues = []SyntheticsPlayingTab{
+	-1,
+	0,
+	1,
+	2,
+	3,
+}
+
 func (v *SyntheticsPlayingTab) UnmarshalJSON(src []byte) error {
 	var value int64
 	err := json.Unmarshal(src, &value)
@@ -32,7 +40,7 @@ func (v *SyntheticsPlayingTab) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SyntheticsPlayingTab(value)
-	for _, existing := range []SyntheticsPlayingTab{-1, 0, 1, 2, 3} {
+	for _, existing := range allowedSyntheticsPlayingTabEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -40,6 +48,27 @@ func (v *SyntheticsPlayingTab) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SyntheticsPlayingTab", value)
+}
+
+// NewSyntheticsPlayingTabFromValue returns a pointer to a valid SyntheticsPlayingTab
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSyntheticsPlayingTabFromValue(v int64) (*SyntheticsPlayingTab, error) {
+	ev := SyntheticsPlayingTab(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SyntheticsPlayingTab: valid values are %v", v, allowedSyntheticsPlayingTabEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SyntheticsPlayingTab) IsValid() bool {
+	for _, existing := range allowedSyntheticsPlayingTabEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SyntheticsPlayingTab value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_resource_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_resource_type.go
@@ -27,6 +27,16 @@ const (
 	SYNTHETICSRESOURCETYPE_OTHER      SyntheticsResourceType = "other"
 )
 
+var allowedSyntheticsResourceTypeEnumValues = []SyntheticsResourceType{
+	"document",
+	"stylesheet",
+	"fetch",
+	"image",
+	"script",
+	"xhr",
+	"other",
+}
+
 func (v *SyntheticsResourceType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -34,7 +44,7 @@ func (v *SyntheticsResourceType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SyntheticsResourceType(value)
-	for _, existing := range []SyntheticsResourceType{"document", "stylesheet", "fetch", "image", "script", "xhr", "other"} {
+	for _, existing := range allowedSyntheticsResourceTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -42,6 +52,27 @@ func (v *SyntheticsResourceType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SyntheticsResourceType", value)
+}
+
+// NewSyntheticsResourceTypeFromValue returns a pointer to a valid SyntheticsResourceType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSyntheticsResourceTypeFromValue(v string) (*SyntheticsResourceType, error) {
+	ev := SyntheticsResourceType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SyntheticsResourceType: valid values are %v", v, allowedSyntheticsResourceTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SyntheticsResourceType) IsValid() bool {
+	for _, existing := range allowedSyntheticsResourceTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SyntheticsResourceType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_step_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_step_type.go
@@ -45,6 +45,34 @@ const (
 	SYNTHETICSSTEPTYPE_WAIT                      SyntheticsStepType = "wait"
 )
 
+var allowedSyntheticsStepTypeEnumValues = []SyntheticsStepType{
+	"assertCurrentUrl",
+	"assertElementAttribute",
+	"assertElementContent",
+	"assertElementPresent",
+	"assertEmail",
+	"assertFileDownload",
+	"assertFromJavascript",
+	"assertPageContains",
+	"assertPageLacks",
+	"click",
+	"extractFromJavascript",
+	"extractVariable",
+	"goToEmailLink",
+	"goToUrl",
+	"goToUrlAndMeasureTti",
+	"hover",
+	"playSubTest",
+	"pressKey",
+	"refresh",
+	"runApiTest",
+	"scroll",
+	"selectOption",
+	"typeText",
+	"uploadFiles",
+	"wait",
+}
+
 func (v *SyntheticsStepType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -52,7 +80,7 @@ func (v *SyntheticsStepType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SyntheticsStepType(value)
-	for _, existing := range []SyntheticsStepType{"assertCurrentUrl", "assertElementAttribute", "assertElementContent", "assertElementPresent", "assertEmail", "assertFileDownload", "assertFromJavascript", "assertPageContains", "assertPageLacks", "click", "extractFromJavascript", "extractVariable", "goToEmailLink", "goToUrl", "goToUrlAndMeasureTti", "hover", "playSubTest", "pressKey", "refresh", "runApiTest", "scroll", "selectOption", "typeText", "uploadFiles", "wait"} {
+	for _, existing := range allowedSyntheticsStepTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -60,6 +88,27 @@ func (v *SyntheticsStepType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SyntheticsStepType", value)
+}
+
+// NewSyntheticsStepTypeFromValue returns a pointer to a valid SyntheticsStepType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSyntheticsStepTypeFromValue(v string) (*SyntheticsStepType, error) {
+	ev := SyntheticsStepType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SyntheticsStepType: valid values are %v", v, allowedSyntheticsStepTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SyntheticsStepType) IsValid() bool {
+	for _, existing := range allowedSyntheticsStepTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SyntheticsStepType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_test_details_sub_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_test_details_sub_type.go
@@ -24,6 +24,13 @@ const (
 	SYNTHETICSTESTDETAILSSUBTYPE_DNS  SyntheticsTestDetailsSubType = "dns"
 )
 
+var allowedSyntheticsTestDetailsSubTypeEnumValues = []SyntheticsTestDetailsSubType{
+	"http",
+	"ssl",
+	"tcp",
+	"dns",
+}
+
 func (v *SyntheticsTestDetailsSubType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -31,7 +38,7 @@ func (v *SyntheticsTestDetailsSubType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SyntheticsTestDetailsSubType(value)
-	for _, existing := range []SyntheticsTestDetailsSubType{"http", "ssl", "tcp", "dns"} {
+	for _, existing := range allowedSyntheticsTestDetailsSubTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -39,6 +46,27 @@ func (v *SyntheticsTestDetailsSubType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SyntheticsTestDetailsSubType", value)
+}
+
+// NewSyntheticsTestDetailsSubTypeFromValue returns a pointer to a valid SyntheticsTestDetailsSubType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSyntheticsTestDetailsSubTypeFromValue(v string) (*SyntheticsTestDetailsSubType, error) {
+	ev := SyntheticsTestDetailsSubType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SyntheticsTestDetailsSubType: valid values are %v", v, allowedSyntheticsTestDetailsSubTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SyntheticsTestDetailsSubType) IsValid() bool {
+	for _, existing := range allowedSyntheticsTestDetailsSubTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SyntheticsTestDetailsSubType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_test_details_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_test_details_type.go
@@ -22,6 +22,11 @@ const (
 	SYNTHETICSTESTDETAILSTYPE_BROWSER SyntheticsTestDetailsType = "browser"
 )
 
+var allowedSyntheticsTestDetailsTypeEnumValues = []SyntheticsTestDetailsType{
+	"api",
+	"browser",
+}
+
 func (v *SyntheticsTestDetailsType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *SyntheticsTestDetailsType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SyntheticsTestDetailsType(value)
-	for _, existing := range []SyntheticsTestDetailsType{"api", "browser"} {
+	for _, existing := range allowedSyntheticsTestDetailsTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *SyntheticsTestDetailsType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SyntheticsTestDetailsType", value)
+}
+
+// NewSyntheticsTestDetailsTypeFromValue returns a pointer to a valid SyntheticsTestDetailsType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSyntheticsTestDetailsTypeFromValue(v string) (*SyntheticsTestDetailsType, error) {
+	ev := SyntheticsTestDetailsType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SyntheticsTestDetailsType: valid values are %v", v, allowedSyntheticsTestDetailsTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SyntheticsTestDetailsType) IsValid() bool {
+	for _, existing := range allowedSyntheticsTestDetailsTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SyntheticsTestDetailsType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_test_monitor_status.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_test_monitor_status.go
@@ -23,6 +23,12 @@ const (
 	SYNTHETICSTESTMONITORSTATUS_NO_DATA     SyntheticsTestMonitorStatus = 2
 )
 
+var allowedSyntheticsTestMonitorStatusEnumValues = []SyntheticsTestMonitorStatus{
+	0,
+	1,
+	2,
+}
+
 func (v *SyntheticsTestMonitorStatus) UnmarshalJSON(src []byte) error {
 	var value int64
 	err := json.Unmarshal(src, &value)
@@ -30,7 +36,7 @@ func (v *SyntheticsTestMonitorStatus) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SyntheticsTestMonitorStatus(value)
-	for _, existing := range []SyntheticsTestMonitorStatus{0, 1, 2} {
+	for _, existing := range allowedSyntheticsTestMonitorStatusEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -38,6 +44,27 @@ func (v *SyntheticsTestMonitorStatus) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SyntheticsTestMonitorStatus", value)
+}
+
+// NewSyntheticsTestMonitorStatusFromValue returns a pointer to a valid SyntheticsTestMonitorStatus
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSyntheticsTestMonitorStatusFromValue(v int64) (*SyntheticsTestMonitorStatus, error) {
+	ev := SyntheticsTestMonitorStatus(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SyntheticsTestMonitorStatus: valid values are %v", v, allowedSyntheticsTestMonitorStatusEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SyntheticsTestMonitorStatus) IsValid() bool {
+	for _, existing := range allowedSyntheticsTestMonitorStatusEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SyntheticsTestMonitorStatus value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_test_pause_status.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_test_pause_status.go
@@ -22,6 +22,11 @@ const (
 	SYNTHETICSTESTPAUSESTATUS_PAUSED SyntheticsTestPauseStatus = "paused"
 )
 
+var allowedSyntheticsTestPauseStatusEnumValues = []SyntheticsTestPauseStatus{
+	"live",
+	"paused",
+}
+
 func (v *SyntheticsTestPauseStatus) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *SyntheticsTestPauseStatus) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SyntheticsTestPauseStatus(value)
-	for _, existing := range []SyntheticsTestPauseStatus{"live", "paused"} {
+	for _, existing := range allowedSyntheticsTestPauseStatusEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *SyntheticsTestPauseStatus) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SyntheticsTestPauseStatus", value)
+}
+
+// NewSyntheticsTestPauseStatusFromValue returns a pointer to a valid SyntheticsTestPauseStatus
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSyntheticsTestPauseStatusFromValue(v string) (*SyntheticsTestPauseStatus, error) {
+	ev := SyntheticsTestPauseStatus(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SyntheticsTestPauseStatus: valid values are %v", v, allowedSyntheticsTestPauseStatusEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SyntheticsTestPauseStatus) IsValid() bool {
+	for _, existing := range allowedSyntheticsTestPauseStatusEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SyntheticsTestPauseStatus value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_test_process_status.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_test_process_status.go
@@ -25,6 +25,14 @@ const (
 	SYNTHETICSTESTPROCESSSTATUS_FINISHED_WITH_ERROR SyntheticsTestProcessStatus = "finished_with_error"
 )
 
+var allowedSyntheticsTestProcessStatusEnumValues = []SyntheticsTestProcessStatus{
+	"not_scheduled",
+	"scheduled",
+	"started",
+	"finished",
+	"finished_with_error",
+}
+
 func (v *SyntheticsTestProcessStatus) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -32,7 +40,7 @@ func (v *SyntheticsTestProcessStatus) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SyntheticsTestProcessStatus(value)
-	for _, existing := range []SyntheticsTestProcessStatus{"not_scheduled", "scheduled", "started", "finished", "finished_with_error"} {
+	for _, existing := range allowedSyntheticsTestProcessStatusEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -40,6 +48,27 @@ func (v *SyntheticsTestProcessStatus) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SyntheticsTestProcessStatus", value)
+}
+
+// NewSyntheticsTestProcessStatusFromValue returns a pointer to a valid SyntheticsTestProcessStatus
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSyntheticsTestProcessStatusFromValue(v string) (*SyntheticsTestProcessStatus, error) {
+	ev := SyntheticsTestProcessStatus(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SyntheticsTestProcessStatus: valid values are %v", v, allowedSyntheticsTestProcessStatusEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SyntheticsTestProcessStatus) IsValid() bool {
+	for _, existing := range allowedSyntheticsTestProcessStatusEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SyntheticsTestProcessStatus value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_tick_interval.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_tick_interval.go
@@ -29,6 +29,18 @@ const (
 	SYNTHETICSTICKINTERVAL_WEEK            SyntheticsTickInterval = 604800
 )
 
+var allowedSyntheticsTickIntervalEnumValues = []SyntheticsTickInterval{
+	60,
+	300,
+	900,
+	1800,
+	3600,
+	21600,
+	43200,
+	86400,
+	604800,
+}
+
 func (v *SyntheticsTickInterval) UnmarshalJSON(src []byte) error {
 	var value int64
 	err := json.Unmarshal(src, &value)
@@ -36,7 +48,7 @@ func (v *SyntheticsTickInterval) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SyntheticsTickInterval(value)
-	for _, existing := range []SyntheticsTickInterval{60, 300, 900, 1800, 3600, 21600, 43200, 86400, 604800} {
+	for _, existing := range allowedSyntheticsTickIntervalEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -44,6 +56,27 @@ func (v *SyntheticsTickInterval) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SyntheticsTickInterval", value)
+}
+
+// NewSyntheticsTickIntervalFromValue returns a pointer to a valid SyntheticsTickInterval
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSyntheticsTickIntervalFromValue(v int64) (*SyntheticsTickInterval, error) {
+	ev := SyntheticsTickInterval(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SyntheticsTickInterval: valid values are %v", v, allowedSyntheticsTickIntervalEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SyntheticsTickInterval) IsValid() bool {
+	for _, existing := range allowedSyntheticsTickIntervalEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SyntheticsTickInterval value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_warning_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_synthetics_warning_type.go
@@ -21,6 +21,10 @@ const (
 	SYNTHETICSWARNINGTYPE_USER_LOCATOR SyntheticsWarningType = "user_locator"
 )
 
+var allowedSyntheticsWarningTypeEnumValues = []SyntheticsWarningType{
+	"user_locator",
+}
+
 func (v *SyntheticsWarningType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *SyntheticsWarningType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SyntheticsWarningType(value)
-	for _, existing := range []SyntheticsWarningType{"user_locator"} {
+	for _, existing := range allowedSyntheticsWarningTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *SyntheticsWarningType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SyntheticsWarningType", value)
+}
+
+// NewSyntheticsWarningTypeFromValue returns a pointer to a valid SyntheticsWarningType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSyntheticsWarningTypeFromValue(v string) (*SyntheticsWarningType, error) {
+	ev := SyntheticsWarningType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SyntheticsWarningType: valid values are %v", v, allowedSyntheticsWarningTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SyntheticsWarningType) IsValid() bool {
+	for _, existing := range allowedSyntheticsWarningTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SyntheticsWarningType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_table_widget_cell_display_mode.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_table_widget_cell_display_mode.go
@@ -22,6 +22,11 @@ const (
 	TABLEWIDGETCELLDISPLAYMODE_BAR    TableWidgetCellDisplayMode = "bar"
 )
 
+var allowedTableWidgetCellDisplayModeEnumValues = []TableWidgetCellDisplayMode{
+	"number",
+	"bar",
+}
+
 func (v *TableWidgetCellDisplayMode) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *TableWidgetCellDisplayMode) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := TableWidgetCellDisplayMode(value)
-	for _, existing := range []TableWidgetCellDisplayMode{"number", "bar"} {
+	for _, existing := range allowedTableWidgetCellDisplayModeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *TableWidgetCellDisplayMode) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid TableWidgetCellDisplayMode", value)
+}
+
+// NewTableWidgetCellDisplayModeFromValue returns a pointer to a valid TableWidgetCellDisplayMode
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewTableWidgetCellDisplayModeFromValue(v string) (*TableWidgetCellDisplayMode, error) {
+	ev := TableWidgetCellDisplayMode(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for TableWidgetCellDisplayMode: valid values are %v", v, allowedTableWidgetCellDisplayModeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v TableWidgetCellDisplayMode) IsValid() bool {
+	for _, existing := range allowedTableWidgetCellDisplayModeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to TableWidgetCellDisplayMode value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_table_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_table_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	TABLEWIDGETDEFINITIONTYPE_QUERY_TABLE TableWidgetDefinitionType = "query_table"
 )
 
+var allowedTableWidgetDefinitionTypeEnumValues = []TableWidgetDefinitionType{
+	"query_table",
+}
+
 func (v *TableWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *TableWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := TableWidgetDefinitionType(value)
-	for _, existing := range []TableWidgetDefinitionType{"query_table"} {
+	for _, existing := range allowedTableWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *TableWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid TableWidgetDefinitionType", value)
+}
+
+// NewTableWidgetDefinitionTypeFromValue returns a pointer to a valid TableWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewTableWidgetDefinitionTypeFromValue(v string) (*TableWidgetDefinitionType, error) {
+	ev := TableWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for TableWidgetDefinitionType: valid values are %v", v, allowedTableWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v TableWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedTableWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to TableWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_table_widget_has_search_bar.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_table_widget_has_search_bar.go
@@ -23,6 +23,12 @@ const (
 	TABLEWIDGETHASSEARCHBAR_AUTO   TableWidgetHasSearchBar = "auto"
 )
 
+var allowedTableWidgetHasSearchBarEnumValues = []TableWidgetHasSearchBar{
+	"always",
+	"never",
+	"auto",
+}
+
 func (v *TableWidgetHasSearchBar) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -30,7 +36,7 @@ func (v *TableWidgetHasSearchBar) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := TableWidgetHasSearchBar(value)
-	for _, existing := range []TableWidgetHasSearchBar{"always", "never", "auto"} {
+	for _, existing := range allowedTableWidgetHasSearchBarEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -38,6 +44,27 @@ func (v *TableWidgetHasSearchBar) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid TableWidgetHasSearchBar", value)
+}
+
+// NewTableWidgetHasSearchBarFromValue returns a pointer to a valid TableWidgetHasSearchBar
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewTableWidgetHasSearchBarFromValue(v string) (*TableWidgetHasSearchBar, error) {
+	ev := TableWidgetHasSearchBar(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for TableWidgetHasSearchBar: valid values are %v", v, allowedTableWidgetHasSearchBarEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v TableWidgetHasSearchBar) IsValid() bool {
+	for _, existing := range allowedTableWidgetHasSearchBarEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to TableWidgetHasSearchBar value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_target_format_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_target_format_type.go
@@ -24,6 +24,13 @@ const (
 	TARGETFORMATTYPE_DOUBLE  TargetFormatType = "double"
 )
 
+var allowedTargetFormatTypeEnumValues = []TargetFormatType{
+	"auto",
+	"string",
+	"integer",
+	"double",
+}
+
 func (v *TargetFormatType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -31,7 +38,7 @@ func (v *TargetFormatType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := TargetFormatType(value)
-	for _, existing := range []TargetFormatType{"auto", "string", "integer", "double"} {
+	for _, existing := range allowedTargetFormatTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -39,6 +46,27 @@ func (v *TargetFormatType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid TargetFormatType", value)
+}
+
+// NewTargetFormatTypeFromValue returns a pointer to a valid TargetFormatType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewTargetFormatTypeFromValue(v string) (*TargetFormatType, error) {
+	ev := TargetFormatType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for TargetFormatType: valid values are %v", v, allowedTargetFormatTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v TargetFormatType) IsValid() bool {
+	for _, existing := range allowedTargetFormatTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to TargetFormatType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_timeseries_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_timeseries_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	TIMESERIESWIDGETDEFINITIONTYPE_TIMESERIES TimeseriesWidgetDefinitionType = "timeseries"
 )
 
+var allowedTimeseriesWidgetDefinitionTypeEnumValues = []TimeseriesWidgetDefinitionType{
+	"timeseries",
+}
+
 func (v *TimeseriesWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *TimeseriesWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := TimeseriesWidgetDefinitionType(value)
-	for _, existing := range []TimeseriesWidgetDefinitionType{"timeseries"} {
+	for _, existing := range allowedTimeseriesWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *TimeseriesWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid TimeseriesWidgetDefinitionType", value)
+}
+
+// NewTimeseriesWidgetDefinitionTypeFromValue returns a pointer to a valid TimeseriesWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewTimeseriesWidgetDefinitionTypeFromValue(v string) (*TimeseriesWidgetDefinitionType, error) {
+	ev := TimeseriesWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for TimeseriesWidgetDefinitionType: valid values are %v", v, allowedTimeseriesWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v TimeseriesWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedTimeseriesWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to TimeseriesWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_toplist_widget_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_toplist_widget_definition_type.go
@@ -21,6 +21,10 @@ const (
 	TOPLISTWIDGETDEFINITIONTYPE_TOPLIST ToplistWidgetDefinitionType = "toplist"
 )
 
+var allowedToplistWidgetDefinitionTypeEnumValues = []ToplistWidgetDefinitionType{
+	"toplist",
+}
+
 func (v *ToplistWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *ToplistWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := ToplistWidgetDefinitionType(value)
-	for _, existing := range []ToplistWidgetDefinitionType{"toplist"} {
+	for _, existing := range allowedToplistWidgetDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *ToplistWidgetDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid ToplistWidgetDefinitionType", value)
+}
+
+// NewToplistWidgetDefinitionTypeFromValue returns a pointer to a valid ToplistWidgetDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewToplistWidgetDefinitionTypeFromValue(v string) (*ToplistWidgetDefinitionType, error) {
+	ev := ToplistWidgetDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for ToplistWidgetDefinitionType: valid values are %v", v, allowedToplistWidgetDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v ToplistWidgetDefinitionType) IsValid() bool {
+	for _, existing := range allowedToplistWidgetDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to ToplistWidgetDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_usage_attribution_sort.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_usage_attribution_sort.go
@@ -38,6 +38,27 @@ const (
 	USAGEATTRIBUTIONSORT_CUSTOM_TIMESERIES_USAGE      UsageAttributionSort = "custom_timeseries_usage"
 )
 
+var allowedUsageAttributionSortEnumValues = []UsageAttributionSort{
+	"api_percentage",
+	"snmp_usage",
+	"lambda_percentage",
+	"apm_host_usage",
+	"api_usage",
+	"container_usage",
+	"custom_timeseries_percentage",
+	"container_percentage",
+	"lambda_usage",
+	"apm_host_percentage",
+	"npm_host_percentage",
+	"browser_percentage",
+	"browser_usage",
+	"infra_host_percentage",
+	"snmp_percentage",
+	"npm_host_usage",
+	"infra_host_usage",
+	"custom_timeseries_usage",
+}
+
 func (v *UsageAttributionSort) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -45,7 +66,7 @@ func (v *UsageAttributionSort) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := UsageAttributionSort(value)
-	for _, existing := range []UsageAttributionSort{"api_percentage", "snmp_usage", "lambda_percentage", "apm_host_usage", "api_usage", "container_usage", "custom_timeseries_percentage", "container_percentage", "lambda_usage", "apm_host_percentage", "npm_host_percentage", "browser_percentage", "browser_usage", "infra_host_percentage", "snmp_percentage", "npm_host_usage", "infra_host_usage", "custom_timeseries_usage"} {
+	for _, existing := range allowedUsageAttributionSortEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -53,6 +74,27 @@ func (v *UsageAttributionSort) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid UsageAttributionSort", value)
+}
+
+// NewUsageAttributionSortFromValue returns a pointer to a valid UsageAttributionSort
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewUsageAttributionSortFromValue(v string) (*UsageAttributionSort, error) {
+	ev := UsageAttributionSort(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for UsageAttributionSort: valid values are %v", v, allowedUsageAttributionSortEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v UsageAttributionSort) IsValid() bool {
+	for _, existing := range allowedUsageAttributionSortEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to UsageAttributionSort value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_usage_metric_category.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_usage_metric_category.go
@@ -22,6 +22,11 @@ const (
 	USAGEMETRICCATEGORY_CUSTOM   UsageMetricCategory = "custom"
 )
 
+var allowedUsageMetricCategoryEnumValues = []UsageMetricCategory{
+	"standard",
+	"custom",
+}
+
 func (v *UsageMetricCategory) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *UsageMetricCategory) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := UsageMetricCategory(value)
-	for _, existing := range []UsageMetricCategory{"standard", "custom"} {
+	for _, existing := range allowedUsageMetricCategoryEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *UsageMetricCategory) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid UsageMetricCategory", value)
+}
+
+// NewUsageMetricCategoryFromValue returns a pointer to a valid UsageMetricCategory
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewUsageMetricCategoryFromValue(v string) (*UsageMetricCategory, error) {
+	ev := UsageMetricCategory(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for UsageMetricCategory: valid values are %v", v, allowedUsageMetricCategoryEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v UsageMetricCategory) IsValid() bool {
+	for _, existing := range allowedUsageMetricCategoryEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to UsageMetricCategory value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_usage_reports_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_usage_reports_type.go
@@ -21,6 +21,10 @@ const (
 	USAGEREPORTSTYPE_REPORTS UsageReportsType = "reports"
 )
 
+var allowedUsageReportsTypeEnumValues = []UsageReportsType{
+	"reports",
+}
+
 func (v *UsageReportsType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *UsageReportsType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := UsageReportsType(value)
-	for _, existing := range []UsageReportsType{"reports"} {
+	for _, existing := range allowedUsageReportsTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *UsageReportsType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid UsageReportsType", value)
+}
+
+// NewUsageReportsTypeFromValue returns a pointer to a valid UsageReportsType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewUsageReportsTypeFromValue(v string) (*UsageReportsType, error) {
+	ev := UsageReportsType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for UsageReportsType: valid values are %v", v, allowedUsageReportsTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v UsageReportsType) IsValid() bool {
+	for _, existing := range allowedUsageReportsTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to UsageReportsType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_usage_sort.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_usage_sort.go
@@ -24,6 +24,13 @@ const (
 	USAGESORT_END_DATE    UsageSort = "end_date"
 )
 
+var allowedUsageSortEnumValues = []UsageSort{
+	"computed_on",
+	"size",
+	"start_date",
+	"end_date",
+}
+
 func (v *UsageSort) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -31,7 +38,7 @@ func (v *UsageSort) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := UsageSort(value)
-	for _, existing := range []UsageSort{"computed_on", "size", "start_date", "end_date"} {
+	for _, existing := range allowedUsageSortEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -39,6 +46,27 @@ func (v *UsageSort) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid UsageSort", value)
+}
+
+// NewUsageSortFromValue returns a pointer to a valid UsageSort
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewUsageSortFromValue(v string) (*UsageSort, error) {
+	ev := UsageSort(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for UsageSort: valid values are %v", v, allowedUsageSortEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v UsageSort) IsValid() bool {
+	for _, existing := range allowedUsageSortEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to UsageSort value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_usage_sort_direction.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_usage_sort_direction.go
@@ -22,6 +22,11 @@ const (
 	USAGESORTDIRECTION_ASC  UsageSortDirection = "asc"
 )
 
+var allowedUsageSortDirectionEnumValues = []UsageSortDirection{
+	"desc",
+	"asc",
+}
+
 func (v *UsageSortDirection) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *UsageSortDirection) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := UsageSortDirection(value)
-	for _, existing := range []UsageSortDirection{"desc", "asc"} {
+	for _, existing := range allowedUsageSortDirectionEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *UsageSortDirection) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid UsageSortDirection", value)
+}
+
+// NewUsageSortDirectionFromValue returns a pointer to a valid UsageSortDirection
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewUsageSortDirectionFromValue(v string) (*UsageSortDirection, error) {
+	ev := UsageSortDirection(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for UsageSortDirection: valid values are %v", v, allowedUsageSortDirectionEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v UsageSortDirection) IsValid() bool {
+	for _, existing := range allowedUsageSortDirectionEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to UsageSortDirection value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_aggregator.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_aggregator.go
@@ -25,6 +25,14 @@ const (
 	WIDGETAGGREGATOR_SUM     WidgetAggregator = "sum"
 )
 
+var allowedWidgetAggregatorEnumValues = []WidgetAggregator{
+	"avg",
+	"last",
+	"max",
+	"min",
+	"sum",
+}
+
 func (v *WidgetAggregator) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -32,7 +40,7 @@ func (v *WidgetAggregator) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetAggregator(value)
-	for _, existing := range []WidgetAggregator{"avg", "last", "max", "min", "sum"} {
+	for _, existing := range allowedWidgetAggregatorEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -40,6 +48,27 @@ func (v *WidgetAggregator) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetAggregator", value)
+}
+
+// NewWidgetAggregatorFromValue returns a pointer to a valid WidgetAggregator
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetAggregatorFromValue(v string) (*WidgetAggregator, error) {
+	ev := WidgetAggregator(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetAggregator: valid values are %v", v, allowedWidgetAggregatorEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetAggregator) IsValid() bool {
+	for _, existing := range allowedWidgetAggregatorEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetAggregator value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_change_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_change_type.go
@@ -22,6 +22,11 @@ const (
 	WIDGETCHANGETYPE_RELATIVE WidgetChangeType = "relative"
 )
 
+var allowedWidgetChangeTypeEnumValues = []WidgetChangeType{
+	"absolute",
+	"relative",
+}
+
 func (v *WidgetChangeType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *WidgetChangeType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetChangeType(value)
-	for _, existing := range []WidgetChangeType{"absolute", "relative"} {
+	for _, existing := range allowedWidgetChangeTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *WidgetChangeType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetChangeType", value)
+}
+
+// NewWidgetChangeTypeFromValue returns a pointer to a valid WidgetChangeType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetChangeTypeFromValue(v string) (*WidgetChangeType, error) {
+	ev := WidgetChangeType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetChangeType: valid values are %v", v, allowedWidgetChangeTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetChangeType) IsValid() bool {
+	for _, existing := range allowedWidgetChangeTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetChangeType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_color_preference.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_color_preference.go
@@ -22,6 +22,11 @@ const (
 	WIDGETCOLORPREFERENCE_TEXT       WidgetColorPreference = "text"
 )
 
+var allowedWidgetColorPreferenceEnumValues = []WidgetColorPreference{
+	"background",
+	"text",
+}
+
 func (v *WidgetColorPreference) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *WidgetColorPreference) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetColorPreference(value)
-	for _, existing := range []WidgetColorPreference{"background", "text"} {
+	for _, existing := range allowedWidgetColorPreferenceEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *WidgetColorPreference) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetColorPreference", value)
+}
+
+// NewWidgetColorPreferenceFromValue returns a pointer to a valid WidgetColorPreference
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetColorPreferenceFromValue(v string) (*WidgetColorPreference, error) {
+	ev := WidgetColorPreference(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetColorPreference: valid values are %v", v, allowedWidgetColorPreferenceEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetColorPreference) IsValid() bool {
+	for _, existing := range allowedWidgetColorPreferenceEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetColorPreference value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_comparator.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_comparator.go
@@ -24,6 +24,13 @@ const (
 	WIDGETCOMPARATOR_LESS_THAN_OR_EQUAL_TO    WidgetComparator = "<="
 )
 
+var allowedWidgetComparatorEnumValues = []WidgetComparator{
+	">",
+	">=",
+	"<",
+	"<=",
+}
+
 func (v *WidgetComparator) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -31,7 +38,7 @@ func (v *WidgetComparator) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetComparator(value)
-	for _, existing := range []WidgetComparator{">", ">=", "<", "<="} {
+	for _, existing := range allowedWidgetComparatorEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -39,6 +46,27 @@ func (v *WidgetComparator) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetComparator", value)
+}
+
+// NewWidgetComparatorFromValue returns a pointer to a valid WidgetComparator
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetComparatorFromValue(v string) (*WidgetComparator, error) {
+	ev := WidgetComparator(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetComparator: valid values are %v", v, allowedWidgetComparatorEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetComparator) IsValid() bool {
+	for _, existing := range allowedWidgetComparatorEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetComparator value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_compare_to.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_compare_to.go
@@ -24,6 +24,13 @@ const (
 	WIDGETCOMPARETO_MONTH_BEFORE WidgetCompareTo = "month_before"
 )
 
+var allowedWidgetCompareToEnumValues = []WidgetCompareTo{
+	"hour_before",
+	"day_before",
+	"week_before",
+	"month_before",
+}
+
 func (v *WidgetCompareTo) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -31,7 +38,7 @@ func (v *WidgetCompareTo) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetCompareTo(value)
-	for _, existing := range []WidgetCompareTo{"hour_before", "day_before", "week_before", "month_before"} {
+	for _, existing := range allowedWidgetCompareToEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -39,6 +46,27 @@ func (v *WidgetCompareTo) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetCompareTo", value)
+}
+
+// NewWidgetCompareToFromValue returns a pointer to a valid WidgetCompareTo
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetCompareToFromValue(v string) (*WidgetCompareTo, error) {
+	ev := WidgetCompareTo(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetCompareTo: valid values are %v", v, allowedWidgetCompareToEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetCompareTo) IsValid() bool {
+	for _, existing := range allowedWidgetCompareToEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetCompareTo value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_display_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_display_type.go
@@ -23,6 +23,12 @@ const (
 	WIDGETDISPLAYTYPE_LINE WidgetDisplayType = "line"
 )
 
+var allowedWidgetDisplayTypeEnumValues = []WidgetDisplayType{
+	"area",
+	"bars",
+	"line",
+}
+
 func (v *WidgetDisplayType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -30,7 +36,7 @@ func (v *WidgetDisplayType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetDisplayType(value)
-	for _, existing := range []WidgetDisplayType{"area", "bars", "line"} {
+	for _, existing := range allowedWidgetDisplayTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -38,6 +44,27 @@ func (v *WidgetDisplayType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetDisplayType", value)
+}
+
+// NewWidgetDisplayTypeFromValue returns a pointer to a valid WidgetDisplayType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetDisplayTypeFromValue(v string) (*WidgetDisplayType, error) {
+	ev := WidgetDisplayType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetDisplayType: valid values are %v", v, allowedWidgetDisplayTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetDisplayType) IsValid() bool {
+	for _, existing := range allowedWidgetDisplayTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetDisplayType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_event_size.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_event_size.go
@@ -22,6 +22,11 @@ const (
 	WIDGETEVENTSIZE_LARGE WidgetEventSize = "l"
 )
 
+var allowedWidgetEventSizeEnumValues = []WidgetEventSize{
+	"s",
+	"l",
+}
+
 func (v *WidgetEventSize) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *WidgetEventSize) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetEventSize(value)
-	for _, existing := range []WidgetEventSize{"s", "l"} {
+	for _, existing := range allowedWidgetEventSizeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *WidgetEventSize) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetEventSize", value)
+}
+
+// NewWidgetEventSizeFromValue returns a pointer to a valid WidgetEventSize
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetEventSizeFromValue(v string) (*WidgetEventSize, error) {
+	ev := WidgetEventSize(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetEventSize: valid values are %v", v, allowedWidgetEventSizeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetEventSize) IsValid() bool {
+	for _, existing := range allowedWidgetEventSizeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetEventSize value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_grouping.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_grouping.go
@@ -22,6 +22,11 @@ const (
 	WIDGETGROUPING_CLUSTER WidgetGrouping = "cluster"
 )
 
+var allowedWidgetGroupingEnumValues = []WidgetGrouping{
+	"check",
+	"cluster",
+}
+
 func (v *WidgetGrouping) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *WidgetGrouping) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetGrouping(value)
-	for _, existing := range []WidgetGrouping{"check", "cluster"} {
+	for _, existing := range allowedWidgetGroupingEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *WidgetGrouping) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetGrouping", value)
+}
+
+// NewWidgetGroupingFromValue returns a pointer to a valid WidgetGrouping
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetGroupingFromValue(v string) (*WidgetGrouping, error) {
+	ev := WidgetGrouping(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetGrouping: valid values are %v", v, allowedWidgetGroupingEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetGrouping) IsValid() bool {
+	for _, existing := range allowedWidgetGroupingEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetGrouping value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_image_sizing.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_image_sizing.go
@@ -23,6 +23,12 @@ const (
 	WIDGETIMAGESIZING_CENTER WidgetImageSizing = "center"
 )
 
+var allowedWidgetImageSizingEnumValues = []WidgetImageSizing{
+	"zoom",
+	"fit",
+	"center",
+}
+
 func (v *WidgetImageSizing) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -30,7 +36,7 @@ func (v *WidgetImageSizing) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetImageSizing(value)
-	for _, existing := range []WidgetImageSizing{"zoom", "fit", "center"} {
+	for _, existing := range allowedWidgetImageSizingEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -38,6 +44,27 @@ func (v *WidgetImageSizing) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetImageSizing", value)
+}
+
+// NewWidgetImageSizingFromValue returns a pointer to a valid WidgetImageSizing
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetImageSizingFromValue(v string) (*WidgetImageSizing, error) {
+	ev := WidgetImageSizing(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetImageSizing: valid values are %v", v, allowedWidgetImageSizingEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetImageSizing) IsValid() bool {
+	for _, existing := range allowedWidgetImageSizingEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetImageSizing value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_layout_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_layout_type.go
@@ -21,6 +21,10 @@ const (
 	WIDGETLAYOUTTYPE_ORDERED WidgetLayoutType = "ordered"
 )
 
+var allowedWidgetLayoutTypeEnumValues = []WidgetLayoutType{
+	"ordered",
+}
+
 func (v *WidgetLayoutType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *WidgetLayoutType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetLayoutType(value)
-	for _, existing := range []WidgetLayoutType{"ordered"} {
+	for _, existing := range allowedWidgetLayoutTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *WidgetLayoutType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetLayoutType", value)
+}
+
+// NewWidgetLayoutTypeFromValue returns a pointer to a valid WidgetLayoutType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetLayoutTypeFromValue(v string) (*WidgetLayoutType, error) {
+	ev := WidgetLayoutType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetLayoutType: valid values are %v", v, allowedWidgetLayoutTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetLayoutType) IsValid() bool {
+	for _, existing := range allowedWidgetLayoutTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetLayoutType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_line_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_line_type.go
@@ -23,6 +23,12 @@ const (
 	WIDGETLINETYPE_SOLID  WidgetLineType = "solid"
 )
 
+var allowedWidgetLineTypeEnumValues = []WidgetLineType{
+	"dashed",
+	"dotted",
+	"solid",
+}
+
 func (v *WidgetLineType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -30,7 +36,7 @@ func (v *WidgetLineType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetLineType(value)
-	for _, existing := range []WidgetLineType{"dashed", "dotted", "solid"} {
+	for _, existing := range allowedWidgetLineTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -38,6 +44,27 @@ func (v *WidgetLineType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetLineType", value)
+}
+
+// NewWidgetLineTypeFromValue returns a pointer to a valid WidgetLineType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetLineTypeFromValue(v string) (*WidgetLineType, error) {
+	ev := WidgetLineType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetLineType: valid values are %v", v, allowedWidgetLineTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetLineType) IsValid() bool {
+	for _, existing := range allowedWidgetLineTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetLineType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_line_width.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_line_width.go
@@ -23,6 +23,12 @@ const (
 	WIDGETLINEWIDTH_THIN   WidgetLineWidth = "thin"
 )
 
+var allowedWidgetLineWidthEnumValues = []WidgetLineWidth{
+	"normal",
+	"thick",
+	"thin",
+}
+
 func (v *WidgetLineWidth) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -30,7 +36,7 @@ func (v *WidgetLineWidth) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetLineWidth(value)
-	for _, existing := range []WidgetLineWidth{"normal", "thick", "thin"} {
+	for _, existing := range allowedWidgetLineWidthEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -38,6 +44,27 @@ func (v *WidgetLineWidth) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetLineWidth", value)
+}
+
+// NewWidgetLineWidthFromValue returns a pointer to a valid WidgetLineWidth
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetLineWidthFromValue(v string) (*WidgetLineWidth, error) {
+	ev := WidgetLineWidth(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetLineWidth: valid values are %v", v, allowedWidgetLineWidthEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetLineWidth) IsValid() bool {
+	for _, existing := range allowedWidgetLineWidthEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetLineWidth value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_live_span.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_live_span.go
@@ -35,6 +35,24 @@ const (
 	WIDGETLIVESPAN_ALERT                WidgetLiveSpan = "alert"
 )
 
+var allowedWidgetLiveSpanEnumValues = []WidgetLiveSpan{
+	"1m",
+	"5m",
+	"10m",
+	"15m",
+	"30m",
+	"1h",
+	"4h",
+	"1d",
+	"2d",
+	"1w",
+	"1mo",
+	"3mo",
+	"6mo",
+	"1y",
+	"alert",
+}
+
 func (v *WidgetLiveSpan) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -42,7 +60,7 @@ func (v *WidgetLiveSpan) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetLiveSpan(value)
-	for _, existing := range []WidgetLiveSpan{"1m", "5m", "10m", "15m", "30m", "1h", "4h", "1d", "2d", "1w", "1mo", "3mo", "6mo", "1y", "alert"} {
+	for _, existing := range allowedWidgetLiveSpanEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -50,6 +68,27 @@ func (v *WidgetLiveSpan) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetLiveSpan", value)
+}
+
+// NewWidgetLiveSpanFromValue returns a pointer to a valid WidgetLiveSpan
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetLiveSpanFromValue(v string) (*WidgetLiveSpan, error) {
+	ev := WidgetLiveSpan(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetLiveSpan: valid values are %v", v, allowedWidgetLiveSpanEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetLiveSpan) IsValid() bool {
+	for _, existing := range allowedWidgetLiveSpanEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetLiveSpan value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_margin.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_margin.go
@@ -22,6 +22,11 @@ const (
 	WIDGETMARGIN_LARGE WidgetMargin = "large"
 )
 
+var allowedWidgetMarginEnumValues = []WidgetMargin{
+	"small",
+	"large",
+}
+
 func (v *WidgetMargin) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *WidgetMargin) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetMargin(value)
-	for _, existing := range []WidgetMargin{"small", "large"} {
+	for _, existing := range allowedWidgetMarginEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *WidgetMargin) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetMargin", value)
+}
+
+// NewWidgetMarginFromValue returns a pointer to a valid WidgetMargin
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetMarginFromValue(v string) (*WidgetMargin, error) {
+	ev := WidgetMargin(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetMargin: valid values are %v", v, allowedWidgetMarginEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetMargin) IsValid() bool {
+	for _, existing := range allowedWidgetMarginEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetMargin value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_message_display.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_message_display.go
@@ -23,6 +23,12 @@ const (
 	WIDGETMESSAGEDISPLAY_EXPANDED_LARGE  WidgetMessageDisplay = "expanded-lg"
 )
 
+var allowedWidgetMessageDisplayEnumValues = []WidgetMessageDisplay{
+	"inline",
+	"expanded-md",
+	"expanded-lg",
+}
+
 func (v *WidgetMessageDisplay) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -30,7 +36,7 @@ func (v *WidgetMessageDisplay) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetMessageDisplay(value)
-	for _, existing := range []WidgetMessageDisplay{"inline", "expanded-md", "expanded-lg"} {
+	for _, existing := range allowedWidgetMessageDisplayEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -38,6 +44,27 @@ func (v *WidgetMessageDisplay) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetMessageDisplay", value)
+}
+
+// NewWidgetMessageDisplayFromValue returns a pointer to a valid WidgetMessageDisplay
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetMessageDisplayFromValue(v string) (*WidgetMessageDisplay, error) {
+	ev := WidgetMessageDisplay(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetMessageDisplay: valid values are %v", v, allowedWidgetMessageDisplayEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetMessageDisplay) IsValid() bool {
+	for _, existing := range allowedWidgetMessageDisplayEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetMessageDisplay value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_monitor_summary_display_format.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_monitor_summary_display_format.go
@@ -23,6 +23,12 @@ const (
 	WIDGETMONITORSUMMARYDISPLAYFORMAT_LIST            WidgetMonitorSummaryDisplayFormat = "list"
 )
 
+var allowedWidgetMonitorSummaryDisplayFormatEnumValues = []WidgetMonitorSummaryDisplayFormat{
+	"counts",
+	"countsAndList",
+	"list",
+}
+
 func (v *WidgetMonitorSummaryDisplayFormat) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -30,7 +36,7 @@ func (v *WidgetMonitorSummaryDisplayFormat) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetMonitorSummaryDisplayFormat(value)
-	for _, existing := range []WidgetMonitorSummaryDisplayFormat{"counts", "countsAndList", "list"} {
+	for _, existing := range allowedWidgetMonitorSummaryDisplayFormatEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -38,6 +44,27 @@ func (v *WidgetMonitorSummaryDisplayFormat) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetMonitorSummaryDisplayFormat", value)
+}
+
+// NewWidgetMonitorSummaryDisplayFormatFromValue returns a pointer to a valid WidgetMonitorSummaryDisplayFormat
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetMonitorSummaryDisplayFormatFromValue(v string) (*WidgetMonitorSummaryDisplayFormat, error) {
+	ev := WidgetMonitorSummaryDisplayFormat(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetMonitorSummaryDisplayFormat: valid values are %v", v, allowedWidgetMonitorSummaryDisplayFormatEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetMonitorSummaryDisplayFormat) IsValid() bool {
+	for _, existing := range allowedWidgetMonitorSummaryDisplayFormatEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetMonitorSummaryDisplayFormat value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_monitor_summary_sort.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_monitor_summary_sort.go
@@ -35,6 +35,24 @@ const (
 	WIDGETMONITORSUMMARYSORT_TRIGGERED_DESCENDING WidgetMonitorSummarySort = "triggered,desc"
 )
 
+var allowedWidgetMonitorSummarySortEnumValues = []WidgetMonitorSummarySort{
+	"name",
+	"group",
+	"status",
+	"tags",
+	"triggered",
+	"group,asc",
+	"group,desc",
+	"name,asc",
+	"name,desc",
+	"status,asc",
+	"status,desc",
+	"tags,asc",
+	"tags,desc",
+	"triggered,asc",
+	"triggered,desc",
+}
+
 func (v *WidgetMonitorSummarySort) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -42,7 +60,7 @@ func (v *WidgetMonitorSummarySort) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetMonitorSummarySort(value)
-	for _, existing := range []WidgetMonitorSummarySort{"name", "group", "status", "tags", "triggered", "group,asc", "group,desc", "name,asc", "name,desc", "status,asc", "status,desc", "tags,asc", "tags,desc", "triggered,asc", "triggered,desc"} {
+	for _, existing := range allowedWidgetMonitorSummarySortEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -50,6 +68,27 @@ func (v *WidgetMonitorSummarySort) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetMonitorSummarySort", value)
+}
+
+// NewWidgetMonitorSummarySortFromValue returns a pointer to a valid WidgetMonitorSummarySort
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetMonitorSummarySortFromValue(v string) (*WidgetMonitorSummarySort, error) {
+	ev := WidgetMonitorSummarySort(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetMonitorSummarySort: valid values are %v", v, allowedWidgetMonitorSummarySortEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetMonitorSummarySort) IsValid() bool {
+	for _, existing := range allowedWidgetMonitorSummarySortEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetMonitorSummarySort value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_node_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_node_type.go
@@ -22,6 +22,11 @@ const (
 	WIDGETNODETYPE_CONTAINER WidgetNodeType = "container"
 )
 
+var allowedWidgetNodeTypeEnumValues = []WidgetNodeType{
+	"host",
+	"container",
+}
+
 func (v *WidgetNodeType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *WidgetNodeType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetNodeType(value)
-	for _, existing := range []WidgetNodeType{"host", "container"} {
+	for _, existing := range allowedWidgetNodeTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *WidgetNodeType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetNodeType", value)
+}
+
+// NewWidgetNodeTypeFromValue returns a pointer to a valid WidgetNodeType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetNodeTypeFromValue(v string) (*WidgetNodeType, error) {
+	ev := WidgetNodeType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetNodeType: valid values are %v", v, allowedWidgetNodeTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetNodeType) IsValid() bool {
+	for _, existing := range allowedWidgetNodeTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetNodeType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_order_by.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_order_by.go
@@ -24,6 +24,13 @@ const (
 	WIDGETORDERBY_PAST    WidgetOrderBy = "past"
 )
 
+var allowedWidgetOrderByEnumValues = []WidgetOrderBy{
+	"change",
+	"name",
+	"present",
+	"past",
+}
+
 func (v *WidgetOrderBy) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -31,7 +38,7 @@ func (v *WidgetOrderBy) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetOrderBy(value)
-	for _, existing := range []WidgetOrderBy{"change", "name", "present", "past"} {
+	for _, existing := range allowedWidgetOrderByEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -39,6 +46,27 @@ func (v *WidgetOrderBy) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetOrderBy", value)
+}
+
+// NewWidgetOrderByFromValue returns a pointer to a valid WidgetOrderBy
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetOrderByFromValue(v string) (*WidgetOrderBy, error) {
+	ev := WidgetOrderBy(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetOrderBy: valid values are %v", v, allowedWidgetOrderByEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetOrderBy) IsValid() bool {
+	for _, existing := range allowedWidgetOrderByEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetOrderBy value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_palette.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_palette.go
@@ -39,6 +39,28 @@ const (
 	WIDGETPALETTE_BLACK_ON_LIGHT_RED    WidgetPalette = "black_on_light_red"
 )
 
+var allowedWidgetPaletteEnumValues = []WidgetPalette{
+	"blue",
+	"custom_bg",
+	"custom_image",
+	"custom_text",
+	"gray_on_white",
+	"grey",
+	"green",
+	"orange",
+	"red",
+	"red_on_white",
+	"white_on_gray",
+	"white_on_green",
+	"green_on_white",
+	"white_on_red",
+	"white_on_yellow",
+	"yellow_on_white",
+	"black_on_light_yellow",
+	"black_on_light_green",
+	"black_on_light_red",
+}
+
 func (v *WidgetPalette) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -46,7 +68,7 @@ func (v *WidgetPalette) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetPalette(value)
-	for _, existing := range []WidgetPalette{"blue", "custom_bg", "custom_image", "custom_text", "gray_on_white", "grey", "green", "orange", "red", "red_on_white", "white_on_gray", "white_on_green", "green_on_white", "white_on_red", "white_on_yellow", "yellow_on_white", "black_on_light_yellow", "black_on_light_green", "black_on_light_red"} {
+	for _, existing := range allowedWidgetPaletteEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -54,6 +76,27 @@ func (v *WidgetPalette) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetPalette", value)
+}
+
+// NewWidgetPaletteFromValue returns a pointer to a valid WidgetPalette
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetPaletteFromValue(v string) (*WidgetPalette, error) {
+	ev := WidgetPalette(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetPalette: valid values are %v", v, allowedWidgetPaletteEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetPalette) IsValid() bool {
+	for _, existing := range allowedWidgetPaletteEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetPalette value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_service_summary_display_format.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_service_summary_display_format.go
@@ -23,6 +23,12 @@ const (
 	WIDGETSERVICESUMMARYDISPLAYFORMAT_THREE_COLUMN WidgetServiceSummaryDisplayFormat = "three_column"
 )
 
+var allowedWidgetServiceSummaryDisplayFormatEnumValues = []WidgetServiceSummaryDisplayFormat{
+	"one_column",
+	"two_column",
+	"three_column",
+}
+
 func (v *WidgetServiceSummaryDisplayFormat) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -30,7 +36,7 @@ func (v *WidgetServiceSummaryDisplayFormat) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetServiceSummaryDisplayFormat(value)
-	for _, existing := range []WidgetServiceSummaryDisplayFormat{"one_column", "two_column", "three_column"} {
+	for _, existing := range allowedWidgetServiceSummaryDisplayFormatEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -38,6 +44,27 @@ func (v *WidgetServiceSummaryDisplayFormat) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetServiceSummaryDisplayFormat", value)
+}
+
+// NewWidgetServiceSummaryDisplayFormatFromValue returns a pointer to a valid WidgetServiceSummaryDisplayFormat
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetServiceSummaryDisplayFormatFromValue(v string) (*WidgetServiceSummaryDisplayFormat, error) {
+	ev := WidgetServiceSummaryDisplayFormat(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetServiceSummaryDisplayFormat: valid values are %v", v, allowedWidgetServiceSummaryDisplayFormatEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetServiceSummaryDisplayFormat) IsValid() bool {
+	for _, existing := range allowedWidgetServiceSummaryDisplayFormatEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetServiceSummaryDisplayFormat value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_size_format.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_size_format.go
@@ -23,6 +23,12 @@ const (
 	WIDGETSIZEFORMAT_LARGE  WidgetSizeFormat = "large"
 )
 
+var allowedWidgetSizeFormatEnumValues = []WidgetSizeFormat{
+	"small",
+	"medium",
+	"large",
+}
+
 func (v *WidgetSizeFormat) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -30,7 +36,7 @@ func (v *WidgetSizeFormat) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetSizeFormat(value)
-	for _, existing := range []WidgetSizeFormat{"small", "medium", "large"} {
+	for _, existing := range allowedWidgetSizeFormatEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -38,6 +44,27 @@ func (v *WidgetSizeFormat) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetSizeFormat", value)
+}
+
+// NewWidgetSizeFormatFromValue returns a pointer to a valid WidgetSizeFormat
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetSizeFormatFromValue(v string) (*WidgetSizeFormat, error) {
+	ev := WidgetSizeFormat(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetSizeFormat: valid values are %v", v, allowedWidgetSizeFormatEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetSizeFormat) IsValid() bool {
+	for _, existing := range allowedWidgetSizeFormatEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetSizeFormat value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_sort.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_sort.go
@@ -22,6 +22,11 @@ const (
 	WIDGETSORT_DESCENDING WidgetSort = "desc"
 )
 
+var allowedWidgetSortEnumValues = []WidgetSort{
+	"asc",
+	"desc",
+}
+
 func (v *WidgetSort) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *WidgetSort) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetSort(value)
-	for _, existing := range []WidgetSort{"asc", "desc"} {
+	for _, existing := range allowedWidgetSortEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *WidgetSort) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetSort", value)
+}
+
+// NewWidgetSortFromValue returns a pointer to a valid WidgetSort
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetSortFromValue(v string) (*WidgetSort, error) {
+	ev := WidgetSort(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetSort: valid values are %v", v, allowedWidgetSortEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetSort) IsValid() bool {
+	for _, existing := range allowedWidgetSortEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetSort value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_summary_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_summary_type.go
@@ -23,6 +23,12 @@ const (
 	WIDGETSUMMARYTYPE_COMBINED WidgetSummaryType = "combined"
 )
 
+var allowedWidgetSummaryTypeEnumValues = []WidgetSummaryType{
+	"monitors",
+	"groups",
+	"combined",
+}
+
 func (v *WidgetSummaryType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -30,7 +36,7 @@ func (v *WidgetSummaryType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetSummaryType(value)
-	for _, existing := range []WidgetSummaryType{"monitors", "groups", "combined"} {
+	for _, existing := range allowedWidgetSummaryTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -38,6 +44,27 @@ func (v *WidgetSummaryType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetSummaryType", value)
+}
+
+// NewWidgetSummaryTypeFromValue returns a pointer to a valid WidgetSummaryType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetSummaryTypeFromValue(v string) (*WidgetSummaryType, error) {
+	ev := WidgetSummaryType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetSummaryType: valid values are %v", v, allowedWidgetSummaryTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetSummaryType) IsValid() bool {
+	for _, existing := range allowedWidgetSummaryTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetSummaryType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_text_align.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_text_align.go
@@ -23,6 +23,12 @@ const (
 	WIDGETTEXTALIGN_RIGHT  WidgetTextAlign = "right"
 )
 
+var allowedWidgetTextAlignEnumValues = []WidgetTextAlign{
+	"center",
+	"left",
+	"right",
+}
+
 func (v *WidgetTextAlign) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -30,7 +36,7 @@ func (v *WidgetTextAlign) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetTextAlign(value)
-	for _, existing := range []WidgetTextAlign{"center", "left", "right"} {
+	for _, existing := range allowedWidgetTextAlignEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -38,6 +44,27 @@ func (v *WidgetTextAlign) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetTextAlign", value)
+}
+
+// NewWidgetTextAlignFromValue returns a pointer to a valid WidgetTextAlign
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetTextAlignFromValue(v string) (*WidgetTextAlign, error) {
+	ev := WidgetTextAlign(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetTextAlign: valid values are %v", v, allowedWidgetTextAlignEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetTextAlign) IsValid() bool {
+	for _, existing := range allowedWidgetTextAlignEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetTextAlign value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_tick_edge.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_tick_edge.go
@@ -24,6 +24,13 @@ const (
 	WIDGETTICKEDGE_TOP    WidgetTickEdge = "top"
 )
 
+var allowedWidgetTickEdgeEnumValues = []WidgetTickEdge{
+	"bottom",
+	"left",
+	"right",
+	"top",
+}
+
 func (v *WidgetTickEdge) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -31,7 +38,7 @@ func (v *WidgetTickEdge) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetTickEdge(value)
-	for _, existing := range []WidgetTickEdge{"bottom", "left", "right", "top"} {
+	for _, existing := range allowedWidgetTickEdgeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -39,6 +46,27 @@ func (v *WidgetTickEdge) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetTickEdge", value)
+}
+
+// NewWidgetTickEdgeFromValue returns a pointer to a valid WidgetTickEdge
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetTickEdgeFromValue(v string) (*WidgetTickEdge, error) {
+	ev := WidgetTickEdge(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetTickEdge: valid values are %v", v, allowedWidgetTickEdgeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetTickEdge) IsValid() bool {
+	for _, existing := range allowedWidgetTickEdgeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetTickEdge value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_time_windows_.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_time_windows_.go
@@ -27,6 +27,16 @@ const (
 	WIDGETTIMEWINDOWS_PREVIOUS_MONTH WidgetTimeWindows = "previous_month"
 )
 
+var allowedWidgetTimeWindowsEnumValues = []WidgetTimeWindows{
+	"7d",
+	"30d",
+	"90d",
+	"week_to_date",
+	"previous_week",
+	"month_to_date",
+	"previous_month",
+}
+
 func (v *WidgetTimeWindows) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -34,7 +44,7 @@ func (v *WidgetTimeWindows) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetTimeWindows(value)
-	for _, existing := range []WidgetTimeWindows{"7d", "30d", "90d", "week_to_date", "previous_week", "month_to_date", "previous_month"} {
+	for _, existing := range allowedWidgetTimeWindowsEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -42,6 +52,27 @@ func (v *WidgetTimeWindows) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetTimeWindows", value)
+}
+
+// NewWidgetTimeWindowsFromValue returns a pointer to a valid WidgetTimeWindows
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetTimeWindowsFromValue(v string) (*WidgetTimeWindows, error) {
+	ev := WidgetTimeWindows(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetTimeWindows: valid values are %v", v, allowedWidgetTimeWindowsEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetTimeWindows) IsValid() bool {
+	for _, existing := range allowedWidgetTimeWindowsEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetTimeWindows value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_view_mode.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_view_mode.go
@@ -23,6 +23,12 @@ const (
 	WIDGETVIEWMODE_BOTH      WidgetViewMode = "both"
 )
 
+var allowedWidgetViewModeEnumValues = []WidgetViewMode{
+	"overall",
+	"component",
+	"both",
+}
+
 func (v *WidgetViewMode) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -30,7 +36,7 @@ func (v *WidgetViewMode) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetViewMode(value)
-	for _, existing := range []WidgetViewMode{"overall", "component", "both"} {
+	for _, existing := range allowedWidgetViewModeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -38,6 +44,27 @@ func (v *WidgetViewMode) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetViewMode", value)
+}
+
+// NewWidgetViewModeFromValue returns a pointer to a valid WidgetViewMode
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetViewModeFromValue(v string) (*WidgetViewMode, error) {
+	ev := WidgetViewMode(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetViewMode: valid values are %v", v, allowedWidgetViewModeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetViewMode) IsValid() bool {
+	for _, existing := range allowedWidgetViewModeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetViewMode value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_viz_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v1/datadog/model_widget_viz_type.go
@@ -22,6 +22,11 @@ const (
 	WIDGETVIZTYPE_TOPLIST    WidgetVizType = "toplist"
 )
 
+var allowedWidgetVizTypeEnumValues = []WidgetVizType{
+	"timeseries",
+	"toplist",
+}
+
 func (v *WidgetVizType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *WidgetVizType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := WidgetVizType(value)
-	for _, existing := range []WidgetVizType{"timeseries", "toplist"} {
+	for _, existing := range allowedWidgetVizTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *WidgetVizType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid WidgetVizType", value)
+}
+
+// NewWidgetVizTypeFromValue returns a pointer to a valid WidgetVizType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewWidgetVizTypeFromValue(v string) (*WidgetVizType, error) {
+	ev := WidgetVizType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for WidgetVizType: valid values are %v", v, allowedWidgetVizTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v WidgetVizType) IsValid() bool {
+	for _, existing := range allowedWidgetVizTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to WidgetVizType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/client.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/client.go
@@ -189,6 +189,14 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 		if err != nil {
 			return nil, err
 		}
+		// Strip any api keys from the response being logged
+		keys, ok := request.Context().Value(ContextAPIKeys).(map[string]APIKey)
+		if keys != nil && ok {
+			for _, apiKey := range keys {
+				valueRegex := regexp.MustCompile(fmt.Sprintf("(?m)%s", apiKey.Key))
+				dump = valueRegex.ReplaceAll(dump, []byte("REDACTED"))
+			}
+		}
 		log.Printf("\n%s\n", string(dump))
 	}
 
@@ -397,7 +405,7 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 					return err
 				}
 			} else {
-				errors.New("Unknown type with GetActualInstance but no unmarshalObj.UnmarshalJSON defined")
+				return errors.New("Unknown type with GetActualInstance but no unmarshalObj.UnmarshalJSON defined")
 			}
 		} else if err = json.Unmarshal(b, v); err != nil { // simple model
 			return err

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_dashboard_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_dashboard_type.go
@@ -25,6 +25,14 @@ const (
 	DASHBOARDTYPE_HOST_TIMEBOARD          DashboardType = "host_timeboard"
 )
 
+var allowedDashboardTypeEnumValues = []DashboardType{
+	"custom_timeboard",
+	"custom_screenboard",
+	"integration_screenboard",
+	"integration_timeboard",
+	"host_timeboard",
+}
+
 func (v *DashboardType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -32,7 +40,7 @@ func (v *DashboardType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := DashboardType(value)
-	for _, existing := range []DashboardType{"custom_timeboard", "custom_screenboard", "integration_screenboard", "integration_timeboard", "host_timeboard"} {
+	for _, existing := range allowedDashboardTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -40,6 +48,27 @@ func (v *DashboardType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid DashboardType", value)
+}
+
+// NewDashboardTypeFromValue returns a pointer to a valid DashboardType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewDashboardTypeFromValue(v string) (*DashboardType, error) {
+	ev := DashboardType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for DashboardType: valid values are %v", v, allowedDashboardTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v DashboardType) IsValid() bool {
+	for _, existing := range allowedDashboardTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to DashboardType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_incident_field_attributes_single_value_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_incident_field_attributes_single_value_type.go
@@ -22,6 +22,11 @@ const (
 	INCIDENTFIELDATTRIBUTESSINGLEVALUETYPE_TEXTBOX  IncidentFieldAttributesSingleValueType = "textbox"
 )
 
+var allowedIncidentFieldAttributesSingleValueTypeEnumValues = []IncidentFieldAttributesSingleValueType{
+	"dropdown",
+	"textbox",
+}
+
 func (v *IncidentFieldAttributesSingleValueType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *IncidentFieldAttributesSingleValueType) UnmarshalJSON(src []byte) error
 		return err
 	}
 	enumTypeValue := IncidentFieldAttributesSingleValueType(value)
-	for _, existing := range []IncidentFieldAttributesSingleValueType{"dropdown", "textbox"} {
+	for _, existing := range allowedIncidentFieldAttributesSingleValueTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *IncidentFieldAttributesSingleValueType) UnmarshalJSON(src []byte) error
 	}
 
 	return fmt.Errorf("%+v is not a valid IncidentFieldAttributesSingleValueType", value)
+}
+
+// NewIncidentFieldAttributesSingleValueTypeFromValue returns a pointer to a valid IncidentFieldAttributesSingleValueType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewIncidentFieldAttributesSingleValueTypeFromValue(v string) (*IncidentFieldAttributesSingleValueType, error) {
+	ev := IncidentFieldAttributesSingleValueType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for IncidentFieldAttributesSingleValueType: valid values are %v", v, allowedIncidentFieldAttributesSingleValueTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v IncidentFieldAttributesSingleValueType) IsValid() bool {
+	for _, existing := range allowedIncidentFieldAttributesSingleValueTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to IncidentFieldAttributesSingleValueType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_incident_field_attributes_value_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_incident_field_attributes_value_type.go
@@ -24,6 +24,13 @@ const (
 	INCIDENTFIELDATTRIBUTESVALUETYPE_AUTOCOMPLETE IncidentFieldAttributesValueType = "autocomplete"
 )
 
+var allowedIncidentFieldAttributesValueTypeEnumValues = []IncidentFieldAttributesValueType{
+	"multiselect",
+	"textarray",
+	"metrictag",
+	"autocomplete",
+}
+
 func (v *IncidentFieldAttributesValueType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -31,7 +38,7 @@ func (v *IncidentFieldAttributesValueType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := IncidentFieldAttributesValueType(value)
-	for _, existing := range []IncidentFieldAttributesValueType{"multiselect", "textarray", "metrictag", "autocomplete"} {
+	for _, existing := range allowedIncidentFieldAttributesValueTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -39,6 +46,27 @@ func (v *IncidentFieldAttributesValueType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid IncidentFieldAttributesValueType", value)
+}
+
+// NewIncidentFieldAttributesValueTypeFromValue returns a pointer to a valid IncidentFieldAttributesValueType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewIncidentFieldAttributesValueTypeFromValue(v string) (*IncidentFieldAttributesValueType, error) {
+	ev := IncidentFieldAttributesValueType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for IncidentFieldAttributesValueType: valid values are %v", v, allowedIncidentFieldAttributesValueTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v IncidentFieldAttributesValueType) IsValid() bool {
+	for _, existing := range allowedIncidentFieldAttributesValueTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to IncidentFieldAttributesValueType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_incident_integration_metadata_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_incident_integration_metadata_type.go
@@ -21,6 +21,10 @@ const (
 	INCIDENTINTEGRATIONMETADATATYPE_INCIDENT_INTEGRATION_METADATA IncidentIntegrationMetadataType = "incident_integration_metadata"
 )
 
+var allowedIncidentIntegrationMetadataTypeEnumValues = []IncidentIntegrationMetadataType{
+	"incident_integration_metadata",
+}
+
 func (v *IncidentIntegrationMetadataType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *IncidentIntegrationMetadataType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := IncidentIntegrationMetadataType(value)
-	for _, existing := range []IncidentIntegrationMetadataType{"incident_integration_metadata"} {
+	for _, existing := range allowedIncidentIntegrationMetadataTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *IncidentIntegrationMetadataType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid IncidentIntegrationMetadataType", value)
+}
+
+// NewIncidentIntegrationMetadataTypeFromValue returns a pointer to a valid IncidentIntegrationMetadataType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewIncidentIntegrationMetadataTypeFromValue(v string) (*IncidentIntegrationMetadataType, error) {
+	ev := IncidentIntegrationMetadataType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for IncidentIntegrationMetadataType: valid values are %v", v, allowedIncidentIntegrationMetadataTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v IncidentIntegrationMetadataType) IsValid() bool {
+	for _, existing := range allowedIncidentIntegrationMetadataTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to IncidentIntegrationMetadataType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_incident_postmortem_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_incident_postmortem_type.go
@@ -21,6 +21,10 @@ const (
 	INCIDENTPOSTMORTEMTYPE_INCIDENT_POSTMORTEMS IncidentPostmortemType = "incident_postmortems"
 )
 
+var allowedIncidentPostmortemTypeEnumValues = []IncidentPostmortemType{
+	"incident_postmortems",
+}
+
 func (v *IncidentPostmortemType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *IncidentPostmortemType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := IncidentPostmortemType(value)
-	for _, existing := range []IncidentPostmortemType{"incident_postmortems"} {
+	for _, existing := range allowedIncidentPostmortemTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *IncidentPostmortemType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid IncidentPostmortemType", value)
+}
+
+// NewIncidentPostmortemTypeFromValue returns a pointer to a valid IncidentPostmortemType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewIncidentPostmortemTypeFromValue(v string) (*IncidentPostmortemType, error) {
+	ev := IncidentPostmortemType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for IncidentPostmortemType: valid values are %v", v, allowedIncidentPostmortemTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v IncidentPostmortemType) IsValid() bool {
+	for _, existing := range allowedIncidentPostmortemTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to IncidentPostmortemType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_incident_service_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_incident_service_type.go
@@ -21,6 +21,10 @@ const (
 	INCIDENTSERVICETYPE_SERVICES IncidentServiceType = "services"
 )
 
+var allowedIncidentServiceTypeEnumValues = []IncidentServiceType{
+	"services",
+}
+
 func (v *IncidentServiceType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *IncidentServiceType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := IncidentServiceType(value)
-	for _, existing := range []IncidentServiceType{"services"} {
+	for _, existing := range allowedIncidentServiceTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *IncidentServiceType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid IncidentServiceType", value)
+}
+
+// NewIncidentServiceTypeFromValue returns a pointer to a valid IncidentServiceType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewIncidentServiceTypeFromValue(v string) (*IncidentServiceType, error) {
+	ev := IncidentServiceType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for IncidentServiceType: valid values are %v", v, allowedIncidentServiceTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v IncidentServiceType) IsValid() bool {
+	for _, existing := range allowedIncidentServiceTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to IncidentServiceType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_incident_team_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_incident_team_type.go
@@ -21,6 +21,10 @@ const (
 	INCIDENTTEAMTYPE_TEAMS IncidentTeamType = "teams"
 )
 
+var allowedIncidentTeamTypeEnumValues = []IncidentTeamType{
+	"teams",
+}
+
 func (v *IncidentTeamType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *IncidentTeamType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := IncidentTeamType(value)
-	for _, existing := range []IncidentTeamType{"teams"} {
+	for _, existing := range allowedIncidentTeamTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *IncidentTeamType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid IncidentTeamType", value)
+}
+
+// NewIncidentTeamTypeFromValue returns a pointer to a valid IncidentTeamType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewIncidentTeamTypeFromValue(v string) (*IncidentTeamType, error) {
+	ev := IncidentTeamType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for IncidentTeamType: valid values are %v", v, allowedIncidentTeamTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v IncidentTeamType) IsValid() bool {
+	for _, existing := range allowedIncidentTeamTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to IncidentTeamType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_incident_timeline_cell_markdown_content_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_incident_timeline_cell_markdown_content_type.go
@@ -21,6 +21,10 @@ const (
 	INCIDENTTIMELINECELLMARKDOWNCONTENTTYPE_MARKDOWN IncidentTimelineCellMarkdownContentType = "markdown"
 )
 
+var allowedIncidentTimelineCellMarkdownContentTypeEnumValues = []IncidentTimelineCellMarkdownContentType{
+	"markdown",
+}
+
 func (v *IncidentTimelineCellMarkdownContentType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *IncidentTimelineCellMarkdownContentType) UnmarshalJSON(src []byte) erro
 		return err
 	}
 	enumTypeValue := IncidentTimelineCellMarkdownContentType(value)
-	for _, existing := range []IncidentTimelineCellMarkdownContentType{"markdown"} {
+	for _, existing := range allowedIncidentTimelineCellMarkdownContentTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *IncidentTimelineCellMarkdownContentType) UnmarshalJSON(src []byte) erro
 	}
 
 	return fmt.Errorf("%+v is not a valid IncidentTimelineCellMarkdownContentType", value)
+}
+
+// NewIncidentTimelineCellMarkdownContentTypeFromValue returns a pointer to a valid IncidentTimelineCellMarkdownContentType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewIncidentTimelineCellMarkdownContentTypeFromValue(v string) (*IncidentTimelineCellMarkdownContentType, error) {
+	ev := IncidentTimelineCellMarkdownContentType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for IncidentTimelineCellMarkdownContentType: valid values are %v", v, allowedIncidentTimelineCellMarkdownContentTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v IncidentTimelineCellMarkdownContentType) IsValid() bool {
+	for _, existing := range allowedIncidentTimelineCellMarkdownContentTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to IncidentTimelineCellMarkdownContentType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_incident_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_incident_type.go
@@ -21,6 +21,10 @@ const (
 	INCIDENTTYPE_INCIDENTS IncidentType = "incidents"
 )
 
+var allowedIncidentTypeEnumValues = []IncidentType{
+	"incidents",
+}
+
 func (v *IncidentType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *IncidentType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := IncidentType(value)
-	for _, existing := range []IncidentType{"incidents"} {
+	for _, existing := range allowedIncidentTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *IncidentType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid IncidentType", value)
+}
+
+// NewIncidentTypeFromValue returns a pointer to a valid IncidentType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewIncidentTypeFromValue(v string) (*IncidentType, error) {
+	ev := IncidentType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for IncidentType: valid values are %v", v, allowedIncidentTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v IncidentType) IsValid() bool {
+	for _, existing := range allowedIncidentTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to IncidentType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_log_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_log_type.go
@@ -21,6 +21,10 @@ const (
 	LOGTYPE_LOG LogType = "log"
 )
 
+var allowedLogTypeEnumValues = []LogType{
+	"log",
+}
+
 func (v *LogType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogType(value)
-	for _, existing := range []LogType{"log"} {
+	for _, existing := range allowedLogTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogType", value)
+}
+
+// NewLogTypeFromValue returns a pointer to a valid LogType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogTypeFromValue(v string) (*LogType, error) {
+	ev := LogType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogType: valid values are %v", v, allowedLogTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogType) IsValid() bool {
+	for _, existing := range allowedLogTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_aggregate_response_status.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_aggregate_response_status.go
@@ -22,6 +22,11 @@ const (
 	LOGSAGGREGATERESPONSESTATUS_TIMEOUT LogsAggregateResponseStatus = "timeout"
 )
 
+var allowedLogsAggregateResponseStatusEnumValues = []LogsAggregateResponseStatus{
+	"done",
+	"timeout",
+}
+
 func (v *LogsAggregateResponseStatus) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *LogsAggregateResponseStatus) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsAggregateResponseStatus(value)
-	for _, existing := range []LogsAggregateResponseStatus{"done", "timeout"} {
+	for _, existing := range allowedLogsAggregateResponseStatusEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *LogsAggregateResponseStatus) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsAggregateResponseStatus", value)
+}
+
+// NewLogsAggregateResponseStatusFromValue returns a pointer to a valid LogsAggregateResponseStatus
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsAggregateResponseStatusFromValue(v string) (*LogsAggregateResponseStatus, error) {
+	ev := LogsAggregateResponseStatus(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsAggregateResponseStatus: valid values are %v", v, allowedLogsAggregateResponseStatusEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsAggregateResponseStatus) IsValid() bool {
+	for _, existing := range allowedLogsAggregateResponseStatusEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsAggregateResponseStatus value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_aggregate_sort_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_aggregate_sort_type.go
@@ -22,6 +22,11 @@ const (
 	LOGSAGGREGATESORTTYPE_MEASURE      LogsAggregateSortType = "measure"
 )
 
+var allowedLogsAggregateSortTypeEnumValues = []LogsAggregateSortType{
+	"alphabetical",
+	"measure",
+}
+
 func (v *LogsAggregateSortType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *LogsAggregateSortType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsAggregateSortType(value)
-	for _, existing := range []LogsAggregateSortType{"alphabetical", "measure"} {
+	for _, existing := range allowedLogsAggregateSortTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *LogsAggregateSortType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsAggregateSortType", value)
+}
+
+// NewLogsAggregateSortTypeFromValue returns a pointer to a valid LogsAggregateSortType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsAggregateSortTypeFromValue(v string) (*LogsAggregateSortType, error) {
+	ev := LogsAggregateSortType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsAggregateSortType: valid values are %v", v, allowedLogsAggregateSortTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsAggregateSortType) IsValid() bool {
+	for _, existing := range allowedLogsAggregateSortTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsAggregateSortType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_aggregation_function.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_aggregation_function.go
@@ -31,6 +31,20 @@ const (
 	LOGSAGGREGATIONFUNCTION_AVG           LogsAggregationFunction = "avg"
 )
 
+var allowedLogsAggregationFunctionEnumValues = []LogsAggregationFunction{
+	"count",
+	"cardinality",
+	"pc75",
+	"pc90",
+	"pc95",
+	"pc98",
+	"pc99",
+	"sum",
+	"min",
+	"max",
+	"avg",
+}
+
 func (v *LogsAggregationFunction) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -38,7 +52,7 @@ func (v *LogsAggregationFunction) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsAggregationFunction(value)
-	for _, existing := range []LogsAggregationFunction{"count", "cardinality", "pc75", "pc90", "pc95", "pc98", "pc99", "sum", "min", "max", "avg"} {
+	for _, existing := range allowedLogsAggregationFunctionEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -46,6 +60,27 @@ func (v *LogsAggregationFunction) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsAggregationFunction", value)
+}
+
+// NewLogsAggregationFunctionFromValue returns a pointer to a valid LogsAggregationFunction
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsAggregationFunctionFromValue(v string) (*LogsAggregationFunction, error) {
+	ev := LogsAggregationFunction(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsAggregationFunction: valid values are %v", v, allowedLogsAggregationFunctionEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsAggregationFunction) IsValid() bool {
+	for _, existing := range allowedLogsAggregationFunctionEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsAggregationFunction value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_archive_destination_azure_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_archive_destination_azure_type.go
@@ -21,6 +21,10 @@ const (
 	LOGSARCHIVEDESTINATIONAZURETYPE_AZURE LogsArchiveDestinationAzureType = "azure"
 )
 
+var allowedLogsArchiveDestinationAzureTypeEnumValues = []LogsArchiveDestinationAzureType{
+	"azure",
+}
+
 func (v *LogsArchiveDestinationAzureType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogsArchiveDestinationAzureType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsArchiveDestinationAzureType(value)
-	for _, existing := range []LogsArchiveDestinationAzureType{"azure"} {
+	for _, existing := range allowedLogsArchiveDestinationAzureTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogsArchiveDestinationAzureType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsArchiveDestinationAzureType", value)
+}
+
+// NewLogsArchiveDestinationAzureTypeFromValue returns a pointer to a valid LogsArchiveDestinationAzureType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsArchiveDestinationAzureTypeFromValue(v string) (*LogsArchiveDestinationAzureType, error) {
+	ev := LogsArchiveDestinationAzureType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsArchiveDestinationAzureType: valid values are %v", v, allowedLogsArchiveDestinationAzureTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsArchiveDestinationAzureType) IsValid() bool {
+	for _, existing := range allowedLogsArchiveDestinationAzureTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsArchiveDestinationAzureType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_archive_destination_gcs_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_archive_destination_gcs_type.go
@@ -21,6 +21,10 @@ const (
 	LOGSARCHIVEDESTINATIONGCSTYPE_GCS LogsArchiveDestinationGCSType = "gcs"
 )
 
+var allowedLogsArchiveDestinationGCSTypeEnumValues = []LogsArchiveDestinationGCSType{
+	"gcs",
+}
+
 func (v *LogsArchiveDestinationGCSType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogsArchiveDestinationGCSType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsArchiveDestinationGCSType(value)
-	for _, existing := range []LogsArchiveDestinationGCSType{"gcs"} {
+	for _, existing := range allowedLogsArchiveDestinationGCSTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogsArchiveDestinationGCSType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsArchiveDestinationGCSType", value)
+}
+
+// NewLogsArchiveDestinationGCSTypeFromValue returns a pointer to a valid LogsArchiveDestinationGCSType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsArchiveDestinationGCSTypeFromValue(v string) (*LogsArchiveDestinationGCSType, error) {
+	ev := LogsArchiveDestinationGCSType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsArchiveDestinationGCSType: valid values are %v", v, allowedLogsArchiveDestinationGCSTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsArchiveDestinationGCSType) IsValid() bool {
+	for _, existing := range allowedLogsArchiveDestinationGCSTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsArchiveDestinationGCSType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_archive_destination_s3_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_archive_destination_s3_type.go
@@ -21,6 +21,10 @@ const (
 	LOGSARCHIVEDESTINATIONS3TYPE_S3 LogsArchiveDestinationS3Type = "s3"
 )
 
+var allowedLogsArchiveDestinationS3TypeEnumValues = []LogsArchiveDestinationS3Type{
+	"s3",
+}
+
 func (v *LogsArchiveDestinationS3Type) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogsArchiveDestinationS3Type) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsArchiveDestinationS3Type(value)
-	for _, existing := range []LogsArchiveDestinationS3Type{"s3"} {
+	for _, existing := range allowedLogsArchiveDestinationS3TypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogsArchiveDestinationS3Type) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsArchiveDestinationS3Type", value)
+}
+
+// NewLogsArchiveDestinationS3TypeFromValue returns a pointer to a valid LogsArchiveDestinationS3Type
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsArchiveDestinationS3TypeFromValue(v string) (*LogsArchiveDestinationS3Type, error) {
+	ev := LogsArchiveDestinationS3Type(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsArchiveDestinationS3Type: valid values are %v", v, allowedLogsArchiveDestinationS3TypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsArchiveDestinationS3Type) IsValid() bool {
+	for _, existing := range allowedLogsArchiveDestinationS3TypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsArchiveDestinationS3Type value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_archive_order_definition_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_archive_order_definition_type.go
@@ -21,6 +21,10 @@ const (
 	LOGSARCHIVEORDERDEFINITIONTYPE_ARCHIVE_ORDER LogsArchiveOrderDefinitionType = "archive_order"
 )
 
+var allowedLogsArchiveOrderDefinitionTypeEnumValues = []LogsArchiveOrderDefinitionType{
+	"archive_order",
+}
+
 func (v *LogsArchiveOrderDefinitionType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *LogsArchiveOrderDefinitionType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsArchiveOrderDefinitionType(value)
-	for _, existing := range []LogsArchiveOrderDefinitionType{"archive_order"} {
+	for _, existing := range allowedLogsArchiveOrderDefinitionTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *LogsArchiveOrderDefinitionType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsArchiveOrderDefinitionType", value)
+}
+
+// NewLogsArchiveOrderDefinitionTypeFromValue returns a pointer to a valid LogsArchiveOrderDefinitionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsArchiveOrderDefinitionTypeFromValue(v string) (*LogsArchiveOrderDefinitionType, error) {
+	ev := LogsArchiveOrderDefinitionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsArchiveOrderDefinitionType: valid values are %v", v, allowedLogsArchiveOrderDefinitionTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsArchiveOrderDefinitionType) IsValid() bool {
+	for _, existing := range allowedLogsArchiveOrderDefinitionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsArchiveOrderDefinitionType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_archive_state.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_archive_state.go
@@ -24,6 +24,13 @@ const (
 	LOGSARCHIVESTATE_WORKING_AUTH_LEGACY LogsArchiveState = "WORKING_AUTH_LEGACY"
 )
 
+var allowedLogsArchiveStateEnumValues = []LogsArchiveState{
+	"UNKNOWN",
+	"WORKING",
+	"FAILING",
+	"WORKING_AUTH_LEGACY",
+}
+
 func (v *LogsArchiveState) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -31,7 +38,7 @@ func (v *LogsArchiveState) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsArchiveState(value)
-	for _, existing := range []LogsArchiveState{"UNKNOWN", "WORKING", "FAILING", "WORKING_AUTH_LEGACY"} {
+	for _, existing := range allowedLogsArchiveStateEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -39,6 +46,27 @@ func (v *LogsArchiveState) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsArchiveState", value)
+}
+
+// NewLogsArchiveStateFromValue returns a pointer to a valid LogsArchiveState
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsArchiveStateFromValue(v string) (*LogsArchiveState, error) {
+	ev := LogsArchiveState(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsArchiveState: valid values are %v", v, allowedLogsArchiveStateEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsArchiveState) IsValid() bool {
+	for _, existing := range allowedLogsArchiveStateEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsArchiveState value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_compute_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_compute_type.go
@@ -22,6 +22,11 @@ const (
 	LOGSCOMPUTETYPE_TOTAL      LogsComputeType = "total"
 )
 
+var allowedLogsComputeTypeEnumValues = []LogsComputeType{
+	"timeseries",
+	"total",
+}
+
 func (v *LogsComputeType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *LogsComputeType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsComputeType(value)
-	for _, existing := range []LogsComputeType{"timeseries", "total"} {
+	for _, existing := range allowedLogsComputeTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *LogsComputeType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsComputeType", value)
+}
+
+// NewLogsComputeTypeFromValue returns a pointer to a valid LogsComputeType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsComputeTypeFromValue(v string) (*LogsComputeType, error) {
+	ev := LogsComputeType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsComputeType: valid values are %v", v, allowedLogsComputeTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsComputeType) IsValid() bool {
+	for _, existing := range allowedLogsComputeTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsComputeType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_sort.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_sort.go
@@ -22,6 +22,11 @@ const (
 	LOGSSORT_TIMESTAMP_DESCENDING LogsSort = "-timestamp"
 )
 
+var allowedLogsSortEnumValues = []LogsSort{
+	"timestamp",
+	"-timestamp",
+}
+
 func (v *LogsSort) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *LogsSort) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsSort(value)
-	for _, existing := range []LogsSort{"timestamp", "-timestamp"} {
+	for _, existing := range allowedLogsSortEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *LogsSort) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsSort", value)
+}
+
+// NewLogsSortFromValue returns a pointer to a valid LogsSort
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsSortFromValue(v string) (*LogsSort, error) {
+	ev := LogsSort(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsSort: valid values are %v", v, allowedLogsSortEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsSort) IsValid() bool {
+	for _, existing := range allowedLogsSortEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsSort value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_sort_order.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_logs_sort_order.go
@@ -22,6 +22,11 @@ const (
 	LOGSSORTORDER_DESCENDING LogsSortOrder = "desc"
 )
 
+var allowedLogsSortOrderEnumValues = []LogsSortOrder{
+	"asc",
+	"desc",
+}
+
 func (v *LogsSortOrder) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *LogsSortOrder) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := LogsSortOrder(value)
-	for _, existing := range []LogsSortOrder{"asc", "desc"} {
+	for _, existing := range allowedLogsSortOrderEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *LogsSortOrder) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid LogsSortOrder", value)
+}
+
+// NewLogsSortOrderFromValue returns a pointer to a valid LogsSortOrder
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewLogsSortOrderFromValue(v string) (*LogsSortOrder, error) {
+	ev := LogsSortOrder(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for LogsSortOrder: valid values are %v", v, allowedLogsSortOrderEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v LogsSortOrder) IsValid() bool {
+	for _, existing := range allowedLogsSortOrderEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to LogsSortOrder value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_organizations_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_organizations_type.go
@@ -21,6 +21,10 @@ const (
 	ORGANIZATIONSTYPE_ORGS OrganizationsType = "orgs"
 )
 
+var allowedOrganizationsTypeEnumValues = []OrganizationsType{
+	"orgs",
+}
+
 func (v *OrganizationsType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *OrganizationsType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := OrganizationsType(value)
-	for _, existing := range []OrganizationsType{"orgs"} {
+	for _, existing := range allowedOrganizationsTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *OrganizationsType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid OrganizationsType", value)
+}
+
+// NewOrganizationsTypeFromValue returns a pointer to a valid OrganizationsType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewOrganizationsTypeFromValue(v string) (*OrganizationsType, error) {
+	ev := OrganizationsType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for OrganizationsType: valid values are %v", v, allowedOrganizationsTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v OrganizationsType) IsValid() bool {
+	for _, existing := range allowedOrganizationsTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to OrganizationsType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_permissions_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_permissions_type.go
@@ -21,6 +21,10 @@ const (
 	PERMISSIONSTYPE_PERMISSIONS PermissionsType = "permissions"
 )
 
+var allowedPermissionsTypeEnumValues = []PermissionsType{
+	"permissions",
+}
+
 func (v *PermissionsType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *PermissionsType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := PermissionsType(value)
-	for _, existing := range []PermissionsType{"permissions"} {
+	for _, existing := range allowedPermissionsTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *PermissionsType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid PermissionsType", value)
+}
+
+// NewPermissionsTypeFromValue returns a pointer to a valid PermissionsType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewPermissionsTypeFromValue(v string) (*PermissionsType, error) {
+	ev := PermissionsType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for PermissionsType: valid values are %v", v, allowedPermissionsTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v PermissionsType) IsValid() bool {
+	for _, existing := range allowedPermissionsTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to PermissionsType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_process_summary_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_process_summary_type.go
@@ -21,6 +21,10 @@ const (
 	PROCESSSUMMARYTYPE_PROCESS ProcessSummaryType = "process"
 )
 
+var allowedProcessSummaryTypeEnumValues = []ProcessSummaryType{
+	"process",
+}
+
 func (v *ProcessSummaryType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *ProcessSummaryType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := ProcessSummaryType(value)
-	for _, existing := range []ProcessSummaryType{"process"} {
+	for _, existing := range allowedProcessSummaryTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *ProcessSummaryType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid ProcessSummaryType", value)
+}
+
+// NewProcessSummaryTypeFromValue returns a pointer to a valid ProcessSummaryType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewProcessSummaryTypeFromValue(v string) (*ProcessSummaryType, error) {
+	ev := ProcessSummaryType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for ProcessSummaryType: valid values are %v", v, allowedProcessSummaryTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v ProcessSummaryType) IsValid() bool {
+	for _, existing := range allowedProcessSummaryTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to ProcessSummaryType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_query_sort_order.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_query_sort_order.go
@@ -22,6 +22,11 @@ const (
 	QUERYSORTORDER_DESC QuerySortOrder = "desc"
 )
 
+var allowedQuerySortOrderEnumValues = []QuerySortOrder{
+	"asc",
+	"desc",
+}
+
 func (v *QuerySortOrder) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *QuerySortOrder) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := QuerySortOrder(value)
-	for _, existing := range []QuerySortOrder{"asc", "desc"} {
+	for _, existing := range allowedQuerySortOrderEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *QuerySortOrder) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid QuerySortOrder", value)
+}
+
+// NewQuerySortOrderFromValue returns a pointer to a valid QuerySortOrder
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewQuerySortOrderFromValue(v string) (*QuerySortOrder, error) {
+	ev := QuerySortOrder(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for QuerySortOrder: valid values are %v", v, allowedQuerySortOrderEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v QuerySortOrder) IsValid() bool {
+	for _, existing := range allowedQuerySortOrderEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to QuerySortOrder value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_roles_sort.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_roles_sort.go
@@ -26,6 +26,15 @@ const (
 	ROLESSORT_USER_COUNT_DESCENDING  RolesSort = "-user_count"
 )
 
+var allowedRolesSortEnumValues = []RolesSort{
+	"name",
+	"-name",
+	"modified_at",
+	"-modified_at",
+	"user_count",
+	"-user_count",
+}
+
 func (v *RolesSort) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -33,7 +42,7 @@ func (v *RolesSort) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := RolesSort(value)
-	for _, existing := range []RolesSort{"name", "-name", "modified_at", "-modified_at", "user_count", "-user_count"} {
+	for _, existing := range allowedRolesSortEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -41,6 +50,27 @@ func (v *RolesSort) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid RolesSort", value)
+}
+
+// NewRolesSortFromValue returns a pointer to a valid RolesSort
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewRolesSortFromValue(v string) (*RolesSort, error) {
+	ev := RolesSort(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for RolesSort: valid values are %v", v, allowedRolesSortEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v RolesSort) IsValid() bool {
+	for _, existing := range allowedRolesSortEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to RolesSort value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_roles_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_roles_type.go
@@ -21,6 +21,10 @@ const (
 	ROLESTYPE_ROLES RolesType = "roles"
 )
 
+var allowedRolesTypeEnumValues = []RolesType{
+	"roles",
+}
+
 func (v *RolesType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *RolesType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := RolesType(value)
-	for _, existing := range []RolesType{"roles"} {
+	for _, existing := range allowedRolesTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *RolesType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid RolesType", value)
+}
+
+// NewRolesTypeFromValue returns a pointer to a valid RolesType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewRolesTypeFromValue(v string) (*RolesType, error) {
+	ev := RolesType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for RolesType: valid values are %v", v, allowedRolesTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v RolesType) IsValid() bool {
+	for _, existing := range allowedRolesTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to RolesType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_security_monitoring_rule_evaluation_window.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_security_monitoring_rule_evaluation_window.go
@@ -28,6 +28,17 @@ const (
 	SECURITYMONITORINGRULEEVALUATIONWINDOW_TWO_HOURS       SecurityMonitoringRuleEvaluationWindow = 7200
 )
 
+var allowedSecurityMonitoringRuleEvaluationWindowEnumValues = []SecurityMonitoringRuleEvaluationWindow{
+	0,
+	60,
+	300,
+	600,
+	900,
+	1800,
+	3600,
+	7200,
+}
+
 func (v *SecurityMonitoringRuleEvaluationWindow) UnmarshalJSON(src []byte) error {
 	var value int32
 	err := json.Unmarshal(src, &value)
@@ -35,7 +46,7 @@ func (v *SecurityMonitoringRuleEvaluationWindow) UnmarshalJSON(src []byte) error
 		return err
 	}
 	enumTypeValue := SecurityMonitoringRuleEvaluationWindow(value)
-	for _, existing := range []SecurityMonitoringRuleEvaluationWindow{0, 60, 300, 600, 900, 1800, 3600, 7200} {
+	for _, existing := range allowedSecurityMonitoringRuleEvaluationWindowEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -43,6 +54,27 @@ func (v *SecurityMonitoringRuleEvaluationWindow) UnmarshalJSON(src []byte) error
 	}
 
 	return fmt.Errorf("%+v is not a valid SecurityMonitoringRuleEvaluationWindow", value)
+}
+
+// NewSecurityMonitoringRuleEvaluationWindowFromValue returns a pointer to a valid SecurityMonitoringRuleEvaluationWindow
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSecurityMonitoringRuleEvaluationWindowFromValue(v int32) (*SecurityMonitoringRuleEvaluationWindow, error) {
+	ev := SecurityMonitoringRuleEvaluationWindow(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SecurityMonitoringRuleEvaluationWindow: valid values are %v", v, allowedSecurityMonitoringRuleEvaluationWindowEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SecurityMonitoringRuleEvaluationWindow) IsValid() bool {
+	for _, existing := range allowedSecurityMonitoringRuleEvaluationWindowEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SecurityMonitoringRuleEvaluationWindow value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_security_monitoring_rule_keep_alive.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_security_monitoring_rule_keep_alive.go
@@ -30,6 +30,19 @@ const (
 	SECURITYMONITORINGRULEKEEPALIVE_SIX_HOURS       SecurityMonitoringRuleKeepAlive = 21600
 )
 
+var allowedSecurityMonitoringRuleKeepAliveEnumValues = []SecurityMonitoringRuleKeepAlive{
+	0,
+	60,
+	300,
+	600,
+	900,
+	1800,
+	3600,
+	7200,
+	10800,
+	21600,
+}
+
 func (v *SecurityMonitoringRuleKeepAlive) UnmarshalJSON(src []byte) error {
 	var value int32
 	err := json.Unmarshal(src, &value)
@@ -37,7 +50,7 @@ func (v *SecurityMonitoringRuleKeepAlive) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SecurityMonitoringRuleKeepAlive(value)
-	for _, existing := range []SecurityMonitoringRuleKeepAlive{0, 60, 300, 600, 900, 1800, 3600, 7200, 10800, 21600} {
+	for _, existing := range allowedSecurityMonitoringRuleKeepAliveEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -45,6 +58,27 @@ func (v *SecurityMonitoringRuleKeepAlive) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SecurityMonitoringRuleKeepAlive", value)
+}
+
+// NewSecurityMonitoringRuleKeepAliveFromValue returns a pointer to a valid SecurityMonitoringRuleKeepAlive
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSecurityMonitoringRuleKeepAliveFromValue(v int32) (*SecurityMonitoringRuleKeepAlive, error) {
+	ev := SecurityMonitoringRuleKeepAlive(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SecurityMonitoringRuleKeepAlive: valid values are %v", v, allowedSecurityMonitoringRuleKeepAliveEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SecurityMonitoringRuleKeepAlive) IsValid() bool {
+	for _, existing := range allowedSecurityMonitoringRuleKeepAliveEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SecurityMonitoringRuleKeepAlive value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_security_monitoring_rule_max_signal_duration.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_security_monitoring_rule_max_signal_duration.go
@@ -32,6 +32,21 @@ const (
 	SECURITYMONITORINGRULEMAXSIGNALDURATION_ONE_DAY         SecurityMonitoringRuleMaxSignalDuration = 86400
 )
 
+var allowedSecurityMonitoringRuleMaxSignalDurationEnumValues = []SecurityMonitoringRuleMaxSignalDuration{
+	0,
+	60,
+	300,
+	600,
+	900,
+	1800,
+	3600,
+	7200,
+	10800,
+	21600,
+	43200,
+	86400,
+}
+
 func (v *SecurityMonitoringRuleMaxSignalDuration) UnmarshalJSON(src []byte) error {
 	var value int32
 	err := json.Unmarshal(src, &value)
@@ -39,7 +54,7 @@ func (v *SecurityMonitoringRuleMaxSignalDuration) UnmarshalJSON(src []byte) erro
 		return err
 	}
 	enumTypeValue := SecurityMonitoringRuleMaxSignalDuration(value)
-	for _, existing := range []SecurityMonitoringRuleMaxSignalDuration{0, 60, 300, 600, 900, 1800, 3600, 7200, 10800, 21600, 43200, 86400} {
+	for _, existing := range allowedSecurityMonitoringRuleMaxSignalDurationEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -47,6 +62,27 @@ func (v *SecurityMonitoringRuleMaxSignalDuration) UnmarshalJSON(src []byte) erro
 	}
 
 	return fmt.Errorf("%+v is not a valid SecurityMonitoringRuleMaxSignalDuration", value)
+}
+
+// NewSecurityMonitoringRuleMaxSignalDurationFromValue returns a pointer to a valid SecurityMonitoringRuleMaxSignalDuration
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSecurityMonitoringRuleMaxSignalDurationFromValue(v int32) (*SecurityMonitoringRuleMaxSignalDuration, error) {
+	ev := SecurityMonitoringRuleMaxSignalDuration(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SecurityMonitoringRuleMaxSignalDuration: valid values are %v", v, allowedSecurityMonitoringRuleMaxSignalDurationEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SecurityMonitoringRuleMaxSignalDuration) IsValid() bool {
+	for _, existing := range allowedSecurityMonitoringRuleMaxSignalDurationEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SecurityMonitoringRuleMaxSignalDuration value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_security_monitoring_rule_query_aggregation.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_security_monitoring_rule_query_aggregation.go
@@ -24,6 +24,13 @@ const (
 	SECURITYMONITORINGRULEQUERYAGGREGATION_MAX         SecurityMonitoringRuleQueryAggregation = "max"
 )
 
+var allowedSecurityMonitoringRuleQueryAggregationEnumValues = []SecurityMonitoringRuleQueryAggregation{
+	"count",
+	"cardinality",
+	"sum",
+	"max",
+}
+
 func (v *SecurityMonitoringRuleQueryAggregation) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -31,7 +38,7 @@ func (v *SecurityMonitoringRuleQueryAggregation) UnmarshalJSON(src []byte) error
 		return err
 	}
 	enumTypeValue := SecurityMonitoringRuleQueryAggregation(value)
-	for _, existing := range []SecurityMonitoringRuleQueryAggregation{"count", "cardinality", "sum", "max"} {
+	for _, existing := range allowedSecurityMonitoringRuleQueryAggregationEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -39,6 +46,27 @@ func (v *SecurityMonitoringRuleQueryAggregation) UnmarshalJSON(src []byte) error
 	}
 
 	return fmt.Errorf("%+v is not a valid SecurityMonitoringRuleQueryAggregation", value)
+}
+
+// NewSecurityMonitoringRuleQueryAggregationFromValue returns a pointer to a valid SecurityMonitoringRuleQueryAggregation
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSecurityMonitoringRuleQueryAggregationFromValue(v string) (*SecurityMonitoringRuleQueryAggregation, error) {
+	ev := SecurityMonitoringRuleQueryAggregation(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SecurityMonitoringRuleQueryAggregation: valid values are %v", v, allowedSecurityMonitoringRuleQueryAggregationEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SecurityMonitoringRuleQueryAggregation) IsValid() bool {
+	for _, existing := range allowedSecurityMonitoringRuleQueryAggregationEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SecurityMonitoringRuleQueryAggregation value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_security_monitoring_rule_severity.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_security_monitoring_rule_severity.go
@@ -25,6 +25,14 @@ const (
 	SECURITYMONITORINGRULESEVERITY_CRITICAL SecurityMonitoringRuleSeverity = "critical"
 )
 
+var allowedSecurityMonitoringRuleSeverityEnumValues = []SecurityMonitoringRuleSeverity{
+	"info",
+	"low",
+	"medium",
+	"high",
+	"critical",
+}
+
 func (v *SecurityMonitoringRuleSeverity) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -32,7 +40,7 @@ func (v *SecurityMonitoringRuleSeverity) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SecurityMonitoringRuleSeverity(value)
-	for _, existing := range []SecurityMonitoringRuleSeverity{"info", "low", "medium", "high", "critical"} {
+	for _, existing := range allowedSecurityMonitoringRuleSeverityEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -40,6 +48,27 @@ func (v *SecurityMonitoringRuleSeverity) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SecurityMonitoringRuleSeverity", value)
+}
+
+// NewSecurityMonitoringRuleSeverityFromValue returns a pointer to a valid SecurityMonitoringRuleSeverity
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSecurityMonitoringRuleSeverityFromValue(v string) (*SecurityMonitoringRuleSeverity, error) {
+	ev := SecurityMonitoringRuleSeverity(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SecurityMonitoringRuleSeverity: valid values are %v", v, allowedSecurityMonitoringRuleSeverityEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SecurityMonitoringRuleSeverity) IsValid() bool {
+	for _, existing := range allowedSecurityMonitoringRuleSeverityEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SecurityMonitoringRuleSeverity value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_security_monitoring_signal_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_security_monitoring_signal_type.go
@@ -21,6 +21,10 @@ const (
 	SECURITYMONITORINGSIGNALTYPE_SIGNAL SecurityMonitoringSignalType = "signal"
 )
 
+var allowedSecurityMonitoringSignalTypeEnumValues = []SecurityMonitoringSignalType{
+	"signal",
+}
+
 func (v *SecurityMonitoringSignalType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *SecurityMonitoringSignalType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SecurityMonitoringSignalType(value)
-	for _, existing := range []SecurityMonitoringSignalType{"signal"} {
+	for _, existing := range allowedSecurityMonitoringSignalTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *SecurityMonitoringSignalType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SecurityMonitoringSignalType", value)
+}
+
+// NewSecurityMonitoringSignalTypeFromValue returns a pointer to a valid SecurityMonitoringSignalType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSecurityMonitoringSignalTypeFromValue(v string) (*SecurityMonitoringSignalType, error) {
+	ev := SecurityMonitoringSignalType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SecurityMonitoringSignalType: valid values are %v", v, allowedSecurityMonitoringSignalTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SecurityMonitoringSignalType) IsValid() bool {
+	for _, existing := range allowedSecurityMonitoringSignalTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SecurityMonitoringSignalType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_security_monitoring_signals_sort.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_security_monitoring_signals_sort.go
@@ -22,6 +22,11 @@ const (
 	SECURITYMONITORINGSIGNALSSORT_TIMESTAMP_DESCENDING SecurityMonitoringSignalsSort = "-timestamp"
 )
 
+var allowedSecurityMonitoringSignalsSortEnumValues = []SecurityMonitoringSignalsSort{
+	"timestamp",
+	"-timestamp",
+}
+
 func (v *SecurityMonitoringSignalsSort) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -29,7 +34,7 @@ func (v *SecurityMonitoringSignalsSort) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := SecurityMonitoringSignalsSort(value)
-	for _, existing := range []SecurityMonitoringSignalsSort{"timestamp", "-timestamp"} {
+	for _, existing := range allowedSecurityMonitoringSignalsSortEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -37,6 +42,27 @@ func (v *SecurityMonitoringSignalsSort) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid SecurityMonitoringSignalsSort", value)
+}
+
+// NewSecurityMonitoringSignalsSortFromValue returns a pointer to a valid SecurityMonitoringSignalsSort
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewSecurityMonitoringSignalsSortFromValue(v string) (*SecurityMonitoringSignalsSort, error) {
+	ev := SecurityMonitoringSignalsSort(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for SecurityMonitoringSignalsSort: valid values are %v", v, allowedSecurityMonitoringSignalsSortEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v SecurityMonitoringSignalsSort) IsValid() bool {
+	for _, existing := range allowedSecurityMonitoringSignalsSortEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to SecurityMonitoringSignalsSort value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_user_invitations_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_user_invitations_type.go
@@ -21,6 +21,10 @@ const (
 	USERINVITATIONSTYPE_USER_INVITATIONS UserInvitationsType = "user_invitations"
 )
 
+var allowedUserInvitationsTypeEnumValues = []UserInvitationsType{
+	"user_invitations",
+}
+
 func (v *UserInvitationsType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *UserInvitationsType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := UserInvitationsType(value)
-	for _, existing := range []UserInvitationsType{"user_invitations"} {
+	for _, existing := range allowedUserInvitationsTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *UserInvitationsType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid UserInvitationsType", value)
+}
+
+// NewUserInvitationsTypeFromValue returns a pointer to a valid UserInvitationsType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewUserInvitationsTypeFromValue(v string) (*UserInvitationsType, error) {
+	ev := UserInvitationsType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for UserInvitationsType: valid values are %v", v, allowedUserInvitationsTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v UserInvitationsType) IsValid() bool {
+	for _, existing := range allowedUserInvitationsTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to UserInvitationsType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_users_type.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/api/v2/datadog/model_users_type.go
@@ -21,6 +21,10 @@ const (
 	USERSTYPE_USERS UsersType = "users"
 )
 
+var allowedUsersTypeEnumValues = []UsersType{
+	"users",
+}
+
 func (v *UsersType) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -28,7 +32,7 @@ func (v *UsersType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := UsersType(value)
-	for _, existing := range []UsersType{"users"} {
+	for _, existing := range allowedUsersTypeEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -36,6 +40,27 @@ func (v *UsersType) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid UsersType", value)
+}
+
+// NewUsersTypeFromValue returns a pointer to a valid UsersType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewUsersTypeFromValue(v string) (*UsersType, error) {
+	ev := UsersType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for UsersType: valid values are %v", v, allowedUsersTypeEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v UsersType) IsValid() bool {
+	for _, existing := range allowedUsersTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to UsersType value

--- a/vendor/github.com/DataDog/datadog-api-client-go/version.go
+++ b/vendor/github.com/DataDog/datadog-api-client-go/version.go
@@ -1,4 +1,4 @@
 package client
 
 // Version used in User-Agent header.
-const Version = "1.0.0-beta.12"
+const Version = "1.0.0-beta.13+dev"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ cloud.google.com/go/internal/optional
 cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 cloud.google.com/go/storage
-# github.com/DataDog/datadog-api-client-go v1.0.0-beta.12
+# github.com/DataDog/datadog-api-client-go v1.0.0-beta.12.0.20201217225655-87ccef56e74b
 github.com/DataDog/datadog-api-client-go
 github.com/DataDog/datadog-api-client-go/api/v1/datadog
 github.com/DataDog/datadog-api-client-go/api/v2/datadog


### PR DESCRIPTION
Bump the datadog-api-client-go to pull in the latest features of the client. 

Most specifically I was confirming the REDACTION logic of the client for API/APP Keys performed as expected. Building the provider with this commit and running `TF_LOG=DEBUG terraform plan` results in a plan with redacted keys:

```
2020-12-17T18:05:38.679-0500 [DEBUG] plugin.terraform-provider-datadog: Content-Length: 417
2020-12-17T18:05:38.679-0500 [DEBUG] plugin.terraform-provider-datadog: Accept: application/json
2020-12-17T18:05:38.679-0500 [DEBUG] plugin.terraform-provider-datadog: Content-Type: application/json
2020-12-17T18:05:38.679-0500 [DEBUG] plugin.terraform-provider-datadog: Dd-Api-Key: REDACTED
2020-12-17T18:05:38.679-0500 [DEBUG] plugin.terraform-provider-datadog: Dd-Application-Key: REDACTED
2020-12-17T18:05:38.679-0500 [DEBUG] plugin.terraform-provider-datadog: Dd-Operation-Id: ValidateMonitor
2020-12-17T18:05:38.679-0500 [DEBUG] plugin.terraform-provider-datadog: Accept-Encoding: gzip
```