### PR TITLE
[Synthetics] Change documentation url for locations

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -77,7 +77,7 @@ func resourceDatadogSyntheticsTest() *schema.Resource {
 				},
 			},
 			"locations": {
-				Description: "Array of locations used to run the test. Refer to [Datadog documentation](https://docs.datadoghq.com/synthetics/api_test/#request) for available locations (e.g. `aws:eu-central-1`).",
+				Description: "Array of locations used to run the test. Refer to [the Datadog Synthetics location data source](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/data-sources/synthetics_locations) to retrieve the list of locations.",
 				Type:        schema.TypeSet,
 				Required:    true,
 				Elem: &schema.Schema{

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -276,7 +276,7 @@ resource "datadog_synthetics_test" "test_browser" {
 
 ### Required
 
-- `locations` (Set of String) Array of locations used to run the test. Refer to [Datadog documentation](https://docs.datadoghq.com/synthetics/api_test/#request) for available locations (e.g. `aws:eu-central-1`).
+- `locations` (Set of String) Array of locations used to run the test. Refer to [the Datadog Synthetics location data source](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/data-sources/synthetics_locations) to retrieve the list of locations.
 - `name` (String) Name of Datadog synthetics test.
 - `status` (String) Define whether you want to start (`live`) or pause (`paused`) a Synthetic test. Valid values are `live`, `paused`.
 - `type` (String) Synthetics test type. Valid values are `api`, `browser`.


### PR DESCRIPTION
The documentation linked for locations is not clear, change it for the data source so the user can have a better idea of the locations they can use.