### PR TITLE
Fixed Terraform examples for  `datadog_integration_aws_log_collection/tag_filter`

### DIFF
--- a/docs/resources/integration_aws_log_collection.md
+++ b/docs/resources/integration_aws_log_collection.md
@@ -13,7 +13,7 @@ Provides a Datadog - Amazon Web Services integration log collection resource. Th
 ## Example Usage
 
 ```terraform
-# Create a new Datadog - Amazon Web Services integration lambda arn
+# Create a new Datadog - Amazon Web Services integration log collection
 resource "datadog_integration_aws_log_collection" "main" {
   account_id = "1234567890"
   services   = ["lambda"]

--- a/docs/resources/integration_aws_tag_filter.md
+++ b/docs/resources/integration_aws_tag_filter.md
@@ -13,6 +13,7 @@ Provides a Datadog AWS tag filter resource. This can be used to create and manag
 ## Example Usage
 
 ```terraform
+# Create a new Datadog - Amazon Web Services integration tag filter
 resource "datadog_integration_aws_tag_filter" "foo" {
   account_id     = "123456789010"
   namespace      = "sqs"

--- a/examples/resources/datadog_integration_aws_log_collection/resource.tf
+++ b/examples/resources/datadog_integration_aws_log_collection/resource.tf
@@ -1,4 +1,4 @@
-# Create a new Datadog - Amazon Web Services integration lambda arn
+# Create a new Datadog - Amazon Web Services integration log collection
 resource "datadog_integration_aws_log_collection" "main" {
   account_id = "1234567890"
   services   = ["lambda"]

--- a/examples/resources/datadog_integration_aws_tag_filter/resource.tf
+++ b/examples/resources/datadog_integration_aws_tag_filter/resource.tf
@@ -1,3 +1,4 @@
+# Create a new Datadog - Amazon Web Services integration tag filter
 resource "datadog_integration_aws_tag_filter" "foo" {
   account_id     = "123456789010"
   namespace      = "sqs"


### PR DESCRIPTION
Noted in the public docs a small typo for resources:

- `datadog_integration_aws_log_collection`
- `datadog_integration_aws_tag_filter`

This should fix the typos on next documentation generate.