### PR TITLE
Documentation - adding `datadog_integration_slack_channel` slack import example

### DIFF
--- a/docs/resources/integration_slack_channel.md
+++ b/docs/resources/integration_slack_channel.md
@@ -13,15 +13,16 @@ Resource for interacting with the Datadog Slack channel API
 ## Example Usage
 
 ```terraform
-resource "datadog_integration_slack_channel" "slack_channel" {
+resource "datadog_integration_slack_channel" "test_channel" {
+  account_name = "foo"
+  channel_name = "#test_channel"
+
   display {
     message  = true
     notified = false
     snapshot = false
     tags     = true
   }
-  channel_name = "#test_channel"
-  account_name = "foo"
 }
 ```
 
@@ -48,4 +49,11 @@ Optional:
 - **snapshot** (Boolean) Show the alert event's snapshot image.
 - **tags** (Boolean) Show the scopes on which the monitor alerted.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+# Slack channel integrations can be imported using their account_name and channel_name separated with a colon (`:`).
+terraform import datadog_integration_slack_channel.test_channel "foo:#test_channel"
+```

--- a/examples/resources/datadog_downtime/import.sh
+++ b/examples/resources/datadog_downtime/import.sh
@@ -1,2 +1,1 @@
 terraform import datadog_downtime.bytes_received_localhost 2081
-

--- a/examples/resources/datadog_integration_aws/import.sh
+++ b/examples/resources/datadog_integration_aws/import.sh
@@ -1,3 +1,2 @@
 # Amazon Web Services integrations can be imported using their account ID and role name separated with a colon (:), while the external_id should be passed by setting an environment variable called EXTERNAL_ID
 EXTERNAL_ID=${external_id} terraform import datadog_integration_aws.test ${account_id}:${role_name}
-

--- a/examples/resources/datadog_integration_aws_lambda_arn/import.sh
+++ b/examples/resources/datadog_integration_aws_lambda_arn/import.sh
@@ -1,3 +1,2 @@
 # Amazon Web Services Lambda ARN integrations can be imported using their account_id and lambda_arn separated with a space (` `).
 terraform import datadog_integration_aws_lambda_arn.test "1234567890 arn:aws:lambda:us-east-1:1234567890:function:datadog-forwarder-Forwarder"
-

--- a/examples/resources/datadog_integration_aws_log_collection/import.sh
+++ b/examples/resources/datadog_integration_aws_log_collection/import.sh
@@ -1,3 +1,2 @@
 # Amazon Web Services log collection integrations can be imported using the `account ID`.
 terraform import datadog_integration_aws_log_collection.test 1234567890
-

--- a/examples/resources/datadog_integration_slack_channel/import.sh
+++ b/examples/resources/datadog_integration_slack_channel/import.sh
@@ -1,0 +1,2 @@
+# Slack channel integrations can be imported using their account_name and channel_name separated with a colon (`:`).
+terraform import datadog_integration_slack_channel.test_channel "foo:#test_channel"

--- a/examples/resources/datadog_integration_slack_channel/resource.tf
+++ b/examples/resources/datadog_integration_slack_channel/resource.tf
@@ -1,10 +1,11 @@
-resource "datadog_integration_slack_channel" "slack_channel" {
+resource "datadog_integration_slack_channel" "test_channel" {
+  account_name = "foo"
+  channel_name = "#test_channel"
+
   display {
     message  = true
     notified = false
     snapshot = false
     tags     = true
   }
-  channel_name = "#test_channel"
-  account_name = "foo"
 }


### PR DESCRIPTION
Noted there wasn't a `terraform import` example for the `datadog_integration_slack_channel` resource type.

E.g.

```sh
terraform import datadog_integration_slack_channel.test_channel "foo:#test_channel"
```