### PR TITLE
[monitor] Update docs for restricted_roles.

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -256,8 +256,7 @@ func resourceDatadogMonitor() *schema.Resource {
 				},
 			},
 			"restricted_roles": {
-				// Uncomment when generally available
-				// Description: "A list of role identifiers to associate with the monitor. Cannot be used with `locked`.",
+				Description:   "A list of unique role identifiers to define which roles are allowed to edit the monitor. Editing a monitor includes any updates to the monitor configuration, monitor deletion, and muting of the monitor for any amount of time. Roles unique identifiers can be pulled from the [Roles API](https://docs.datadoghq.com/api/latest/roles/#list-roles) in the `data.id` field.",
 				Type:          schema.TypeSet,
 				Optional:      true,
 				Elem:          &schema.Schema{Type: schema.TypeString},

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -82,7 +82,7 @@ We recommend at least 2x the monitor timeframe for metric alerts or 2 minutes fo
 - **require_full_window** (Boolean) A boolean indicating whether this monitor needs a full window of data before it's evaluated.
 
 We highly recommend you set this to `false` for sparse metrics, otherwise some evaluations will be skipped. Default: `true` for `on average`, `at all times` and `in total` aggregation. `false` otherwise.
-- **restricted_roles** (Set of String)
+- **restricted_roles** (Set of String) A list of unique role identifiers to define which roles are allowed to edit the monitor. Editing a monitor includes any updates to the monitor configuration, monitor deletion, and muting of the monitor for any amount of time. Roles unique identifiers can be pulled from the [Roles API](https://docs.datadoghq.com/api/latest/roles/#list-roles) in the `data.id` field.
 - **tags** (Set of String) A list of tags to associate with your monitor. This can help you categorize and filter monitors in the manage monitors page of the UI. Note: it's not currently possible to filter by these tags when querying via the API
 - **timeout_h** (Number) The number of hours of the monitor not reporting data before it will automatically resolve from a triggered state.
 - **validate** (Boolean) If set to `false`, skip the validation call done during plan.


### PR DESCRIPTION
`restricted_roles` are now generally available via the API for all customers. This updates the terraform docs to match how we (will) document it in the API docs.

