### PR TITLE
Add `available_values` property to dashboard template variables

### DIFF
--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -11013,6 +11013,7 @@ Required:
 
 Optional:
 
+- **available_values** (List of String) The list of values that the template variable drop-down is be limited to
 - **default** (String) The default value for the template variable on dashboard load.
 - **prefix** (String) The tag prefix associated with the variable. Only tags with this prefix appear in the variable dropdown.
 

--- a/examples/resources/datadog_dashboard/resource.tf
+++ b/examples/resources/datadog_dashboard/resource.tf
@@ -372,16 +372,14 @@ resource "datadog_dashboard" "ordered_dashboard" {
   }
 
   template_variable {
-    name             = "var_1"
-    prefix           = "host"
-    default          = "aws"
-    available_values = ["aws", "gcp"]
+    name    = "var_1"
+    prefix  = "host"
+    default = "aws"
   }
   template_variable {
-    name             = "var_2"
-    prefix           = "service_name"
-    default          = "autoscaling"
-    available_values = ["autoscaling", "kubernetes"]
+    name    = "var_2"
+    prefix  = "service_name"
+    default = "autoscaling"
   }
 
   template_variable_preset {
@@ -642,17 +640,14 @@ resource "datadog_dashboard" "free_dashboard" {
   }
 
   template_variable {
-    name             = "var_1"
-    prefix           = "host"
-    default          = "aws"
-    available_values = ["aws", "gcp"]
-
+    name    = "var_1"
+    prefix  = "host"
+    default = "aws"
   }
   template_variable {
-    name             = "var_2"
-    prefix           = "service_name"
-    default          = "autoscaling"
-    available_values = ["autoscaling", "kubernetes"]
+    name    = "var_2"
+    prefix  = "service_name"
+    default = "autoscaling"
   }
 
   template_variable_preset {

--- a/examples/resources/datadog_dashboard/resource.tf
+++ b/examples/resources/datadog_dashboard/resource.tf
@@ -372,14 +372,16 @@ resource "datadog_dashboard" "ordered_dashboard" {
   }
 
   template_variable {
-    name    = "var_1"
-    prefix  = "host"
-    default = "aws"
+    name             = "var_1"
+    prefix           = "host"
+    default          = "aws"
+    available_values = ["aws", "gcp"]
   }
   template_variable {
-    name    = "var_2"
-    prefix  = "service_name"
-    default = "autoscaling"
+    name             = "var_2"
+    prefix           = "service_name"
+    default          = "autoscaling"
+    available_values = ["autoscaling", "kubernetes"]
   }
 
   template_variable_preset {
@@ -640,14 +642,17 @@ resource "datadog_dashboard" "free_dashboard" {
   }
 
   template_variable {
-    name    = "var_1"
-    prefix  = "host"
-    default = "aws"
+    name             = "var_1"
+    prefix           = "host"
+    default          = "aws"
+    available_values = ["aws", "gcp"]
+
   }
   template_variable {
-    name    = "var_2"
-    prefix  = "service_name"
-    default = "autoscaling"
+    name             = "var_2"
+    prefix           = "service_name"
+    default          = "autoscaling"
+    available_values = ["autoscaling", "kubernetes"]
   }
 
   template_variable_preset {

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-datadog
 
 require (
-	github.com/DataDog/datadog-api-client-go v1.3.0
+	github.com/DataDog/datadog-api-client-go v1.3.1-0.20210909131424-901b75865816
 	github.com/DataDog/datadog-go v3.6.0+incompatible // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/dnaeon/go-vcr v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DataDog/datadog-api-client-go v1.3.0 h1:HK7SJ6tNZkGUYPZiUAK7nuq915cFgxC4pfu8W3+oAs8=
-github.com/DataDog/datadog-api-client-go v1.3.0/go.mod h1:QzaQF1cDO1/BIQG1fz14VrY+6RECUGkiwzDCtVbfP5c=
+github.com/DataDog/datadog-api-client-go v1.3.1-0.20210909131424-901b75865816 h1:uQdFvyZZy2hDHmMeokYnMb/F9tXHQiHxw2GKzLGn6Qk=
+github.com/DataDog/datadog-api-client-go v1.3.1-0.20210909131424-901b75865816/go.mod h1:QzaQF1cDO1/BIQG1fz14VrY+6RECUGkiwzDCtVbfP5c=
 github.com/DataDog/datadog-go v3.6.0+incompatible h1:ILg7c5Y1KvZFDOaVS0higGmJ5Fal5O1KQrkrT9j6dSM=
 github.com/DataDog/datadog-go v3.6.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/dd-trace-go v1.29.0-alpha.1.0.20210128154316-c84d7933b726 h1:E6y5wxU93et78p5JhD1tl/QDdFofxiSadMJ2p0AqO4Y=


### PR DESCRIPTION
This PR adds the `available_values`  property to template variables.
**Related PRs:**
- https://github.com/DataDog/datadog-api-spec/pull/1133
- https://github.com/DataDog/dogweb/pull/63689