### PR TITLE
Remove US only constraint from docs

### DIFF
--- a/datadog/resource_datadog_integration_aws_tag_filter.go
+++ b/datadog/resource_datadog_integration_aws_tag_filter.go
@@ -14,7 +14,7 @@ import (
 
 func resourceDatadogIntegrationAwsTagFilter() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Provides a Datadog AWS tag filter resource. This can be used to create and manage Datadog AWS tag filters - US site’s endpoint only",
+		Description:   "Provides a Datadog AWS tag filter resource. This can be used to create and manage Datadog AWS tag filters.",
 		CreateContext: resourceDatadogIntegrationAwsTagFilterCreate,
 		UpdateContext: resourceDatadogIntegrationAwsTagFilterUpdate,
 		ReadContext:   resourceDatadogIntegrationAwsTagFilterRead,

--- a/docs/resources/integration_aws_tag_filter.md
+++ b/docs/resources/integration_aws_tag_filter.md
@@ -3,12 +3,12 @@
 page_title: "datadog_integration_aws_tag_filter Resource - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  Provides a Datadog AWS tag filter resource. This can be used to create and manage Datadog AWS tag filters - US site’s endpoint only
+  Provides a Datadog AWS tag filter resource. This can be used to create and manage Datadog AWS tag filters.
 ---
 
 # datadog_integration_aws_tag_filter (Resource)
 
-Provides a Datadog AWS tag filter resource. This can be used to create and manage Datadog AWS tag filters - US site’s endpoint only
+Provides a Datadog AWS tag filter resource. This can be used to create and manage Datadog AWS tag filters.
 
 ## Example Usage
 


### PR DESCRIPTION
EU endpoints are now supported. This PR removes the US endpoint only constraint from documentation.