### PR TITLE
Update traces from the provider

### DIFF
--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -58,4 +58,4 @@ jobs:
                 DD_ENV: prod
                 DD_SERVICE: terraform-provider-datadog
                 DD_VERSION: $(Build.SourceVersion)
-                DD_TAGS: "team:integration-tools-and-libraries,build.requested_by:$(Build.RequestedForId),build.attempt:$(System.StageAttempt),pull_request.number:$(System.PullRequest.PullRequestNumber)"
+                DD_TAGS: "team:integration-tools-and-libraries"

--- a/datadog/provider_test.go
+++ b/datadog/provider_test.go
@@ -357,7 +357,7 @@ func testSpan(ctx context.Context, t *testing.T) (context.Context, func()) {
 }
 
 func initAccProvider(ctx context.Context, t *testing.T, httpClient *http.Client) *schema.Provider {
-	ctx, finish := testSpan(context.Background(), t)
+	ctx, finish := testSpan(ctx, t)
 	defer finish()
 
 	p := Provider().(*schema.Provider)

--- a/datadog/provider_test.go
+++ b/datadog/provider_test.go
@@ -346,7 +346,7 @@ func testSpan(ctx context.Context, t *testing.T) (context.Context, func()) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	return ddtesting.StartSpanWithFinish(ctx, t, ddtesting.WithSkipFrames(2), ddtesting.WithSpanOptions(
+	return ddtesting.StartSpanWithFinish(ctx, t, ddtesting.WithSkipFrames(3), ddtesting.WithSpanOptions(
 		// We need to make the tag be something that is then searchable in monitors
 		// https://docs.datadoghq.com/tracing/guide/metrics_namespace/#errors
 		// "version" is really the only one we can use here

--- a/datadog/provider_test.go
+++ b/datadog/provider_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	datadogCommunity "github.com/zorkian/go-datadog-api"
 	ddhttp "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+	ddtesting "gopkg.in/DataDog/dd-trace-go.v1/contrib/testing"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -345,19 +346,14 @@ func testSpan(ctx context.Context, t *testing.T) (context.Context, func()) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	span, ctx := tracer.StartSpanFromContext(
-		ctx,
-		"test",
-		tracer.SpanType("test"),
-		tracer.ResourceName(t.Name()),
-		tracer.Tag(ext.AnalyticsEvent, true),
-		tracer.Measured(),
-	)
-	span.SetTag("version", tag)
-	return ctx, func() {
-		span.SetTag(ext.Error, t.Failed())
-		span.Finish()
-	}
+	return ddtesting.StartSpanWithFinish(ctx, t, ddtesting.WithSkipFrames(2), ddtesting.WithSpanOptions(
+		// We need to make the tag be something that is then searchable in monitors
+		// https://docs.datadoghq.com/tracing/guide/metrics_namespace/#errors
+		// "version" is really the only one we can use here
+		// NOTE: version is treated in slightly different way, because it's a special tag;
+		// if we set it in StartSpanFromContext, it would get overwritten
+		tracer.Tag(ext.Version, tag),
+	))
 }
 
 func initAccProvider(ctx context.Context, t *testing.T, httpClient *http.Client) *schema.Provider {

--- a/datadog/provider_test.go
+++ b/datadog/provider_test.go
@@ -346,7 +346,7 @@ func testSpan(ctx context.Context, t *testing.T) (context.Context, func()) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	return ddtesting.StartSpanWithFinish(ctx, t, ddtesting.WithSkipFrames(3), ddtesting.WithSpanOptions(
+	return ddtesting.StartSpanWithFinish(ctx, t, ddtesting.WithSkipFrames(4), ddtesting.WithSpanOptions(
 		// We need to make the tag be something that is then searchable in monitors
 		// https://docs.datadoghq.com/tracing/guide/metrics_namespace/#errors
 		// "version" is really the only one we can use here

--- a/go.mod
+++ b/go.mod
@@ -15,10 +15,13 @@ require (
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/zorkian/go-datadog-api v2.30.0+incompatible
-	gopkg.in/DataDog/dd-trace-go.v1 v1.28.0
+	gopkg.in/DataDog/dd-trace-go.v1 v1.29.0-alpha.1.0.20210128154316-c84d7933b726
 )
 
 go 1.15
 
 // Use custom fork with performance fix in DecoderSpec
 replace github.com/hashicorp/terraform-plugin-sdk v1.15.0 => github.com/therve/terraform-plugin-sdk v1.16.1-0.20210202202613-4d59f03d3b5f
+
+// Use branch of dd-trace-go for additional APM features
+replace gopkg.in/DataDog/dd-trace-go.v1 => github.com/DataDog/dd-trace-go v1.29.0-alpha.1.0.20210128154316-c84d7933b726

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/DataDog/datadog-api-client-go v1.0.0-beta.15 h1:LDqEvKkBSchv09WUGCol8
 github.com/DataDog/datadog-api-client-go v1.0.0-beta.15/go.mod h1:8d96upv05/AXyn/0ftvml/+hD6Rt/tKnUdMX00iSP7A=
 github.com/DataDog/datadog-go v3.6.0+incompatible h1:ILg7c5Y1KvZFDOaVS0higGmJ5Fal5O1KQrkrT9j6dSM=
 github.com/DataDog/datadog-go v3.6.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/DataDog/dd-trace-go v1.29.0-alpha.1.0.20210128154316-c84d7933b726 h1:E6y5wxU93et78p5JhD1tl/QDdFofxiSadMJ2p0AqO4Y=
+github.com/DataDog/dd-trace-go v1.29.0-alpha.1.0.20210128154316-c84d7933b726/go.mod h1:Sp1lku8WJMvNV0kjDI4Ni/T7J/U3BO5ct5kEaoVU8+I=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
@@ -644,10 +646,6 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
-gopkg.in/DataDog/dd-trace-go.v1 v1.24.1 h1:CGQIcKZxAsFtMTUiXw0TxBWwj+l+b2bS2V8l1bIsfk4=
-gopkg.in/DataDog/dd-trace-go.v1 v1.24.1/go.mod h1:DVp8HmDh8PuTu2Z0fVVlBsyWaC++fzwVCaGWylTe3tg=
-gopkg.in/DataDog/dd-trace-go.v1 v1.28.0 h1:EmglUJuykRsTwsQDcKaAo3CmOunWU6Dqk7U2lo7Pjss=
-gopkg.in/DataDog/dd-trace-go.v1 v1.28.0/go.mod h1:Sp1lku8WJMvNV0kjDI4Ni/T7J/U3BO5ct5kEaoVU8+I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Get us more in-line with how we're doing traces in the go client. See - https://github.com/DataDog/datadog-api-client-go/pull/500