### PR TITLE
[Synthetics] Remove unparsed check for `datadog_synthetics_test` data source

### DIFF
--- a/datadog/data_source_datadog_synthetics_test_.go
+++ b/datadog/data_source_datadog_synthetics_test_.go
@@ -51,9 +51,6 @@ func dataSourceDatadogSyntheticsTestRead(ctx context.Context, d *schema.Resource
 	if err != nil {
 		return utils.TranslateClientErrorDiag(err, httpresp, "error getting synthetic tests")
 	}
-	if err := utils.CheckForUnparsed(tests); err != nil {
-		return diag.FromErr(err)
-	}
 
 	searchedId := d.Get("test_id").(string)
 


### PR DESCRIPTION
Because of this https://github.com/DataDog/terraform-provider-datadog/issues/1335, older tests can break this data source, so we remove the check for unparsed objects.