### PR TITLE
Allow dependabot to check go packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This change allows dependabot to check go dependencies which this project uses and submit PRs with version bumps in order to keep dependencies up-to-date.

https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates