### PR TITLE
[PA-291] add aggregations option to metric_tag_configuration TF resource

### DIFF
--- a/datadog/tests/resource_datadog_metric_tag_configuration_test.go
+++ b/datadog/tests/resource_datadog_metric_tag_configuration_test.go
@@ -32,6 +32,10 @@ func TestAccDatadogMetricTagConfiguration_Error(t *testing.T) {
 				Config:      testAccCheckDatadogMetricTagConfigurationIncludePercentilesError(uniqueMetricTagConfig, "gauge"),
 				ExpectError: regexp.MustCompile("cannot use include_percentiles with a metric_type of gauge*"),
 			},
+			{
+				Config:      testAccCheckDatadogMetricTagConfigurationIncludePercentilesError(uniqueMetricTagConfig, "distribution"),
+				ExpectError: regexp.MustCompile("cannot use aggregations with a metric_type of distribution*"),
+			}
 		},
 	})
 }
@@ -43,6 +47,17 @@ func testAccCheckDatadogMetricTagConfigurationIncludePercentilesError(uniq strin
 			metric_type = "%s"
 			tags = ["sport"]
 			include_percentiles = false
+        }
+    `, uniq, metricType)
+}
+
+func testAccCheckDatadogMetricTagConfigurationAggregationsError(uniq string, metricType string) string {
+	return fmt.Sprintf(`
+        resource "datadog_metric_tag_configuration" "testing_metric_tag_config_aggregations" {
+			metric_name = "%s"
+			metric_type = "%s"
+			tags = ["sport"]
+			aggregations = [{"time": "sum", "space": "sum"}, {"time": "avg", "space": "avg"}]
         }
     `, uniq, metricType)
 }


### PR DESCRIPTION
This PR adds support for a new `aggregations` field which can be used with `count, rate, gauge` metric tag configurations.

Updated go client here: https://github.com/DataDog/datadog-api-spec/pull/1126

Verified the following cases and used the `GET /api/v2/{metric_name}/tags` to verify attributes:

- Create a new distribution, count, gauge tag configuration without aggregations and proper default is set
- Update each type of tag configuration (change tags, toggle percentiles, update aggregations) 
- Ensure we cannot toggle percentiles for non-distribution metrics 
- Ensure we cannot add aggregations for distribution metrics
- Import each type of tag configuration 