### PR TITLE
Add top level descriptions

### DIFF
--- a/datadog/data_source_datadog_dashboard.go
+++ b/datadog/data_source_datadog_dashboard.go
@@ -10,7 +10,8 @@ import (
 
 func dataSourceDatadogDashboard() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDatadogDashboardRead,
+		Description: "Use this data source to retrieve information about an existing dashboard, for use in other resources. In particular, it can be used in a monitor message to link to a specific dashboard.",
+		Read:        dataSourceDatadogDashboardRead,
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/datadog/data_source_datadog_dashboard_list.go
+++ b/datadog/data_source_datadog_dashboard_list.go
@@ -11,7 +11,8 @@ import (
 
 func dataSourceDatadogDashboardList() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDatadogDashboardListRead,
+		Description: "Use this data source to retrieve information about an existing dashboard list, for use in other resources. In particular, it can be used in a dashboard to register it in the list.",
+		Read:        dataSourceDatadogDashboardListRead,
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/datadog/data_source_datadog_ip_ranges.go
+++ b/datadog/data_source_datadog_ip_ranges.go
@@ -6,7 +6,8 @@ import (
 
 func dataSourceDatadogIpRanges() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDatadogIPRangesRead,
+		Description: "Use this data source to retrieve information about Datadog's IP addresses.",
+		Read:        dataSourceDatadogIPRangesRead,
 
 		// IP ranges are divided between ipv4 and ipv6
 		Schema: map[string]*schema.Schema{

--- a/datadog/data_source_datadog_monitor.go
+++ b/datadog/data_source_datadog_monitor.go
@@ -12,7 +12,8 @@ import (
 
 func dataSourceDatadogMonitor() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDatadogMonitorsRead,
+		Description: "Use this data source to retrieve information about an existing monitor for use in other resources.",
+		Read:        dataSourceDatadogMonitorsRead,
 		Schema: map[string]*schema.Schema{
 			"name_filter": {
 				Description: "A monitor name to limit the search.",
@@ -156,7 +157,7 @@ func dataSourceDatadogMonitor() *schema.Resource {
 				Computed:    true,
 			},
 			"include_tags": {
-				Description: "Whether or not notifications from the monitor automatically inserts its triggering tags into the title.\n",
+				Description: "Whether or not notifications from the monitor automatically inserts its triggering tags into the title.",
 				Type:        schema.TypeBool,
 				Computed:    true,
 			},

--- a/datadog/data_source_datadog_permissions.go
+++ b/datadog/data_source_datadog_permissions.go
@@ -6,7 +6,8 @@ import (
 
 func dataSourceDatadogPermissions() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDatadogPermissionsRead,
+		Description: "Use this data source to retrieve the list of Datadog permissions by name and their corresponding ID, for use in the role resource.",
+		Read:        dataSourceDatadogPermissionsRead,
 
 		Schema: map[string]*schema.Schema{
 			// Computed values

--- a/datadog/data_source_datadog_role.go
+++ b/datadog/data_source_datadog_role.go
@@ -9,7 +9,8 @@ import (
 
 func dataSourceDatadogRole() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDatadogRoleRead,
+		Description: "Use this data source to retrieve information about an existing role for use in other resources.",
+		Read:        dataSourceDatadogRoleRead,
 
 		Schema: map[string]*schema.Schema{
 			"filter": {

--- a/datadog/data_source_datadog_security_monitoring_rules.go
+++ b/datadog/data_source_datadog_security_monitoring_rules.go
@@ -16,7 +16,8 @@ import (
 
 func dataSourceDatadogSecurityMonitoringRules() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDatadogSecurityMonitoringRulesRead,
+		Description: "Use this data source to retrieve information about existing security monitoring rules for use in other resources.",
+		Read:        dataSourceDatadogSecurityMonitoringRulesRead,
 
 		Schema: map[string]*schema.Schema{
 			// Filters

--- a/datadog/data_source_datadog_synthetics_locations.go
+++ b/datadog/data_source_datadog_synthetics_locations.go
@@ -6,7 +6,8 @@ import (
 
 func dataSourceDatadogSyntheticsLocations() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDatadogSyntheticsLocationsRead,
+		Description: "Use this data source to retrieve Datadog's Synthetics Locations (to be used in Synthetics tests).",
+		Read:        dataSourceDatadogSyntheticsLocationsRead,
 
 		// Locations are a map of IDs to names
 		Schema: map[string]*schema.Schema{

--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -33,21 +33,25 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"DATADOG_API_KEY", "DD_API_KEY"}, nil),
+				Description: "(Required unless validate is false) Datadog API key. This can also be set via the DD_API_KEY environment variable.",
 			},
 			"app_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"DATADOG_APP_KEY", "DD_APP_KEY"}, nil),
+				Description: "(Required unless validate is false) Datadog APP key. This can also be set via the DD_APP_KEY environment variable.",
 			},
 			"api_url": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"DATADOG_HOST", "DD_HOST"}, nil),
+				Description: "The API Url. This can be also be set via the DD_HOST environment variable. Note that this URL must not end with the /api/ path. For example, https://api.datadoghq.com/ is a correct value, while https://api.datadoghq.com/api/ is not. And if you're working with \"EU\" version of Datadog, use https://api.datadoghq.eu/.",
 			},
 			"validate": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Enables validation of the provided API and APP keys during provider initialization. Default is true. When false, api_key and app_keywon't be checked.",
 			},
 		},
 

--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -15,11 +15,12 @@ import (
 
 func resourceDatadogDashboard() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogDashboardCreate,
-		Update: resourceDatadogDashboardUpdate,
-		Read:   resourceDatadogDashboardRead,
-		Delete: resourceDatadogDashboardDelete,
-		Exists: resourceDatadogDashboardExists,
+		Description: "Provides a Datadog dashboard resource. This can be used to create and manage Datadog dashboards.",
+		Create:      resourceDatadogDashboardCreate,
+		Update:      resourceDatadogDashboardUpdate,
+		Read:        resourceDatadogDashboardRead,
+		Delete:      resourceDatadogDashboardDelete,
+		Exists:      resourceDatadogDashboardExists,
 		CustomizeDiff: func(diff *schema.ResourceDiff, meta interface{}) error {
 			old, new := diff.GetChange("dashboard_lists")
 			if !old.(*schema.Set).Equal(new.(*schema.Set)) {

--- a/datadog/resource_datadog_dashboard_list.go
+++ b/datadog/resource_datadog_dashboard_list.go
@@ -12,11 +12,12 @@ import (
 
 func resourceDatadogDashboardList() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogDashboardListCreate,
-		Update: resourceDatadogDashboardListUpdate,
-		Read:   resourceDatadogDashboardListRead,
-		Delete: resourceDatadogDashboardListDelete,
-		Exists: resourceDatadogDashboardListExists,
+		Description: "Provides a Datadog dashboard_list resource. This can be used to create and manage Datadog Dashboard Lists and the individual dashboards within them.",
+		Create:      resourceDatadogDashboardListCreate,
+		Update:      resourceDatadogDashboardListUpdate,
+		Read:        resourceDatadogDashboardListRead,
+		Delete:      resourceDatadogDashboardListDelete,
+		Exists:      resourceDatadogDashboardListExists,
 		Importer: &schema.ResourceImporter{
 			State: resourceDatadogDashboardListImport,
 		},

--- a/datadog/resource_datadog_downtime.go
+++ b/datadog/resource_datadog_downtime.go
@@ -19,11 +19,12 @@ import (
 
 func resourceDatadogDowntime() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogDowntimeCreate,
-		Read:   resourceDatadogDowntimeRead,
-		Update: resourceDatadogDowntimeUpdate,
-		Delete: resourceDatadogDowntimeDelete,
-		Exists: resourceDatadogDowntimeExists,
+		Description: "Provides a Datadog downtime resource. This can be used to create and manage Datadog downtimes.",
+		Create:      resourceDatadogDowntimeCreate,
+		Read:        resourceDatadogDowntimeRead,
+		Update:      resourceDatadogDowntimeUpdate,
+		Delete:      resourceDatadogDowntimeDelete,
+		Exists:      resourceDatadogDowntimeExists,
 		Importer: &schema.ResourceImporter{
 			State: resourceDatadogDowntimeImport,
 		},

--- a/datadog/resource_datadog_integration_aws.go
+++ b/datadog/resource_datadog_integration_aws.go
@@ -22,11 +22,12 @@ func accountAndRoleFromID(id string) (string, string, error) {
 
 func resourceDatadogIntegrationAws() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogIntegrationAwsCreate,
-		Read:   resourceDatadogIntegrationAwsRead,
-		Update: resourceDatadogIntegrationAwsUpdate,
-		Delete: resourceDatadogIntegrationAwsDelete,
-		Exists: resourceDatadogIntegrationAwsExists,
+		DeprecationMessage: "Provides a Datadog - Amazon Web Services integration resource. This can be used to create and manage Datadog - Amazon Web Services integration.\n\n",
+		Create:             resourceDatadogIntegrationAwsCreate,
+		Read:               resourceDatadogIntegrationAwsRead,
+		Update:             resourceDatadogIntegrationAwsUpdate,
+		Delete:             resourceDatadogIntegrationAwsDelete,
+		Exists:             resourceDatadogIntegrationAwsExists,
 		Importer: &schema.ResourceImporter{
 			State: resourceDatadogIntegrationAwsImport,
 		},

--- a/datadog/resource_datadog_integration_aws_lambda_arn.go
+++ b/datadog/resource_datadog_integration_aws_lambda_arn.go
@@ -26,10 +26,11 @@ func buildDatadogIntegrationAwsLambdaArnStruct(d *schema.ResourceData) *datadogV
 
 func resourceDatadogIntegrationAwsLambdaArn() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogIntegrationAwsLambdaArnCreate,
-		Read:   resourceDatadogIntegrationAwsLambdaArnRead,
-		Delete: resourceDatadogIntegrationAwsLambdaArnDelete,
-		Exists: resourceDatadogIntegrationAwsLambdaArnExists,
+		Description: "Provides a Datadog - Amazon Web Services integration Lambda ARN resource. This can be used to create and manage the log collection Lambdas for an account.\n\nUpdate operations are currently not supported with datadog API so any change forces a new resource.",
+		Create:      resourceDatadogIntegrationAwsLambdaArnCreate,
+		Read:        resourceDatadogIntegrationAwsLambdaArnRead,
+		Delete:      resourceDatadogIntegrationAwsLambdaArnDelete,
+		Exists:      resourceDatadogIntegrationAwsLambdaArnExists,
 		Importer: &schema.ResourceImporter{
 			State: resourceDatadogIntegrationAwsLambdaArnImport,
 		},

--- a/datadog/resource_datadog_integration_aws_log_collection.go
+++ b/datadog/resource_datadog_integration_aws_log_collection.go
@@ -9,11 +9,12 @@ import (
 
 func resourceDatadogIntegrationAwsLogCollection() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogIntegrationAwsLogCollectionCreate,
-		Read:   resourceDatadogIntegrationAwsLogCollectionRead,
-		Update: resourceDatadogIntegrationAwsLogCollectionUpdate,
-		Delete: resourceDatadogIntegrationAwsLogCollectionDelete,
-		Exists: resourceDatadogIntegrationAwsLogCollectionExists,
+		Description: "Provides a Datadog - Amazon Web Services integration log collection resource. This can be used to manage which AWS services logs are collected from for an account.",
+		Create:      resourceDatadogIntegrationAwsLogCollectionCreate,
+		Read:        resourceDatadogIntegrationAwsLogCollectionRead,
+		Update:      resourceDatadogIntegrationAwsLogCollectionUpdate,
+		Delete:      resourceDatadogIntegrationAwsLogCollectionDelete,
+		Exists:      resourceDatadogIntegrationAwsLogCollectionExists,
 		Importer: &schema.ResourceImporter{
 			State: resourceDatadogIntegrationAwsLogCollectionImport,
 		},

--- a/datadog/resource_datadog_integration_azure.go
+++ b/datadog/resource_datadog_integration_azure.go
@@ -10,10 +10,11 @@ import (
 
 func resourceDatadogIntegrationAzure() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogIntegrationAzureCreate,
-		Read:   resourceDatadogIntegrationAzureRead,
-		Update: resourceDatadogIntegrationAzureUpdate,
-		Delete: resourceDatadogIntegrationAzureDelete,
+		Description: "Provides a Datadog - Microsoft Azure integration resource. This can be used to create and manage the integrations.",
+		Create:      resourceDatadogIntegrationAzureCreate,
+		Read:        resourceDatadogIntegrationAzureRead,
+		Update:      resourceDatadogIntegrationAzureUpdate,
+		Delete:      resourceDatadogIntegrationAzureDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceDatadogIntegrationAzureImport,
 		},

--- a/datadog/resource_datadog_integration_gcp.go
+++ b/datadog/resource_datadog_integration_gcp.go
@@ -9,11 +9,12 @@ import (
 
 func resourceDatadogIntegrationGcp() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogIntegrationGcpCreate,
-		Read:   resourceDatadogIntegrationGcpRead,
-		Update: resourceDatadogIntegrationGcpUpdate,
-		Delete: resourceDatadogIntegrationGcpDelete,
-		Exists: resourceDatadogIntegrationGcpExists,
+		Description: "Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.",
+		Create:      resourceDatadogIntegrationGcpCreate,
+		Read:        resourceDatadogIntegrationGcpRead,
+		Update:      resourceDatadogIntegrationGcpUpdate,
+		Delete:      resourceDatadogIntegrationGcpDelete,
+		Exists:      resourceDatadogIntegrationGcpExists,
 		Importer: &schema.ResourceImporter{
 			State: resourceDatadogIntegrationGcpImport,
 		},

--- a/datadog/resource_datadog_integration_pagerduty.go
+++ b/datadog/resource_datadog_integration_pagerduty.go
@@ -16,6 +16,7 @@ var integrationPdMutex = sync.Mutex{}
 
 func resourceDatadogIntegrationPagerduty() *schema.Resource {
 	return &schema.Resource{
+		Description:        "Provides a Datadog - PagerDuty resource. This can be used to create and manage Datadog - PagerDuty integration. This resource is deprecated and should only be used for legacy purposes.\n\n",
 		DeprecationMessage: "This resource is deprecated. You can use datadog_integration_pagerduty_service_object resources directly once the integration is activated",
 		Create:             resourceDatadogIntegrationPagerdutyCreate,
 		Read:               resourceDatadogIntegrationPagerdutyRead,

--- a/datadog/resource_datadog_integration_pagerduty_service_object.go
+++ b/datadog/resource_datadog_integration_pagerduty_service_object.go
@@ -11,11 +11,12 @@ const maskedSecret = "*****"
 
 func resourceDatadogIntegrationPagerdutySO() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogIntegrationPagerdutySOCreate,
-		Read:   resourceDatadogIntegrationPagerdutySORead,
-		Exists: resourceDatadogIntegrationPagerdutySOExists,
-		Update: resourceDatadogIntegrationPagerdutySOUpdate,
-		Delete: resourceDatadogIntegrationPagerdutySODelete,
+		Description: "Provides access to individual Service Objects of Datadog - PagerDuty integrations. Note that the Datadog - PagerDuty integration must be activated in the Datadog UI in order for this resource to be usable.",
+		Create:      resourceDatadogIntegrationPagerdutySOCreate,
+		Read:        resourceDatadogIntegrationPagerdutySORead,
+		Exists:      resourceDatadogIntegrationPagerdutySOExists,
+		Update:      resourceDatadogIntegrationPagerdutySOUpdate,
+		Delete:      resourceDatadogIntegrationPagerdutySODelete,
 		// since the API never returns service_key, it's impossible to meaningfully import resources
 		Importer: nil,
 

--- a/datadog/resource_datadog_logs_archive.go
+++ b/datadog/resource_datadog_logs_archive.go
@@ -9,11 +9,12 @@ import (
 
 func resourceDatadogLogsArchive() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogLogsArchiveCreate,
-		Update: resourceDatadogLogsArchiveUpdate,
-		Read:   resourceDatadogLogsArchiveRead,
-		Delete: resourceDatadogLogsArchiveDelete,
-		Exists: resourceDatadogLogsArchiveExists,
+		Description: "Provides a Datadog Logs Archive API resource, which is used to create and manage Datadog logs archives.",
+		Create:      resourceDatadogLogsArchiveCreate,
+		Update:      resourceDatadogLogsArchiveUpdate,
+		Read:        resourceDatadogLogsArchiveRead,
+		Delete:      resourceDatadogLogsArchiveDelete,
+		Exists:      resourceDatadogLogsArchiveExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/datadog/resource_datadog_logs_archive_order.go
+++ b/datadog/resource_datadog_logs_archive_order.go
@@ -10,11 +10,12 @@ import (
 
 func resourceDatadogLogsArchiveOrder() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogLogsArchiveOrderCreate,
-		Update: resourceDatadogLogsArchiveOrderUpdate,
-		Read:   resourceDatadogLogsArchiveOrderRead,
-		Delete: resourceDatadogLogsArchiveOrderDelete,
-		Exists: resourceDatadogLogsArchiveOrderExists,
+		Description: "Provides a Datadog Logs Archive API resource, which is used to manage Datadog log archives order.",
+		Create:      resourceDatadogLogsArchiveOrderCreate,
+		Update:      resourceDatadogLogsArchiveOrderUpdate,
+		Read:        resourceDatadogLogsArchiveOrderRead,
+		Delete:      resourceDatadogLogsArchiveOrderDelete,
+		Exists:      resourceDatadogLogsArchiveOrderExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/datadog/resource_datadog_logs_custom_pipeline.go
+++ b/datadog/resource_datadog_logs_custom_pipeline.go
@@ -85,6 +85,7 @@ var arithmeticProcessor = &schema.Schema{
 	MaxItems: 1,
 	Optional: true,
 	Elem: &schema.Resource{
+		Description: "Provides a Datadog Logs Pipeline API resource, which is used to create and manage Datadog logs custom pipelines.",
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Description: "Your pipeline name.",

--- a/datadog/resource_datadog_logs_index.go
+++ b/datadog/resource_datadog_logs_index.go
@@ -71,11 +71,12 @@ var exclusionFilterSchema = map[string]*schema.Schema{
 
 func resourceDatadogLogsIndex() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogLogsIndexCreate,
-		Update: resourceDatadogLogsIndexUpdate,
-		Read:   resourceDatadogLogsIndexRead,
-		Delete: resourceDatadogLogsIndexDelete,
-		Exists: resourceDatadogLogsIndexExists,
+		Description: "Provides a Datadog Logs Index API resource. This can be used to create and manage Datadog logs indexes.",
+		Create:      resourceDatadogLogsIndexCreate,
+		Update:      resourceDatadogLogsIndexUpdate,
+		Read:        resourceDatadogLogsIndexRead,
+		Delete:      resourceDatadogLogsIndexDelete,
+		Exists:      resourceDatadogLogsIndexExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/datadog/resource_datadog_logs_index_order.go
+++ b/datadog/resource_datadog_logs_index_order.go
@@ -7,11 +7,12 @@ import (
 
 func resourceDatadogLogsIndexOrder() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogLogsIndexOrderCreate,
-		Update: resourceDatadogLogsIndexOrderUpdate,
-		Read:   resourceDatadogLogsIndexOrderRead,
-		Delete: resourceDatadogLogsIndexOrderDelete,
-		Exists: resourceDatadogLogsIndexOrderExists,
+		Description: "Provides a Datadog Logs Index API resource. This can be used to manage the order of Datadog logs indexes.",
+		Create:      resourceDatadogLogsIndexOrderCreate,
+		Update:      resourceDatadogLogsIndexOrderUpdate,
+		Read:        resourceDatadogLogsIndexOrderRead,
+		Delete:      resourceDatadogLogsIndexOrderDelete,
+		Exists:      resourceDatadogLogsIndexOrderExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/datadog/resource_datadog_logs_integration_pipeline.go
+++ b/datadog/resource_datadog_logs_integration_pipeline.go
@@ -10,11 +10,12 @@ import (
 
 func resourceDatadogLogsIntegrationPipeline() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogLogsIntegrationPipelineCreate,
-		Update: resourceDatadogLogsIntegrationPipelineUpdate,
-		Read:   resourceDatadogLogsIntegrationPipelineRead,
-		Delete: resourceDatadogLogsIntegrationPipelineDelete,
-		Exists: resourceDatadogLogsIntegrationPipelineExists,
+		Description: "Provides a Datadog Logs Pipeline API resource to manage the integrations.\n\nIntegration pipelines are the pipelines that are automatically installed for your organization when sending the logs with specific sources. You don't need to maintain or update these types of pipelines. Keeping them as resources, however, allows you to manage the order of your pipelines by referencing them in your datadog_logs_pipeline_order resource. If you don't need the pipeline_order feature, this resource declaration can be omitted.",
+		Create:      resourceDatadogLogsIntegrationPipelineCreate,
+		Update:      resourceDatadogLogsIntegrationPipelineUpdate,
+		Read:        resourceDatadogLogsIntegrationPipelineRead,
+		Delete:      resourceDatadogLogsIntegrationPipelineDelete,
+		Exists:      resourceDatadogLogsIntegrationPipelineExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/datadog/resource_datadog_logs_pipeline_order.go
+++ b/datadog/resource_datadog_logs_pipeline_order.go
@@ -10,11 +10,12 @@ import (
 
 func resourceDatadogLogsPipelineOrder() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogLogsPipelineOrderCreate,
-		Update: resourceDatadogLogsPipelineOrderUpdate,
-		Read:   resourceDatadogLogsPipelineOrderRead,
-		Delete: resourceDatadogLogsPipelineOrderDelete,
-		Exists: resourceDatadogLogsPipelineOrderExists,
+		Description: "Provides a Datadog Logs Pipeline API resource, which is used to manage Datadog log pipelines order.",
+		Create:      resourceDatadogLogsPipelineOrderCreate,
+		Update:      resourceDatadogLogsPipelineOrderUpdate,
+		Read:        resourceDatadogLogsPipelineOrderRead,
+		Delete:      resourceDatadogLogsPipelineOrderDelete,
+		Exists:      resourceDatadogLogsPipelineOrderExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/datadog/resource_datadog_metric_metadata.go
+++ b/datadog/resource_datadog_metric_metadata.go
@@ -9,11 +9,12 @@ import (
 
 func resourceDatadogMetricMetadata() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogMetricMetadataCreate,
-		Read:   resourceDatadogMetricMetadataRead,
-		Update: resourceDatadogMetricMetadataUpdate,
-		Delete: resourceDatadogMetricMetadataDelete,
-		Exists: resourceDatadogMetricMetadataExists,
+		Description: "Provides a Datadog metric_metadata resource. This can be used to manage a metric's metadata.",
+		Create:      resourceDatadogMetricMetadataCreate,
+		Read:        resourceDatadogMetricMetadataRead,
+		Update:      resourceDatadogMetricMetadataUpdate,
+		Delete:      resourceDatadogMetricMetadataDelete,
+		Exists:      resourceDatadogMetricMetadataExists,
 		Importer: &schema.ResourceImporter{
 			State: resourceDatadogMetricMetadataImport,
 		},

--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -20,6 +20,7 @@ type BuiltResource interface {
 
 func resourceDatadogMonitor() *schema.Resource {
 	return &schema.Resource{
+		Description:   "Provides a Datadog monitor resource. This can be used to create and manage Datadog monitors.",
 		Create:        resourceDatadogMonitorCreate,
 		Read:          resourceDatadogMonitorRead,
 		Update:        resourceDatadogMonitorUpdate,

--- a/datadog/resource_datadog_role.go
+++ b/datadog/resource_datadog_role.go
@@ -15,11 +15,12 @@ var validPermissions map[string]string
 
 func resourceDatadogRole() *schema.Resource {
 	return &schema.Resource{
-		Exists: resourceDatadogRoleExists,
-		Create: resourceDatadogRoleCreate,
-		Read:   resourceDatadogRoleRead,
-		Update: resourceDatadogRoleUpdate,
-		Delete: resourceDatadogRoleDelete,
+		Description: "Provides a Datadog role resource. This can be used to create and manage Datadog roles.",
+		Exists:      resourceDatadogRoleExists,
+		Create:      resourceDatadogRoleCreate,
+		Read:        resourceDatadogRoleRead,
+		Update:      resourceDatadogRoleUpdate,
+		Delete:      resourceDatadogRoleDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceDatadogRoleImport,
 		},

--- a/datadog/resource_datadog_screenboard.go
+++ b/datadog/resource_datadog_screenboard.go
@@ -776,6 +776,7 @@ func resourceDatadogScreenboard() *schema.Resource {
 	}
 
 	return &schema.Resource{
+		Description:        "Provides a Datadog screenboard resource. This can be used to create and manage Datadog screenboards.",
 		DeprecationMessage: "This resource is deprecated. Instead use the Dashboard resource",
 		Create:             resourceDatadogScreenboardCreate,
 		Read:               resourceDatadogScreenboardRead,

--- a/datadog/resource_datadog_security_monitoring_default_rule.go
+++ b/datadog/resource_datadog_security_monitoring_default_rule.go
@@ -10,10 +10,11 @@ import (
 
 func resourceDatadogSecurityMonitoringDefaultRule() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogSecurityMonitoringDefaultRuleCreate,
-		Read:   resourceDatadogSecurityMonitoringDefaultRuleRead,
-		Update: resourceDatadogSecurityMonitoringDefaultRuleUpdate,
-		Delete: resourceDatadogSecurityMonitoringDefaultRuleDelete,
+		Description: "Provides a Datadog Security Monitoring Rule API resource for default rules.",
+		Create:      resourceDatadogSecurityMonitoringDefaultRuleCreate,
+		Read:        resourceDatadogSecurityMonitoringDefaultRuleRead,
+		Update:      resourceDatadogSecurityMonitoringDefaultRuleUpdate,
+		Delete:      resourceDatadogSecurityMonitoringDefaultRuleDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/datadog/resource_datadog_security_monitoring_rule.go
+++ b/datadog/resource_datadog_security_monitoring_rule.go
@@ -8,10 +8,11 @@ import (
 
 func resourceDatadogSecurityMonitoringRule() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogSecurityMonitoringRuleCreate,
-		Read:   resourceDatadogSecurityMonitoringRuleRead,
-		Update: resourceDatadogSecurityMonitoringRuleUpdate,
-		Delete: resourceDatadogSecurityMonitoringRuleDelete,
+		Description: "Provides a Datadog Security Monitoring Rule API resource. This can be used to create and manage Datadog security monitoring rules. To change settings for a default rule use datadog_security_default_rule instead.",
+		Create:      resourceDatadogSecurityMonitoringRuleCreate,
+		Read:        resourceDatadogSecurityMonitoringRuleRead,
+		Update:      resourceDatadogSecurityMonitoringRuleUpdate,
+		Delete:      resourceDatadogSecurityMonitoringRuleDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/datadog/resource_datadog_service_level_objective.go
+++ b/datadog/resource_datadog_service_level_objective.go
@@ -12,6 +12,7 @@ import (
 
 func resourceDatadogServiceLevelObjective() *schema.Resource {
 	return &schema.Resource{
+		Description:   "Provides a Datadog service level objective resource. This can be used to create and manage Datadog service level objectives.",
 		Create:        resourceDatadogServiceLevelObjectiveCreate,
 		Read:          resourceDatadogServiceLevelObjectiveRead,
 		Update:        resourceDatadogServiceLevelObjectiveUpdate,

--- a/datadog/resource_datadog_synthetics_global_variable.go
+++ b/datadog/resource_datadog_synthetics_global_variable.go
@@ -10,10 +10,11 @@ import (
 
 func resourceDatadogSyntheticsGlobalVariable() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogSyntheticsGlobalVariableCreate,
-		Read:   resourceDatadogSyntheticsGlobalVariableRead,
-		Update: resourceDatadogSyntheticsGlobalVariableUpdate,
-		Delete: resourceDatadogSyntheticsGlobalVariableDelete,
+		Description: "Provides a Datadog synthetics global variable resource. This can be used to create and manage Datadog synthetics global variables.",
+		Create:      resourceDatadogSyntheticsGlobalVariableCreate,
+		Read:        resourceDatadogSyntheticsGlobalVariableRead,
+		Update:      resourceDatadogSyntheticsGlobalVariableUpdate,
+		Delete:      resourceDatadogSyntheticsGlobalVariableDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/datadog/resource_datadog_synthetics_private_location.go
+++ b/datadog/resource_datadog_synthetics_private_location.go
@@ -9,10 +9,11 @@ import (
 
 func resourceDatadogSyntheticsPrivateLocation() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogSyntheticsPrivateLocationCreate,
-		Read:   resourceDatadogSyntheticsPrivateLocationRead,
-		Update: resourceDatadogSyntheticsPrivateLocationUpdate,
-		Delete: resourceDatadogSyntheticsPrivateLocationDelete,
+		Description: "Provides a Datadog synthetics private location resource. This can be used to create and manage Datadog synthetics private locations.",
+		Create:      resourceDatadogSyntheticsPrivateLocationCreate,
+		Read:        resourceDatadogSyntheticsPrivateLocationRead,
+		Update:      resourceDatadogSyntheticsPrivateLocationUpdate,
+		Delete:      resourceDatadogSyntheticsPrivateLocationDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -17,10 +17,11 @@ import (
 
 func resourceDatadogSyntheticsTest() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogSyntheticsTestCreate,
-		Read:   resourceDatadogSyntheticsTestRead,
-		Update: resourceDatadogSyntheticsTestUpdate,
-		Delete: resourceDatadogSyntheticsTestDelete,
+		Description: "Provides a Datadog synthetics test resource. This can be used to create and manage Datadog synthetics test.",
+		Create:      resourceDatadogSyntheticsTestCreate,
+		Read:        resourceDatadogSyntheticsTestRead,
+		Update:      resourceDatadogSyntheticsTestUpdate,
+		Delete:      resourceDatadogSyntheticsTestDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/datadog/resource_datadog_timeboard.go
+++ b/datadog/resource_datadog_timeboard.go
@@ -446,6 +446,7 @@ func resourceDatadogTimeboard() *schema.Resource {
 	}
 
 	return &schema.Resource{
+		Description:        "Provides a Datadog timeboard resource. This can be used to create and manage Datadog timeboards.",
 		DeprecationMessage: "This resource is deprecated. Instead use the Dashboard resource",
 		Create:             resourceDatadogTimeboardCreate,
 		Update:             resourceDatadogTimeboardUpdate,

--- a/datadog/resource_datadog_user.go
+++ b/datadog/resource_datadog_user.go
@@ -19,10 +19,11 @@ func isV2User(id string) bool {
 
 func resourceDatadogUser() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogUserCreate,
-		Read:   resourceDatadogUserRead,
-		Update: resourceDatadogUserUpdate,
-		Delete: resourceDatadogUserDelete,
+		Description: "Provides a Datadog user resource. This can be used to create and manage Datadog users.",
+		Create:      resourceDatadogUserCreate,
+		Read:        resourceDatadogUserRead,
+		Update:      resourceDatadogUserUpdate,
+		Delete:      resourceDatadogUserDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceDatadogUserImport,
 		},


### PR DESCRIPTION
Add top level descriptions to providers and data sources. Most schema element descriptions were added in #803 but this adds the top level descriptions. 

Makes #798 smaller and more around just the tooling