### PR TITLE
Mark AWS account as non existent if GET returns 400 when AWS integration not installed

### DIFF
--- a/datadog/resource_datadog_integration_aws.go
+++ b/datadog/resource_datadog_integration_aws.go
@@ -143,8 +143,13 @@ func resourceDatadogIntegrationAwsRead(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	integrations, _, err := datadogClientV1.AWSIntegrationApi.ListAWSAccounts(authV1)
+	integrations, httpresp, err := datadogClientV1.AWSIntegrationApi.ListAWSAccounts(authV1)
 	if err != nil {
+		if httpresp != nil && httpresp.StatusCode == 400 {
+			// API returns 400 if integration is not installed
+			d.SetId("")
+			return nil
+		}
 		return utils.TranslateClientError(err, "error getting AWS integration")
 	}
 


### PR DESCRIPTION
A 400 on GET means the integration is not installed.
In this case, set ID to `""` so terraform knows it has to create the integration.
Fixes #1046 