### PR TITLE
Fix day_limit and retention type log index attributes

### DIFF
--- a/datadog/resource_datadog_logs_index.go
+++ b/datadog/resource_datadog_logs_index.go
@@ -19,12 +19,12 @@ var indexSchema = map[string]*schema.Schema{
 	},
 	"daily_limit": {
 		Description: "The number of log events you can send in this index per day before you are rate-limited.",
-		Type:        schema.TypeString,
+		Type:        schema.TypeInt,
 		Required:    true,
 	},
 	"retention_days": {
 		Description: "The number of days before logs are deleted from this index.",
-		Type:        schema.TypeString,
+		Type:        schema.TypeInt,
 		Required:    true,
 	},
 	"filter": {

--- a/docs/resources/logs_index.md
+++ b/docs/resources/logs_index.md
@@ -46,10 +46,10 @@ resource "datadog_logs_index" "sample_index" {
 
 ### Required
 
-- **daily_limit** (String) The number of log events you can send in this index per day before you are rate-limited.
+- **daily_limit** (Number) The number of log events you can send in this index per day before you are rate-limited.
 - **filter** (Block List, Min: 1) Logs filter (see [below for nested schema](#nestedblock--filter))
 - **name** (String) The name of the index.
-- **retention_days** (String) The number of days before logs are deleted from this index.
+- **retention_days** (Number) The number of days before logs are deleted from this index.
 
 ### Optional
 


### PR DESCRIPTION
from https://docs.datadoghq.com/api/latest/logs-indexes/#create-an-index
it seems to be integers
also getting errors while trying to apply with the current version:
  Error: daily_limit: '' expected type 'string', got unconvertible type 'int64'

Closes #1113 