### PR TITLE
[datadog_service_account] fix migration compilation error

### DIFF
--- a/datadog/resource_datadog_service_account.go
+++ b/datadog/resource_datadog_service_account.go
@@ -92,7 +92,7 @@ func resourceDatadogServiceAccountCreate(ctx context.Context, d *schema.Resource
 	var userID string
 	updated := false
 
-	createResponse, httpresp, err := apiInstances.GetUsersApiV2().CreateServiceAccount(auth, *serviceAccountRequest)
+	createResponse, httpresp, err := apiInstances.GetServiceAccountsApiV2().CreateServiceAccount(auth, *serviceAccountRequest)
 	if err != nil {
 		// Datadog does not actually delete users, so CreateUser might return a 409.
 		// We ignore that case and proceed, likely re-enabling the user.

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-datadog
 
 require (
-	github.com/DataDog/datadog-api-client-go/v2 v2.7.1-0.20230120075132-4b9844ff6888
+	github.com/DataDog/datadog-api-client-go/v2 v2.7.1-0.20230201191519-cc26ddbcaf08
 	github.com/DataDog/dd-sdk-go-testing v0.0.0-20211116174033-1cd082e322ad
 	github.com/dnaeon/go-vcr v1.0.1
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/datadog-api-client-go/v2 v2.7.1-0.20230120075132-4b9844ff6888 h1:MLHiIxHYnsZaV2HCkuJ/QraIQms9d2k2VwIxid2QKB8=
-github.com/DataDog/datadog-api-client-go/v2 v2.7.1-0.20230120075132-4b9844ff6888/go.mod h1:sHt3EuVMN8PSYJu065qwp3pZxCwR3RZP4sJnYwj/ZQY=
+github.com/DataDog/datadog-api-client-go/v2 v2.7.1-0.20230201191519-cc26ddbcaf08 h1:TgYhn5zwM0eLcL2/wJLqXg2WUA+Y0vC2NxSf1CtZv90=
+github.com/DataDog/datadog-api-client-go/v2 v2.7.1-0.20230201191519-cc26ddbcaf08/go.mod h1:sHt3EuVMN8PSYJu065qwp3pZxCwR3RZP4sJnYwj/ZQY=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=


### PR DESCRIPTION
Service account got moved. This code needs to be updated because the provider currently doesn't compile with a go client version bump.

Spec update: https://github.com/DataDog/datadog-api-spec/pull/2030