### PR TITLE
Improve consistency by using response from POST/PUT requests directly to save state

### DIFF
--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -202,6 +202,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	configV1.SetUnstableOperationEnabled("GetLogsIndex", true)
 	configV1.SetUnstableOperationEnabled("ListLogIndexes", true)
 	configV1.SetUnstableOperationEnabled("UpdateLogsIndex", true)
+	configV1.SetUnstableOperationEnabled("GetLogsIndexOrder", true)
 	configV1.SetUnstableOperationEnabled("UpdateLogsIndexOrder", true)
 
 	configV1.SetUnstableOperationEnabled("CreateSLOCorrection", true)

--- a/datadog/resource_datadog_logs_index.go
+++ b/datadog/resource_datadog_logs_index.go
@@ -93,6 +93,19 @@ func resourceDatadogLogsIndexCreate(d *schema.ResourceData, meta interface{}) er
 	return resourceDatadogLogsIndexUpdate(d, meta)
 }
 
+func updateLogsIndexState(d *schema.ResourceData, index *datadogV1.LogsIndex) error {
+	if err := d.Set("name", index.GetName()); err != nil {
+		return err
+	}
+	if err := d.Set("filter", buildTerraformIndexFilter(index.GetFilter())); err != nil {
+		return err
+	}
+	if err := d.Set("exclusion_filter", buildTerraformExclusionFilters(index.GetExclusionFilters())); err != nil {
+		return err
+	}
+	return nil
+}
+
 func resourceDatadogLogsIndexRead(d *schema.ResourceData, meta interface{}) error {
 	providerConf := meta.(*ProviderConfiguration)
 	datadogClientV1 := providerConf.DatadogClientV1
@@ -106,16 +119,7 @@ func resourceDatadogLogsIndexRead(d *schema.ResourceData, meta interface{}) erro
 		}
 		return translateClientError(err, "error getting logs index")
 	}
-	if err = d.Set("name", ddIndex.GetName()); err != nil {
-		return err
-	}
-	if err = d.Set("filter", buildTerraformIndexFilter(ddIndex.GetFilter())); err != nil {
-		return err
-	}
-	if err = d.Set("exclusion_filter", buildTerraformExclusionFilters(ddIndex.GetExclusionFilters())); err != nil {
-		return err
-	}
-	return nil
+	return updateLogsIndexState(d, &ddIndex)
 }
 
 func resourceDatadogLogsIndexUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -128,17 +132,18 @@ func resourceDatadogLogsIndexUpdate(d *schema.ResourceData, meta interface{}) er
 	authV1 := providerConf.AuthV1
 
 	tfName := d.Get("name").(string)
-	if _, _, err := datadogClientV1.LogsIndexesApi.UpdateLogsIndex(authV1, tfName).Body(*ddIndex).Execute(); err != nil {
+	updatedIndex, _, err := datadogClientV1.LogsIndexesApi.UpdateLogsIndex(authV1, tfName).Body(*ddIndex).Execute()
+	if err != nil {
 		if strings.Contains(err.Error(), "404 Not Found") {
 			return fmt.Errorf("logs index creation is not allowed, index_name: %s", tfName)
 		}
 		return translateClientError(err, "error updating logs index")
 	}
 	d.SetId(tfName)
-	return resourceDatadogLogsIndexRead(d, meta)
+	return updateLogsIndexState(d, &updatedIndex)
 }
 
-func resourceDatadogLogsIndexDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDatadogLogsIndexDelete(_ *schema.ResourceData, _ interface{}) error {
 	return nil
 }
 

--- a/datadog/resource_datadog_logs_index_order.go
+++ b/datadog/resource_datadog_logs_index_order.go
@@ -51,24 +51,30 @@ func resourceDatadogLogsIndexOrderUpdate(d *schema.ResourceData, meta interface{
 	datadogClientV1 := providerConf.DatadogClientV1
 	authV1 := providerConf.AuthV1
 
-	if _, _, err := datadogClientV1.LogsIndexesApi.UpdateLogsIndexOrder(authV1).Body(ddIndexList).Execute(); err != nil {
+	updatedOrder, _, err := datadogClientV1.LogsIndexesApi.UpdateLogsIndexOrder(authV1).Body(ddIndexList).Execute()
+	if err != nil {
 		return translateClientError(err, "error updating logs index list")
 	}
 	d.SetId(tfId)
-	return resourceDatadogLogsIndexOrderRead(d, meta)
+	return updateLogsIndexOrderState(d, &updatedOrder)
+}
+
+func updateLogsIndexOrderState(d *schema.ResourceData, order *datadogV1.LogsIndexesOrder) error {
+	if err := d.Set("indexes", order.GetIndexNames()); err != nil {
+		return err
+	}
+	return nil
 }
 
 func resourceDatadogLogsIndexOrderRead(d *schema.ResourceData, meta interface{}) error {
 	providerConf := meta.(*ProviderConfiguration)
-	client := providerConf.CommunityClient
-	ddIndexList, err := client.GetLogsIndexList()
+	client := providerConf.DatadogClientV1
+	auth := providerConf.AuthV1
+	ddIndexList, _, err := client.LogsIndexesApi.GetLogsIndexOrder(auth).Execute()
 	if err != nil {
 		return translateClientError(err, "error getting logs index list")
 	}
-	if err := d.Set("indexes", ddIndexList.IndexNames); err != nil {
-		return err
-	}
-	return nil
+	return updateLogsIndexOrderState(d, &ddIndexList)
 }
 
 func resourceDatadogLogsIndexOrderDelete(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
Avoid consistency issues, due to replication delays, caused by calling the GET endpoint right after POST/PUT

Also fixes some linting warnings