### PR TITLE
Update synthetics docs for global variable + browser test

### DIFF
--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -14,16 +14,27 @@ Provides a Datadog synthetics test resource. This can be used to create and mana
 #### *Warning*
 Starting from version 3.1.0+, the direct usage of global variables in the configuration is deprecated, in favor of
 local variables of type `global`. As an example, if you were previously using `{{ GLOBAL_VAR }}` directly in your
-configuration, you now need to add a `configVariable` of type `global` and whose `id` must be the `id` 
-of the global variable `GLOBAL_VAR` (you can find it in Synthetics UI) and whose name can be chosen freely. 
+configuration, add a `config_variable` of type `global` with the `id` matching the `id` of the global variable `GLOBAL_VAR`, which can be found in the Synthetics UI or from the output of the `datadog_synthetics_global_variable` resource. The name can be chosen freely. 
+
 In practice, it means going from (simplified configuration):
+
 ```
 url = https://{{ GLOBAL_VAR }}
 ```
+
 to
+
+```
+config_variable = {
+  name = "LOCAL_VAR"
+  id = [your_global_variable_id]
+  type = "global"
+}
+```
+
+which you can now use in your request definition:
 ```
 url = https://{{ LOCAL_VAR }}
-configVariable = {name: "LOCAL_VAR", id: GLOBAL_VAR.id, type: "global"}
 ```
 
 ## Example Usage
@@ -229,13 +240,13 @@ resource "datadog_synthetics_test" "test_browser" {
 
   status = "paused"
 
-  step {
+  browser_step {
     name = "Check current url"
     type = "assertCurrentUrl"
-    params = jsonencode({
-      "check" : "contains",
-      "value" : "datadoghq"
-    })
+    params {
+      check = "contains",
+      value = "datadoghq"
+    }
   }
 
   browser_variable {

--- a/examples/resources/datadog_synthetics_test/resource.tf
+++ b/examples/resources/datadog_synthetics_test/resource.tf
@@ -199,13 +199,13 @@ resource "datadog_synthetics_test" "test_browser" {
 
   status = "paused"
 
-  step {
+  browser_step {
     name = "Check current url"
     type = "assertCurrentUrl"
-    params = jsonencode({
-      "check" : "contains",
-      "value" : "datadoghq"
-    })
+    params {
+      check = "contains",
+      value = "datadoghq"
+    }
   }
 
   browser_variable {

--- a/templates/resources/synthetics_test.md.tmpl
+++ b/templates/resources/synthetics_test.md.tmpl
@@ -13,17 +13,28 @@ description: |-
 
 #### *Warning*
 Starting from version 3.1.0+, the direct usage of global variables in the configuration is deprecated, in favor of
-local variables of type `global`. As an example, if you were previously using `{{ "{{ GLOBAL_VAR }}" }}` directly in your
-configuration, you now need to add a `configVariable` of type `global` and whose `id` must be the `id` 
-of the global variable `GLOBAL_VAR` (you can find it in Synthetics UI) and whose name can be chosen freely. 
+local variables of type `global`. As an example, if you were previously using `{{ GLOBAL_VAR }}` directly in your
+configuration, add a `config_variable` of type `global` with the `id` matching the `id` of the global variable `GLOBAL_VAR`, which can be found in the Synthetics UI or from the output of the `datadog_synthetics_global_variable` resource. The name can be chosen freely. 
+
 In practice, it means going from (simplified configuration):
+
 ```
-url = {{ "https://{{ GLOBAL_VAR }}" }}
+url = https://{{ GLOBAL_VAR }}
 ```
+
 to
+
 ```
-url = {{ "https://{{ LOCAL_VAR }}" }}
-configVariable = {name: "LOCAL_VAR", id: GLOBAL_VAR.id, type: "global"}
+config_variable = {
+  name = "LOCAL_VAR"
+  id = [your_global_variable_id]
+  type = "global"
+}
+```
+
+which you can now use in your request definition:
+```
+url = https://{{ LOCAL_VAR }}
 ```
 
 ## Example Usage

--- a/templates/resources/synthetics_test.md.tmpl
+++ b/templates/resources/synthetics_test.md.tmpl
@@ -13,13 +13,13 @@ description: |-
 
 #### *Warning*
 Starting from version 3.1.0+, the direct usage of global variables in the configuration is deprecated, in favor of
-local variables of type `global`. As an example, if you were previously using `{{ GLOBAL_VAR }}` directly in your
+local variables of type `global`. As an example, if you were previously using `{{ "{{ GLOBAL_VAR }}" }}` directly in your
 configuration, add a `config_variable` of type `global` with the `id` matching the `id` of the global variable `GLOBAL_VAR`, which can be found in the Synthetics UI or from the output of the `datadog_synthetics_global_variable` resource. The name can be chosen freely. 
 
 In practice, it means going from (simplified configuration):
 
 ```
-url = https://{{ GLOBAL_VAR }}
+url = {{ "https://{{ GLOBAL_VAR }}" }}
 ```
 
 to
@@ -34,7 +34,7 @@ config_variable = {
 
 which you can now use in your request definition:
 ```
-url = https://{{ LOCAL_VAR }}
+url = {{ "https://{{ LOCAL_VAR }}" }}
 ```
 
 ## Example Usage


### PR DESCRIPTION
## What 
- Clarifies the use of `config_variable` for global variables
- Fixes the format and name of the `browser_step` bloc

## Notes
- I can't currently get the `make docs` command to work properly
```bash
/Users/pcothenet/Projects/terraform-provider-datadog/scripts/generate-docs.sh: line 19: tfplugindocs: command not found
```
- Downloading the latest binary for `tfplugindocs` generates more than 46 changes to the docs, which are out of scope for my fix.
- I'm happy letting you take it from here.
