### PR TITLE
Run terraform fmt on examples and regenerate

### DIFF
--- a/docs/data-sources/monitor.md
+++ b/docs/data-sources/monitor.md
@@ -13,7 +13,7 @@ Use this data source to retrieve information about an existing monitor for use i
 
 ```terraform
 data "datadog_monitor" "test" {
-  name_filter = "My awesome monitor"
+  name_filter         = "My awesome monitor"
   monitor_tags_filter = ["foo:bar"]
 }
 ```

--- a/docs/data-sources/security_monitoring_rules.md
+++ b/docs/data-sources/security_monitoring_rules.md
@@ -13,8 +13,8 @@ Use this data source to retrieve information about existing security monitoring 
 
 ```terraform
 data "datadog_security_monitoring_rules" "test" {
-  name_filter = "attack"
-  tags_filter = ["foo:bar"]
+  name_filter         = "attack"
+  tags_filter         = ["foo:bar"]
   default_only_filter = true
 }
 ```

--- a/docs/data-sources/synthetics_locations.md
+++ b/docs/data-sources/synthetics_locations.md
@@ -15,7 +15,7 @@ Use this data source to retrieve Datadog's Synthetics Locations (to be used in S
 data "datadog_synthetics_locations" "test" {}
 
 resource "datadog_synthetics_test" "test_api" {
-  type = "api"
+  type      = "api"
   locations = keys(data.datadog_synthetics_locations.test.locations)
 }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ Use the navigation to the left to read about the available resources.
 terraform {
   required_providers {
     datadog = {
-      source  = "DataDog/datadog"
+      source = "DataDog/datadog"
     }
   }
 }

--- a/docs/resources/integration_aws.md
+++ b/docs/resources/integration_aws.md
@@ -14,15 +14,15 @@ Provides a Datadog - Amazon Web Services integration resource. This can be used 
 ```terraform
 # Create a new Datadog - Amazon Web Services integration
 resource "datadog_integration_aws" "sandbox" {
-    account_id = "1234567890"
-    role_name = "DatadogAWSIntegrationRole"
-    filter_tags = ["key:value"]
-    host_tags = ["key:value", "key2:value2"]
-    account_specific_namespace_rules = {
-        auto_scaling = false
-        opsworks = false
-    }
-    excluded_regions = ["us-east-1", "us-west-2"]
+  account_id  = "1234567890"
+  role_name   = "DatadogAWSIntegrationRole"
+  filter_tags = ["key:value"]
+  host_tags   = ["key:value", "key2:value2"]
+  account_specific_namespace_rules = {
+    auto_scaling = false
+    opsworks     = false
+  }
+  excluded_regions = ["us-east-1", "us-west-2"]
 }
 ```
 

--- a/docs/resources/integration_aws_log_collection.md
+++ b/docs/resources/integration_aws_log_collection.md
@@ -15,7 +15,7 @@ Provides a Datadog - Amazon Web Services integration log collection resource. Th
 # Create a new Datadog - Amazon Web Services integration lambda arn
 resource "datadog_integration_aws_log_collection" "main" {
   account_id = "1234567890"
-  services = ["lambda"]
+  services   = ["lambda"]
 }
 ```
 

--- a/docs/resources/integration_azure.md
+++ b/docs/resources/integration_azure.md
@@ -14,10 +14,10 @@ Provides a Datadog - Microsoft Azure integration resource. This can be used to c
 ```terraform
 # Create a new Datadog - Microsoft Azure integration
 resource "datadog_integration_azure" "sandbox" {
-    tenant_name = "<azure_tenant_name>"
-    client_id = "<azure_client_id>"
-    client_secret = "<azure_client_secret_key>"
-    host_filters = "examplefilter:true,example:true"
+  tenant_name   = "<azure_tenant_name>"
+  client_id     = "<azure_client_id>"
+  client_secret = "<azure_client_secret_key>"
+  host_filters  = "examplefilter:true,example:true"
 }
 ```
 

--- a/docs/resources/security_monitoring_default_rule.md
+++ b/docs/resources/security_monitoring_default_rule.md
@@ -13,14 +13,14 @@ Provides a Datadog Security Monitoring Rule API resource for default rules.
 
 ```terraform
 resource "datadog_security_monitoring_default_rule" "adefaultrule" {
-    rule_id = "ojo-qef-3g3"
-    enabled = true
+  rule_id = "ojo-qef-3g3"
+  enabled = true
 
-    # Change the notifications for the high case
-    case {
-        status = "high"
-        notifications = ["@me"]
-    }
+  # Change the notifications for the high case
+  case {
+    status        = "high"
+    notifications = ["@me"]
+  }
 }
 ```
 

--- a/docs/resources/security_monitoring_rule.md
+++ b/docs/resources/security_monitoring_rule.md
@@ -13,39 +13,39 @@ Provides a Datadog Security Monitoring Rule API resource. This can be used to cr
 
 ```terraform
 resource "datadog_security_monitoring_rule" "myrule" {
-    name = "My rule"
+  name = "My rule"
 
-    message = "The rule has triggered."
-    enabled = true
+  message = "The rule has triggered."
+  enabled = true
 
-    query {
-        name = "errors"
-        query = "status:error"
-        aggregation = "count"
-        group_by_fields = ["host"]
-    }
+  query {
+    name            = "errors"
+    query           = "status:error"
+    aggregation     = "count"
+    group_by_fields = ["host"]
+  }
 
-    query {
-        name = "warnings"
-        query = "status:warning"
-        aggregation = "count"
-        group_by_fields = ["host"]
-    }
+  query {
+    name            = "warnings"
+    query           = "status:warning"
+    aggregation     = "count"
+    group_by_fields = ["host"]
+  }
 
-    case {
-        status = "high"
-        condition = "errors > 3 && warnings > 10"
-        notifications = ["@user"]
-    }
+  case {
+    status        = "high"
+    condition     = "errors > 3 && warnings > 10"
+    notifications = ["@user"]
+  }
 
-     options {
-         evaluation_window = 300
-         keep_alive = 600
-         max_signal_duration = 900
-     }
+  options {
+    evaluation_window   = 300
+    keep_alive          = 600
+    max_signal_duration = 900
+  }
 
-     tags = ["type:dos"]
- }
+  tags = ["type:dos"]
+}
 ```
 
 ## Schema

--- a/docs/resources/synthetics_global_variable.md
+++ b/docs/resources/synthetics_global_variable.md
@@ -13,10 +13,10 @@ Provides a Datadog synthetics global variable resource. This can be used to crea
 
 ```terraform
 resource "datadog_synthetics_global_variable" "test_variable" {
-    name = "EXAMPLE_VARIABLE"
-    description = "Description of the variable"
-    tags = ["foo:bar", "env:test"]
-    value = "variable-value"
+  name        = "EXAMPLE_VARIABLE"
+  description = "Description of the variable"
+  tags        = ["foo:bar", "env:test"]
+  value       = "variable-value"
 }
 ```
 

--- a/docs/resources/synthetics_private_location.md
+++ b/docs/resources/synthetics_private_location.md
@@ -13,9 +13,9 @@ Provides a Datadog synthetics private location resource. This can be used to cre
 
 ```terraform
 resource "datadog_synthetics_private_location" "private_location" {
-    name = "First private location"
-    description = "Description of the private location"
-    tags = ["foo:bar", "env:test"]
+  name        = "First private location"
+  description = "Description of the private location"
+  tags        = ["foo:bar", "env:test"]
 }
 ```
 

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -15,27 +15,27 @@ Provides a Datadog synthetics test resource. This can be used to create and mana
 # Example Usage (Synthetics API test)
 # Create a new Datadog Synthetics API/HTTP test on https://www.example.org
 resource "datadog_synthetics_test" "test_api" {
-  type = "api"
+  type    = "api"
   subtype = "http"
   request_definition {
     method = "GET"
-    url = "https://www.example.org"
+    url    = "https://www.example.org"
   }
   request_headers = {
-    Content-Type = "application/json"
+    Content-Type   = "application/json"
     Authentication = "Token: 1234566789"
   }
   assertion {
-      type = "statusCode"
-      operator = "is"
-      target = "200"
+    type     = "statusCode"
+    operator = "is"
+    target   = "200"
   }
-  locations = [ "aws:eu-central-1" ]
+  locations = ["aws:eu-central-1"]
   options_list {
     tick_every = 900
 
     retry {
-      count = 2
+      count    = 2
       interval = 300
     }
 
@@ -43,9 +43,9 @@ resource "datadog_synthetics_test" "test_api" {
       renotify_interval = 100
     }
   }
-  name = "An API test on example.org"
+  name    = "An API test on example.org"
   message = "Notify @pagerduty"
-  tags = ["foo:bar", "foo", "env:test"]
+  tags    = ["foo:bar", "foo", "env:test"]
 
   status = "live"
 }
@@ -54,25 +54,25 @@ resource "datadog_synthetics_test" "test_api" {
 # Example Usage (Synthetics SSL test)
 # Create a new Datadog Synthetics API/SSL test on example.org
 resource "datadog_synthetics_test" "test_ssl" {
-  type = "api"
+  type    = "api"
   subtype = "ssl"
   request_definition {
     host = "example.org"
     port = 443
   }
   assertion {
-      type = "certificate"
-      operator = "isInMoreThan"
-      target = 30
+    type     = "certificate"
+    operator = "isInMoreThan"
+    target   = 30
   }
-  locations = [ "aws:eu-central-1" ]
+  locations = ["aws:eu-central-1"]
   options_list {
-    tick_every = 900
+    tick_every         = 900
     accept_self_signed = true
   }
-  name = "An API test on example.org"
+  name    = "An API test on example.org"
   message = "Notify @pagerduty"
-  tags = ["foo:bar", "foo", "env:test"]
+  tags    = ["foo:bar", "foo", "env:test"]
 
   status = "live"
 }
@@ -81,24 +81,24 @@ resource "datadog_synthetics_test" "test_ssl" {
 # Example Usage (Synthetics TCP test)
 # Create a new Datadog Synthetics API/TCP test on example.org
 resource "datadog_synthetics_test" "test_tcp" {
-  type = "api"
+  type    = "api"
   subtype = "tcp"
   request_definition {
     host = "example.org"
     port = 443
   }
   assertion {
-      type = "responseTime"
-      operator = "lessThan"
-      target = 2000
+    type     = "responseTime"
+    operator = "lessThan"
+    target   = 2000
   }
-  locations = [ "aws:eu-central-1" ]
+  locations = ["aws:eu-central-1"]
   options_list {
     tick_every = 900
   }
-  name = "An API test on example.org"
+  name    = "An API test on example.org"
   message = "Notify @pagerduty"
-  tags = ["foo:bar", "foo", "env:test"]
+  tags    = ["foo:bar", "foo", "env:test"]
 
   status = "live"
 }
@@ -107,24 +107,24 @@ resource "datadog_synthetics_test" "test_tcp" {
 # Example Usage (Synthetics DNS test)
 # Create a new Datadog Synthetics API/DNS test on example.org
 resource "datadog_synthetics_test" "test_dns" {
-  type = "api"
+  type    = "api"
   subtype = "dns"
   request_definition {
     host = "example.org"
   }
   assertion {
-    type = "recordSome"
+    type     = "recordSome"
     operator = "is"
     property = "A"
-    target = "0.0.0.0"
+    target   = "0.0.0.0"
   }
-  locations = [ "aws:eu-central-1" ]
+  locations = ["aws:eu-central-1"]
   options_list {
     tick_every = 900
   }
-  name = "An API test on example.org"
+  name    = "An API test on example.org"
   message = "Notify @pagerduty"
-  tags = ["foo:bar", "foo", "env:test"]
+  tags    = ["foo:bar", "foo", "env:test"]
 
   status = "live"
 }
@@ -148,7 +148,7 @@ resource "datadog_synthetics_test" "test_browser" {
     tick_every = 3600
   }
 
-  name = "A Browser test on example.org"
+  name    = "A Browser test on example.org"
   message = "Notify @qa"
   tags    = []
 
@@ -158,8 +158,8 @@ resource "datadog_synthetics_test" "test_browser" {
     name = "Check current url"
     type = "assertCurrentUrl"
     params = jsonencode({
-        "check": "contains",
-        "value": "datadoghq"
+      "check" : "contains",
+      "value" : "datadoghq"
     })
   }
 

--- a/examples/data-sources/datadog_monitor/data-source.tf
+++ b/examples/data-sources/datadog_monitor/data-source.tf
@@ -1,4 +1,4 @@
 data "datadog_monitor" "test" {
-  name_filter = "My awesome monitor"
+  name_filter         = "My awesome monitor"
   monitor_tags_filter = ["foo:bar"]
 }

--- a/examples/data-sources/datadog_security_monitoring_rules/data-source.tf
+++ b/examples/data-sources/datadog_security_monitoring_rules/data-source.tf
@@ -1,5 +1,5 @@
 data "datadog_security_monitoring_rules" "test" {
-  name_filter = "attack"
-  tags_filter = ["foo:bar"]
+  name_filter         = "attack"
+  tags_filter         = ["foo:bar"]
   default_only_filter = true
 }

--- a/examples/data-sources/datadog_synthetics_locations/data-source.tf
+++ b/examples/data-sources/datadog_synthetics_locations/data-source.tf
@@ -1,6 +1,6 @@
 data "datadog_synthetics_locations" "test" {}
 
 resource "datadog_synthetics_test" "test_api" {
-  type = "api"
+  type      = "api"
   locations = keys(data.datadog_synthetics_locations.test.locations)
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@
 terraform {
   required_providers {
     datadog = {
-      source  = "DataDog/datadog"
+      source = "DataDog/datadog"
     }
   }
 }

--- a/examples/resources/datadog_integration_aws/resource.tf
+++ b/examples/resources/datadog_integration_aws/resource.tf
@@ -1,12 +1,12 @@
 # Create a new Datadog - Amazon Web Services integration
 resource "datadog_integration_aws" "sandbox" {
-    account_id = "1234567890"
-    role_name = "DatadogAWSIntegrationRole"
-    filter_tags = ["key:value"]
-    host_tags = ["key:value", "key2:value2"]
-    account_specific_namespace_rules = {
-        auto_scaling = false
-        opsworks = false
-    }
-    excluded_regions = ["us-east-1", "us-west-2"]
+  account_id  = "1234567890"
+  role_name   = "DatadogAWSIntegrationRole"
+  filter_tags = ["key:value"]
+  host_tags   = ["key:value", "key2:value2"]
+  account_specific_namespace_rules = {
+    auto_scaling = false
+    opsworks     = false
+  }
+  excluded_regions = ["us-east-1", "us-west-2"]
 }

--- a/examples/resources/datadog_integration_aws_log_collection/resource.tf
+++ b/examples/resources/datadog_integration_aws_log_collection/resource.tf
@@ -1,5 +1,5 @@
 # Create a new Datadog - Amazon Web Services integration lambda arn
 resource "datadog_integration_aws_log_collection" "main" {
   account_id = "1234567890"
-  services = ["lambda"]
+  services   = ["lambda"]
 }

--- a/examples/resources/datadog_integration_azure/resource.tf
+++ b/examples/resources/datadog_integration_azure/resource.tf
@@ -1,7 +1,7 @@
 # Create a new Datadog - Microsoft Azure integration
 resource "datadog_integration_azure" "sandbox" {
-    tenant_name = "<azure_tenant_name>"
-    client_id = "<azure_client_id>"
-    client_secret = "<azure_client_secret_key>"
-    host_filters = "examplefilter:true,example:true"
+  tenant_name   = "<azure_tenant_name>"
+  client_id     = "<azure_client_id>"
+  client_secret = "<azure_client_secret_key>"
+  host_filters  = "examplefilter:true,example:true"
 }

--- a/examples/resources/datadog_security_monitoring_default_rule/resource.tf
+++ b/examples/resources/datadog_security_monitoring_default_rule/resource.tf
@@ -1,10 +1,10 @@
 resource "datadog_security_monitoring_default_rule" "adefaultrule" {
-    rule_id = "ojo-qef-3g3"
-    enabled = true
+  rule_id = "ojo-qef-3g3"
+  enabled = true
 
-    # Change the notifications for the high case
-    case {
-        status = "high"
-        notifications = ["@me"]
-    }
+  # Change the notifications for the high case
+  case {
+    status        = "high"
+    notifications = ["@me"]
+  }
 }

--- a/examples/resources/datadog_security_monitoring_rule/resource.tf
+++ b/examples/resources/datadog_security_monitoring_rule/resource.tf
@@ -1,34 +1,34 @@
 resource "datadog_security_monitoring_rule" "myrule" {
-    name = "My rule"
+  name = "My rule"
 
-    message = "The rule has triggered."
-    enabled = true
+  message = "The rule has triggered."
+  enabled = true
 
-    query {
-        name = "errors"
-        query = "status:error"
-        aggregation = "count"
-        group_by_fields = ["host"]
-    }
+  query {
+    name            = "errors"
+    query           = "status:error"
+    aggregation     = "count"
+    group_by_fields = ["host"]
+  }
 
-    query {
-        name = "warnings"
-        query = "status:warning"
-        aggregation = "count"
-        group_by_fields = ["host"]
-    }
+  query {
+    name            = "warnings"
+    query           = "status:warning"
+    aggregation     = "count"
+    group_by_fields = ["host"]
+  }
 
-    case {
-        status = "high"
-        condition = "errors > 3 && warnings > 10"
-        notifications = ["@user"]
-    }
+  case {
+    status        = "high"
+    condition     = "errors > 3 && warnings > 10"
+    notifications = ["@user"]
+  }
 
-     options {
-         evaluation_window = 300
-         keep_alive = 600
-         max_signal_duration = 900
-     }
+  options {
+    evaluation_window   = 300
+    keep_alive          = 600
+    max_signal_duration = 900
+  }
 
-     tags = ["type:dos"]
- }
+  tags = ["type:dos"]
+}

--- a/examples/resources/datadog_synthetics_global_variable/resource.tf
+++ b/examples/resources/datadog_synthetics_global_variable/resource.tf
@@ -1,6 +1,6 @@
 resource "datadog_synthetics_global_variable" "test_variable" {
-    name = "EXAMPLE_VARIABLE"
-    description = "Description of the variable"
-    tags = ["foo:bar", "env:test"]
-    value = "variable-value"
+  name        = "EXAMPLE_VARIABLE"
+  description = "Description of the variable"
+  tags        = ["foo:bar", "env:test"]
+  value       = "variable-value"
 }

--- a/examples/resources/datadog_synthetics_private_location/resource.tf
+++ b/examples/resources/datadog_synthetics_private_location/resource.tf
@@ -1,5 +1,5 @@
 resource "datadog_synthetics_private_location" "private_location" {
-    name = "First private location"
-    description = "Description of the private location"
-    tags = ["foo:bar", "env:test"]
+  name        = "First private location"
+  description = "Description of the private location"
+  tags        = ["foo:bar", "env:test"]
 }

--- a/examples/resources/datadog_synthetics_test/resource.tf
+++ b/examples/resources/datadog_synthetics_test/resource.tf
@@ -1,27 +1,27 @@
 # Example Usage (Synthetics API test)
 # Create a new Datadog Synthetics API/HTTP test on https://www.example.org
 resource "datadog_synthetics_test" "test_api" {
-  type = "api"
+  type    = "api"
   subtype = "http"
   request_definition {
     method = "GET"
-    url = "https://www.example.org"
+    url    = "https://www.example.org"
   }
   request_headers = {
-    Content-Type = "application/json"
+    Content-Type   = "application/json"
     Authentication = "Token: 1234566789"
   }
   assertion {
-      type = "statusCode"
-      operator = "is"
-      target = "200"
+    type     = "statusCode"
+    operator = "is"
+    target   = "200"
   }
-  locations = [ "aws:eu-central-1" ]
+  locations = ["aws:eu-central-1"]
   options_list {
     tick_every = 900
 
     retry {
-      count = 2
+      count    = 2
       interval = 300
     }
 
@@ -29,9 +29,9 @@ resource "datadog_synthetics_test" "test_api" {
       renotify_interval = 100
     }
   }
-  name = "An API test on example.org"
+  name    = "An API test on example.org"
   message = "Notify @pagerduty"
-  tags = ["foo:bar", "foo", "env:test"]
+  tags    = ["foo:bar", "foo", "env:test"]
 
   status = "live"
 }
@@ -40,25 +40,25 @@ resource "datadog_synthetics_test" "test_api" {
 # Example Usage (Synthetics SSL test)
 # Create a new Datadog Synthetics API/SSL test on example.org
 resource "datadog_synthetics_test" "test_ssl" {
-  type = "api"
+  type    = "api"
   subtype = "ssl"
   request_definition {
     host = "example.org"
     port = 443
   }
   assertion {
-      type = "certificate"
-      operator = "isInMoreThan"
-      target = 30
+    type     = "certificate"
+    operator = "isInMoreThan"
+    target   = 30
   }
-  locations = [ "aws:eu-central-1" ]
+  locations = ["aws:eu-central-1"]
   options_list {
-    tick_every = 900
+    tick_every         = 900
     accept_self_signed = true
   }
-  name = "An API test on example.org"
+  name    = "An API test on example.org"
   message = "Notify @pagerduty"
-  tags = ["foo:bar", "foo", "env:test"]
+  tags    = ["foo:bar", "foo", "env:test"]
 
   status = "live"
 }
@@ -67,24 +67,24 @@ resource "datadog_synthetics_test" "test_ssl" {
 # Example Usage (Synthetics TCP test)
 # Create a new Datadog Synthetics API/TCP test on example.org
 resource "datadog_synthetics_test" "test_tcp" {
-  type = "api"
+  type    = "api"
   subtype = "tcp"
   request_definition {
     host = "example.org"
     port = 443
   }
   assertion {
-      type = "responseTime"
-      operator = "lessThan"
-      target = 2000
+    type     = "responseTime"
+    operator = "lessThan"
+    target   = 2000
   }
-  locations = [ "aws:eu-central-1" ]
+  locations = ["aws:eu-central-1"]
   options_list {
     tick_every = 900
   }
-  name = "An API test on example.org"
+  name    = "An API test on example.org"
   message = "Notify @pagerduty"
-  tags = ["foo:bar", "foo", "env:test"]
+  tags    = ["foo:bar", "foo", "env:test"]
 
   status = "live"
 }
@@ -93,24 +93,24 @@ resource "datadog_synthetics_test" "test_tcp" {
 # Example Usage (Synthetics DNS test)
 # Create a new Datadog Synthetics API/DNS test on example.org
 resource "datadog_synthetics_test" "test_dns" {
-  type = "api"
+  type    = "api"
   subtype = "dns"
   request_definition {
     host = "example.org"
   }
   assertion {
-    type = "recordSome"
+    type     = "recordSome"
     operator = "is"
     property = "A"
-    target = "0.0.0.0"
+    target   = "0.0.0.0"
   }
-  locations = [ "aws:eu-central-1" ]
+  locations = ["aws:eu-central-1"]
   options_list {
     tick_every = 900
   }
-  name = "An API test on example.org"
+  name    = "An API test on example.org"
   message = "Notify @pagerduty"
-  tags = ["foo:bar", "foo", "env:test"]
+  tags    = ["foo:bar", "foo", "env:test"]
 
   status = "live"
 }
@@ -134,7 +134,7 @@ resource "datadog_synthetics_test" "test_browser" {
     tick_every = 3600
   }
 
-  name = "A Browser test on example.org"
+  name    = "A Browser test on example.org"
   message = "Notify @qa"
   tags    = []
 
@@ -144,8 +144,8 @@ resource "datadog_synthetics_test" "test_browser" {
     name = "Check current url"
     type = "assertCurrentUrl"
     params = jsonencode({
-        "check": "contains",
-        "value": "datadoghq"
+      "check" : "contains",
+      "value" : "datadoghq"
     })
   }
 


### PR DESCRIPTION
Using tf 0.12, I ran `terraform fmt -recursive examples` and regenerated the docs.
(Note, due to the bug with generating security_monitoring_rules data-source docs, I have to manually change Computed: false and make an edit in the generated doc). 

This should have no functional impact, just cleans up the examples according to `terraform fmt`. 

Using terraform 0.14 to run `fmt` causes the same output, except for the index where it tries to remove `${` around the variables here - https://github.com/DataDog/terraform-provider-datadog/blob/master/examples/provider/provider.tf#L35-L36 However this syntax is needed for earlier versions of terraform. 