### PR TITLE
Fix logs_index update method

### DIFF
--- a/datadog/resource_datadog_logs_index.go
+++ b/datadog/resource_datadog_logs_index.go
@@ -21,6 +21,7 @@ var indexSchema = map[string]*schema.Schema{
 		Description: "The number of log events you can send in this index per day before you are rate-limited.",
 		Type:        schema.TypeInt,
 		Optional:    true,
+		Computed:    true,
 	},
 	"retention_days": {
 		Description: "The number of days before logs are deleted from this index.",
@@ -171,6 +172,14 @@ func buildDatadogIndex(d *schema.ResourceData) (*datadogV1.LogsIndexUpdateReques
 	var ddIndex datadogV1.LogsIndexUpdateRequest
 	if tfFilter := d.Get("filter").([]interface{}); len(tfFilter) > 0 {
 		ddIndex.SetFilter(*buildDatadogIndexFilter(tfFilter[0].(map[string]interface{})))
+	}
+
+	if v, ok := d.GetOk("daily_limit"); ok {
+		ddIndex.SetDailyLimit(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("retention_days"); ok {
+		ddIndex.SetNumRetentionDays(int64(v.(int)))
 	}
 
 	ddIndex.ExclusionFilters = buildDatadogExclusionFilters(d.Get("exclusion_filter").([]interface{}))

--- a/datadog/resource_datadog_logs_index.go
+++ b/datadog/resource_datadog_logs_index.go
@@ -195,11 +195,9 @@ func buildDatadogIndex(d *schema.ResourceData) (*datadogV1.LogsIndexUpdateReques
 	if v, ok := d.GetOk("daily_limit"); ok {
 		ddIndex.SetDailyLimit(int64(v.(int)))
 	}
-
 	if v, ok := d.GetOk("disable_daily_limit"); ok {
 		ddIndex.SetDisableDailyLimit(v.(bool))
 	}
-
 	if v, ok := d.GetOk("retention_days"); ok {
 		ddIndex.SetNumRetentionDays(int64(v.(int)))
 	}

--- a/docs/resources/logs_index.md
+++ b/docs/resources/logs_index.md
@@ -52,6 +52,7 @@ resource "datadog_logs_index" "sample_index" {
 ### Optional
 
 - **daily_limit** (Number) The number of log events you can send in this index per day before you are rate-limited.
+- **disable_daily_limit** (Boolean) If true, sets the daily_limit value to null and the index is not limited on a daily basis (any specified daily_limit value in the request is ignored). If false or omitted, the index's current daily_limit is maintained.
 - **exclusion_filter** (Block List) List of exclusion filters. (see [below for nested schema](#nestedblock--exclusion_filter))
 - **retention_days** (Number) The number of days before logs are deleted from this index.
 


### PR DESCRIPTION
This PR ensures we properly update `daily_limit` and `retention_days` fields on Update request. 

Resource update + import has been manually tested. We cannot implement a test feature at the moment as Logs index creation is not supported.