### PR TITLE
Re-introduce monitor type diff suppression for query/metric alerts

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -75,6 +75,15 @@ func resourceDatadogMonitor() *schema.Resource {
 				Required:         true,
 				ForceNew:         true,
 				ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewMonitorTypeFromValue),
+				// Datadog API quirk, see https://github.com/hashicorp/terraform/issues/13784
+				DiffSuppressFunc: func(k, oldVal, newVal string, d *schema.ResourceData) bool {
+					if (oldVal == "query alert" && newVal == "metric alert") ||
+						(oldVal == "metric alert" && newVal == "query alert") {
+						log.Printf("[DEBUG] Monitor '%s' got a '%s' response for an expected '%s' type. Suppressing change.", d.Get("name"), newVal, oldVal)
+						return true
+					}
+					return newVal == oldVal
+				},
 			},
 			"priority": {
 				Description: "Integer from 1 (high) to 5 (low) indicating alert severity.",


### PR DESCRIPTION
There are still cases where the api will return `query alert` for `metric alert` types. This PR introduces the previous removed `DiffSuppressFunc`.

Fixes #1100 