### PR TITLE
Remove timeout from non-HTTP tests docs

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -15,8 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
-var syntheticsConfigVariableTypes = []string{"text"}
-
 func resourceDatadogSyntheticsTest() *schema.Resource {
 	return &schema.Resource{
 		Description: "Provides a Datadog synthetics test resource. This can be used to create and manage Datadog synthetics test.",

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -211,7 +211,6 @@ The following arguments are supported:
 -   `request`: (Required) if type=api and subtype=ssl or subtype=tcp or subtype=dns
     -   `host`: (Required) host name
     -   `port`: (Required) port number
-    -   `timeout`: (Optional) For type=api, any value between 0 and 60 (Default = 60)
     -   `dns_server`: (Optional) For subtype=dns, DNS server to use
 -   `request`: (Required) if type=browser
     -   `method`: (Required) no-op, use GET


### PR DESCRIPTION
Timeout is only supported by HTTP tests for now.
This also removes an unused variable.

Closes #828