### PR TITLE
[docs] Add Import section to datadog_dashboard_json resource

### DIFF
--- a/docs/resources/dashboard_json.md
+++ b/docs/resources/dashboard_json.md
@@ -522,4 +522,11 @@ EOF
 - `dashboard_lists_removed` (Set of Number) The list of dashboard lists this dashboard should be removed from. Internal only.
 - `id` (String) The ID of this resource.
 
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import datadog_dashboard_json.my_service_dashboard sv7-gyh-kas
+```
 


### PR DESCRIPTION
I wanted to import the contents of a dashboard of mine today and noticed that the `datadog_dashboard_json` docs didn't mention anything regarding Imports, but the code [defined an `Importer`](https://github.com/DataDog/terraform-provider-datadog/blob/d6512010cb96a2f5469b9191cd88df5d554beac5/datadog/resource_datadog_dashboard_json.go#L46).

I gave it a shot, and it worked as expected, so I'm adding a mention to these docs.