### PR TITLE
Fix typo in the datadog_monitor page

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -243,7 +243,7 @@ func resourceDatadogMonitor() *schema.Resource {
 				Default:     true,
 			},
 			"locked": {
-				Description:   "A boolean indicating whether changes to to this monitor should be restricted to the creator or admins. Defaults to `false`.",
+				Description:   "A boolean indicating whether changes to this monitor should be restricted to the creator or admins. Defaults to `false`.",
 				Type:          schema.TypeBool,
 				Optional:      true,
 				ConflictsWith: []string{"restricted_roles"},

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -64,7 +64,7 @@ For example, if the value is set to `300` (5min), the `timeframe` is set to `las
 - **force_delete** (Boolean) A boolean indicating whether this monitor can be deleted even if it’s referenced by other resources (e.g. SLO, composite monitor).
 - **groupby_simple_monitor** (Boolean) Whether or not to trigger one alert if any source breaches a threshold. This is only used by log monitors. Defaults to `false`.
 - **include_tags** (Boolean) A boolean indicating whether notifications from this monitor automatically insert its triggering tags into the title. Defaults to `true`.
-- **locked** (Boolean) A boolean indicating whether changes to to this monitor should be restricted to the creator or admins. Defaults to `false`.
+- **locked** (Boolean) A boolean indicating whether changes to this monitor should be restricted to the creator or admins. Defaults to `false`.
 - **monitor_threshold_windows** (Block List, Max: 1) A mapping containing `recovery_window` and `trigger_window` values, e.g. `last_15m` . Can only be used for, and are required for, anomaly monitors. (see [below for nested schema](#nestedblock--monitor_threshold_windows))
 - **monitor_thresholds** (Block List, Max: 1) Alert thresholds of the monitor. (see [below for nested schema](#nestedblock--monitor_thresholds))
 - **new_group_delay** (Number) Time (in seconds) to skip evaluations for new groups.


### PR DESCRIPTION
# Problem

`A boolean indicating whether changes to to this monitor` reads poorly because of the back to back `to`s

# Solution

Remove one of the two `to`s

# Methodology

I ran:
```
$ git grep 'A boolean indicating whether changes to to'
```

to find all instances of this string and then changed them

# Testing Done

I ran `make docs` and everything seemed to work