### PR TITLE
[resource_datadog_metric_metadata] Clarify supported metric types

### DIFF
--- a/datadog/resource_datadog_metric_metadata.go
+++ b/datadog/resource_datadog_metric_metadata.go
@@ -28,7 +28,7 @@ func resourceDatadogMetricMetadata() *schema.Resource {
 				Required:    true,
 			},
 			"type": {
-				Description: "Type of the metric.",
+				Description: "Metric type such as `gauge` or `rate`.",
 				Type:        schema.TypeString,
 				Optional:    true,
 			},

--- a/docs/resources/metric_metadata.md
+++ b/docs/resources/metric_metadata.md
@@ -42,3 +42,5 @@ resource "datadog_metric_metadata" "request_time" {
 ### Read-Only
 
 - **id** (String) The ID of this resource.
+
+

--- a/docs/resources/metric_metadata.md
+++ b/docs/resources/metric_metadata.md
@@ -36,11 +36,9 @@ resource "datadog_metric_metadata" "request_time" {
 - **per_unit** (String) Per unit of the metric such as `second` in `bytes per second`.
 - **short_name** (String) A short name of the metric.
 - **statsd_interval** (Number) If applicable, statsd flush interval in seconds for the metric.
-- **type** (String) Type of the metric.
+- **type** (String) Metric type such as `gauge` or `rate`.
 - **unit** (String) Primary unit of the metric such as `byte` or `operation`.
 
 ### Read-Only
 
 - **id** (String) The ID of this resource.
-
-


### PR DESCRIPTION
Clarify supported metric types, `gauge`, `rate` on the `resource_datadog_metric_metadata` document.
`resource_datadog_metric_metadata` depends on [Edit metric metadata](https://docs.datadoghq.com/api/latest/metrics/#edit-metric-metadata), so metric types must be `gauge` or `rate`. That should be documented.
![Metrics 2022-04-04 at 2 14 21 PM](https://user-images.githubusercontent.com/41987730/161479171-7383074e-7598-4c3c-8a17-04f1ab9d2843.jpg)

