### PR TITLE
[datadog_metric_metadata] Add import examples

### DIFF
--- a/docs/resources/metric_metadata.md
+++ b/docs/resources/metric_metadata.md
@@ -43,4 +43,10 @@ resource "datadog_metric_metadata" "request_time" {
 
 - `id` (String) The ID of this resource.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import datadog_metric_metadata.request_time request.time
+```

--- a/docs/resources/metric_tag_configuration.md
+++ b/docs/resources/metric_tag_configuration.md
@@ -63,4 +63,10 @@ Required:
 - `space` (String) A space aggregation for use in query. Valid values are `avg`, `max`, `min`, `sum`.
 - `time` (String) A time aggregation for use in query. Valid values are `avg`, `count`, `max`, `min`, `sum`.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import datadog_metric_tag_configuration.example_dist_metric example.terraform.dist.metric
+```

--- a/examples/resources/datadog_metric_metadata/import.sh
+++ b/examples/resources/datadog_metric_metadata/import.sh
@@ -1,0 +1,1 @@
+terraform import datadog_metric_metadata.request_time request.time

--- a/examples/resources/datadog_metric_tag_configuration/import.sh
+++ b/examples/resources/datadog_metric_tag_configuration/import.sh
@@ -1,0 +1,1 @@
+terraform import datadog_metric_tag_configuration.example_dist_metric example.terraform.dist.metric


### PR DESCRIPTION
Adds example documentation for metric_metadata and metric_tag_configuration

Resolves #1705 