### PR TITLE
[examples] Fix invalid monitor timeout_h example

### DIFF
--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -33,7 +33,6 @@ resource "datadog_monitor" "foo" {
   renotify_interval = 60
 
   notify_audit = false
-  timeout_h    = 60
   include_tags = true
 
   tags = ["foo:bar", "baz"]

--- a/examples/resources/datadog_monitor/resource.tf
+++ b/examples/resources/datadog_monitor/resource.tf
@@ -18,7 +18,6 @@ resource "datadog_monitor" "foo" {
   renotify_interval = 60
 
   notify_audit = false
-  timeout_h    = 60
   include_tags = true
 
   tags = ["foo:bar", "baz"]


### PR DESCRIPTION
`timeout_h` values greater than 24 hours are not supported. This example has unfortunately led to many invalid monitors.