### PR TITLE
[datadog_monitor] Mark locked as deprecated

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -246,6 +246,7 @@ func resourceDatadogMonitor() *schema.Resource {
 				Description:   "A boolean indicating whether changes to this monitor should be restricted to the creator or admins. Defaults to `false`.",
 				Type:          schema.TypeBool,
 				Optional:      true,
+				Deprecated:    "Use `restricted_roles`.",
 				ConflictsWith: []string{"restricted_roles"},
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					// if restricted_roles is defined, ignore locked

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -63,7 +63,7 @@ For example, if the value is set to `300` (5min), the `timeframe` is set to `las
 - **force_delete** (Boolean) A boolean indicating whether this monitor can be deleted even if it’s referenced by other resources (e.g. SLO, composite monitor).
 - **groupby_simple_monitor** (Boolean) Whether or not to trigger one alert if any source breaches a threshold. This is only used by log monitors. Defaults to `false`.
 - **include_tags** (Boolean) A boolean indicating whether notifications from this monitor automatically insert its triggering tags into the title. Defaults to `true`.
-- **locked** (Boolean) A boolean indicating whether changes to this monitor should be restricted to the creator or admins. Defaults to `false`.
+- **locked** (Boolean, Deprecated) A boolean indicating whether changes to this monitor should be restricted to the creator or admins. Defaults to `false`. **Deprecated.** Use `restricted_roles`.
 - **monitor_threshold_windows** (Block List, Max: 1) A mapping containing `recovery_window` and `trigger_window` values, e.g. `last_15m` . Can only be used for, and are required for, anomaly monitors. (see [below for nested schema](#nestedblock--monitor_threshold_windows))
 - **monitor_thresholds** (Block List, Max: 1) Alert thresholds of the monitor. (see [below for nested schema](#nestedblock--monitor_thresholds))
 - **new_group_delay** (Number) The time (in seconds) to skip evaluations for new groups.


### PR DESCRIPTION
With monitor restricted roles being GA, this marks the previous locked as deprecated.

@DataDog/monitor-app 