### PR TITLE
[docs] [r/logs_index_order] Remove depends_on, use modern refs without string interpolation

### DIFF
--- a/docs/resources/logs_index_order.md
+++ b/docs/resources/logs_index_order.md
@@ -15,11 +15,8 @@ Provides a Datadog Logs Index API resource. This can be used to manage the order
 ```terraform
 resource "datadog_logs_index_order" "sample_index_order" {
   name = "sample_index_order"
-  depends_on = [
-    "datadog_logs_index.sample_index"
-  ]
   indexes = [
-    "${datadog_logs_index.sample_index.id}"
+    datadog_logs_index.sample_index.id
   ]
 }
 ```


### PR DESCRIPTION
The depends on should not be necessary as this establishes an explicit relationship in the DAG that is already present as an implicit relationship in the `.id` calls for listed resources. This therefore seems like a simpler, less error prone example would not use `depends_on` which is generally discouraged unless needed for cases where there are no implicit relationships.

Also, updated the syntax in the example for TF 0.12+ as string interpolation is no longer required

----

Not sure what this means for the codegen part of how these documents are produced, but I did want to surface these changes.