### PR TITLE
[datadog_user] Match existing users based on email

### DIFF
--- a/datadog/resource_datadog_user.go
+++ b/datadog/resource_datadog_user.go
@@ -170,8 +170,8 @@ func resourceDatadogUserCreate(ctx context.Context, d *schema.ResourceData, meta
 		}
 		email := d.Get("email").(string)
 		log.Printf("[INFO] Updating existing Datadog user %s", email)
-		
-		var existingUser datadogV2.User
+
+		var existingUser *datadogV2.User
 		// Find user ID by listing user and filtering by email
 		listResponse, _, err := datadogClientV2.UsersApi.ListUsers(authV2,
 			*datadogV2.NewListUsersOptionalParameters().WithFilter(email))
@@ -185,13 +185,15 @@ func resourceDatadogUserCreate(ctx context.Context, d *schema.ResourceData, meta
 		if len(responseData) > 1 {
 			for _, user := range responseData {
 				if user.Attributes.GetEmail() == email {
-					existingUser = user
+					existingUser = &user
 					break
 				}
+			}
+			if existingUser == nil {
 				return diag.Errorf("could not find single user with email %s", email)
 			}
 		} else {
-			existingUser = responseData[0]
+			existingUser = &responseData[0]
 		}
 
 		userID = existingUser.GetId()


### PR DESCRIPTION
The ListUsers endpoints filter attribute filters both on `email` and `name`. In this case we should match the results based on email and use that corresponding user. See https://datadoghq.atlassian.net/browse/WEBPS-3876 