### PR TITLE
Add documentation on limits for Monitors timeout_h option

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -232,7 +232,7 @@ func resourceDatadogMonitor() *schema.Resource {
 				Optional:    true,
 			},
 			"timeout_h": {
-				Description: "The number of hours of the monitor not reporting data before it will automatically resolve from a triggered state.",
+				Description: "The number of hours of the monitor not reporting data before it automatically resolves from a triggered state. The minimum allowed value is 0 hours. The maximum allowed value is 24 hours.",
 				Type:        schema.TypeInt,
 				Optional:    true,
 			},

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -84,7 +84,7 @@ We recommend at least 2x the monitor timeframe for metric alerts or 2 minutes fo
 We highly recommend you set this to `false` for sparse metrics, otherwise some evaluations will be skipped. Default: `true` for `on average`, `at all times` and `in total` aggregation. `false` otherwise.
 - **restricted_roles** (Set of String) A list of unique role identifiers to define which roles are allowed to edit the monitor. Editing a monitor includes any updates to the monitor configuration, monitor deletion, and muting of the monitor for any amount of time. Roles unique identifiers can be pulled from the [Roles API](https://docs.datadoghq.com/api/latest/roles/#list-roles) in the `data.id` field.
 - **tags** (Set of String) A list of tags to associate with your monitor. This can help you categorize and filter monitors in the manage monitors page of the UI. Note: it's not currently possible to filter by these tags when querying via the API
-- **timeout_h** (Number) The number of hours of the monitor not reporting data before it will automatically resolve from a triggered state.
+- **timeout_h** (Number) The number of hours of the monitor not reporting data before it automatically resolves from a triggered state. The minimum allowed value is 0 hours. The maximum allowed value is 24 hours.
 - **validate** (Boolean) If set to `false`, skip the validation call done during plan.
 
 ### Read-Only


### PR DESCRIPTION
Update description of monitors `timeout_h` option to make it consistent with the [API](https://docs.datadoghq.com/api/latest/monitors/#create-a-monitor).