### PR TITLE
[datadog_security_monitoring_default_rule] Add missing schema attribute `type`

### DIFF
--- a/datadog/resource_datadog_security_monitoring_default_rule.go
+++ b/datadog/resource_datadog_security_monitoring_default_rule.go
@@ -92,6 +92,12 @@ func resourceDatadogSecurityMonitoringDefaultRule() *schema.Resource {
 					},
 				},
 			},
+
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The rule type.",
+			},
 		},
 	}
 }
@@ -149,6 +155,8 @@ func resourceDatadogSecurityMonitoringDefaultRuleRead(ctx context.Context, d *sc
 	}
 
 	d.Set("filter", ruleFilters)
+
+	d.Set("type", ruleResponse.GetType())
 
 	responseOptions := ruleResponse.GetOptions()
 	ruleOptions := []map[string]interface{}{{

--- a/docs/resources/security_monitoring_default_rule.md
+++ b/docs/resources/security_monitoring_default_rule.md
@@ -37,6 +37,7 @@ resource "datadog_security_monitoring_default_rule" "adefaultrule" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `type` (String) The rule type.
 
 <a id="nestedblock--case"></a>
 ### Nested Schema for `case`


### PR DESCRIPTION
Closes: https://github.com/DataDog/terraform-provider-datadog/issues/1578