### PR TITLE
Fix perpetual diff on some monitor JSON fields

### DIFF
--- a/datadog/resource_datadog_monitor_json.go
+++ b/datadog/resource_datadog_monitor_json.go
@@ -68,6 +68,16 @@ func resourceDatadogMonitorJSON() *schema.Resource {
 					for _, f := range monitorComputedFields {
 						utils.DeleteKeyInMap(attrMap, strings.Split(f, "."))
 					}
+					if name, ok := attrMap["name"]; ok {
+						if name, ok := name.(string); ok {
+							attrMap["name"] = strings.TrimSpace(name)
+						}
+					}
+					if msg, ok := attrMap["message"]; ok {
+						if msg, ok := msg.(string); ok {
+							attrMap["message"] = strings.TrimSpace(msg)
+						}
+					}
 
 					res, _ := structure.FlattenJsonToString(attrMap)
 					return res


### PR DESCRIPTION
name and message are trimmed server side so we get a perpetual diff if
those fields start or end with spaces. This fixes it by tweaking the
state function.

Closes #1289