### PR TITLE
Explicitly check monitor_id for nil value

### DIFF
--- a/datadog/resource_datadog_downtime.go
+++ b/datadog/resource_datadog_downtime.go
@@ -374,10 +374,9 @@ func updateDowntimeState(d *schema.ResourceData, dt *datadogV1.Downtime) error {
 	if err := d.Set("message", dt.GetMessage()); err != nil {
 		return err
 	}
-	if err := d.Set("monitor_id", dt.GetMonitorId()); err != nil {
-		return err
+	if v, ok := dt.GetMonitorIdOk(); ok && v != nil {
+		d.Set("monitor_id", v)
 	}
-
 	if err := d.Set("timezone", dt.GetTimezone()); err != nil {
 		return err
 	}

--- a/datadog/resource_datadog_downtime.go
+++ b/datadog/resource_datadog_downtime.go
@@ -375,7 +375,9 @@ func updateDowntimeState(d *schema.ResourceData, dt *datadogV1.Downtime) error {
 		return err
 	}
 	if v, ok := dt.GetMonitorIdOk(); ok && v != nil {
-		d.Set("monitor_id", v)
+		if err := d.Set("monitor_id", v); err != nil {
+			return err
+		}
 	}
 	if err := d.Set("timezone", dt.GetTimezone()); err != nil {
 		return err


### PR DESCRIPTION
This PR checks if monitor_id is nil before setting it. Previous approach was causing value of 0 to be stored in state. See terraformer issue here: https://github.com/GoogleCloudPlatform/terraformer/issues/818