### PR TITLE
Fix `retention_days` and `daily_limit` attributes 

### DIFF
--- a/datadog/resource_datadog_logs_index.go
+++ b/datadog/resource_datadog_logs_index.go
@@ -26,6 +26,7 @@ var indexSchema = map[string]*schema.Schema{
 		Description: "The number of days before logs are deleted from this index.",
 		Type:        schema.TypeInt,
 		Optional:    true,
+		Computed:    true,
 	},
 	"filter": {
 		Description: "Logs filter",

--- a/datadog/resource_datadog_logs_index.go
+++ b/datadog/resource_datadog_logs_index.go
@@ -20,7 +20,7 @@ var indexSchema = map[string]*schema.Schema{
 	"daily_limit": {
 		Description: "The number of log events you can send in this index per day before you are rate-limited.",
 		Type:        schema.TypeInt,
-		Required:    true,
+		Optional:    true,
 	},
 	"retention_days": {
 		Description: "The number of days before logs are deleted from this index.",

--- a/datadog/resource_datadog_logs_index.go
+++ b/datadog/resource_datadog_logs_index.go
@@ -25,7 +25,7 @@ var indexSchema = map[string]*schema.Schema{
 	"retention_days": {
 		Description: "The number of days before logs are deleted from this index.",
 		Type:        schema.TypeInt,
-		Required:    true,
+		Optional:    true,
 	},
 	"filter": {
 		Description: "Logs filter",

--- a/docs/resources/logs_index.md
+++ b/docs/resources/logs_index.md
@@ -46,13 +46,13 @@ resource "datadog_logs_index" "sample_index" {
 
 ### Required
 
-- **daily_limit** (Number) The number of log events you can send in this index per day before you are rate-limited.
 - **filter** (Block List, Min: 1) Logs filter (see [below for nested schema](#nestedblock--filter))
 - **name** (String) The name of the index.
 - **retention_days** (Number) The number of days before logs are deleted from this index.
 
 ### Optional
 
+- **daily_limit** (Number) The number of log events you can send in this index per day before you are rate-limited.
 - **exclusion_filter** (Block List) List of exclusion filters. (see [below for nested schema](#nestedblock--exclusion_filter))
 
 ### Read-Only

--- a/docs/resources/logs_index.md
+++ b/docs/resources/logs_index.md
@@ -48,12 +48,12 @@ resource "datadog_logs_index" "sample_index" {
 
 - **filter** (Block List, Min: 1) Logs filter (see [below for nested schema](#nestedblock--filter))
 - **name** (String) The name of the index.
-- **retention_days** (Number) The number of days before logs are deleted from this index.
 
 ### Optional
 
 - **daily_limit** (Number) The number of log events you can send in this index per day before you are rate-limited.
 - **exclusion_filter** (Block List) List of exclusion filters. (see [below for nested schema](#nestedblock--exclusion_filter))
+- **retention_days** (Number) The number of days before logs are deleted from this index.
 
 ### Read-Only
 


### PR DESCRIPTION
From https://docs.datadoghq.com/api/latest/logs-indexes/#create-an-index it seems like `daily_limit` is optional which would align with the UI as well. 