### PR TITLE
[logs_metrics] add nil check to Logs Metrics getGroupBys

### DIFF
--- a/datadog/resource_datadog_logs_metric.go
+++ b/datadog/resource_datadog_logs_metric.go
@@ -158,8 +158,10 @@ func getFilter(d *schema.ResourceData) (*datadogV2.LogsMetricFilter, error) {
 func getGroupBys(d *schema.ResourceData) ([]datadogV2.LogsMetricGroupBy, error) {
 	resourceGroupBys := d.Get("group_by").([]interface{})
 	groupBys := make([]datadogV2.LogsMetricGroupBy, len(resourceGroupBys))
-
 	for i, v := range resourceGroupBys {
+		if v == nil {
+			continue
+		}
 		resourceGroupBy := v.(map[string]interface{})
 		groupBy := datadogV2.NewLogsMetricGroupByWithDefaults()
 		if path, ok := resourceGroupBy["path"]; ok {


### PR DESCRIPTION
Resolves the crash exposed in #1607 where `for_each` meta-argument results in nil `group_by` blocks.