### PR TITLE
[provider] Support monitor `notification_preset_name`

### DIFF
--- a/datadog/data_source_datadog_monitor.go
+++ b/datadog/data_source_datadog_monitor.go
@@ -265,6 +265,11 @@ func dataSourceDatadogMonitor() *schema.Resource {
 					},
 				},
 			},
+			"notification_preset_name": {
+				Description: "Toggles the display of additional content sent in the monitor notification. Valid values are: `show_all`, `hide_query`, `hide_handles`, and `hide_all`.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -373,6 +378,7 @@ func dataSourceDatadogMonitorRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("restricted_roles", restricted_roles)
 	d.Set("groupby_simple_monitor", m.Options.GetGroupbySimpleMonitor())
 	d.Set("notify_by", m.Options.GetNotifyBy())
+	d.Set("notification_preset_name", m.Options.GetNotificationPresetName())
 
 	evaluation_window := make(map[string]interface{})
 	if e, ok := m.Options.SchedulingOptions.GetEvaluationWindowOk(); ok {

--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -368,6 +368,12 @@ func resourceDatadogMonitor() *schema.Resource {
 					},
 				},
 			},
+			"notification_preset_name": {
+				Description:      "Toggles the display of additional content sent in the monitor notification. Valid values are: `show_all`, `hide_query`, `hide_handles`, and `hide_all`.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewMonitorOptionsNotificationPresetsFromValue),
+			},
 		},
 	}
 }
@@ -663,6 +669,10 @@ func buildMonitorStruct(d utils.Resource) (*datadogV1.Monitor, *datadogV1.Monito
 		}
 		scheduling_options.SetEvaluationWindow(*evaluation_window)
 		o.SetSchedulingOptions(*scheduling_options)
+	}
+
+	if attr, ok := d.GetOk("notification_preset_name"); ok {
+		o.SetNotificationPresetName(datadogV1.MonitorOptionsNotificationPresets(attr.(string)))
 	}
 
 	m := datadogV1.NewMonitor(d.Get("query").(string), monitorType)
@@ -1004,6 +1014,10 @@ func updateMonitorState(d *schema.ResourceData, meta interface{}, m *datadogV1.M
 		if err := d.Set("scheduling_options", []interface{}{scheduling_options}); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if err := d.Set("notification_preset_name", m.Options.GetNotificationPresetName()); err != nil {
+		return diag.FromErr(err)
 	}
 
 	return nil

--- a/datadog/tests/resource_datadog_monitor_test.go
+++ b/datadog/tests/resource_datadog_monitor_test.go
@@ -943,6 +943,49 @@ func TestAccDatadogMonitor_SchedulingOptions(t *testing.T) {
 	})
 }
 
+func TestAccDatadogMonitor_NotificationPresetName(t *testing.T) {
+	t.Parallel()
+	ctx, accProviders := testAccProviders(context.Background(), t)
+	monitorName := uniqueEntityName(ctx, t)
+	accProvider := testAccProvider(t, accProviders)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: accProviders,
+		CheckDestroy:      testAccCheckDatadogMonitorDestroy(accProvider),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDatadogMonitorWithNotificationPresetName(monitorName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogMonitorExists(accProvider),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "name", monitorName),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "notification_preset_name", "hide_query"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDatadogMonitorWithNotificationPresetName(uniq string) string {
+	return fmt.Sprintf(`
+resource "datadog_monitor" "foo" {
+  name = "%s"
+  type = "metric alert"
+  message = "a message"
+  priority = 3
+
+  query = "avg(current_1mo):avg:system.load.5{*} > 0.5"
+
+  monitor_thresholds {
+	critical = "0.5"
+  }
+  
+	notification_preset_name = "hide_query"
+}`, uniq)
+}
+
 func testAccCheckDatadogMonitorWithSchedulingOptions(uniq string) string {
 	return fmt.Sprintf(`
 resource "datadog_monitor" "foo" {

--- a/docs/data-sources/monitor.md
+++ b/docs/data-sources/monitor.md
@@ -46,6 +46,7 @@ data "datadog_monitor" "test" {
 - `new_group_delay` (Number) Time (in seconds) to skip evaluations for new groups.
 - `new_host_delay` (Number) Time (in seconds) allowing a host to boot and applications to fully start before starting the evaluation of monitor results.
 - `no_data_timeframe` (Number) The number of minutes before the monitor notifies when data stops reporting.
+- `notification_preset_name` (String) Toggles the display of additional content sent in the monitor notification. Valid values are: `show_all`, `hide_query`, `hide_handles`, and `hide_all`.
 - `notify_audit` (Boolean) Whether or not tagged users are notified on changes to the monitor.
 - `notify_by` (Set of String) Controls what granularity a monitor alerts on. Only available for monitors with groupings. For instance, a monitor grouped by `cluster`, `namespace`, and `pod` can be configured to only notify on each new `cluster` violating the alert conditions by setting `notify_by` to `['cluster']`. Tags mentioned in `notify_by` must be a subset of the grouping tags in the query. For example, a query grouped by `cluster` and `namespace` cannot notify on `region`. Setting `notify_by` to `[*]` configures the monitor to notify as a simple-alert.
 - `notify_no_data` (Boolean) Whether or not this monitor notifies when data stops reporting.

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -67,6 +67,7 @@ For example, if the value is set to `300` (5min), the `timeframe` is set to `las
 - `no_data_timeframe` (Number) The number of minutes before a monitor will notify when data stops reporting. Provider defaults to 10 minutes.
 
 We recommend at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks.
+- `notification_preset_name` (String) Toggles the display of additional content sent in the monitor notification. Valid values are: `show_all`, `hide_query`, `hide_handles`, and `hide_all`. Valid values are `show_all`, `hide_query`, `hide_handles`, `hide_all`.
 - `notify_audit` (Boolean) A boolean indicating whether tagged users will be notified on changes to this monitor. Defaults to `false`.
 - `notify_by` (Set of String) Controls what granularity a monitor alerts on. Only available for monitors with groupings. For instance, a monitor grouped by `cluster`, `namespace`, and `pod` can be configured to only notify on each new `cluster` violating the alert conditions by setting `notify_by` to `['cluster']`. Tags mentioned in `notify_by` must be a subset of the grouping tags in the query. For example, a query grouped by `cluster` and `namespace` cannot notify on `region`. Setting `notify_by` to `[*]` configures the monitor to notify as a simple-alert. **NOTE:** Currently in private beta. To request access, contact Support at support@datadoghq.com
 - `notify_no_data` (Boolean) A boolean indicating whether this monitor will notify when data stops reporting. Defaults to `false`.


### PR DESCRIPTION
Implementing issue #1729 

I do not have access to a testing/sandbox Datadog environnement unfortunately so I could not run the acceptance tests.