### PR TITLE
Remove read from monitor creation

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -568,7 +568,7 @@ func resourceDatadogMonitorCreate(d *schema.ResourceData, meta interface{}) erro
 	mCreatedID := strconv.FormatInt(mCreated.GetId(), 10)
 	d.SetId(mCreatedID)
 
-	return resourceDatadogMonitorRead(d, meta)
+	return updateMonitorState(d, meta, &mCreated)
 }
 
 func updateMonitorState(d *schema.ResourceData, meta interface{}, m *datadogV1.Monitor) error {


### PR DESCRIPTION
Remove the read to improve consistency and update the state directly
instead.