### PR TITLE
Terraform fails on capitalised provider source

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ Use the navigation to the left to read about the available resources.
 terraform {
   required_providers {
     datadog = {
-      source = "DataDog/datadog"
+      source = "datadog/datadog"
     }
   }
 }


### PR DESCRIPTION
Terraform 1.3.0 fails to download the provider unless it is lowercase.