### PR TITLE
[monitor] set `new_host_delay` when `new_group_delay` is not defined

### DIFF
--- a/datadog/tests/resource_datadog_monitor_test.go
+++ b/datadog/tests/resource_datadog_monitor_test.go
@@ -227,8 +227,6 @@ func TestAccDatadogMonitor_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "new_group_delay", "500"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "new_host_delay", "300"),
-					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "evaluation_delay", "700"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "renotify_interval", "60"),
@@ -376,8 +374,6 @@ func TestAccDatadogMonitor_UpdatedToRemoveTags(t *testing.T) {
 						"datadog_monitor.foo", "notify_no_data", "false"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "new_group_delay", "500"),
-					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "new_host_delay", "300"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "evaluation_delay", "700"),
 					resource.TestCheckResourceAttr(


### PR DESCRIPTION
Fix a bug in generated monitors: `new_host_delay` is deprecated, and should not be set when `new_group_delay` is defined