### PR TITLE
Update Monitors Terraform Resource Example

### DIFF
--- a/docs/guides/monitors.md
+++ b/docs/guides/monitors.md
@@ -37,6 +37,7 @@ resource "datadog_monitor" "watchdog_monitor" {
   renotify_interval = 60
 
   notify_audit = false
+  timeout_h    = 60
   include_tags = true
 
   tags = ["foo:bar", "baz"]
@@ -51,16 +52,16 @@ resource "datadog_monitor" "cpu_anomalous" {
   type    = "query alert"
   message = "CPU utilization is outside normal bounds"
   query   = "avg(last_4h):anomalies(ewma_20(avg:system.cpu.system{env:prod,service:website}.as_rate()), 'robust', 3, direction='below', alert_window='last_30m', interval=60, count_default_zero='true', seasonality='weekly') >= 1"
-  
   monitor_thresholds {
-    critical          = 1.0x
+    critical          = 1.0
+    critical_recovery = 0.0
   }
-
   monitor_threshold_windows {
     trigger_window  = "last_30m"
     recovery_window = "last_30m"
   }
 
+  notify_no_data    = false
   renotify_interval = 60
 }
 ```
@@ -73,11 +74,12 @@ resource "datadog_monitor" "process_alert_example" {
   type    = "process alert"
   message = "Multiple Java processes running on example-tag"
   query   = "processes('java').over('example-tag').rollup('count').last('10m') > 1"
-
   monitor_thresholds {
     critical          = 1.0
+    critical_recovery = 0.0
   }
 
+  notify_no_data    = false
   renotify_interval = 60
 }
 ```

--- a/docs/guides/monitors.md
+++ b/docs/guides/monitors.md
@@ -37,7 +37,6 @@ resource "datadog_monitor" "watchdog_monitor" {
   renotify_interval = 60
 
   notify_audit = false
-  timeout_h    = 60
   include_tags = true
 
   tags = ["foo:bar", "baz"]
@@ -52,16 +51,16 @@ resource "datadog_monitor" "cpu_anomalous" {
   type    = "query alert"
   message = "CPU utilization is outside normal bounds"
   query   = "avg(last_4h):anomalies(ewma_20(avg:system.cpu.system{env:prod,service:website}.as_rate()), 'robust', 3, direction='below', alert_window='last_30m', interval=60, count_default_zero='true', seasonality='weekly') >= 1"
+  
   monitor_thresholds {
-    critical          = 1.0
-    critical_recovery = 0.0
+    critical          = 1.0x
   }
+
   monitor_threshold_windows {
     trigger_window  = "last_30m"
     recovery_window = "last_30m"
   }
 
-  notify_no_data    = false
   renotify_interval = 60
 }
 ```
@@ -74,12 +73,11 @@ resource "datadog_monitor" "process_alert_example" {
   type    = "process alert"
   message = "Multiple Java processes running on example-tag"
   query   = "processes('java').over('example-tag').rollup('count').last('10m') > 1"
+
   monitor_thresholds {
     critical          = 1.0
-    critical_recovery = 0.0
   }
 
-  notify_no_data    = false
   renotify_interval = 60
 }
 ```

--- a/docs/guides/monitors.md
+++ b/docs/guides/monitors.md
@@ -36,8 +36,6 @@ resource "datadog_monitor" "watchdog_monitor" {
   notify_no_data    = false
   renotify_interval = 60
 
-  notify_audit = false
-  timeout_h    = 60
   include_tags = true
 
   tags = ["foo:bar", "baz"]
@@ -54,14 +52,12 @@ resource "datadog_monitor" "cpu_anomalous" {
   query   = "avg(last_4h):anomalies(ewma_20(avg:system.cpu.system{env:prod,service:website}.as_rate()), 'robust', 3, direction='below', alert_window='last_30m', interval=60, count_default_zero='true', seasonality='weekly') >= 1"
   monitor_thresholds {
     critical          = 1.0
-    critical_recovery = 0.0
   }
   monitor_threshold_windows {
     trigger_window  = "last_30m"
     recovery_window = "last_30m"
   }
 
-  notify_no_data    = false
   renotify_interval = 60
 }
 ```
@@ -76,10 +72,8 @@ resource "datadog_monitor" "process_alert_example" {
   query   = "processes('java').over('example-tag').rollup('count').last('10m') > 1"
   monitor_thresholds {
     critical          = 1.0
-    critical_recovery = 0.0
   }
 
-  notify_no_data    = false
   renotify_interval = 60
 }
 ```

--- a/docs/guides/monitors.md
+++ b/docs/guides/monitors.md
@@ -33,9 +33,6 @@ resource "datadog_monitor" "watchdog_monitor" {
 
   query = "events('priority:all sources:watchdog tags:story_type:service,env:test_env,service:test_service:_aggregate').by('service,resource_name').rollup('count').last('30m') > 0"
 
-  notify_no_data    = false
-  renotify_interval = 60
-
   include_tags = true
 
   tags = ["foo:bar", "baz"]
@@ -50,9 +47,11 @@ resource "datadog_monitor" "cpu_anomalous" {
   type    = "query alert"
   message = "CPU utilization is outside normal bounds"
   query   = "avg(last_4h):anomalies(ewma_20(avg:system.cpu.system{env:prod,service:website}.as_rate()), 'robust', 3, direction='below', alert_window='last_30m', interval=60, count_default_zero='true', seasonality='weekly') >= 1"
+
   monitor_thresholds {
-    critical          = 1.0
+    critical = 1.0
   }
+
   monitor_threshold_windows {
     trigger_window  = "last_30m"
     recovery_window = "last_30m"
@@ -70,8 +69,9 @@ resource "datadog_monitor" "process_alert_example" {
   type    = "process alert"
   message = "Multiple Java processes running on example-tag"
   query   = "processes('java').over('example-tag').rollup('count').last('10m') > 1"
+
   monitor_thresholds {
-    critical          = 1.0
+    critical = 1.0
   }
 
   renotify_interval = 60

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -20,16 +20,22 @@ resource "datadog_monitor" "foo" {
   message            = "Monitor triggered. Notify: @hipchat-channel"
   escalation_message = "Escalation message @pagerduty"
 
-  query = "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:bar} by {host} > 4"
+  query = "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host} > 4"
 
   monitor_thresholds {
     warning           = 2
+    warning_recovery  = 1
     critical          = 4
+    critical_recovery = 3
   }
 
-  notify_audit = false
+  notify_no_data    = false
+  renotify_interval = 60
 
-  tags = ["foo:bar", "team:fooBar"]
+  notify_audit = false
+  include_tags = true
+
+  tags = ["foo:bar", "baz"]
 }
 ```
 

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -13,18 +13,17 @@ Provides a Datadog monitor resource. This can be used to create and manage Datad
 ## Example Usage
 
 ```terraform
-# Create a new Datadog monitor
 resource "datadog_monitor" "foo" {
   name               = "Name for monitor foo"
   type               = "metric alert"
   message            = "Monitor triggered. Notify: @hipchat-channel"
   escalation_message = "Escalation message @pagerduty"
 
-  query = "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:bar} by {host} > 4"
+  query = "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host} > 4"
 
   monitor_thresholds {
-    warning           = 2
-    critical          = 4
+    warning  = 2
+    critical = 4
   }
 
   include_tags = true

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -20,22 +20,16 @@ resource "datadog_monitor" "foo" {
   message            = "Monitor triggered. Notify: @hipchat-channel"
   escalation_message = "Escalation message @pagerduty"
 
-  query = "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host} > 4"
+  query = "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:bar} by {host} > 4"
 
   monitor_thresholds {
     warning           = 2
-    warning_recovery  = 1
     critical          = 4
-    critical_recovery = 3
   }
 
-  notify_no_data    = false
-  renotify_interval = 60
-
   notify_audit = false
-  include_tags = true
 
-  tags = ["foo:bar", "baz"]
+  tags = ["foo:bar", "team:fooBar"]
 }
 ```
 

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -20,22 +20,16 @@ resource "datadog_monitor" "foo" {
   message            = "Monitor triggered. Notify: @hipchat-channel"
   escalation_message = "Escalation message @pagerduty"
 
-  query = "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host} > 4"
+  query = "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:bar} by {host} > 4"
 
   monitor_thresholds {
     warning           = 2
-    warning_recovery  = 1
     critical          = 4
-    critical_recovery = 3
   }
 
-  notify_no_data    = false
-  renotify_interval = 60
-
-  notify_audit = false
   include_tags = true
 
-  tags = ["foo:bar", "baz"]
+  tags = ["foo:bar", "team:fooBar"]
 }
 ```
 

--- a/examples/guides/anomaly_monitor.tf
+++ b/examples/guides/anomaly_monitor.tf
@@ -3,15 +3,15 @@ resource "datadog_monitor" "cpu_anomalous" {
   type    = "query alert"
   message = "CPU utilization is outside normal bounds"
   query   = "avg(last_4h):anomalies(ewma_20(avg:system.cpu.system{env:prod,service:website}.as_rate()), 'robust', 3, direction='below', alert_window='last_30m', interval=60, count_default_zero='true', seasonality='weekly') >= 1"
+
   monitor_thresholds {
-    critical          = 1.0
-    critical_recovery = 0.0
+    critical = 1.0
   }
+
   monitor_threshold_windows {
     trigger_window  = "last_30m"
     recovery_window = "last_30m"
   }
 
-  notify_no_data    = false
   renotify_interval = 60
 }

--- a/examples/guides/process_monitor.tf
+++ b/examples/guides/process_monitor.tf
@@ -3,11 +3,10 @@ resource "datadog_monitor" "process_alert_example" {
   type    = "process alert"
   message = "Multiple Java processes running on example-tag"
   query   = "processes('java').over('example-tag').rollup('count').last('10m') > 1"
+
   monitor_thresholds {
-    critical          = 1.0
-    critical_recovery = 0.0
+    critical = 1.0
   }
 
-  notify_no_data    = false
   renotify_interval = 60
 }

--- a/examples/guides/watchdog_monitor.tf
+++ b/examples/guides/watchdog_monitor.tf
@@ -6,11 +6,6 @@ resource "datadog_monitor" "watchdog_monitor" {
 
   query = "events('priority:all sources:watchdog tags:story_type:service,env:test_env,service:test_service:_aggregate').by('service,resource_name').rollup('count').last('30m') > 0"
 
-  notify_no_data    = false
-  renotify_interval = 60
-
-  notify_audit = false
-  timeout_h    = 60
   include_tags = true
 
   tags = ["foo:bar", "baz"]

--- a/examples/resources/datadog_monitor/resource.tf
+++ b/examples/resources/datadog_monitor/resource.tf
@@ -1,4 +1,3 @@
-# Create a new Datadog monitor
 resource "datadog_monitor" "foo" {
   name               = "Name for monitor foo"
   type               = "metric alert"
@@ -8,17 +7,11 @@ resource "datadog_monitor" "foo" {
   query = "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host} > 4"
 
   monitor_thresholds {
-    warning           = 2
-    warning_recovery  = 1
-    critical          = 4
-    critical_recovery = 3
+    warning  = 2
+    critical = 4
   }
 
-  notify_no_data    = false
-  renotify_interval = 60
-
-  notify_audit = false
   include_tags = true
 
-  tags = ["foo:bar", "baz"]
+  tags = ["foo:bar", "team:fooBar"]
 }


### PR DESCRIPTION
Customers copy paste the example resource config assuming this is somewhat of a default monitor config. This PR removes unnecessary options that the customer doesn't always need immediately.

Also updates monitor resource examples in guide page.