### PR TITLE
Handle result in 404 case in monitor

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -461,6 +461,10 @@ func resourceDatadogMonitorRead(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
+	if d.Id() == "" {
+		return nil
+	}
+
 	thresholds := make(map[string]string)
 
 	if v, ok := m.Options.Thresholds.GetOkOk(); ok {


### PR DESCRIPTION
If we have a 404 in the retry, we need to check the ID again outside of
it.

Closes #822