### PR TITLE
Update monitor `critical` threshold documentation

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -147,7 +147,7 @@ func resourceDatadogMonitor() *schema.Resource {
 							Optional:     true,
 						},
 						"critical": {
-							Description:  "The monitor `CRITICAL` recovery threshold. Must be a number.",
+							Description:  "The monitor `CRITICAL` threshold. Must be a number.",
 							Type:         schema.TypeString,
 							ValidateFunc: validators.ValidateFloatString,
 							Optional:     true,

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -109,7 +109,7 @@ Optional:
 
 Optional:
 
-- **critical** (String) The monitor `CRITICAL` recovery threshold. Must be a number.
+- **critical** (String) The monitor `CRITICAL` threshold. Must be a number.
 - **critical_recovery** (String) The monitor `CRITICAL` recovery threshold. Must be a number.
 - **ok** (String) The monitor `OK` threshold. Must be a number.
 - **unknown** (String) The monitor `UNKNOWN` threshold. Must be a number.


### PR DESCRIPTION
Under the schema for `monitor_thresholds`, `critical` is listed as the "recovery threshold" rather than "threshold".