### PR TITLE
[dashboard datasource] Retry on 504 errors

### DIFF
--- a/datadog/data_source_datadog_dashboard.go
+++ b/datadog/data_source_datadog_dashboard.go
@@ -6,6 +6,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 
 	datadogV1 "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
@@ -43,30 +44,34 @@ func dataSourceDatadogDashboardRead(d *schema.ResourceData, meta interface{}) er
 	datadogClientV1 := providerConf.DatadogClientV1
 	authV1 := providerConf.AuthV1
 
-	dashResponse, _, err := datadogClientV1.DashboardsApi.ListDashboards(authV1).Execute()
-
-	if err != nil {
-		return utils.TranslateClientError(err, "error querying dashboard")
-	}
-
-	searchedName := d.Get("name")
-	var foundDashes []datadogV1.DashboardSummaryDefinition
-
-	for _, dash := range dashResponse.GetDashboards() {
-		if dash.GetTitle() == searchedName {
-			foundDashes = append(foundDashes, dash)
+	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		dashResponse, httpresp, err := datadogClientV1.DashboardsApi.ListDashboards(authV1).Execute()
+		if err != nil {
+			if httpresp != nil && httpresp.StatusCode == 504 {
+				return resource.RetryableError(utils.TranslateClientError(err, "error querying dashboard, retrying"))
+			}
+			return resource.NonRetryableError(utils.TranslateClientError(err, "error querying dashboard"))
 		}
-	}
 
-	if len(foundDashes) == 0 {
-		return fmt.Errorf("Couldn't find a dashboard named %s", searchedName)
-	} else if len(foundDashes) > 1 {
-		return fmt.Errorf("%s returned more than one dashboard", searchedName)
-	}
+		searchedName := d.Get("name")
+		var foundDashes []datadogV1.DashboardSummaryDefinition
 
-	d.SetId(foundDashes[0].GetId())
-	d.Set("url", foundDashes[0].GetUrl())
-	d.Set("title", foundDashes[0].GetTitle())
+		for _, dash := range dashResponse.GetDashboards() {
+			if dash.GetTitle() == searchedName {
+				foundDashes = append(foundDashes, dash)
+			}
+		}
 
-	return nil
+		if len(foundDashes) == 0 {
+			return resource.NonRetryableError(fmt.Errorf("Couldn't find a dashboard named %s", searchedName))
+		} else if len(foundDashes) > 1 {
+			return resource.NonRetryableError(fmt.Errorf("%s returned more than one dashboard", searchedName))
+		}
+
+		d.SetId(foundDashes[0].GetId())
+		d.Set("url", foundDashes[0].GetUrl())
+		d.Set("title", foundDashes[0].GetTitle())
+
+		return nil
+	})
 }

--- a/datadog/data_source_datadog_dashboard.go
+++ b/datadog/data_source_datadog_dashboard.go
@@ -44,7 +44,7 @@ func dataSourceDatadogDashboardRead(d *schema.ResourceData, meta interface{}) er
 	datadogClientV1 := providerConf.DatadogClientV1
 	authV1 := providerConf.AuthV1
 
-	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+	return resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
 		dashResponse, httpresp, err := datadogClientV1.DashboardsApi.ListDashboards(authV1).Execute()
 		if err != nil {
 			if httpresp != nil && httpresp.StatusCode == 504 {


### PR DESCRIPTION
The `/api/v1/dashboard` endpoint can sometimes result in a 504 timeout due to the extended processing time when there's many dashboards to list out. This PR adds a simple retry in hopes that a subsequent request is successful. 