### PR TITLE
Fix azure pipelines build

### DIFF
--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -33,12 +33,12 @@ jobs:
       pool:
           vmImage: "Ubuntu-20.04"
       container:
-          image: golang:latest
+          image: golang:1.16
       services:
           datadog-agent: datadog-agent
       steps:
-          - script: make testall
-            displayName: Run all tests
+          - script: make testacc
+            displayName: Run integration tests
             env:
                 RECORD: "none"
                 CI: "true"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,9 +57,9 @@ jobs:
             - name: Set TF_ACC_TERRAFORM_PATH env var on windows platform
               if: ${{ matrix.platform == 'windows-latest' }}
               run: echo ("TF_ACC_TERRAFORM_PATH=" + (Get-Command terraform).Path) >> $env:GITHUB_ENV
+            - name: Check Docs Are Up To Date
+              run: make check-docs
             - name: Test
               run: make testall
               env:
                   RECORD: false
-            - name: Check Docs Are Up To Date
-              run: make check-docs

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -24,7 +24,7 @@ test: get-test-deps fmtcheck
 	gotestsum --hide-summary skipped --format testname --debug --packages $(TEST) -- $(TESTARGS) -timeout=30s
 
 # Run acceptance tests (this runs integration CRUD tests through the terraform test framework)
-testacc: get-test-deps fmtcheck
+testacc: get-test-deps
 	RECORD=$(RECORD) TF_ACC=1 gotestsum --format testname --debug --rerun-fails --packages ./... -- -v $(TESTARGS) -timeout 120m
 
 # Run both unit and acceptance tests

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -244,7 +244,7 @@ resource "datadog_synthetics_test" "test_browser" {
     name = "Check current url"
     type = "assertCurrentUrl"
     params {
-      check = "contains",
+      check = "contains"
       value = "datadoghq"
     }
   }

--- a/examples/resources/datadog_synthetics_test/resource.tf
+++ b/examples/resources/datadog_synthetics_test/resource.tf
@@ -203,7 +203,7 @@ resource "datadog_synthetics_test" "test_browser" {
     name = "Check current url"
     type = "assertCurrentUrl"
     params {
-      check = "contains",
+      check = "contains"
       value = "datadoghq"
     }
   }

--- a/scripts/fmtcheck.sh
+++ b/scripts/fmtcheck.sh
@@ -2,11 +2,11 @@
 
 EXIT_CODE=0
 
-set -eo pipefail
+set -o pipefail
 
 # Check goimports
 echo "==> Checking that code complies with goimports requirements..."
-goimports_files=$(goimports -format-only -d -l `find . -name '*.go' | grep -v vendor`)
+goimports_files=$(goimports -format-only -d -l $(find . -name '*.go' | grep -v vendor))
 if [[ -n ${goimports_files} ]]; then
     echo 'gofmt needs running on the following files:'
     echo "${goimports_files}"
@@ -16,10 +16,11 @@ fi
 
 # Check the example terraform files pass terraform fmt
 echo "==> Checking that examples pass with terraform fmt requirements"
-if [[ -n $(terraform fmt -recursive -check -diff examples)  ]]; then
+terraform_fmt=$(terraform fmt -recursive -check -diff examples 2>&1)
+if [[ -n ${terraform_fmt}  ]]; then
     echo "Files in the \`example\` folder aren't terraform formatted"
     echo "You can use the command \`make fmt\` to reformat the following:"
-    echo "$(terraform fmt -recursive -diff examples)"
+    echo "${terraform_fmt}"
     EXIT_CODE=2
 fi
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools


### PR DESCRIPTION
- Use Golang 1.16 that's used for building the provider
- Add Golang 1.17 new build syntax
- Stop running fmtcheck on integration tests, it's already run in unit tests
- Fix fmtcheck that wouldn't exit with an exit code properly on terraform fmt