### PR TITLE
Fix monitor restricted_roles diff

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -290,13 +290,6 @@ func resourceDatadogMonitor() *schema.Resource {
 				Optional:      true,
 				Elem:          &schema.Schema{Type: schema.TypeString},
 				ConflictsWith: []string{"locked"},
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// if locked is defined, ignore restricted_roles
-					if _, ok := d.GetOk("locked"); ok {
-						return true
-					}
-					return false
-				},
 			},
 			"silenced": {
 				Description: "Each scope will be muted until the given POSIX timestamp or forever if the value is `0`. Use `-1` if you want to unmute the scope. Deprecated: the silenced parameter is being deprecated in favor of the downtime resource. This will be removed in the next major version of the Terraform Provider.",


### PR DESCRIPTION
It shouldn't check for locked, as it's still present in the state,
and thus remove the possibility of updating it.