### PR TITLE
[datadog_logs_archive] mark `path` as optional

### DIFF
--- a/datadog/resource_datadog_logs_archive.go
+++ b/datadog/resource_datadog_logs_archive.go
@@ -34,7 +34,7 @@ func resourceDatadogLogsArchive() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"bucket":     {Description: "Name of your s3 bucket.", Type: schema.TypeString, Required: true},
-						"path":       {Description: "Path where the archive will be stored.", Type: schema.TypeString, Required: true},
+						"path":       {Description: "Path where the archive will be stored.", Type: schema.TypeString, Optional: true},
 						"account_id": {Description: "Your AWS account id.", Type: schema.TypeString, Required: true},
 						"role_name":  {Description: "Your AWS role name", Type: schema.TypeString, Required: true},
 					},
@@ -63,7 +63,7 @@ func resourceDatadogLogsArchive() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"bucket":       {Description: "Name of your GCS bucket.", Type: schema.TypeString, Required: true},
-						"path":         {Description: "Path where the archive will be stored.", Type: schema.TypeString, Required: true},
+						"path":         {Description: "Path where the archive will be stored.", Type: schema.TypeString, Optional: true},
 						"client_email": {Description: "Your client email.", Type: schema.TypeString, Required: true},
 						"project_id":   {Description: "Your project id.", Type: schema.TypeString, Required: true},
 					},

--- a/datadog/resource_datadog_logs_archive.go
+++ b/datadog/resource_datadog_logs_archive.go
@@ -34,7 +34,7 @@ func resourceDatadogLogsArchive() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"bucket":     {Description: "Name of your s3 bucket.", Type: schema.TypeString, Required: true},
-						"path":       {Description: "Path where the archive will be stored.", Type: schema.TypeString, Optional: true},
+						"path":       {Description: "Path where the archive is stored.", Type: schema.TypeString, Optional: true},
 						"account_id": {Description: "Your AWS account id.", Type: schema.TypeString, Required: true},
 						"role_name":  {Description: "Your AWS role name", Type: schema.TypeString, Required: true},
 					},
@@ -47,11 +47,11 @@ func resourceDatadogLogsArchive() *schema.Resource {
 				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"container":       {Description: "The container where the archive will be stored.", Type: schema.TypeString, Required: true},
+						"container":       {Description: "The container where the archive is stored.", Type: schema.TypeString, Required: true},
 						"client_id":       {Description: "Your client id.", Type: schema.TypeString, Required: true},
 						"tenant_id":       {Description: "Your tenant id.", Type: schema.TypeString, Required: true},
 						"storage_account": {Description: "The associated storage account.", Type: schema.TypeString, Required: true},
-						"path":            {Description: "The path where the archive will be stored.", Type: schema.TypeString, Optional: true},
+						"path":            {Description: "The path where the archive is stored.", Type: schema.TypeString, Optional: true},
 					},
 				},
 			},
@@ -63,7 +63,7 @@ func resourceDatadogLogsArchive() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"bucket":       {Description: "Name of your GCS bucket.", Type: schema.TypeString, Required: true},
-						"path":         {Description: "Path where the archive will be stored.", Type: schema.TypeString, Optional: true},
+						"path":         {Description: "Path where the archive is stored.", Type: schema.TypeString, Optional: true},
 						"client_email": {Description: "Your client email.", Type: schema.TypeString, Required: true},
 						"project_id":   {Description: "Your project id.", Type: schema.TypeString, Required: true},
 					},

--- a/docs/resources/logs_archive.md
+++ b/docs/resources/logs_archive.md
@@ -52,13 +52,13 @@ resource "datadog_logs_archive" "my_s3_archive" {
 Required:
 
 - `client_id` (String) Your client id.
-- `container` (String) The container where the archive will be stored.
+- `container` (String) The container where the archive is stored.
 - `storage_account` (String) The associated storage account.
 - `tenant_id` (String) Your tenant id.
 
 Optional:
 
-- `path` (String) The path where the archive will be stored.
+- `path` (String) The path where the archive is stored.
 
 
 <a id="nestedblock--gcs_archive"></a>
@@ -72,7 +72,7 @@ Required:
 
 Optional:
 
-- `path` (String) Path where the archive will be stored.
+- `path` (String) Path where the archive is stored.
 
 
 <a id="nestedblock--s3_archive"></a>
@@ -86,7 +86,7 @@ Required:
 
 Optional:
 
-- `path` (String) Path where the archive will be stored.
+- `path` (String) Path where the archive is stored.
 
 ## Import
 

--- a/docs/resources/logs_archive.md
+++ b/docs/resources/logs_archive.md
@@ -68,8 +68,11 @@ Required:
 
 - `bucket` (String) Name of your GCS bucket.
 - `client_email` (String) Your client email.
-- `path` (String) Path where the archive will be stored.
 - `project_id` (String) Your project id.
+
+Optional:
+
+- `path` (String) Path where the archive will be stored.
 
 
 <a id="nestedblock--s3_archive"></a>
@@ -79,8 +82,11 @@ Required:
 
 - `account_id` (String) Your AWS account id.
 - `bucket` (String) Name of your s3 bucket.
-- `path` (String) Path where the archive will be stored.
 - `role_name` (String) Your AWS role name
+
+Optional:
+
+- `path` (String) Path where the archive will be stored.
 
 ## Import
 


### PR DESCRIPTION
Properly mark `path` attribute as optional. Closes: https://github.com/DataDog/terraform-provider-datadog/issues/1646