### PR TITLE
[datadog_security_monitoring] Update security-monitoring to use new api format

### DIFF
--- a/datadog/data_source_datadog_security_monitoring_rules.go
+++ b/datadog/data_source_datadog_security_monitoring_rules.go
@@ -121,7 +121,12 @@ func dataSourceDatadogSecurityMonitoringRulesRead(ctx context.Context, d *schema
 			return diag.FromErr(err)
 		}
 
-		for _, rule := range response.GetData() {
+		for _, ruleR := range response.GetData() {
+			if ruleR.SecurityMonitoringStandardRuleResponse == nil {
+				continue
+			}
+
+			rule := ruleR.SecurityMonitoringStandardRuleResponse
 			if !matchesSecMonRuleFilters(rule, nameFilter, defaultFilter, tagFilter) {
 				continue
 			}
@@ -180,7 +185,7 @@ func computeSecMonDataSourceRulesID(nameFilter *string, defaultFilter *bool, tag
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
-func buildSecurityMonitoringTfRule(rule datadogV2.SecurityMonitoringRuleResponse) map[string]interface{} {
+func buildSecurityMonitoringTfRule(rule *datadogV2.SecurityMonitoringStandardRuleResponse) map[string]interface{} {
 	tfRule := make(map[string]interface{})
 
 	cases := make([]map[string]interface{}, len(rule.GetCases()))
@@ -242,7 +247,7 @@ func buildSecurityMonitoringTfRule(rule datadogV2.SecurityMonitoringRuleResponse
 }
 
 func matchesSecMonRuleFilters(
-	rule datadogV2.SecurityMonitoringRuleResponse,
+	rule *datadogV2.SecurityMonitoringStandardRuleResponse,
 	nameFilter *string,
 	defaultFilter *bool,
 	tagFilter map[string]bool) bool {

--- a/datadog/resource_datadog_security_monitoring_rule.go
+++ b/datadog/resource_datadog_security_monitoring_rule.go
@@ -2,6 +2,7 @@ package datadog
 
 import (
 	"context"
+
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
 

--- a/datadog/tests/data_source_datadog_security_monitoring_rules_test.go
+++ b/datadog/tests/data_source_datadog_security_monitoring_rules_test.go
@@ -100,7 +100,11 @@ func securityMonitoringCheckRuleCountNameFilter(accProvider func() (*schema.Prov
 
 		ruleCount := 0
 		for _, rule := range *allRules {
-			if strings.Contains(rule.GetName(), name) {
+			if rule.SecurityMonitoringStandardRuleResponse == nil {
+				continue
+			}
+
+			if strings.Contains(rule.SecurityMonitoringStandardRuleResponse.GetName(), name) {
 				ruleCount++
 			}
 		}
@@ -120,7 +124,11 @@ func securityMonitoringCheckRuleCountTagsFilter(accProvider func() (*schema.Prov
 
 		ruleCount := 0
 		for _, rule := range *allRules {
-			for _, tag := range rule.GetTags() {
+			if rule.SecurityMonitoringStandardRuleResponse == nil {
+				continue
+			}
+
+			for _, tag := range rule.SecurityMonitoringStandardRuleResponse.GetTags() {
 				if strings.Contains(tag, filterTag) {
 					ruleCount++
 				}
@@ -141,7 +149,11 @@ func securityMonitoringCheckRuleCountDefaultFilter(accProvider func() (*schema.P
 
 		ruleCount := 0
 		for _, rule := range *allRules {
-			if rule.GetIsDefault() == isDefault {
+			if rule.SecurityMonitoringStandardRuleResponse == nil {
+				continue
+			}
+
+			if rule.SecurityMonitoringStandardRuleResponse.GetIsDefault() == isDefault {
 				ruleCount++
 			}
 		}

--- a/docs/resources/security_monitoring_rule.md
+++ b/docs/resources/security_monitoring_rule.md
@@ -96,7 +96,7 @@ Required:
 Optional:
 
 - `agent_rule` (Block List, Deprecated) **Deprecated**. It won't be applied anymore. **Deprecated.** `agent_rule` has been deprecated in favor of new Agent Rule resource. (see [below for nested schema](#nestedblock--query--agent_rule))
-- `aggregation` (String) The aggregation type. Valid values are `count`, `cardinality`, `sum`, `max`, `new_value`, `geo_data`.
+- `aggregation` (String) The aggregation type. Valid values are `count`, `cardinality`, `sum`, `max`, `new_value`, `geo_data`, `event_count`.
 - `distinct_fields` (List of String) Field for which the cardinality is measured. Sent as an array.
 - `group_by_fields` (List of String) Fields to group by.
 - `metric` (String) The target field to aggregate over when using the `sum`, `max`, or `new_value` aggregations.

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-datadog
 
 require (
-	github.com/DataDog/datadog-api-client-go/v2 v2.2.1-0.20220912161001-91d6ffb4d0dd
+	github.com/DataDog/datadog-api-client-go/v2 v2.3.1-0.20220927131516-5670becf79ac
 	github.com/DataDog/dd-sdk-go-testing v0.0.0-20211116174033-1cd082e322ad
 	github.com/dnaeon/go-vcr v1.0.1
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-datadog
 
 require (
-	github.com/DataDog/datadog-api-client-go/v2 v2.3.1-0.20220927131516-5670becf79ac
+	github.com/DataDog/datadog-api-client-go/v2 v2.3.1
 	github.com/DataDog/dd-sdk-go-testing v0.0.0-20211116174033-1cd082e322ad
 	github.com/dnaeon/go-vcr v1.0.1
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/datadog-api-client-go/v2 v2.2.1-0.20220912161001-91d6ffb4d0dd h1:w8gZX+jeqRf10W32Ri69NO0DPJ/rAU9atOxLacZIkyY=
-github.com/DataDog/datadog-api-client-go/v2 v2.2.1-0.20220912161001-91d6ffb4d0dd/go.mod h1:98b/MtTwSAr/yhTfhCR1oxAqQ/4tMkdrgKH7fYiDA0g=
+github.com/DataDog/datadog-api-client-go/v2 v2.3.1-0.20220927131516-5670becf79ac h1:0OZHmHgGPrTBEm2eqCl0ifUgMSQgLAXZLNsYgAzuxhU=
+github.com/DataDog/datadog-api-client-go/v2 v2.3.1-0.20220927131516-5670becf79ac/go.mod h1:98b/MtTwSAr/yhTfhCR1oxAqQ/4tMkdrgKH7fYiDA0g=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/datadog-api-client-go/v2 v2.3.1-0.20220927131516-5670becf79ac h1:0OZHmHgGPrTBEm2eqCl0ifUgMSQgLAXZLNsYgAzuxhU=
-github.com/DataDog/datadog-api-client-go/v2 v2.3.1-0.20220927131516-5670becf79ac/go.mod h1:98b/MtTwSAr/yhTfhCR1oxAqQ/4tMkdrgKH7fYiDA0g=
+github.com/DataDog/datadog-api-client-go/v2 v2.3.1 h1:+0FHme5n4AuJEGmzaN8+n3OWKFLiJoBP+FNI60EqvuU=
+github.com/DataDog/datadog-api-client-go/v2 v2.3.1/go.mod h1:98b/MtTwSAr/yhTfhCR1oxAqQ/4tMkdrgKH7fYiDA0g=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=


### PR DESCRIPTION
There will be a separate PR to introduce support for signal correlation rule type since it requires schema changes. 