### PR TITLE
[monitor resource] Retry on 504

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -525,7 +525,7 @@ func resourceDatadogMonitorCustomizeDiff(diff *schema.ResourceDiff, meta interfa
 	return resource.Retry(retryTimeout, func() *resource.RetryError {
 		_, httpresp, err := datadogClientV1.MonitorsApi.ValidateMonitor(authV1).Body(*m).Execute()
 		if err != nil {
-			if httpresp != nil && httpresp.StatusCode == 502 {
+			if httpresp != nil && (httpresp.StatusCode == 502 || httpresp.StatusCode == 504) {
 				return resource.RetryableError(utils.TranslateClientError(err, "error validating monitor, retrying"))
 			}
 			return resource.NonRetryableError(utils.TranslateClientError(err, "error validating monitor"))


### PR DESCRIPTION
It appears that in addition to 502's, we can sometimes get a 504 and simply retrying avoids a complete Terraform run failure. 