### PR TITLE
[datadog_service_definition_yaml] Move `404 statusCode` check into the error check block

### DIFF
--- a/datadog/resource_datadog_service_definition_yaml.go
+++ b/datadog/resource_datadog_service_definition_yaml.go
@@ -192,12 +192,12 @@ func resourceDatadogServiceDefinitionRead(_ context.Context, d *schema.ResourceD
 	id := d.Id()
 	respByte, resp, err := utils.SendRequest(auth, apiInstances.HttpClient, "GET", serviceDefinitionPath+"/"+id, nil)
 	if err != nil {
-		return utils.TranslateClientErrorDiag(err, resp, fmt.Sprintf("error retrieving service definition %s", id))
-	}
+		if resp.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 
-	if resp.StatusCode == 404 {
-		d.SetId("")
-		return nil
+		return utils.TranslateClientErrorDiag(err, resp, fmt.Sprintf("error retrieving service definition %s", id))
 	}
 
 	var response getSDResponse


### PR DESCRIPTION
Correctly set id to nil when resource does not exist.