### PR TITLE
Use code formatting in description for attribute remapper

### DIFF
--- a/datadog/resource_datadog_logs_custom_pipeline.go
+++ b/datadog/resource_datadog_logs_custom_pipeline.go
@@ -128,9 +128,9 @@ var attributeRemapper = &schema.Schema{
 			"name":        {Description: "Name of the processor", Type: schema.TypeString, Optional: true},
 			"is_enabled":  {Description: "If the processor is enabled or not.", Type: schema.TypeBool, Optional: true},
 			"sources":     {Description: "List of source attributes or tags.", Type: schema.TypeList, Required: true, Elem: &schema.Schema{Type: schema.TypeString}},
-			"source_type": {Description: "Defines where the sources are from (log attribute or tag).", Type: schema.TypeString, Required: true},
+			"source_type": {Description: "Defines where the sources are from (log `attribute` or `tag`).", Type: schema.TypeString, Required: true},
 			"target":      {Description: "Final attribute or tag name to remap the sources.", Type: schema.TypeString, Required: true},
-			"target_type": {Description: "Defines if the target is a log attribute or tag.", Type: schema.TypeString, Required: true},
+			"target_type": {Description: "Defines if the target is a log `attribute` or `tag`.", Type: schema.TypeString, Required: true},
 			"target_format": {
 				Description:  "If the `target_type` of the remapper is `attribute`, try to cast the value to a new specific type. If the cast is not possible, the original type is kept. `string`, `integer`, or `double` are the possible types. If the `target_type` is `tag`, this parameter may not be specified.",
 				Type:         schema.TypeString,

--- a/docs/resources/logs_custom_pipeline.md
+++ b/docs/resources/logs_custom_pipeline.md
@@ -229,10 +229,10 @@ Optional:
 
 Required:
 
-- **source_type** (String) Defines where the sources are from (log attribute or tag).
+- **source_type** (String) Defines where the sources are from (log `attribute` or `tag`).
 - **sources** (List of String) List of source attributes or tags.
 - **target** (String) Final attribute or tag name to remap the sources.
-- **target_type** (String) Defines if the target is a log attribute or tag.
+- **target_type** (String) Defines if the target is a log `attribute` or `tag`.
 
 Optional:
 
@@ -415,10 +415,10 @@ Optional:
 
 Required:
 
-- **source_type** (String) Defines where the sources are from (log attribute or tag).
+- **source_type** (String) Defines where the sources are from (log `attribute` or `tag`).
 - **sources** (List of String) List of source attributes or tags.
 - **target** (String) Final attribute or tag name to remap the sources.
-- **target_type** (String) Defines if the target is a log attribute or tag.
+- **target_type** (String) Defines if the target is a log `attribute` or `tag`.
 
 Optional:
 


### PR DESCRIPTION
From "log attribute or tag", it's not clear what the permitted values of `source_type` and `target_type` are, exactly (`log attribute` and `tag`? `log-attribute` and `tag`? `attribute` and `tag`? ...). The examples all use `tag`, so the correct way to specify attribute isn't clear. The API docs use code formatting for `attribute` and `tag` and make it clear (see option 6 in [the "create a pipeline" section][1] of the API docs):

<img width="860" alt="image" src="https://user-images.githubusercontent.com/83797086/117787747-b6a93580-b281-11eb-9e3c-531ee95127e9.png">

Doing the same here would increase clarity.

[1]: https://docs.datadoghq.com/api/latest/logs-pipelines/#create-a-pipeline