### PR TITLE
[Synthetics] defaults api_step timeout to 60 to avoid it defaulting to 0

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -147,6 +147,7 @@ func syntheticsTestRequest() *schema.Resource {
 				Description: "Timeout in seconds for the test. Defaults to `60`.",
 				Type:        schema.TypeInt,
 				Optional:    true,
+				Default:     60,
 			},
 			"host": {
 				Description: "Host name to perform the test with.",


### PR DESCRIPTION
If no timeout is provided, the fact that timeout is of type int makes TF changing it from nil to 0 which is then what is saved by the api. The actual default should be 60.