### PR TITLE
[datadog_dashboard] Add support for style field in dashboard widget formulas

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -128,10 +128,10 @@ func syntheticsTestRequest() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"method": {
-				Description:      "The HTTP method.",
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewHTTPMethodFromValue),
+				Description: "The HTTP method.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				//ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewHTTPMethodFromValue),
 			},
 			"url": {
 				Description: "The URL to send the request to.",
@@ -1275,7 +1275,7 @@ func buildSyntheticsAPITestStruct(d *schema.ResourceData) *datadogV1.SyntheticsA
 
 	request := datadogV1.SyntheticsTestRequest{}
 	if attr, ok := k.GetOkWith("method"); ok {
-		request.SetMethod(datadogV1.HTTPMethod(attr.(string)))
+		request.SetMethod(attr.(string))
 	}
 	if attr, ok := k.GetOkWith("url"); ok {
 		request.SetUrl(attr.(string))
@@ -1380,7 +1380,7 @@ func buildSyntheticsAPITestStruct(d *schema.ResourceData) *datadogV1.SyntheticsA
 			requests := stepMap["request_definition"].([]interface{})
 			if len(requests) > 0 && requests[0] != nil {
 				requestMap := requests[0].(map[string]interface{})
-				request.SetMethod(datadogV1.HTTPMethod(requestMap["method"].(string)))
+				request.SetMethod(requestMap["method"].(string))
 				request.SetUrl(requestMap["url"].(string))
 				request.SetBody(requestMap["body"].(string))
 				if v, ok := requestMap["body_type"].(string); ok && v != "" {
@@ -1762,7 +1762,7 @@ func buildSyntheticsBrowserTestStruct(d *schema.ResourceData) *datadogV1.Synthet
 	parts := "request_definition.0"
 	k.Add(parts)
 	if attr, ok := k.GetOkWith("method"); ok {
-		request.SetMethod(datadogV1.HTTPMethod(attr.(string)))
+		request.SetMethod(attr.(string))
 	}
 	if attr, ok := k.GetOkWith("url"); ok {
 		request.SetUrl(attr.(string))
@@ -2950,8 +2950,6 @@ func convertToString(i interface{}) string {
 		return strconv.FormatFloat(v, 'f', -1, 64)
 	case string:
 		return v
-	case datadogV1.HTTPMethod:
-		return string(v)
 	default:
 		// TODO: manage target for JSON body assertions
 		valStrr, err := json.Marshal(v)

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -933,6 +933,7 @@ Optional:
 - `cell_display_mode` (String) A list of display modes for each table cell. Valid values are `number`, `bar`.
 - `conditional_formats` (Block List) Conditional formats allow you to set the color of your widget content or background depending on the rule applied to your data. Multiple `conditional_formats` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--change_definition--request--formula--conditional_formats))
 - `limit` (Block List, Max: 1) The options for limiting results returned. (see [below for nested schema](#nestedblock--widget--change_definition--request--formula--limit))
+- `style` (Block List, Max: 1) Styling options for widget formulas. (see [below for nested schema](#nestedblock--widget--change_definition--request--formula--style))
 
 <a id="nestedblock--widget--change_definition--request--formula--conditional_formats"></a>
 ### Nested Schema for `widget.change_definition.request.formula.conditional_formats`
@@ -960,6 +961,15 @@ Optional:
 
 - `count` (Number) The number of results to return
 - `order` (String) The direction of the sort. Valid values are `asc`, `desc`.
+
+
+<a id="nestedblock--widget--change_definition--request--formula--style"></a>
+### Nested Schema for `widget.change_definition.request.formula.style`
+
+Optional:
+
+- `palette` (String) The color palette used to display the formula. A guide to the available color palettes can be found at https://docs.datadoghq.com/dashboards/guide/widget_colors
+- `palette_index` (Number) Index specifying which color to use within the palette.
 
 
 
@@ -1784,6 +1794,7 @@ Optional:
 - `cell_display_mode` (String) A list of display modes for each table cell. Valid values are `number`, `bar`.
 - `conditional_formats` (Block List) Conditional formats allow you to set the color of your widget content or background depending on the rule applied to your data. Multiple `conditional_formats` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--geomap_definition--request--formula--conditional_formats))
 - `limit` (Block List, Max: 1) The options for limiting results returned. (see [below for nested schema](#nestedblock--widget--geomap_definition--request--formula--limit))
+- `style` (Block List, Max: 1) Styling options for widget formulas. (see [below for nested schema](#nestedblock--widget--geomap_definition--request--formula--style))
 
 <a id="nestedblock--widget--geomap_definition--request--formula--conditional_formats"></a>
 ### Nested Schema for `widget.geomap_definition.request.formula.conditional_formats`
@@ -1811,6 +1822,15 @@ Optional:
 
 - `count` (Number) The number of results to return
 - `order` (String) The direction of the sort. Valid values are `asc`, `desc`.
+
+
+<a id="nestedblock--widget--geomap_definition--request--formula--style"></a>
+### Nested Schema for `widget.geomap_definition.request.formula.style`
+
+Optional:
+
+- `palette` (String) The color palette used to display the formula. A guide to the available color palettes can be found at https://docs.datadoghq.com/dashboards/guide/widget_colors
+- `palette_index` (Number) Index specifying which color to use within the palette.
 
 
 
@@ -2310,6 +2330,7 @@ Optional:
 - `cell_display_mode` (String) A list of display modes for each table cell. Valid values are `number`, `bar`.
 - `conditional_formats` (Block List) Conditional formats allow you to set the color of your widget content or background depending on the rule applied to your data. Multiple `conditional_formats` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--group_definition--widget--change_definition--request--formula--conditional_formats))
 - `limit` (Block List, Max: 1) The options for limiting results returned. (see [below for nested schema](#nestedblock--widget--group_definition--widget--change_definition--request--formula--limit))
+- `style` (Block List, Max: 1) Styling options for widget formulas. (see [below for nested schema](#nestedblock--widget--group_definition--widget--change_definition--request--formula--style))
 
 <a id="nestedblock--widget--group_definition--widget--change_definition--request--formula--conditional_formats"></a>
 ### Nested Schema for `widget.group_definition.widget.change_definition.request.formula.conditional_formats`
@@ -2337,6 +2358,15 @@ Optional:
 
 - `count` (Number) The number of results to return
 - `order` (String) The direction of the sort. Valid values are `asc`, `desc`.
+
+
+<a id="nestedblock--widget--group_definition--widget--change_definition--request--formula--style"></a>
+### Nested Schema for `widget.group_definition.widget.change_definition.request.formula.style`
+
+Optional:
+
+- `palette` (String) The color palette used to display the formula. A guide to the available color palettes can be found at https://docs.datadoghq.com/dashboards/guide/widget_colors
+- `palette_index` (Number) Index specifying which color to use within the palette.
 
 
 
@@ -3161,6 +3191,7 @@ Optional:
 - `cell_display_mode` (String) A list of display modes for each table cell. Valid values are `number`, `bar`.
 - `conditional_formats` (Block List) Conditional formats allow you to set the color of your widget content or background depending on the rule applied to your data. Multiple `conditional_formats` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--group_definition--widget--geomap_definition--request--formula--conditional_formats))
 - `limit` (Block List, Max: 1) The options for limiting results returned. (see [below for nested schema](#nestedblock--widget--group_definition--widget--geomap_definition--request--formula--limit))
+- `style` (Block List, Max: 1) Styling options for widget formulas. (see [below for nested schema](#nestedblock--widget--group_definition--widget--geomap_definition--request--formula--style))
 
 <a id="nestedblock--widget--group_definition--widget--geomap_definition--request--formula--conditional_formats"></a>
 ### Nested Schema for `widget.group_definition.widget.geomap_definition.request.formula.conditional_formats`
@@ -3188,6 +3219,15 @@ Optional:
 
 - `count` (Number) The number of results to return
 - `order` (String) The direction of the sort. Valid values are `asc`, `desc`.
+
+
+<a id="nestedblock--widget--group_definition--widget--geomap_definition--request--formula--style"></a>
+### Nested Schema for `widget.group_definition.widget.geomap_definition.request.formula.style`
+
+Optional:
+
+- `palette` (String) The color palette used to display the formula. A guide to the available color palettes can be found at https://docs.datadoghq.com/dashboards/guide/widget_colors
+- `palette_index` (Number) Index specifying which color to use within the palette.
 
 
 
@@ -4750,6 +4790,7 @@ Optional:
 - `cell_display_mode` (String) A list of display modes for each table cell. Valid values are `number`, `bar`.
 - `conditional_formats` (Block List) Conditional formats allow you to set the color of your widget content or background depending on the rule applied to your data. Multiple `conditional_formats` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--group_definition--widget--query_table_definition--request--formula--conditional_formats))
 - `limit` (Block List, Max: 1) The options for limiting results returned. (see [below for nested schema](#nestedblock--widget--group_definition--widget--query_table_definition--request--formula--limit))
+- `style` (Block List, Max: 1) Styling options for widget formulas. (see [below for nested schema](#nestedblock--widget--group_definition--widget--query_table_definition--request--formula--style))
 
 <a id="nestedblock--widget--group_definition--widget--query_table_definition--request--formula--conditional_formats"></a>
 ### Nested Schema for `widget.group_definition.widget.query_table_definition.request.formula.conditional_formats`
@@ -4777,6 +4818,15 @@ Optional:
 
 - `count` (Number) The number of results to return
 - `order` (String) The direction of the sort. Valid values are `asc`, `desc`.
+
+
+<a id="nestedblock--widget--group_definition--widget--query_table_definition--request--formula--style"></a>
+### Nested Schema for `widget.group_definition.widget.query_table_definition.request.formula.style`
+
+Optional:
+
+- `palette` (String) The color palette used to display the formula. A guide to the available color palettes can be found at https://docs.datadoghq.com/dashboards/guide/widget_colors
+- `palette_index` (Number) Index specifying which color to use within the palette.
 
 
 
@@ -5342,6 +5392,7 @@ Optional:
 - `cell_display_mode` (String) A list of display modes for each table cell. Valid values are `number`, `bar`.
 - `conditional_formats` (Block List) Conditional formats allow you to set the color of your widget content or background depending on the rule applied to your data. Multiple `conditional_formats` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--group_definition--widget--query_value_definition--request--formula--conditional_formats))
 - `limit` (Block List, Max: 1) The options for limiting results returned. (see [below for nested schema](#nestedblock--widget--group_definition--widget--query_value_definition--request--formula--limit))
+- `style` (Block List, Max: 1) Styling options for widget formulas. (see [below for nested schema](#nestedblock--widget--group_definition--widget--query_value_definition--request--formula--style))
 
 <a id="nestedblock--widget--group_definition--widget--query_value_definition--request--formula--conditional_formats"></a>
 ### Nested Schema for `widget.group_definition.widget.query_value_definition.request.formula.conditional_formats`
@@ -5369,6 +5420,15 @@ Optional:
 
 - `count` (Number) The number of results to return
 - `order` (String) The direction of the sort. Valid values are `asc`, `desc`.
+
+
+<a id="nestedblock--widget--group_definition--widget--query_value_definition--request--formula--style"></a>
+### Nested Schema for `widget.group_definition.widget.query_value_definition.request.formula.style`
+
+Optional:
+
+- `palette` (String) The color palette used to display the formula. A guide to the available color palettes can be found at https://docs.datadoghq.com/dashboards/guide/widget_colors
+- `palette_index` (Number) Index specifying which color to use within the palette.
 
 
 
@@ -6838,6 +6898,7 @@ Optional:
 - `cell_display_mode` (String) A list of display modes for each table cell. Valid values are `number`, `bar`.
 - `conditional_formats` (Block List) Conditional formats allow you to set the color of your widget content or background depending on the rule applied to your data. Multiple `conditional_formats` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--group_definition--widget--sunburst_definition--request--formula--conditional_formats))
 - `limit` (Block List, Max: 1) The options for limiting results returned. (see [below for nested schema](#nestedblock--widget--group_definition--widget--sunburst_definition--request--formula--limit))
+- `style` (Block List, Max: 1) Styling options for widget formulas. (see [below for nested schema](#nestedblock--widget--group_definition--widget--sunburst_definition--request--formula--style))
 
 <a id="nestedblock--widget--group_definition--widget--sunburst_definition--request--formula--conditional_formats"></a>
 ### Nested Schema for `widget.group_definition.widget.sunburst_definition.request.formula.conditional_formats`
@@ -6865,6 +6926,15 @@ Optional:
 
 - `count` (Number) The number of results to return
 - `order` (String) The direction of the sort. Valid values are `asc`, `desc`.
+
+
+<a id="nestedblock--widget--group_definition--widget--sunburst_definition--request--formula--style"></a>
+### Nested Schema for `widget.group_definition.widget.sunburst_definition.request.formula.style`
+
+Optional:
+
+- `palette` (String) The color palette used to display the formula. A guide to the available color palettes can be found at https://docs.datadoghq.com/dashboards/guide/widget_colors
+- `palette_index` (Number) Index specifying which color to use within the palette.
 
 
 
@@ -7506,6 +7576,7 @@ Optional:
 - `cell_display_mode` (String) A list of display modes for each table cell. Valid values are `number`, `bar`.
 - `conditional_formats` (Block List) Conditional formats allow you to set the color of your widget content or background depending on the rule applied to your data. Multiple `conditional_formats` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--group_definition--widget--timeseries_definition--request--formula--conditional_formats))
 - `limit` (Block List, Max: 1) The options for limiting results returned. (see [below for nested schema](#nestedblock--widget--group_definition--widget--timeseries_definition--request--formula--limit))
+- `style` (Block List, Max: 1) Styling options for widget formulas. (see [below for nested schema](#nestedblock--widget--group_definition--widget--timeseries_definition--request--formula--style))
 
 <a id="nestedblock--widget--group_definition--widget--timeseries_definition--request--formula--conditional_formats"></a>
 ### Nested Schema for `widget.group_definition.widget.timeseries_definition.request.formula.conditional_formats`
@@ -7533,6 +7604,15 @@ Optional:
 
 - `count` (Number) The number of results to return
 - `order` (String) The direction of the sort. Valid values are `asc`, `desc`.
+
+
+<a id="nestedblock--widget--group_definition--widget--timeseries_definition--request--formula--style"></a>
+### Nested Schema for `widget.group_definition.widget.timeseries_definition.request.formula.style`
+
+Optional:
+
+- `palette` (String) The color palette used to display the formula. A guide to the available color palettes can be found at https://docs.datadoghq.com/dashboards/guide/widget_colors
+- `palette_index` (Number) Index specifying which color to use within the palette.
 
 
 
@@ -8203,6 +8283,7 @@ Optional:
 - `cell_display_mode` (String) A list of display modes for each table cell. Valid values are `number`, `bar`.
 - `conditional_formats` (Block List) Conditional formats allow you to set the color of your widget content or background depending on the rule applied to your data. Multiple `conditional_formats` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--group_definition--widget--toplist_definition--request--formula--conditional_formats))
 - `limit` (Block List, Max: 1) The options for limiting results returned. (see [below for nested schema](#nestedblock--widget--group_definition--widget--toplist_definition--request--formula--limit))
+- `style` (Block List, Max: 1) Styling options for widget formulas. (see [below for nested schema](#nestedblock--widget--group_definition--widget--toplist_definition--request--formula--style))
 
 <a id="nestedblock--widget--group_definition--widget--toplist_definition--request--formula--conditional_formats"></a>
 ### Nested Schema for `widget.group_definition.widget.toplist_definition.request.formula.conditional_formats`
@@ -8230,6 +8311,15 @@ Optional:
 
 - `count` (Number) The number of results to return
 - `order` (String) The direction of the sort. Valid values are `asc`, `desc`.
+
+
+<a id="nestedblock--widget--group_definition--widget--toplist_definition--request--formula--style"></a>
+### Nested Schema for `widget.group_definition.widget.toplist_definition.request.formula.style`
+
+Optional:
+
+- `palette` (String) The color palette used to display the formula. A guide to the available color palettes can be found at https://docs.datadoghq.com/dashboards/guide/widget_colors
+- `palette_index` (Number) Index specifying which color to use within the palette.
 
 
 
@@ -8694,6 +8784,7 @@ Optional:
 - `cell_display_mode` (String) A list of display modes for each table cell. Valid values are `number`, `bar`.
 - `conditional_formats` (Block List) Conditional formats allow you to set the color of your widget content or background depending on the rule applied to your data. Multiple `conditional_formats` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--group_definition--widget--treemap_definition--request--formula--conditional_formats))
 - `limit` (Block List, Max: 1) The options for limiting results returned. (see [below for nested schema](#nestedblock--widget--group_definition--widget--treemap_definition--request--formula--limit))
+- `style` (Block List, Max: 1) Styling options for widget formulas. (see [below for nested schema](#nestedblock--widget--group_definition--widget--treemap_definition--request--formula--style))
 
 <a id="nestedblock--widget--group_definition--widget--treemap_definition--request--formula--conditional_formats"></a>
 ### Nested Schema for `widget.group_definition.widget.treemap_definition.request.formula.conditional_formats`
@@ -8721,6 +8812,15 @@ Optional:
 
 - `count` (Number) The number of results to return
 - `order` (String) The direction of the sort. Valid values are `asc`, `desc`.
+
+
+<a id="nestedblock--widget--group_definition--widget--treemap_definition--request--formula--style"></a>
+### Nested Schema for `widget.group_definition.widget.treemap_definition.request.formula.style`
+
+Optional:
+
+- `palette` (String) The color palette used to display the formula. A guide to the available color palettes can be found at https://docs.datadoghq.com/dashboards/guide/widget_colors
+- `palette_index` (Number) Index specifying which color to use within the palette.
 
 
 
@@ -10163,6 +10263,7 @@ Optional:
 - `cell_display_mode` (String) A list of display modes for each table cell. Valid values are `number`, `bar`.
 - `conditional_formats` (Block List) Conditional formats allow you to set the color of your widget content or background depending on the rule applied to your data. Multiple `conditional_formats` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--query_table_definition--request--formula--conditional_formats))
 - `limit` (Block List, Max: 1) The options for limiting results returned. (see [below for nested schema](#nestedblock--widget--query_table_definition--request--formula--limit))
+- `style` (Block List, Max: 1) Styling options for widget formulas. (see [below for nested schema](#nestedblock--widget--query_table_definition--request--formula--style))
 
 <a id="nestedblock--widget--query_table_definition--request--formula--conditional_formats"></a>
 ### Nested Schema for `widget.query_table_definition.request.formula.conditional_formats`
@@ -10190,6 +10291,15 @@ Optional:
 
 - `count` (Number) The number of results to return
 - `order` (String) The direction of the sort. Valid values are `asc`, `desc`.
+
+
+<a id="nestedblock--widget--query_table_definition--request--formula--style"></a>
+### Nested Schema for `widget.query_table_definition.request.formula.style`
+
+Optional:
+
+- `palette` (String) The color palette used to display the formula. A guide to the available color palettes can be found at https://docs.datadoghq.com/dashboards/guide/widget_colors
+- `palette_index` (Number) Index specifying which color to use within the palette.
 
 
 
@@ -10755,6 +10865,7 @@ Optional:
 - `cell_display_mode` (String) A list of display modes for each table cell. Valid values are `number`, `bar`.
 - `conditional_formats` (Block List) Conditional formats allow you to set the color of your widget content or background depending on the rule applied to your data. Multiple `conditional_formats` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--query_value_definition--request--formula--conditional_formats))
 - `limit` (Block List, Max: 1) The options for limiting results returned. (see [below for nested schema](#nestedblock--widget--query_value_definition--request--formula--limit))
+- `style` (Block List, Max: 1) Styling options for widget formulas. (see [below for nested schema](#nestedblock--widget--query_value_definition--request--formula--style))
 
 <a id="nestedblock--widget--query_value_definition--request--formula--conditional_formats"></a>
 ### Nested Schema for `widget.query_value_definition.request.formula.conditional_formats`
@@ -10782,6 +10893,15 @@ Optional:
 
 - `count` (Number) The number of results to return
 - `order` (String) The direction of the sort. Valid values are `asc`, `desc`.
+
+
+<a id="nestedblock--widget--query_value_definition--request--formula--style"></a>
+### Nested Schema for `widget.query_value_definition.request.formula.style`
+
+Optional:
+
+- `palette` (String) The color palette used to display the formula. A guide to the available color palettes can be found at https://docs.datadoghq.com/dashboards/guide/widget_colors
+- `palette_index` (Number) Index specifying which color to use within the palette.
 
 
 
@@ -12251,6 +12371,7 @@ Optional:
 - `cell_display_mode` (String) A list of display modes for each table cell. Valid values are `number`, `bar`.
 - `conditional_formats` (Block List) Conditional formats allow you to set the color of your widget content or background depending on the rule applied to your data. Multiple `conditional_formats` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--sunburst_definition--request--formula--conditional_formats))
 - `limit` (Block List, Max: 1) The options for limiting results returned. (see [below for nested schema](#nestedblock--widget--sunburst_definition--request--formula--limit))
+- `style` (Block List, Max: 1) Styling options for widget formulas. (see [below for nested schema](#nestedblock--widget--sunburst_definition--request--formula--style))
 
 <a id="nestedblock--widget--sunburst_definition--request--formula--conditional_formats"></a>
 ### Nested Schema for `widget.sunburst_definition.request.formula.conditional_formats`
@@ -12278,6 +12399,15 @@ Optional:
 
 - `count` (Number) The number of results to return
 - `order` (String) The direction of the sort. Valid values are `asc`, `desc`.
+
+
+<a id="nestedblock--widget--sunburst_definition--request--formula--style"></a>
+### Nested Schema for `widget.sunburst_definition.request.formula.style`
+
+Optional:
+
+- `palette` (String) The color palette used to display the formula. A guide to the available color palettes can be found at https://docs.datadoghq.com/dashboards/guide/widget_colors
+- `palette_index` (Number) Index specifying which color to use within the palette.
 
 
 
@@ -12919,6 +13049,7 @@ Optional:
 - `cell_display_mode` (String) A list of display modes for each table cell. Valid values are `number`, `bar`.
 - `conditional_formats` (Block List) Conditional formats allow you to set the color of your widget content or background depending on the rule applied to your data. Multiple `conditional_formats` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--timeseries_definition--request--formula--conditional_formats))
 - `limit` (Block List, Max: 1) The options for limiting results returned. (see [below for nested schema](#nestedblock--widget--timeseries_definition--request--formula--limit))
+- `style` (Block List, Max: 1) Styling options for widget formulas. (see [below for nested schema](#nestedblock--widget--timeseries_definition--request--formula--style))
 
 <a id="nestedblock--widget--timeseries_definition--request--formula--conditional_formats"></a>
 ### Nested Schema for `widget.timeseries_definition.request.formula.conditional_formats`
@@ -12946,6 +13077,15 @@ Optional:
 
 - `count` (Number) The number of results to return
 - `order` (String) The direction of the sort. Valid values are `asc`, `desc`.
+
+
+<a id="nestedblock--widget--timeseries_definition--request--formula--style"></a>
+### Nested Schema for `widget.timeseries_definition.request.formula.style`
+
+Optional:
+
+- `palette` (String) The color palette used to display the formula. A guide to the available color palettes can be found at https://docs.datadoghq.com/dashboards/guide/widget_colors
+- `palette_index` (Number) Index specifying which color to use within the palette.
 
 
 
@@ -13616,6 +13756,7 @@ Optional:
 - `cell_display_mode` (String) A list of display modes for each table cell. Valid values are `number`, `bar`.
 - `conditional_formats` (Block List) Conditional formats allow you to set the color of your widget content or background depending on the rule applied to your data. Multiple `conditional_formats` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--toplist_definition--request--formula--conditional_formats))
 - `limit` (Block List, Max: 1) The options for limiting results returned. (see [below for nested schema](#nestedblock--widget--toplist_definition--request--formula--limit))
+- `style` (Block List, Max: 1) Styling options for widget formulas. (see [below for nested schema](#nestedblock--widget--toplist_definition--request--formula--style))
 
 <a id="nestedblock--widget--toplist_definition--request--formula--conditional_formats"></a>
 ### Nested Schema for `widget.toplist_definition.request.formula.conditional_formats`
@@ -13643,6 +13784,15 @@ Optional:
 
 - `count` (Number) The number of results to return
 - `order` (String) The direction of the sort. Valid values are `asc`, `desc`.
+
+
+<a id="nestedblock--widget--toplist_definition--request--formula--style"></a>
+### Nested Schema for `widget.toplist_definition.request.formula.style`
+
+Optional:
+
+- `palette` (String) The color palette used to display the formula. A guide to the available color palettes can be found at https://docs.datadoghq.com/dashboards/guide/widget_colors
+- `palette_index` (Number) Index specifying which color to use within the palette.
 
 
 
@@ -14107,6 +14257,7 @@ Optional:
 - `cell_display_mode` (String) A list of display modes for each table cell. Valid values are `number`, `bar`.
 - `conditional_formats` (Block List) Conditional formats allow you to set the color of your widget content or background depending on the rule applied to your data. Multiple `conditional_formats` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--treemap_definition--request--formula--conditional_formats))
 - `limit` (Block List, Max: 1) The options for limiting results returned. (see [below for nested schema](#nestedblock--widget--treemap_definition--request--formula--limit))
+- `style` (Block List, Max: 1) Styling options for widget formulas. (see [below for nested schema](#nestedblock--widget--treemap_definition--request--formula--style))
 
 <a id="nestedblock--widget--treemap_definition--request--formula--conditional_formats"></a>
 ### Nested Schema for `widget.treemap_definition.request.formula.conditional_formats`
@@ -14134,6 +14285,15 @@ Optional:
 
 - `count` (Number) The number of results to return
 - `order` (String) The direction of the sort. Valid values are `asc`, `desc`.
+
+
+<a id="nestedblock--widget--treemap_definition--request--formula--style"></a>
+### Nested Schema for `widget.treemap_definition.request.formula.style`
+
+Optional:
+
+- `palette` (String) The color palette used to display the formula. A guide to the available color palettes can be found at https://docs.datadoghq.com/dashboards/guide/widget_colors
+- `palette_index` (Number) Index specifying which color to use within the palette.
 
 
 

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -453,7 +453,7 @@ Optional:
 - `follow_redirects` (Boolean) Determines whether or not the API HTTP test should follow redirects.
 - `host` (String) Host name to perform the test with.
 - `message` (String) For UDP and websocket tests, message to send with the request.
-- `method` (String) The HTTP method. Valid values are `GET`, `POST`, `PATCH`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`.
+- `method` (String) The HTTP method.
 - `no_saving_response_body` (Boolean) Determines whether or not to save the response body.
 - `number_of_packets` (Number) Number of pings to use per test for ICMP tests (`subtype = "icmp"`) between 0 and 10.
 - `port` (Number) Port to use when performing the test.
@@ -757,7 +757,7 @@ Optional:
 - `dns_server_port` (Number) DNS server port to use for DNS tests.
 - `host` (String) Host name to perform the test with.
 - `message` (String) For UDP and websocket tests, message to send with the request.
-- `method` (String) The HTTP method. Valid values are `GET`, `POST`, `PATCH`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`.
+- `method` (String) The HTTP method.
 - `no_saving_response_body` (Boolean) Determines whether or not to save the response body.
 - `number_of_packets` (Number) Number of pings to use per test for ICMP tests (`subtype = "icmp"`) between 0 and 10.
 - `port` (Number) Port to use when performing the test.

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-datadog
 
 require (
-	github.com/DataDog/datadog-api-client-go/v2 v2.5.1-0.20221121201220-2d9c3da841c8
+	github.com/DataDog/datadog-api-client-go/v2 v2.5.1-0.20221213185544-3e16a9def237
 	github.com/DataDog/dd-sdk-go-testing v0.0.0-20211116174033-1cd082e322ad
 	github.com/dnaeon/go-vcr v1.0.1
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/datadog-api-client-go/v2 v2.5.1-0.20221121201220-2d9c3da841c8 h1:RjR1/ZvlkbuKxeWVUQK5ydPYH4EV/8rK6ay9Zw9XJbk=
-github.com/DataDog/datadog-api-client-go/v2 v2.5.1-0.20221121201220-2d9c3da841c8/go.mod h1:sHt3EuVMN8PSYJu065qwp3pZxCwR3RZP4sJnYwj/ZQY=
+github.com/DataDog/datadog-api-client-go/v2 v2.5.1-0.20221213185544-3e16a9def237 h1:wn19QrtXYcPCIaZaNer0zHqYRxmZvWSLNZGnFIXaQ2o=
+github.com/DataDog/datadog-api-client-go/v2 v2.5.1-0.20221213185544-3e16a9def237/go.mod h1:sHt3EuVMN8PSYJu065qwp3pZxCwR3RZP4sJnYwj/ZQY=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=


### PR DESCRIPTION
Resolves #1627, adds a previously undocumented field in the API for changing the color of a dashboard widget formula's visualization.

Depends on datadog-api-client-go v2.6.0 release

Synthetics changes are unrelated and for a temporary unblock. Will remove before merge.