### PR TITLE
Update timeout on gotestsum to be 20 minutes

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -35,7 +35,7 @@ test: get-test-deps fmtcheck
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
 		xargs -t -n4 gotestsum --format testname -- $(TESTARGS) -timeout=30s -parallel=4
-	DD_API_KEY=fake DD_APP_KEY=fake RECORD=false TF_ACC=1 gotestsum --format testname -- $(TEST) -v $(TESTARGS) -timeout=15m
+	DD_API_KEY=fake DD_APP_KEY=fake RECORD=false TF_ACC=1 gotestsum --format testname -- $(TEST) -v $(TESTARGS) -timeout=20m
 
 testacc: get-test-deps fmtcheck
 	TF_ACC=1 gotestsum --format testname -- $(TEST) -v $(TESTARGS) -timeout 120m


### PR DESCRIPTION
Bump timeout to be 20 minutes instead of 15. 
As new resources and endpoints are being added, the tests seem to be starting to hit the 15 minute timeout