### PR TITLE
Improve consistency by using response from POST/PUT requests directly to save state

### DIFF
--- a/datadog/resource_datadog_metric_metadata.go
+++ b/datadog/resource_datadog_metric_metadata.go
@@ -73,14 +73,37 @@ func resourceDatadogMetricMetadataCreate(d *schema.ResourceData, meta interface{
 	authV1 := providerConf.AuthV1
 
 	id, m := buildMetricMetadataStruct(d)
-	_, _, err := datadogClientV1.MetricsApi.UpdateMetricMetadata(authV1, id).Body(*m).Execute()
+	createdMetadata, _, err := datadogClientV1.MetricsApi.UpdateMetricMetadata(authV1, id).Body(*m).Execute()
 	if err != nil {
 		return translateClientError(err, "error creating metric metadata")
 	}
 
 	d.SetId(id)
 
-	return resourceDatadogMetricMetadataRead(d, meta)
+	return updateMetricMetadataState(d, &createdMetadata)
+}
+
+func updateMetricMetadataState(d *schema.ResourceData, metadata *datadogV1.MetricMetadata) error {
+	if err := d.Set("type", metadata.GetType()); err != nil {
+		return err
+	}
+	if err := d.Set("description", metadata.GetDescription()); err != nil {
+		return err
+	}
+	if err := d.Set("short_name", metadata.GetShortName()); err != nil {
+		return err
+	}
+	if err := d.Set("unit", metadata.GetUnit()); err != nil {
+		return err
+	}
+	if err := d.Set("per_unit", metadata.GetPerUnit()); err != nil {
+		return err
+	}
+	if err := d.Set("statsd_interval", metadata.GetStatsdInterval()); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func resourceDatadogMetricMetadataRead(d *schema.ResourceData, meta interface{}) error {
@@ -98,15 +121,7 @@ func resourceDatadogMetricMetadataRead(d *schema.ResourceData, meta interface{})
 		}
 		return translateClientError(err, "error getting metric metadata")
 	}
-
-	d.Set("type", m.GetType())
-	d.Set("description", m.GetDescription())
-	d.Set("short_name", m.GetShortName())
-	d.Set("unit", m.GetUnit())
-	d.Set("per_unit", m.GetPerUnit())
-	d.Set("statsd_interval", m.GetStatsdInterval())
-
-	return nil
+	return updateMetricMetadataState(d, &m)
 }
 
 func resourceDatadogMetricMetadataUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -136,14 +151,15 @@ func resourceDatadogMetricMetadataUpdate(d *schema.ResourceData, meta interface{
 		m.SetStatsdInterval(int64(attr.(int)))
 	}
 
-	if _, _, err := datadogClientV1.MetricsApi.UpdateMetricMetadata(authV1, id).Body(*m).Execute(); err != nil {
+	updatedMetadata, _, err := datadogClientV1.MetricsApi.UpdateMetricMetadata(authV1, id).Body(*m).Execute()
+	if err != nil {
 		return translateClientError(err, "error updating metric metadata")
 	}
 
-	return resourceDatadogMetricMetadataRead(d, meta)
+	return updateMetricMetadataState(d, &updatedMetadata)
 }
 
-func resourceDatadogMetricMetadataDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDatadogMetricMetadataDelete(_ *schema.ResourceData, _ interface{}) error {
 	return nil
 }
 


### PR DESCRIPTION
Avoid consistency issues, due to replication delays, caused by calling the GET endpoint right after POST/PUT

Also fixes some linting warnings