### PR TITLE
[datadog_security_monitoring_rule] Add default for aggregation

### DIFF
--- a/datadog/resource_datadog_security_monitoring_rule.go
+++ b/datadog/resource_datadog_security_monitoring_rule.go
@@ -182,6 +182,7 @@ func datadogSecurityMonitoringRuleSchema() map[string]*schema.Schema {
 						ValidateDiagFunc: validators.ValidateEnumValue(datadogV2.NewSecurityMonitoringRuleQueryAggregationFromValue),
 						Optional:         true,
 						Description:      "The aggregation type.",
+						Default:          datadogV2.SECURITYMONITORINGRULEQUERYAGGREGATION_COUNT,
 					},
 					"distinct_fields": {
 						Type:        schema.TypeList,


### PR DESCRIPTION
Adds a default of "count" for the aggregation in queries in security
rules. The previous default was an empty string, which caused a
validation error at the API level.
This change makes sure we're using the same default as the web app.