### PR TITLE
[service_definition_yaml] Add tag normalization util

### DIFF
--- a/datadog/internal/utils/tags.go
+++ b/datadog/internal/utils/tags.go
@@ -1,0 +1,102 @@
+package utils
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+// NormalizeTag takes a string and parses it in accordance to USM Tagging conventions
+func NormalizeTag(tag string) string {
+	// Fast path: Check if the tag is valid and only contains ASCII characters,
+	// if yes return it as-is right away.
+	MaxTagLength := 200
+
+	if isNormalizedASCIITag(tag, MaxTagLength) {
+		return tag
+	}
+
+	bufSize := len(tag)
+	if bufSize > MaxTagLength {
+		bufSize = MaxTagLength // Limit size of allocation
+	}
+	buf := make([]byte, 0, bufSize+utf8.UTFMax-1)
+
+	lastWasUnderscore := false
+	for _, c := range tag {
+		if len(buf) >= MaxTagLength {
+			break
+		}
+
+		switch {
+		// fast path for ascii alphabet
+		case c >= 'a' && c <= 'z':
+			buf = append(buf, byte(c))
+			lastWasUnderscore = false
+		case c >= 'A' && c <= 'Z':
+			buf = append(buf, byte(c+('a'-'A')))
+			lastWasUnderscore = false
+		// ':' may be the first character of a tag
+		case c == ':':
+			buf = append(buf, byte(c))
+			lastWasUnderscore = false
+		case unicode.IsLetter(c):
+			buf = utf8.AppendRune(buf, unicode.ToLower(c))
+			lastWasUnderscore = false
+		// skip any code points that can't start the string
+		// (we only reach this case if we've not seen a valid starting code point yet)
+		case len(buf) == 0:
+		// handle valid code points that can't start the string.
+		case c == '.' || c == '/' || c == '-':
+			buf = append(buf, byte(c))
+			lastWasUnderscore = false
+		case unicode.IsDigit(c):
+			buf = utf8.AppendRune(buf, c)
+			lastWasUnderscore = false
+		// convert anything else to underscores (including underscores), but only allow one in a row.
+		case !lastWasUnderscore:
+			buf = append(buf, '_')
+			lastWasUnderscore = true
+		}
+	}
+
+	if lastWasUnderscore {
+		buf = buf[:len(buf)-1]
+	}
+	return string(buf)
+}
+
+func isNormalizedASCIITag(tag string, maxTagLength int) bool {
+	if len(tag) == 0 {
+		return true
+	}
+	if len(tag) > maxTagLength {
+		return false
+	}
+	if !isValidASCIIStartChar(tag[0]) {
+		return false
+	}
+	for i := 1; i < len(tag); i++ {
+		b := tag[i]
+		// TODO: Attempt to optimize this check using SIMD/vectorization.
+		if isValidASCIITagChar(b) {
+			// okay!
+		} else if b == '_' {
+			// an underscore is only okay if followed by a valid non-underscore character
+			i++
+			if i == len(tag) || !isValidASCIITagChar(tag[i]) {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return true
+}
+
+func isValidASCIIStartChar(c byte) bool {
+	return ('a' <= c && c <= 'z') || c == ':'
+}
+
+func isValidASCIITagChar(c byte) bool {
+	return isValidASCIIStartChar(c) || ('0' <= c && c <= '9') || c == '.' || c == '/' || c == '-'
+}

--- a/datadog/internal/utils/tags_test.go
+++ b/datadog/internal/utils/tags_test.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestTagNormalization(t *testing.T) {
+	cases := map[string]string{
+		"foo":     "foo",
+		"Foo":     "foo",
+		"1foo":    "foo",
+		"foo_bar": "foo_bar",
+	}
+	for tag, expected_tag := range cases {
+		normalized := NormalizeTag(tag)
+		if normalized != expected_tag {
+			t.Errorf("Expected tag '%s' normalized to '%s', got '%s' instead.", tag, expected_tag, normalized)
+		}
+	}
+}

--- a/datadog/internal/utils/tags_test.go
+++ b/datadog/internal/utils/tags_test.go
@@ -6,10 +6,15 @@ import (
 
 func TestTagNormalization(t *testing.T) {
 	cases := map[string]string{
-		"foo":     "foo",
-		"Foo":     "foo",
-		"1foo":    "foo",
-		"foo_bar": "foo_bar",
+		"foo":                "foo",
+		"FOO":                "foo",
+		"1foo":               "foo",
+		"foo_":               "foo",
+		":foo":               ":foo",
+		"foo_bar":            "foo_bar",
+		"foo__bar":           "foo_bar",
+		"foo123":             "foo123",
+		"f!@#$%^&*(),./-=_+": "f_./-",
 	}
 	for tag, expected_tag := range cases {
 		normalized := NormalizeTag(tag)

--- a/datadog/resource_datadog_service_definition_yaml.go
+++ b/datadog/resource_datadog_service_definition_yaml.go
@@ -114,9 +114,14 @@ func prepServiceDefinitionResource(attrMap map[string]interface{}) map[string]in
 		if len(tags) == 0 {
 			delete(attrMap, "tags")
 		} else {
-			sort.SliceStable(tags, func(i, j int) bool {
-				return tags[i].(string) < tags[j].(string)
+			normalized_tags := make([]string, 0)
+			for _, tag := range tags {
+				normalized_tags = append(normalized_tags, utils.NormalizeTag(tag.(string)))
+			}
+			sort.SliceStable(normalized_tags, func(i, j int) bool {
+				return normalized_tags[i] < normalized_tags[j]
 			})
+			attrMap["tags"] = normalized_tags
 		}
 	}
 

--- a/datadog/resource_datadog_service_definition_yaml.go
+++ b/datadog/resource_datadog_service_definition_yaml.go
@@ -55,8 +55,7 @@ func resourceDatadogServiceDefinitionYAML() *schema.Resource {
 			if !ok {
 				return true
 			}
-
-			return oldName != newName
+			return utils.NormalizeTag(oldName) != utils.NormalizeTag(newName)
 		}),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -105,6 +104,10 @@ func prepServiceDefinitionResource(attrMap map[string]interface{}) map[string]in
 
 	for _, field := range fieldsWithName {
 		normalizeArrayField(attrMap, field)
+	}
+
+	if service, ok := attrMap["dd-service"].(string); ok {
+		attrMap["dd-service"] = utils.NormalizeTag(service)
 	}
 
 	if tags, ok := attrMap["tags"].([]interface{}); ok {

--- a/datadog/resource_datadog_service_level_objective.go
+++ b/datadog/resource_datadog_service_level_objective.go
@@ -49,7 +49,12 @@ func resourceDatadogServiceLevelObjective() *schema.Resource {
 				Type:        schema.TypeSet,
 				Description: "A list of tags to associate with your service level objective. This can help you categorize and filter service level objectives in the service level objectives page of the UI. Note: it's not currently possible to filter by these tags when querying via the API",
 				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					StateFunc: func(val any) string {
+						return utils.NormalizeTag(val.(string))
+					},
+				},
 			},
 			"thresholds": {
 				Description: "A list of thresholds and targets that define the service level objectives from the provided SLIs.",


### PR DESCRIPTION
Adds a tag normalization function for use with any fields that conform to USM Tagging (https://docs.datadoghq.com/getting_started/tagging/)

Affects service_definition_yaml and service_level_objective