### PR TITLE
Added support for template_variable defaults - multiple default values

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -398,6 +398,12 @@ func getTemplateVariableSchema() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "The default value for the template variable on dashboard load.",
 		},
+		"defaults": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "The default values for the template variable on dashboard load.",
+		},
 		"available_values": {
 			Type:        schema.TypeList,
 			Optional:    true,
@@ -428,6 +434,13 @@ func buildDatadogTemplateVariables(terraformTemplateVariables *[]interface{}) *[
 			}
 			datadogTemplateVariable.SetAvailableValues(availableValues)
 		}
+		if v, ok := terraformTemplateVariable["defaults"].([]interface{}); ok && len(v) > 0 {
+			defaultValues := make([]string, len(v))
+			for i, defaultValue := range v {
+				defaultValues[i] = defaultValue.(string)
+			}
+			datadogTemplateVariable.SetDefaults(defaultValues)
+		}
 		datadogTemplateVariables[i] = datadogTemplateVariable
 	}
 	return &datadogTemplateVariables
@@ -452,6 +465,13 @@ func buildTerraformTemplateVariables(datadogTemplateVariables *[]datadogV1.Dashb
 				availableValues[i] = availableValue
 			}
 			terraformTemplateVariable["available_values"] = availableValues
+		}
+		if v, ok := templateVariable.GetDefaultsOk(); ok {
+			defaultValues := make([]string, len(*v))
+			for i, defaultValue := range *v {
+				defaultValues[i] = defaultValue
+			}
+			terraformTemplateVariable["defaults"] = defaultValues
 		}
 		terraformTemplateVariables[i] = terraformTemplateVariable
 	}

--- a/datadog/tests/resource_datadog_dashboard_test.go
+++ b/datadog/tests/resource_datadog_dashboard_test.go
@@ -416,13 +416,11 @@ resource "datadog_dashboard" "ordered_dashboard" {
 	template_variable {
 		name   = "var_1"
 		prefix = "host"
-		default = "aws"
                 defaults = ["aws"]
 	}
 	template_variable {
 		name   = "var_2"
 		prefix = "service_name"
-		default = "autoscaling"
 		defaults = ["autoscaling"]
 	}
 	template_variable_preset {
@@ -469,13 +467,11 @@ resource "datadog_dashboard" "simple_dashboard" {
 	template_variable {
 		name   = "var_1"
 		prefix = "host"
-		default = "aws"
 		defaults = ["aws"]
 	}
 	template_variable {
 		name   = "var_2"
 		prefix = "service_name"
-		default = "autoscaling"
 		defaults = ["autoscaling"]
 	}
 	template_variable_preset {
@@ -648,13 +644,11 @@ resource "datadog_dashboard" "free_dashboard" {
 	template_variable {
 		name   = "var_1"
 		prefix = "host"
-		default = "aws"
 		defaults = ["aws"]
 	}
 	template_variable {
 		name   = "var_2"
 		prefix = "service_name"
-		default = "autoscaling"
 		defaults = ["autoscaling"]
 	}
 	template_variable_preset {
@@ -707,13 +701,11 @@ resource "datadog_dashboard" "simple_dashboard" {
 	template_variable {
 		name   = "var_1"
 		prefix = "host"
-		default = "aws"
 		defaults = ["aws"]
 	}
 	template_variable {
 		name   = "var_2"
 		prefix = "service_name"
-		default = "autoscaling"
 		defaults = ["autoscaling"]
 	}
 	template_variable_preset {
@@ -757,11 +749,9 @@ var datadogSimpleOrderedDashboardAsserts = []string{
 	"template_variable.# = 2",
 	"template_variable.0.name = var_1",
 	"template_variable.0.prefix = host",
-	"template_variable.0.default = aws",
 	"template_variable.0.defaults = [\"aws\"]",
 	"template_variable.1.name = var_2",
 	"template_variable.1.prefix = service_name",
-	"template_variable.1.default = autoscaling",
 	"template_variable.1.defaults = [\"autoscaling\"]",
 	"description = Created using the Datadog provider in Terraform",
 	// Template Variable Presets
@@ -796,11 +786,9 @@ var datadogSimpleFreeDashboardAsserts = []string{
 	"template_variable.# = 2",
 	"template_variable.0.name = var_1",
 	"template_variable.0.prefix = host",
-	"template_variable.0.default = aws",
 	"template_variable.0.defaults = [\"aws\"]",
 	"template_variable.1.name = var_2",
 	"template_variable.1.prefix = service_name",
-	"template_variable.1.default = autoscaling",
 	"template_variable.1.defaults = [\"autoscaling\"]",
 	"description = Created using the Datadog provider in Terraform",
 	// Template Variable Presets
@@ -1060,11 +1048,9 @@ var datadogOrderedDashboardAsserts = []string{
 	"template_variable.# = 2",
 	"template_variable.0.name = var_1",
 	"template_variable.0.prefix = host",
-	"template_variable.0.default = aws",
 	"template_variable.0.defaults = [\"aws\"]",
 	"template_variable.1.name = var_2",
 	"template_variable.1.prefix = service_name",
-	"template_variable.1.default = autoscaling",
 	"template_variable.1.defaults = [\"autoscaling\"]",
 	"description = Created using the Datadog provider in Terraform",
 
@@ -1178,11 +1164,9 @@ var datadogFreeDashboardAsserts = []string{
 	"widget.7.trace_service_definition.0.live_span = 1h",
 	// Template Variables
 	"template_variable.# = 2",
-	"template_variable.0.default = aws",
 	"template_variable.0.defaults = [\"aws\"]",
 	"template_variable.0.name = var_1",
 	"template_variable.0.prefix = host",
-	"template_variable.1.default = autoscaling",
 	"template_variable.1.defaults = [\"autoscaling\"]",
 	"template_variable.1.name = var_2",
 	"template_variable.1.prefix = service_name",

--- a/datadog/tests/resource_datadog_dashboard_test.go
+++ b/datadog/tests/resource_datadog_dashboard_test.go
@@ -417,11 +417,13 @@ resource "datadog_dashboard" "ordered_dashboard" {
 		name   = "var_1"
 		prefix = "host"
 		default = "aws"
+                defaults = ["aws"]
 	}
 	template_variable {
 		name   = "var_2"
 		prefix = "service_name"
 		default = "autoscaling"
+		defaults = ["autoscaling"]
 	}
 	template_variable_preset {
 		name = "preset_1"
@@ -468,11 +470,13 @@ resource "datadog_dashboard" "simple_dashboard" {
 		name   = "var_1"
 		prefix = "host"
 		default = "aws"
+		defaults = ["aws"]
 	}
 	template_variable {
 		name   = "var_2"
 		prefix = "service_name"
 		default = "autoscaling"
+		defaults = ["autoscaling"]
 	}
 	template_variable_preset {
 		name = "preset_1"
@@ -645,11 +649,13 @@ resource "datadog_dashboard" "free_dashboard" {
 		name   = "var_1"
 		prefix = "host"
 		default = "aws"
+		defaults = ["aws"]
 	}
 	template_variable {
 		name   = "var_2"
 		prefix = "service_name"
 		default = "autoscaling"
+		defaults = ["autoscaling"]
 	}
 	template_variable_preset {
 		name = "preset_1"
@@ -702,11 +708,13 @@ resource "datadog_dashboard" "simple_dashboard" {
 		name   = "var_1"
 		prefix = "host"
 		default = "aws"
+		defaults = ["aws"]
 	}
 	template_variable {
 		name   = "var_2"
 		prefix = "service_name"
 		default = "autoscaling"
+		defaults = ["autoscaling"]
 	}
 	template_variable_preset {
 		name = "preset_1"
@@ -750,9 +758,11 @@ var datadogSimpleOrderedDashboardAsserts = []string{
 	"template_variable.0.name = var_1",
 	"template_variable.0.prefix = host",
 	"template_variable.0.default = aws",
+	"template_variable.0.defaults = [\"aws\"]",
 	"template_variable.1.name = var_2",
 	"template_variable.1.prefix = service_name",
 	"template_variable.1.default = autoscaling",
+	"template_variable.1.defaults = [\"autoscaling\"]",
 	"description = Created using the Datadog provider in Terraform",
 	// Template Variable Presets
 	"template_variable_preset.# = 3",
@@ -787,9 +797,11 @@ var datadogSimpleFreeDashboardAsserts = []string{
 	"template_variable.0.name = var_1",
 	"template_variable.0.prefix = host",
 	"template_variable.0.default = aws",
+	"template_variable.0.defaults = [\"aws\"]",
 	"template_variable.1.name = var_2",
 	"template_variable.1.prefix = service_name",
 	"template_variable.1.default = autoscaling",
+	"template_variable.1.defaults = [\"autoscaling\"]",
 	"description = Created using the Datadog provider in Terraform",
 	// Template Variable Presets
 	"template_variable_preset.# = 3",
@@ -1049,9 +1061,11 @@ var datadogOrderedDashboardAsserts = []string{
 	"template_variable.0.name = var_1",
 	"template_variable.0.prefix = host",
 	"template_variable.0.default = aws",
+	"template_variable.0.defaults = [\"aws\"]",
 	"template_variable.1.name = var_2",
 	"template_variable.1.prefix = service_name",
 	"template_variable.1.default = autoscaling",
+	"template_variable.1.defaults = [\"autoscaling\"]",
 	"description = Created using the Datadog provider in Terraform",
 
 	// Template Variable Presets
@@ -1165,9 +1179,11 @@ var datadogFreeDashboardAsserts = []string{
 	// Template Variables
 	"template_variable.# = 2",
 	"template_variable.0.default = aws",
+	"template_variable.0.defaults = [\"aws\"]",
 	"template_variable.0.name = var_1",
 	"template_variable.0.prefix = host",
 	"template_variable.1.default = autoscaling",
+	"template_variable.1.defaults = [\"autoscaling\"]",
 	"template_variable.1.name = var_2",
 	"template_variable.1.prefix = service_name",
 


### PR DESCRIPTION
datadog-api-client-go now supports multiple default values for template_variable. 
https://github.com/DataDog/datadog-api-client-go/blob/1c6033006d72db906faef2daeecda0ccd20cb48e/api/datadogV1/model_dashboard_template_variable.go#L22

Added support for template_variable defaults - multiple default values