### PR TITLE
[datadog_application_key] Manage application key scopes

### DIFF
--- a/datadog/data_source_datadog_application_key.go
+++ b/datadog/data_source_datadog_application_key.go
@@ -26,7 +26,12 @@ func dataSourceDatadogApplicationKey() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 			},
-
+			"scopes": {
+				Description: "Authorization scopes for the Application Key.",
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 			// Computed values
 			"key": {
 				Description: "The value of the Application Key.",

--- a/datadog/resource_datadog_application_key.go
+++ b/datadog/resource_datadog_application_key.go
@@ -27,6 +27,12 @@ func resourceDatadogApplicationKey() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
+			"scopes": {
+				Description: "Authorization scopes for the Application Key.",
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 			"key": {
 				Description: "The value of the Application Key.",
 				Type:        schema.TypeString,
@@ -58,6 +64,9 @@ func updateApplicationKeyState(d *schema.ResourceData, applicationKeyData *datad
 	applicationKeyAttributes := applicationKeyData.GetAttributes()
 
 	if err := d.Set("name", applicationKeyAttributes.GetName()); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("scopes", applicationKeyAttributes.GetScopes()); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("key", applicationKeyAttributes.GetKey()); err != nil {

--- a/datadog/resource_datadog_cloud_configuration_rule.go
+++ b/datadog/resource_datadog_cloud_configuration_rule.go
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
 )

--- a/datadog/tests/resource_datadog_application_key_test.go
+++ b/datadog/tests/resource_datadog_application_key_test.go
@@ -22,6 +22,10 @@ func TestAccDatadogApplicationKey_Update(t *testing.T) {
 	accProvider := testAccProvider(t, accProviders)
 	applicationKeyName := uniqueEntityName(ctx, t)
 	applicationKeyNameUpdate := applicationKeyName + "-2"
+	applicationKeyScopes := []string{
+		"dashboards_read",
+		"dashboards_write",
+	}
 	resourceName := "datadog_application_key.foo"
 
 	resource.Test(t, resource.TestCase{
@@ -42,6 +46,14 @@ func TestAccDatadogApplicationKey_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatadogApplicationKeyExists(accProvider, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", applicationKeyNameUpdate),
+					testAccCheckDatadogApplicationKeyValueMatches(accProvider, resourceName),
+				),
+			},
+			{
+				Config: testAccCheckDatadogApplicationKeyConfigScopesRequired(applicationKeyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogApplicationKeyExists(accProvider, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "scopes", applicationKeyScopes),
 					testAccCheckDatadogApplicationKeyValueMatches(accProvider, resourceName),
 				),
 			},
@@ -68,6 +80,9 @@ func TestDatadogApplicationKey_import(t *testing.T) {
 				Config: testAccCheckDatadogApplicationKeyConfigRequired(applicationKeyName),
 			},
 			{
+				Config: testAccCheckDatadogApplicationKeyConfigScopesRequired(applicationKeyName),
+			},
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -80,6 +95,14 @@ func testAccCheckDatadogApplicationKeyConfigRequired(uniq string) string {
 	return fmt.Sprintf(`
 resource "datadog_application_key" "foo" {
   name = "%s"
+}`, uniq)
+}
+
+func testAccCheckDatadogApplicationKeyConfigScopesRequired(uniq string) string {
+	return fmt.Sprintf(`
+resource "datadog_application_key" "foo" {
+  name = "%s"
+  scopes = ["dashboards_read", "dashboards_write"]
 }`, uniq)
 }
 

--- a/docs/resources/application_key.md
+++ b/docs/resources/application_key.md
@@ -16,6 +16,19 @@ Provides a Datadog Application Key resource. This can be used to create and mana
 # Create a new Datadog Application Key
 resource "datadog_application_key" "foo" {
   name = "foo-application"
+```
+
+If the authorization scopes beta is enabled, you can provide scopes for the key:
+
+# Create a scoped Datadog Application Key
+
+```terraform
+resource "datadog_application_key" "foo_scoped" {
+  name = "foo-application"
+  scopes = [
+    "dashboards_read",
+    "dashboards_write",
+  ]
 }
 ```
 
@@ -25,6 +38,10 @@ resource "datadog_application_key" "foo" {
 ### Required
 
 - `name` (String) Name for Application Key.
+
+### Optional
+
+- `scopes` (List of String) An array of scopes authorized for the key [Key Management #scopes](https://docs.datadoghq.com/account_management/api-app-keys/#scopes)
 
 ### Read-Only
 


### PR DESCRIPTION
Add the ability to manage application key scopes.

```terraform
resource "datadog_application_key" "foo_scoped" {
  name = "foo-application"
  scopes = [
    "dashboards_read",
    "dashboards_write",
  ]
}
```

Works with import and create:

```shell
$ terraform state show datadog_application_key.foo_scoped
# datadog_application_key.foo_scoped:
resource "datadog_application_key" "foo_scoped" {
    id     = "**snip**"
    name   = "foo-application"
    scopes = [
        "dashboards_read",
        "dashboards_write",
    ]
}
```