### PR TITLE
Fix panic when converting params

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -1275,8 +1275,8 @@ func buildSyntheticsTestStruct(d *schema.ResourceData) *datadogV1.SyntheticsTest
 			stepTypeParams := getParamsKeysForStepType(step.GetType())
 
 			for _, key := range stepTypeParams {
-				if stepParams.(map[string]interface{})[key] != "" {
-					convertedValue := convertStepParamsValueForConfig(step.GetType(), key, stepParams.(map[string]interface{})[key])
+				if stepMap, ok := stepParams.(map[string]interface{}); ok && stepMap[key] != "" {
+					convertedValue := convertStepParamsValueForConfig(step.GetType(), key, stepMap[key])
 					params[convertStepParamsKey(key)] = convertedValue
 				}
 			}


### PR DESCRIPTION
If params is empty, then we fail to parse the map and it ends up in a
panic.