### PR TITLE
Update 3rd Party License file and add check to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
               uses: actions/checkout@v2
             - name: Vet
               run: make vet
+            - name: License Check
+              run: make license-check
             - name: Test
               run: make testall
               env:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -52,7 +52,6 @@ fmtcheck:
 errcheck:
 	@sh -c "'$(CURDIR)/scripts/errcheck.sh'"
 
-
 test-compile: get-test-deps
 	@if [ "$(TEST)" = "./..." ]; then \
 		echo "ERROR: Set TEST to a specific package. For example,"; \
@@ -70,4 +69,7 @@ update-go-client:
 get-test-deps:
 	gotestsum --version || (cd `mktemp -d`;	GO111MODULE=off GOFLAGS='' go get -u gotest.tools/gotestsum; cd -)
 
-.PHONY: build test testall testacc cassettes vet fmt fmtcheck errcheck test-compile get-test-deps
+license-check:
+	@sh -c "'$(CURDIR)/scripts/license-check.sh'"
+
+.PHONY: build test testall testacc cassettes vet fmt fmtcheck errcheck test-compile get-test-deps license-check

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -136,21 +136,21 @@ go.sum,honnef.co/go/tools,MIT,2016 Dominik Honnef
 go.sum,rsc.io/binaryregexp,BSD-3-Clause,2009 The Go Authors
 go.sum,cloud.google.com/go/pubsub,Apache-2.0,Copyright 2018 Google LLC
 go.sum,cloud.google.com/go/storage,Apache-2.0,Copyright 2014 Google LLC
-go.sum,dmitri.shuralyov.com/gpu/mtl,<LICENSE>,<COPYRIGHT>
+go.sum,dmitri.shuralyov.com/gpu/mtl,BSD-3-Clause,2018 The Go Authors.
 go.sum,github.com/alcortesm/tgz,MIT,2016 Alberto Cortés
 go.sum,github.com/anmitsu/go-shlex,MIT,anmitsu <anmitsu.s@gmail.com>
 go.sum,github.com/armon/go-socks5,MIT,2014 Armon Dadgar
 go.sum,github.com/chzyer/logex,MIT,2015Chzyer
 go.sum,github.com/chzyer/readline,MIT,2015 Chzyer
 go.sum,github.com/chzyer/test,MIT,2016 Chzyer
-go.sum,github.com/cncf/udpa/go,Apache-2.0,<COPYRIGHT>
-go.sum,github.com/emirpasic/gods,<LICENSE>,"2015, Emir Pasic"
-go.sum,github.com/flynn/go-shlex,<LICENSE>,<COPYRIGHT>
+go.sum,github.com/cncf/udpa/go,Apache-2.0,The Authors
+go.sum,github.com/emirpasic/gods,BSD2,"2015, Emir Pasic"
+go.sum,github.com/flynn/go-shlex,Apache-2.0,2012 Google Inc.
 go.sum,github.com/gliderlabs/ssh,BSD 3-Clause "New" or "Revised" License,2016 Glider Labs
-go.sum,github.com/go-git/gcfg,<LICENSE>,2012 Péter Surányi. Portions Copyright (c) 2009 The Go
-go.sum,github.com/go-git/go-billy/v5,Apache-2.0,<COPYRIGHT>
-go.sum,github.com/go-git/go-git-fixtures/v4,Apache-2.0,<COPYRIGHT>
-go.sum,github.com/go-git/go-git/v5,Apache-2.0,<COPYRIGHT>
+go.sum,github.com/go-git/gcfg,BSD 3-Clause,2012 Péter Surányi. Portions Copyright (c) 2009 The Go
+go.sum,github.com/go-git/go-billy/v5,Apache-2.0,The Authors
+go.sum,github.com/go-git/go-git-fixtures/v4,Apache-2.0,The Authors
+go.sum,github.com/go-git/go-git/v5,Apache-2.0,The Authors
 go.sum,github.com/go-gl/glfw,BSD-3-Clause,2012 The glfw3-go Authors
 go.sum,github.com/go-gl/glfw/v3.3/glfw,BSD-3-Clause,2012 The glfw3-go Authors
 go.sum,github.com/golang/groupcache,Apache-2.0,2013 Google Inc.
@@ -163,14 +163,14 @@ go.sum,github.com/ianlancetaylor/demangle,BSD-3-Clause,2015 The Go Authors.
 go.sum,github.com/imdario/mergo,BSD 3-Clause "New" or "Revised" License,2013 Dario Castañé. 2012 The Go Authors.
 go.sum,github.com/jbenet/go-context,MIT,2014 Juan Batiz-Benet
 go.sum,github.com/jessevdk/go-flags,BSD 3-Clause "New" or "Revised" License,2012 Jesse van den Kieboom.
-go.sum,github.com/jhump/protoreflect,Apache-2.0,<COPYRIGHT>
-go.sum,github.com/kevinburke/ssh_config,<LICENSE>,<COPYRIGHT>
+go.sum,github.com/jhump/protoreflect,Apache-2.0,The Authors
+go.sum,github.com/kevinburke/ssh_config,MIT,2017 Kevin Burke.
 go.sum,github.com/rogpeppe/go-internal,BSD 3-Clause "New" or "Revised" License,2018 The Go Authors.
 go.sum,github.com/therve/terraform-plugin-sdk,MPL-2.0,
 go.sum,github.com/xanzy/ssh-agent,Apache-2.0,"2015, Sander van Harmelen"
 go.sum,github.com/yuin/goldmark,MIT,2019 Yusuke Inuzuka
-go.sum,golang.org/x/mod,<LICENSE>,2009 The Go Authors.
-go.sum,google.golang.org/protobuf,<LICENSE>,2018 The Go Authors.
+go.sum,golang.org/x/mod,BSD 3-Clause,2009 The Go Authors.
+go.sum,google.golang.org/protobuf,BSD 3-Clause,2018 The Go Authors.
 go.sum,gopkg.in/errgo.v2,BSD 3-Clause "New" or "Revised" License,"Copyright © 2013, Roger Peppe"
 go.sum,gopkg.in/warnings.v0,BSD 2-Clause "Simplified" License,2016 Péter Surányi.
 go.sum,rsc.io/quote/v3,BSD 3-Clause "New" or "Revised" License,2009 The Go Authors.

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -134,3 +134,44 @@ go.sum,gopkg.in/yaml.v2,Apache-2.0,2011-2016 Canonical Ltd.
 go.sum,gotest.tools,Apache-2.0,2018 gotest.tools authors
 go.sum,honnef.co/go/tools,MIT,2016 Dominik Honnef
 go.sum,rsc.io/binaryregexp,BSD-3-Clause,2009 The Go Authors
+go.sum,cloud.google.com/go/pubsub,Apache-2.0,Copyright 2018 Google LLC
+go.sum,cloud.google.com/go/storage,Apache-2.0,Copyright 2014 Google LLC
+go.sum,dmitri.shuralyov.com/gpu/mtl,<LICENSE>,<COPYRIGHT>
+go.sum,github.com/alcortesm/tgz,MIT,2016 Alberto Cortés
+go.sum,github.com/anmitsu/go-shlex,MIT,anmitsu <anmitsu.s@gmail.com>
+go.sum,github.com/armon/go-socks5,MIT,2014 Armon Dadgar
+go.sum,github.com/chzyer/logex,MIT,2015Chzyer
+go.sum,github.com/chzyer/readline,MIT,2015 Chzyer
+go.sum,github.com/chzyer/test,MIT,2016 Chzyer
+go.sum,github.com/cncf/udpa/go,Apache-2.0,<COPYRIGHT>
+go.sum,github.com/emirpasic/gods,<LICENSE>,"2015, Emir Pasic"
+go.sum,github.com/flynn/go-shlex,<LICENSE>,<COPYRIGHT>
+go.sum,github.com/gliderlabs/ssh,BSD 3-Clause "New" or "Revised" License,2016 Glider Labs
+go.sum,github.com/go-git/gcfg,<LICENSE>,2012 Péter Surányi. Portions Copyright (c) 2009 The Go
+go.sum,github.com/go-git/go-billy/v5,Apache-2.0,<COPYRIGHT>
+go.sum,github.com/go-git/go-git-fixtures/v4,Apache-2.0,<COPYRIGHT>
+go.sum,github.com/go-git/go-git/v5,Apache-2.0,<COPYRIGHT>
+go.sum,github.com/go-gl/glfw,BSD-3-Clause,2012 The glfw3-go Authors
+go.sum,github.com/go-gl/glfw/v3.3/glfw,BSD-3-Clause,2012 The glfw3-go Authors
+go.sum,github.com/golang/groupcache,Apache-2.0,2013 Google Inc.
+go.sum,github.com/google/martian/v3,Apache-2.0,2015 Google Inc.
+go.sum,github.com/google/renameio,Apache-2.0,2018 Google Inc.
+go.sum,github.com/hashicorp/go-checkpoint,MPL-2.0,
+go.sum,github.com/hashicorp/terraform-exec,MPL-2.0,
+go.sum,github.com/hashicorp/terraform-plugin-test/v2,MPL-2.0,
+go.sum,github.com/ianlancetaylor/demangle,BSD-3-Clause,2015 The Go Authors.
+go.sum,github.com/imdario/mergo,BSD 3-Clause "New" or "Revised" License,2013 Dario Castañé. 2012 The Go Authors.
+go.sum,github.com/jbenet/go-context,MIT,2014 Juan Batiz-Benet
+go.sum,github.com/jessevdk/go-flags,BSD 3-Clause "New" or "Revised" License,2012 Jesse van den Kieboom.
+go.sum,github.com/jhump/protoreflect,Apache-2.0,<COPYRIGHT>
+go.sum,github.com/kevinburke/ssh_config,<LICENSE>,<COPYRIGHT>
+go.sum,github.com/rogpeppe/go-internal,BSD 3-Clause "New" or "Revised" License,2018 The Go Authors.
+go.sum,github.com/therve/terraform-plugin-sdk,MPL-2.0,
+go.sum,github.com/xanzy/ssh-agent,Apache-2.0,"2015, Sander van Harmelen"
+go.sum,github.com/yuin/goldmark,MIT,2019 Yusuke Inuzuka
+go.sum,golang.org/x/mod,<LICENSE>,2009 The Go Authors.
+go.sum,google.golang.org/protobuf,<LICENSE>,2018 The Go Authors.
+go.sum,gopkg.in/errgo.v2,BSD 3-Clause "New" or "Revised" License,"Copyright © 2013, Roger Peppe"
+go.sum,gopkg.in/warnings.v0,BSD 2-Clause "Simplified" License,2016 Péter Surányi.
+go.sum,rsc.io/quote/v3,BSD 3-Clause "New" or "Revised" License,2009 The Go Authors.
+go.sum,rsc.io/sampler,BSD 3-Clause "New" or "Revised" License,2009 The Go Authors.

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -144,10 +144,10 @@ go.sum,github.com/chzyer/logex,MIT,2015Chzyer
 go.sum,github.com/chzyer/readline,MIT,2015 Chzyer
 go.sum,github.com/chzyer/test,MIT,2016 Chzyer
 go.sum,github.com/cncf/udpa/go,Apache-2.0,The Authors
-go.sum,github.com/emirpasic/gods,BSD2,"2015, Emir Pasic"
+go.sum,github.com/emirpasic/gods,BSD 2-Clause,"2015, Emir Pasic"
 go.sum,github.com/flynn/go-shlex,Apache-2.0,2012 Google Inc.
-go.sum,github.com/gliderlabs/ssh,BSD 3-Clause "New" or "Revised" License,2016 Glider Labs
-go.sum,github.com/go-git/gcfg,BSD 3-Clause,2012 Péter Surányi. Portions Copyright (c) 2009 The Go
+go.sum,github.com/gliderlabs/ssh,BSD-3-Clause,2016 Glider Labs
+go.sum,github.com/go-git/gcfg,BSD-3-Clause,2012 Péter Surányi. Portions Copyright (c) 2009 The Go
 go.sum,github.com/go-git/go-billy/v5,Apache-2.0,The Authors
 go.sum,github.com/go-git/go-git-fixtures/v4,Apache-2.0,The Authors
 go.sum,github.com/go-git/go-git/v5,Apache-2.0,The Authors
@@ -160,18 +160,18 @@ go.sum,github.com/hashicorp/go-checkpoint,MPL-2.0,
 go.sum,github.com/hashicorp/terraform-exec,MPL-2.0,
 go.sum,github.com/hashicorp/terraform-plugin-test/v2,MPL-2.0,
 go.sum,github.com/ianlancetaylor/demangle,BSD-3-Clause,2015 The Go Authors.
-go.sum,github.com/imdario/mergo,BSD 3-Clause "New" or "Revised" License,2013 Dario Castañé. 2012 The Go Authors.
+go.sum,github.com/imdario/mergo,BSD-3-Clause,2013 Dario Castañé. 2012 The Go Authors.
 go.sum,github.com/jbenet/go-context,MIT,2014 Juan Batiz-Benet
-go.sum,github.com/jessevdk/go-flags,BSD 3-Clause "New" or "Revised" License,2012 Jesse van den Kieboom.
+go.sum,github.com/jessevdk/go-flags,BSD-3-Clause,2012 Jesse van den Kieboom.
 go.sum,github.com/jhump/protoreflect,Apache-2.0,The Authors
 go.sum,github.com/kevinburke/ssh_config,MIT,2017 Kevin Burke.
-go.sum,github.com/rogpeppe/go-internal,BSD 3-Clause "New" or "Revised" License,2018 The Go Authors.
+go.sum,github.com/rogpeppe/go-internal,BSD-3-Clause,2018 The Go Authors.
 go.sum,github.com/therve/terraform-plugin-sdk,MPL-2.0,
 go.sum,github.com/xanzy/ssh-agent,Apache-2.0,"2015, Sander van Harmelen"
 go.sum,github.com/yuin/goldmark,MIT,2019 Yusuke Inuzuka
-go.sum,golang.org/x/mod,BSD 3-Clause,2009 The Go Authors.
-go.sum,google.golang.org/protobuf,BSD 3-Clause,2018 The Go Authors.
-go.sum,gopkg.in/errgo.v2,BSD 3-Clause "New" or "Revised" License,"Copyright © 2013, Roger Peppe"
+go.sum,golang.org/x/mod,BSD-3-Clause,2009 The Go Authors.
+go.sum,google.golang.org/protobuf,BSD-3-Clause,2018 The Go Authors.
+go.sum,gopkg.in/errgo.v2,BSD-3-Clause,"Copyright © 2013, Roger Peppe"
 go.sum,gopkg.in/warnings.v0,BSD 2-Clause "Simplified" License,2016 Péter Surányi.
-go.sum,rsc.io/quote/v3,BSD 3-Clause "New" or "Revised" License,2009 The Go Authors.
-go.sum,rsc.io/sampler,BSD 3-Clause "New" or "Revised" License,2009 The Go Authors.
+go.sum,rsc.io/quote/v3,BSD-3-Clause,2009 The Go Authors.
+go.sum,rsc.io/sampler,BSD-3-Clause,2009 The Go Authors.

--- a/scripts/license-check.sh
+++ b/scripts/license-check.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+echo "Ensuring all dependencies are present in LICENSE-3rdparty.csv ..."
+go mod tidy
+ALL_DEPS=`cat go.sum | awk '{print $1}' | uniq | sort | sed "s|^\(.*\)|go.sum,\1,|"`
+DEPS_NOT_FOUND=""
+for one_dep in `echo $ALL_DEPS`; do
+    cat LICENSE-3rdparty.csv | grep "$one_dep" > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        DEPS_NOT_FOUND="${DEPS_NOT_FOUND}\n${one_dep}<LICENSE>,<COPYRIGHT>"
+    fi
+done
+if [ -n "$DEPS_NOT_FOUND" ]; then
+    printf "Some dependencies were not found in LICENSE-3rdparty.csv, please add: $DEPS_NOT_FOUND\n\n"
+    exit 1
+else
+    echo "LICENSE-3rdparty.csv is up to date"
+fi


### PR DESCRIPTION
* Updates the 3rd party csv file to note all the deps we have in go.sum
* Adds a new script `license-check.sh`, essentially a copy from the datadog-api-client-go with a change from `echo` -> `printf`
  * Run the script via `make license-check` and add this to the github action CI