### PR TITLE
[datadog_monitor] Properly handle `new_host_delay` when `new_group_delay` is set

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -208,7 +208,11 @@ func resourceDatadogMonitor() *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     300,
-				Deprecated:  "Use `new_group_delay` except when setting `new_host_delay` to zero.",
+				DiffSuppressFunc: func(_, _, _ string, d *schema.ResourceData) bool {
+					_, newGroupDelayPresent := d.GetOk("new_group_delay")
+					return newGroupDelayPresent
+				},
+				Deprecated: "Use `new_group_delay` instead.",
 			},
 			"evaluation_delay": {
 				Description: "(Only applies to metric alert) Time (in seconds) to delay evaluation, as a non-negative integer.\n\nFor example, if the value is set to `300` (5min), the `timeframe` is set to `last_5m` and the time is 7:00, the monitor will evaluate data from 6:50 to 6:55. This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor will always have data during evaluation.",

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -63,7 +63,7 @@ For example, if the value is set to `300` (5min), the `timeframe` is set to `las
 - `new_group_delay` (Number) The time (in seconds) to skip evaluations for new groups.
 
 `new_group_delay` overrides `new_host_delay` if it is set to a nonzero value.
-- `new_host_delay` (Number, Deprecated) **Deprecated**. See `new_group_delay`. Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of monitor results. Should be a non-negative integer. This value is ignored for simple monitors and monitors not grouped by host. Defaults to `300`. The only case when this should be used is to override the default and set `new_host_delay` to zero for monitors grouped by host. **Deprecated.** Use `new_group_delay` except when setting `new_host_delay` to zero.
+- `new_host_delay` (Number, Deprecated) **Deprecated**. See `new_group_delay`. Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of monitor results. Should be a non-negative integer. This value is ignored for simple monitors and monitors not grouped by host. Defaults to `300`. The only case when this should be used is to override the default and set `new_host_delay` to zero for monitors grouped by host. **Deprecated.** Use `new_group_delay` instead.
 - `no_data_timeframe` (Number) The number of minutes before a monitor will notify when data stops reporting. Provider defaults to 10 minutes.
 
 We recommend at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks.


### PR DESCRIPTION
Since `new_group_delay` overrides `new_host_delay`, do not set default for the latter and don't include its value in the payload.

Closes: https://github.com/DataDog/terraform-provider-datadog/issues/1533