### PR TITLE
Fix docs and example for security monitoring default rule

### DIFF
--- a/datadog/resource_datadog_security_monitoring_default_rule.go
+++ b/datadog/resource_datadog_security_monitoring_default_rule.go
@@ -15,7 +15,7 @@ import (
 
 func resourceDatadogSecurityMonitoringDefaultRule() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Provides a Datadog Security Monitoring Rule API resource for default rules.",
+		Description:   "Provides a Datadog Security Monitoring Rule API resource for default rules. It can only be imported, you can't create a default rule.",
 		CreateContext: resourceDatadogSecurityMonitoringDefaultRuleCreate,
 		ReadContext:   resourceDatadogSecurityMonitoringDefaultRuleRead,
 		UpdateContext: resourceDatadogSecurityMonitoringDefaultRuleUpdate,

--- a/docs/resources/security_monitoring_default_rule.md
+++ b/docs/resources/security_monitoring_default_rule.md
@@ -8,13 +8,12 @@ description: |-
 
 # datadog_security_monitoring_default_rule (Resource)
 
-Provides a Datadog Security Monitoring Rule API resource for default rules.
+Provides a Datadog Security Monitoring Rule API resource for default rules. It can only be imported, you can't create a default rule.
 
 ## Example Usage
 
 ```terraform
 resource "datadog_security_monitoring_default_rule" "adefaultrule" {
-  rule_id = "ojo-qef-3g3"
   enabled = true
 
   # Change the notifications for the high case

--- a/examples/resources/datadog_security_monitoring_default_rule/resource.tf
+++ b/examples/resources/datadog_security_monitoring_default_rule/resource.tf
@@ -1,5 +1,4 @@
 resource "datadog_security_monitoring_default_rule" "adefaultrule" {
-  rule_id = "ojo-qef-3g3"
   enabled = true
 
   # Change the notifications for the high case


### PR DESCRIPTION
The example mentioned rule_id which is not a parameter. I also
re-enforced the fact that it can't be created.

Closes #1243