### PR TITLE
Remove access_role default value from users attribute

### DIFF
--- a/datadog/resource_datadog_user.go
+++ b/datadog/resource_datadog_user.go
@@ -58,7 +58,6 @@ func resourceDatadogUser() *schema.Resource {
 				Description: "Role description for user. Can be `st` (standard user), `adm` (admin user) or `ro` (read-only user). Default is `st`. `access_role` is ignored for new users created with this resource. New users have to use the `roles` attribute.",
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "st",
 				DiffSuppressFunc: func(k, oldVal, newVal string, d *schema.ResourceData) bool {
 					return (d.Get("roles").(*schema.Set)).Len() > 0
 				},


### PR DESCRIPTION
This PR removes the `access_role` attributes default value in users resource. This is needed for when importing users via v2 api. 

Since read only users can return an empty list for `roles`, the default values always causes a diff.