### PR TITLE
Add import documentation for datadog_dashboard_json

### DIFF
--- a/docs/resources/dashboard_json.md
+++ b/docs/resources/dashboard_json.md
@@ -522,4 +522,10 @@ EOF
 - `dashboard_lists_removed` (Set of Number) The list of dashboard lists this dashboard should be removed from. Internal only.
 - `id` (String) The ID of this resource.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import datadog_dashboard_json.my_service_dashboard sv7-gyh-kas
+```

--- a/examples/resources/datadog_dashboard_json/import.sh
+++ b/examples/resources/datadog_dashboard_json/import.sh
@@ -1,0 +1,1 @@
+terraform import datadog_dashboard_json.my_service_dashboard sv7-gyh-kas


### PR DESCRIPTION
Originally raised by #1609 , this adds the example that the docs are autogenerated from