### PR TITLE
[datadog_synthetics_test] Add missing disable_cors option

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -583,6 +583,11 @@ func syntheticsTestOptionsList() *schema.Schema {
 					Type:        schema.TypeBool,
 					Optional:    true,
 				},
+				"disable_cors": {
+					Description: "Disable Cross-Origin Resource Sharing for browser tests.",
+					Type:        schema.TypeBool,
+					Optional:    true,
+				},
 				"initial_navigation_timeout": {
 					Description: "Timeout before declaring the initial step as failed (in seconds) for browser tests.",
 					Type:        schema.TypeInt,
@@ -1934,6 +1939,10 @@ func buildSyntheticsBrowserTestStruct(d *schema.ResourceData) *datadogV1.Synthet
 			options.SetDisableCsp(disableCsp.(bool))
 		}
 
+		if disableCors, ok := d.GetOk("options_list.0.disable_cors"); ok {
+			options.SetDisableCors(disableCors.(bool))
+		}
+
 		if initialNavigationTimeout, ok := d.GetOk("options_list.0.initial_navigation_timeout"); ok {
 			options.SetInitialNavigationTimeout(int64(initialNavigationTimeout.(int)))
 		}
@@ -2432,6 +2441,9 @@ func updateSyntheticsBrowserTestLocalState(d *schema.ResourceData, syntheticsTes
 	}
 	if actualOptions.HasDisableCsp() {
 		localOptionsList["disable_csp"] = actualOptions.GetDisableCsp()
+	}
+	if actualOptions.HasDisableCors() {
+		localOptionsList["disable_cors"] = actualOptions.GetDisableCors()
 	}
 	if actualOptions.HasInitialNavigationTimeout() {
 		localOptionsList["initial_navigation_timeout"] = actualOptions.GetInitialNavigationTimeout()

--- a/datadog/tests/resource_datadog_synthetics_test_test.go
+++ b/datadog/tests/resource_datadog_synthetics_test_test.go
@@ -2344,7 +2344,7 @@ resource "datadog_synthetics_test" "bar" {
 
 		ignore_server_certificate_error = true
 		disable_csp = true
-        disable_cors = true
+		disable_cors = true
 		initial_navigation_timeout = 150
 	}
 

--- a/datadog/tests/resource_datadog_synthetics_test_test.go
+++ b/datadog/tests/resource_datadog_synthetics_test_test.go
@@ -2230,6 +2230,8 @@ func createSyntheticsBrowserTestStep(ctx context.Context, accProvider func() (*s
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.bar", "options_list.0.disable_csp", "true"),
 			resource.TestCheckResourceAttr(
+				"datadog_synthetics_test.bar", "options_list.0.disable_cors", "true"),
+			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.bar", "options_list.0.initial_navigation_timeout", "150"),
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.bar", "name", testName),
@@ -2342,6 +2344,7 @@ resource "datadog_synthetics_test" "bar" {
 
 		ignore_server_certificate_error = true
 		disable_csp = true
+        disable_cors = true
 		initial_navigation_timeout = 150
 	}
 

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -619,6 +619,7 @@ Optional:
 - `check_certificate_revocation` (Boolean) For SSL test, whether or not the test should fail on revoked certificate in stapled OCSP.
 - `ci` (Block List, Max: 1) CI/CD options for a Synthetic test. (see [below for nested schema](#nestedblock--options_list--ci))
 - `disable_csp` (Boolean) Disable Content Security Policy for browser tests.
+- `disable_cors` (Boolean) Disable Cross-Origin Resource Sharing for browser tests.
 - `follow_redirects` (Boolean) Determines whether or not the API HTTP test should follow redirects.
 - `ignore_server_certificate_error` (Boolean) Ignore server certificate error.
 - `initial_navigation_timeout` (Number) Timeout before declaring the initial step as failed (in seconds) for browser tests.


### PR DESCRIPTION
Add support for  `disable_cors` option for Synthetics tests.

Fixes #1602 