### PR TITLE
#1616 Support value `0` for `Not Defined` priority

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -495,7 +495,7 @@ func syntheticsTestOptionsList() *schema.Schema {
 				"monitor_priority": {
 					Type:         schema.TypeInt,
 					Optional:     true,
-					ValidateFunc: validation.IntBetween(1, 5),
+					ValidateFunc: validation.IntBetween(0, 5),
 				},
 				"restricted_roles": {
 					Description: "A list of role identifiers pulled from the Roles API to restrict read and write access.",


### PR DESCRIPTION
Proposed solution to address https://github.com/DataDog/terraform-provider-datadog/issues/1616