### PR TITLE
fix: panic on resource name change

### DIFF
--- a/datadog/resource_datadog_monitor_json.go
+++ b/datadog/resource_datadog_monitor_json.go
@@ -55,7 +55,13 @@ func resourceDatadogMonitorJSON() *schema.Resource {
 			if !ok {
 				return true
 			}
-			return oldType != newAttrMap["type"].(string)
+			
+			newType, ok := newAttrMap["type"].(string)
+			if !ok {
+                                return true
+                        }
+			
+			return oldType != newType
 		}),
 		Schema: map[string]*schema.Schema{
 			"monitor": {

--- a/datadog/resource_datadog_monitor_json.go
+++ b/datadog/resource_datadog_monitor_json.go
@@ -55,12 +55,12 @@ func resourceDatadogMonitorJSON() *schema.Resource {
 			if !ok {
 				return true
 			}
-			
+
 			newType, ok := newAttrMap["type"].(string)
 			if !ok {
-                                return true
-                        }
-			
+				return true
+			}
+
 			return oldType != newType
 		}),
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
On resource name change the old is still there, and the new is empty, so there
the `new.(string)` is empty, so `newAttrMap` is `interface{}`
And terraform panics on that line.
This defensive programming action fixes the panic, but I think (guess?) that the code should never
get to this point on this case.