### PR TITLE
Add 12 hour cron to AZP runs

### DIFF
--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -9,6 +9,14 @@ pr:
         include:
             - master
 
+schedules:
+  - cron: "0 */12 * * *"
+    displayName: Scheduled CI run every 12 hours
+    always: true
+    branches:
+      include:
+        - master
+
 resources:
     containers:
         - container: datadog-agent

--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -10,12 +10,12 @@ pr:
             - master
 
 schedules:
-  - cron: "0 */12 * * *"
-    displayName: Scheduled CI run every 12 hours
-    always: true
-    branches:
-      include:
-        - master
+    - cron: "0 */12 * * *"
+      displayName: Scheduled CI run every 12 hours
+      always: true
+      branches:
+          include:
+              - master
 
 resources:
     containers:


### PR DESCRIPTION
Add a scheduled 12 hour cron to the Azure Pipeline. 

This will ensure we run the CI on master if there are no PRs for a bit and let us bisect the start of potential issues.