### PR TITLE
Remove deprecation on PagerDuty resource

### DIFF
--- a/datadog/resource_datadog_integration_pagerduty.go
+++ b/datadog/resource_datadog_integration_pagerduty.go
@@ -16,8 +16,7 @@ var integrationPdMutex = sync.Mutex{}
 
 func resourceDatadogIntegrationPagerduty() *schema.Resource {
 	return &schema.Resource{
-		Description:        "Provides a Datadog - PagerDuty resource. This can be used to create and manage Datadog - PagerDuty integration. See also [PagerDuty Integration Guide](https://www.pagerduty.com/docs/guides/datadog-integration-guide/). This resource is deprecated and should only be used for legacy purposes.",
-		DeprecationMessage: "This resource is deprecated. You can use datadog_integration_pagerduty_service_object resources directly once the integration is activated",
+		Description:        "Provides a Datadog - PagerDuty resource. This can be used to create and manage Datadog - PagerDuty integration. See also [PagerDuty Integration Guide](https://www.pagerduty.com/docs/guides/datadog-integration-guide/).",
 		Create:             resourceDatadogIntegrationPagerdutyCreate,
 		Read:               resourceDatadogIntegrationPagerdutyRead,
 		Update:             resourceDatadogIntegrationPagerdutyUpdate,

--- a/datadog/resource_datadog_integration_pagerduty.go
+++ b/datadog/resource_datadog_integration_pagerduty.go
@@ -16,11 +16,11 @@ var integrationPdMutex = sync.Mutex{}
 
 func resourceDatadogIntegrationPagerduty() *schema.Resource {
 	return &schema.Resource{
-		Description:        "Provides a Datadog - PagerDuty resource. This can be used to create and manage Datadog - PagerDuty integration. See also [PagerDuty Integration Guide](https://www.pagerduty.com/docs/guides/datadog-integration-guide/).",
-		Create:             resourceDatadogIntegrationPagerdutyCreate,
-		Read:               resourceDatadogIntegrationPagerdutyRead,
-		Update:             resourceDatadogIntegrationPagerdutyUpdate,
-		Delete:             resourceDatadogIntegrationPagerdutyDelete,
+		Description: "Provides a Datadog - PagerDuty resource. This can be used to create and manage Datadog - PagerDuty integration. See also [PagerDuty Integration Guide](https://www.pagerduty.com/docs/guides/datadog-integration-guide/).",
+		Create:      resourceDatadogIntegrationPagerdutyCreate,
+		Read:        resourceDatadogIntegrationPagerdutyRead,
+		Update:      resourceDatadogIntegrationPagerdutyUpdate,
+		Delete:      resourceDatadogIntegrationPagerdutyDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/docs/resources/integration_pagerduty.md
+++ b/docs/resources/integration_pagerduty.md
@@ -2,12 +2,12 @@
 page_title: "datadog_integration_pagerduty Resource - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  Provides a Datadog - PagerDuty resource. This can be used to create and manage Datadog - PagerDuty integration. See also PagerDuty Integration Guide https://www.pagerduty.com/docs/guides/datadog-integration-guide/. This resource is deprecated and should only be used for legacy purposes.
+  Provides a Datadog - PagerDuty resource. This can be used to create and manage Datadog - PagerDuty integration. See also PagerDuty Integration Guide https://www.pagerduty.com/docs/guides/datadog-integration-guide/.
 ---
 
 # Resource `datadog_integration_pagerduty`
 
-Provides a Datadog - PagerDuty resource. This can be used to create and manage Datadog - PagerDuty integration. See also [PagerDuty Integration Guide](https://www.pagerduty.com/docs/guides/datadog-integration-guide/). This resource is deprecated and should only be used for legacy purposes.
+Provides a Datadog - PagerDuty resource. This can be used to create and manage Datadog - PagerDuty integration. See also [PagerDuty Integration Guide](https://www.pagerduty.com/docs/guides/datadog-integration-guide/).
 
 ## Example Usage
 


### PR DESCRIPTION
Until we have a way to manage schedules to appear in the event stream,
this is still required.

Closes #665