### PR TITLE
Correct `downtime.monitor_tags` description

### DIFF
--- a/datadog/resource_datadog_downtime.go
+++ b/datadog/resource_datadog_downtime.go
@@ -245,7 +245,7 @@ func resourceDatadogDowntime() *schema.Resource {
 				// TypeSet makes Terraform ignore differences in order when creating a plan
 				Type:        schema.TypeSet,
 				Optional:    true,
-				Description: "A list of monitor tags (up to 25), i.e. tags that are applied directly to monitors to which the downtime applies",
+				Description: "A list of monitor tags (up to 32) to base the scheduled downtime on. Only monitors that have all selected tags are silenced",
 				// MonitorTags conflicts with MonitorId and it also has a default of `["*"]`, which brings some problems:
 				// * We can't use DefaultFunc to default to ["*"], since that's incompatible with
 				//   ConflictsWith

--- a/docs/resources/downtime.md
+++ b/docs/resources/downtime.md
@@ -54,7 +54,7 @@ resource "datadog_downtime" "foo" {
 - **end_date** (String) String representing date and time to end the downtime in RFC3339 format.
 - **message** (String) An optional message to provide when creating the downtime, can include notification handles
 - **monitor_id** (Number) When specified, this downtime will only apply to this monitor
-- **monitor_tags** (Set of String) A list of monitor tags (up to 32) to base the scheduled downtime on. Only monitors that have all selected tags are silenced.
+- **monitor_tags** (Set of String) A list of monitor tags (up to 32) to base the scheduled downtime on. Only monitors that have all selected tags are silenced
 - **recurrence** (Block List, Max: 1) Optional recurring schedule for this downtime (see [below for nested schema](#nestedblock--recurrence))
 - **start** (Number) Specify when this downtime should start
 - **start_date** (String) String representing date and time to start the downtime in RFC3339 format.


### PR DESCRIPTION
The description on how to make use of `monitor_tags` is incorrect.

From the Downtime [docs](https://docs.datadoghq.com/monitors/notify/downtimes/?tab=bymonitortags):
>  Schedule a downtime based on one or more monitor tags. You must select at least one tag with a limit of 32 tags. Each tag can be at most 256 characters long. Only monitors that have ALL selected tags are silenced. You can also select scopes for additional constraints.

The corrected version matches the UI usage and I am also using the Terraform version in a production environment