### PR TITLE
[Synthetics] Prevent certificate update with wrong value

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -1665,14 +1665,10 @@ func validateSyntheticsAssertionOperator(val interface{}, key string) (warns []s
 }
 
 func isCertHash(content string) bool {
-	contentBytes := []byte(content)
+	// a sha256 hash consists of 64 hexadecimal characters
+	isHash, _ := regexp.MatchString("^[A-Fa-f0-9]{64}$", content)
 
-	// hacky way to detect if the value is already a sha256 hash
-	if len(contentBytes) == 64 {
-		return true
-	}
-
-	return false
+	return isHash
 }
 
 // get the sha256 of a client certificate content


### PR DESCRIPTION
To avoid leaking sensitive data we [store a hash of the client certificate field in the state](https://github.com/DataDog/terraform-provider-datadog/pull/835). The issue is that in the update process of terraform, we get the values from the state and not from the config. This means we send the hashed version of the client certificate instead of the correct value, and it breaks tests since the configuration is not valid anymore.
This PR fixes this by checking if the client certificate looks like a sha256 hash, and if that's the case we don't send the value (in the backend the value is write-only and if the value is not present it will not be overwritten). It's a bit hacky but we're already doing a check like this to save the state.

Unfortunately this can't be checked in the tests (we need to check if the certificate value is still the correct one in the DB, since the value is write-only).