### PR TITLE
Correct event_stream_definition documentation for event_size

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -1833,7 +1833,7 @@ func getEventStreamDefinitionSchema() map[string]*schema.Schema {
 			Required:    true,
 		},
 		"event_size": {
-			Description:  "The alignment of the widget's title. One of `left`, `center`, or `right`.",
+			Description:  "The size to use to display an event. One of `s`, `l`",
 			Type:         schema.TypeString,
 			ValidateFunc: validateEnumValue(datadogV1.NewWidgetEventSizeFromValue),
 			Optional:     true,

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -1354,7 +1354,7 @@ Required:
 
 Optional:
 
-- **event_size** (String, Optional) The alignment of the widget's title. One of `left`, `center`, or `right`.
+- **event_size** (String, Optional) The size to use to display an event. One of `s`, `l`.
 - **live_span** (String, Optional) The timeframe to use when displaying the widget. One of `10m`, `30m`, `1h`, `4h`, `1d`, `2d`, `1w`, `1mo`, `3mo`, `6mo`, `1y`, `alert`.
 - **tags_execution** (String, Optional) The execution method for multi-value filters. Can be either `and` or `or`.
 - **time** (Map of String, Optional, Deprecated) Nested block describing the timeframe to use when displaying the widget. The structure of this block is described below. **Deprecated.** Define `live_span` directly in the widget definition instead.


### PR DESCRIPTION
In the documentation about `event_stream_definition`, the description of the attribute `event_size` states the following:

- **event_size** (String, Optional) The alignment of the widget's title. One of `left`, `center`, or `right`. 

This is the description of the **title_align** attribute. The description according to the Datadog API documentation should be the one proposed in this Pull Request.

Reference: [Event Stream Widget](https://docs.datadoghq.com/dashboards/widgets/event_stream/)