### PR TITLE
[datasource dashboard] Retry on 502s

### DIFF
--- a/datadog/data_source_datadog_dashboard.go
+++ b/datadog/data_source_datadog_dashboard.go
@@ -47,7 +47,7 @@ func dataSourceDatadogDashboardRead(d *schema.ResourceData, meta interface{}) er
 	return resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
 		dashResponse, httpresp, err := datadogClientV1.DashboardsApi.ListDashboards(authV1).Execute()
 		if err != nil {
-			if httpresp != nil && httpresp.StatusCode == 504 {
+			if httpresp != nil && (httpresp.StatusCode == 504 || httpresp.StatusCode == 502) {
 				return resource.RetryableError(utils.TranslateClientError(err, "error querying dashboard, retrying"))
 			}
 			return resource.NonRetryableError(utils.TranslateClientError(err, "error querying dashboard"))


### PR DESCRIPTION
Relates to https://github.com/DataDog/terraform-provider-datadog/pull/975 

In addition to occasional 504's, the `/api/v1/dashboard` endpoint also appears to return occasional 502's. This PR updates the logic to attempt to retry the operation for both 504's and 502's as that appears to do the trick. 