### PR TITLE
Cleanup makefile, add testall, add rerun-failed

### DIFF
--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -46,9 +46,10 @@ jobs:
       services:
           datadog-agent: datadog-agent
       steps:
-          - script: make testacc
-            displayName: Run integration tests
+          - script: make testall
+            displayName: Run all tests
             env:
+                RECORD: "none"
                 CI: "true"
                 DD_AGENT_HOST: datadog-agent
                 DD_PROFILER_API_KEY: $(ddAPIKey)

--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -59,5 +59,3 @@ jobs:
                 DD_SERVICE: terraform-provider-datadog
                 DD_VERSION: $(Build.SourceVersion)
                 DD_TAGS: "team:integration-tools-and-libraries,build.requested_by:$(Build.RequestedForId),build.attempt:$(System.StageAttempt),pull_request.number:$(System.PullRequest.PullRequestNumber)"
-                # rerun-fails/packages is incompatible with running a single test, so we only rerun-fails in CI so devs can locally run single tests
-                GOTESTSUMARGS: "--rerun-fails --packages $(go list ./...)"

--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -59,3 +59,5 @@ jobs:
                 DD_SERVICE: terraform-provider-datadog
                 DD_VERSION: $(Build.SourceVersion)
                 DD_TAGS: "team:integration-tools-and-libraries,build.requested_by:$(Build.RequestedForId),build.attempt:$(System.StageAttempt),pull_request.number:$(System.PullRequest.PullRequestNumber)"
+                # rerun-fails/packages is incompatible with running a single test, so we only rerun-fails in CI so devs can locally run single tests
+                GOTESTSUMARGS: "--rerun-fails --packages $(go list ./...)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,4 @@ jobs:
             - name: Test
               run: make testall
               env:
-                RECORD: false
+                  RECORD: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,4 +44,6 @@ jobs:
             - name: Vet
               run: make vet
             - name: Test
-              run: make test
+              run: make testall
+              env:
+                RECORD: false

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -69,16 +69,16 @@ The Datadog terraform provider uses the standard [Terraform Testing Framework][6
 
 **NOTE** Use the API and APP keys for a sandbox/test organization, never an account hosting production data. This test suite will create/update/delete real resources.
 
--   `DD_API_KEY="<api_key>" DD_APP_KEY=<app_key> make testacc` will run the test suite against the real Datadog API.
+-   `DD_API_KEY="<api_key>" DD_APP_KEY=<app_key> make testall` will run the test suite against the real Datadog API.
 
 We also use `cassettes` to record API request/responses, which allows the test suite to be reliable and run very quickly. There are a few environment variables that can control this behavior (All commands are assumed to be prefixed with `DD_API_KEY=` and `DD_APP_KEY=`)
 
 -   `TESTARGS`: Allows passing extra flags directly to the underlying `go test` command. Most often used to run individual tests:
-    -   Ex: `TESTARGS="-run TestAccDatadogServiceLevelObjective_Basic" make test`
+    -   Ex: `TESTARGS="-run TestAccDatadogServiceLevelObjective_Basic" make testall`
 -   `RECORD`: This denotes whether the test suite should interact with the real Datadog API. Available options are:
-    -   `RECORD=none make testacc`: Run against the real Datadog API.
-    -   `RECORD=true make testacc`: Run against the real Datadog API and record the request/response to be used later.
-    -   `RECORD=false make testacc`: Don't interact with the real Datadog API, instead playback against the recorded cassettes.
+    -   `RECORD=none make testall`: Run against the real Datadog API.
+    -   `RECORD=true make testall`: Run against the real Datadog API and record the request/response to be used later.
+    -   `RECORD=false make testall`: Don't interact with the real Datadog API, instead playback against the recorded cassettes.
 
 ## Generating Documentation
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -21,18 +21,17 @@ uninstall:
 # Run unit tests; these tests don't interact with the API and don't support/need RECORD
 test: get-test-deps fmtcheck
 	echo $(TEST) | \
-		xargs -t -n4 gotestsum --hide-summary skipped --format testname --debug $(GOTESTSUMARGS) -- $(TESTARGS) -timeout=30s
+		xargs -t -n4 gotestsum --hide-summary skipped --format testname --debug --packages ./... -- $(TESTARGS) -timeout=30s
 
 # Run acceptance tests (this runs integration CRUD tests through the terraform test framework)
-# gotestsum's rerun-fails/packages isn't compatible with running a single test (`-run <TEST>`). Pass this through GOTESTSUMARGS if running the full suite.
 testacc: get-test-deps fmtcheck
-	RECORD=$(RECORD) TF_ACC=1 gotestsum --format testname --debug $(GOTESTSUMARGS) -- -v $(TESTARGS) -timeout 120m
+	RECORD=$(RECORD) TF_ACC=1 gotestsum --format testname --debug --rerun-fails --packages ./... -- -v $(TESTARGS) -timeout 120m
 
 # Run both unit and acceptance tests
 testall: test testacc
 
 cassettes: get-test-deps fmtcheck
-	RECORD=true TF_ACC=1 gotestsum --format testname -- -v $(TESTARGS) -timeout 120m
+	RECORD=true TF_ACC=1 gotestsum --format testname --packages ./... -- -v $(TESTARGS) -timeout 120m
 
 vet:
 	@echo "go vet ."

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -32,7 +32,7 @@ testacc: get-test-deps fmtcheck
 testall: test testacc
 
 cassettes: get-test-deps fmtcheck
-	RECORD=true TF_ACC=1 gotestsum --rerun-fails --format testname  --packages $(TEST) -- -v $(TESTARGS) -timeout 120m
+	RECORD=true TF_ACC=1 gotestsum --format testname -- -v $(TESTARGS) -timeout 120m
 
 vet:
 	@echo "go vet ."

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -70,4 +70,4 @@ update-go-client:
 get-test-deps:
 	gotestsum --version || (cd `mktemp -d`;	GO111MODULE=off GOFLAGS='' go get -u gotest.tools/gotestsum; cd -)
 
-.PHONY: build test testacc cassettes vet fmt fmtcheck errcheck test-compile get-test-deps
+.PHONY: build test testall testacc cassettes vet fmt fmtcheck errcheck test-compile get-test-deps

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -21,11 +21,12 @@ uninstall:
 # Run unit tests; these tests don't interact with the API and don't support/need RECORD
 test: get-test-deps fmtcheck
 	echo $(TEST) | \
-		xargs -t -n4 gotestsum --hide-summary skipped --format testname --packages $(TEST) -- $(TESTARGS) -timeout=30s
+		xargs -t -n4 gotestsum --hide-summary skipped --format testname --debug $(GOTESTSUMARGS) -- $(TESTARGS) -timeout=30s
 
 # Run acceptance tests (this runs integration CRUD tests through the terraform test framework)
+# gotestsum's rerun-fails/packages isn't compatible with running a single test (`-run <TEST>`). Pass this through GOTESTSUMARGS if running the full suite.
 testacc: get-test-deps fmtcheck
-	RECORD=$(RECORD) TF_ACC=1 gotestsum --rerun-fails --format testname --packages $(TEST) -- -v $(TESTARGS) -timeout 120m
+	RECORD=$(RECORD) TF_ACC=1 gotestsum --format testname --debug $(GOTESTSUMARGS) -- -v $(TESTARGS) -timeout 120m
 
 # Run both unit and acceptance tests
 testall: test testacc


### PR DESCRIPTION
This PR aims to cleanup the Makefile and the way tests are run:

* Adds rerun-failed to gotestsum so we can retry individual errors
  * The default here is sane, the test will be retried twice, and if more than 10 tests are failing, tests won't be retried at all by gotestsum since there's likely a larger issue at play
  * gotestsum requires you pass in the packages to it, so I also moved the `go list` to be part of the invocation to `gotestsum` instead of `go test` flags. 
* Add a new `make testall` command that will run both acceptance and unit tests
  * Stop `make test` from running the acceptance tests in record mode
* Set the default `RECORD` to `false` in the makefile and allow it to run `make testacc` or `make testall` with the flag to control if we playback or record during testing
* Remove the special make commands for installing the provider as a plugin for terraform 0.13; we explicitly document how to do this using terraform 0.14 in the new DEVELOPMENT.md file. 
* Update the DEV doc for people to use `testall` instead of `testacc`