### PR TITLE
Remove unnecessary `depends_on` in examples

### DIFF
--- a/docs/resources/dashboard_list.md
+++ b/docs/resources/dashboard_list.md
@@ -15,11 +15,6 @@ Provides a Datadog dashboard_list resource. This can be used to create and manag
 ```terraform
 # Create a new Dashboard List with two Dashboards
 resource "datadog_dashboard_list" "new_list" {
-  depends_on = [
-    datadog_dashboard.screen,
-    datadog_dashboard.time
-  ]
-
   name = "Terraform Created List"
   dash_item {
     type    = "custom_timeboard"

--- a/docs/resources/logs_archive_order.md
+++ b/docs/resources/logs_archive_order.md
@@ -15,8 +15,8 @@ Provides a Datadog [Logs Archive API](https://docs.datadoghq.com/api/v2/logs-arc
 ```terraform
 resource "datadog_logs_archive_order" "sample_archive_order" {
   archive_ids = [
-    "${datadog_logs_archive.sample_archive_1.id}",
-    "${datadog_logs_archive.sample_archive_2.id}"
+    datadog_logs_archive.sample_archive_1.id,
+    datadog_logs_archive.sample_archive_2.id
   ]
 }
 ```

--- a/docs/resources/logs_index_order.md
+++ b/docs/resources/logs_index_order.md
@@ -15,11 +15,9 @@ Provides a Datadog Logs Index API resource. This can be used to manage the order
 ```terraform
 resource "datadog_logs_index_order" "sample_index_order" {
   name = "sample_index_order"
-  depends_on = [
-    "datadog_logs_index.sample_index"
-  ]
+
   indexes = [
-    "${datadog_logs_index.sample_index.id}"
+    datadog_logs_index.sample_index.id
   ]
 }
 ```

--- a/docs/resources/logs_pipeline_order.md
+++ b/docs/resources/logs_pipeline_order.md
@@ -15,13 +15,10 @@ Provides a Datadog Logs Pipeline API resource, which is used to manage Datadog l
 ```terraform
 resource "datadog_logs_pipeline_order" "sample_pipeline_order" {
   name = "sample_pipeline_order"
-  depends_on = [
-    "datadog_logs_custom_pipeline.sample_pipeline",
-    "datadog_logs_integration_pipeline.python"
-  ]
+
   pipelines = [
-    "${datadog_logs_custom_pipeline.sample_pipeline.id}",
-    "${datadog_logs_integration_pipeline.python.id}"
+    datadog_logs_custom_pipeline.sample_pipeline.id,
+    datadog_logs_integration_pipeline.python.id
   ]
 }
 ```

--- a/examples/resources/datadog_dashboard_list/resource.tf
+++ b/examples/resources/datadog_dashboard_list/resource.tf
@@ -1,10 +1,5 @@
 # Create a new Dashboard List with two Dashboards
 resource "datadog_dashboard_list" "new_list" {
-  depends_on = [
-    datadog_dashboard.screen,
-    datadog_dashboard.time
-  ]
-
   name = "Terraform Created List"
   dash_item {
     type    = "custom_timeboard"

--- a/examples/resources/datadog_logs_archive_order/resource.tf
+++ b/examples/resources/datadog_logs_archive_order/resource.tf
@@ -1,6 +1,6 @@
 resource "datadog_logs_archive_order" "sample_archive_order" {
   archive_ids = [
-    "${datadog_logs_archive.sample_archive_1.id}",
-    "${datadog_logs_archive.sample_archive_2.id}"
+    datadog_logs_archive.sample_archive_1.id,
+    datadog_logs_archive.sample_archive_2.id
   ]
 }

--- a/examples/resources/datadog_logs_index_order/resource.tf
+++ b/examples/resources/datadog_logs_index_order/resource.tf
@@ -1,9 +1,7 @@
 resource "datadog_logs_index_order" "sample_index_order" {
   name = "sample_index_order"
-  depends_on = [
-    "datadog_logs_index.sample_index"
-  ]
+
   indexes = [
-    "${datadog_logs_index.sample_index.id}"
+    datadog_logs_index.sample_index.id
   ]
 }

--- a/examples/resources/datadog_logs_pipeline_order/resource.tf
+++ b/examples/resources/datadog_logs_pipeline_order/resource.tf
@@ -1,12 +1,9 @@
 resource "datadog_logs_pipeline_order" "sample_pipeline_order" {
   name = "sample_pipeline_order"
-  depends_on = [
-    "datadog_logs_custom_pipeline.sample_pipeline",
-    "datadog_logs_integration_pipeline.python"
-  ]
+
   pipelines = [
-    "${datadog_logs_custom_pipeline.sample_pipeline.id}",
-    "${datadog_logs_integration_pipeline.python.id}"
+    datadog_logs_custom_pipeline.sample_pipeline.id,
+    datadog_logs_integration_pipeline.python.id
   ]
 }
 


### PR DESCRIPTION
Follow up to: https://github.com/DataDog/terraform-provider-datadog/pull/1271