### PR TITLE
Rename the security-monitoring Github team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,9 +26,9 @@ docs/data-sources/monitor*                @DataDog/integrations-tools-and-librar
 docs/resources/monitor*                   @DataDog/integrations-tools-and-libraries @DataDog/monitor-app @DataDog/documentation
 datadog/*datadog_screenboard*             @DataDog/integrations-tools-and-libraries @DataDog/dashboards
 docs/resources/screenboard*               @DataDog/integrations-tools-and-libraries @DataDog/dashboards @DataDog/documentation
-datadog/*security_monitoring*             @DataDog/integrations-tools-and-libraries @DataDog/security-monitoring
-docs/data-sources/security_monitoring*    @DataDog/integrations-tools-and-libraries @DataDog/security-monitoring @DataDog/documentation
-docs/resources/security_monitoring*       @DataDog/integrations-tools-and-libraries @DataDog/security-monitoring @DataDog/documentation
+datadog/*security_monitoring*             @DataDog/integrations-tools-and-libraries @DataDog/k9-cloud-security-platform
+docs/data-sources/security_monitoring*    @DataDog/integrations-tools-and-libraries @DataDog/k9-cloud-security-platform @DataDog/documentation
+docs/resources/security_monitoring*       @DataDog/integrations-tools-and-libraries @DataDog/k9-cloud-security-platform @DataDog/documentation
 datadog/*datadog_service_level_objective* @DataDog/integrations-tools-and-libraries @DataDog/monitor-app
 docs/resources/service_level_objective*   @DataDog/integrations-tools-and-libraries @DataDog/monitor-app @DataDog/documentation
 datadog/*datadog_synthetics*              @DataDog/integrations-tools-and-libraries @DataDog/synthetics-app


### PR DESCRIPTION
The new handle is `k9-cloud-security-platform`.