### PR TITLE
Save `has_extended_title` and `enabled` in state

### DIFF
--- a/datadog/data_source_datadog_security_monitoring_rules.go
+++ b/datadog/data_source_datadog_security_monitoring_rules.go
@@ -197,7 +197,6 @@ func buildSecurityMonitoringTfRule(rule datadogV2.SecurityMonitoringRuleResponse
 	tfRule["name"] = rule.GetName()
 	tfRule["has_extended_title"] = rule.GetHasExtendedTitle()
 
-
 	tfOptions := extractTfOptions(rule.GetOptions())
 	tfRule["options"] = []map[string]interface{}{tfOptions}
 

--- a/datadog/resource_datadog_security_monitoring_rule.go
+++ b/datadog/resource_datadog_security_monitoring_rule.go
@@ -429,6 +429,7 @@ func updateResourceDataFromResponse(d *schema.ResourceData, ruleResponse datadog
 	d.Set("message", ruleResponse.GetMessage())
 	d.Set("name", ruleResponse.GetName())
 	d.Set("has_extended_title", ruleResponse.GetHasExtendedTitle())
+	d.Set("enabled", ruleResponse.GetIsEnabled())
 
 	options := extractTfOptions(ruleResponse.GetOptions())
 

--- a/datadog/resource_datadog_security_monitoring_rule.go
+++ b/datadog/resource_datadog_security_monitoring_rule.go
@@ -87,7 +87,6 @@ func datadogSecurityMonitoringRuleSchema() map[string]*schema.Schema {
 			Description: "Whether the notifications include the triggering group-by values in their title.",
 		},
 
-
 		"options": {
 			Type:        schema.TypeList,
 			Optional:    true,
@@ -231,7 +230,6 @@ func buildCreatePayload(d *schema.ResourceData) (datadogV2.SecurityMonitoringRul
 	payload.Message = d.Get("message").(string)
 	payload.Name = d.Get("name").(string)
 	payload.SetHasExtendedTitle(d.Get("has_extended_title").(bool))
-
 
 	if v, ok := d.GetOk("options"); ok {
 		tfOptionsList := v.([]interface{})
@@ -430,6 +428,7 @@ func updateResourceDataFromResponse(d *schema.ResourceData, ruleResponse datadog
 	d.Set("case", ruleCases)
 	d.Set("message", ruleResponse.GetMessage())
 	d.Set("name", ruleResponse.GetName())
+	d.Set("has_extended_title", ruleResponse.GetHasExtendedTitle())
 
 	options := extractTfOptions(ruleResponse.GetOptions())
 

--- a/datadog/tests/data_source_datadog_security_monitoring_rules_test.go
+++ b/datadog/tests/data_source_datadog_security_monitoring_rules_test.go
@@ -19,7 +19,6 @@ import (
 const tfSecurityRulesSource = "data.datadog_security_monitoring_rules.acceptance_test"
 
 func TestAccDatadogSecurityMonitoringRuleDatasource(t *testing.T) {
-	t.Parallel()
 	ctx, accProviders := testAccProviders(context.Background(), t)
 	ruleName := uniqueEntityName(ctx, t)
 	accProvider := testAccProvider(t, accProviders)

--- a/datadog/tests/resource_datadog_security_monitoring_rule_test.go
+++ b/datadog/tests/resource_datadog_security_monitoring_rule_test.go
@@ -105,7 +105,7 @@ func TestAccDatadogSecurityMonitoringRule_Import(t *testing.T) {
 				ResourceName:            tfSecurityRuleName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"enabled","has_extended_title"},
+				ImportStateVerifyIgnore: []string{"enabled"},
 				Check:                   testAccCheckDatadogSecurityMonitorCreatedRequiredCheck(accProvider, ruleName),
 			},
 		},

--- a/datadog/tests/resource_datadog_security_monitoring_rule_test.go
+++ b/datadog/tests/resource_datadog_security_monitoring_rule_test.go
@@ -102,11 +102,10 @@ func TestAccDatadogSecurityMonitoringRule_Import(t *testing.T) {
 				Config: testAccCheckDatadogSecurityMonitoringCreatedRequiredConfig(ruleName),
 			},
 			{
-				ResourceName:            tfSecurityRuleName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"enabled"},
-				Check:                   testAccCheckDatadogSecurityMonitorCreatedRequiredCheck(accProvider, ruleName),
+				ResourceName:      tfSecurityRuleName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				Check:             testAccCheckDatadogSecurityMonitorCreatedRequiredCheck(accProvider, ruleName),
 			},
 		},
 	})


### PR DESCRIPTION
Was missing from https://github.com/DataDog/terraform-provider-datadog/pull/1130, not sure how the create and update tests were passing correctly if we didn't save the value in the state 😕 