### PR TITLE
[datadog_integration_pagerduty] Mark API Token as required argument

### DIFF
--- a/datadog/resource_datadog_integration_pagerduty.go
+++ b/datadog/resource_datadog_integration_pagerduty.go
@@ -43,7 +43,7 @@ func resourceDatadogIntegrationPagerduty() *schema.Resource {
 			"api_token": {
 				Description: "Your PagerDuty API token.",
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 				Sensitive:   true,
 			},
 		},

--- a/docs/resources/integration_pagerduty.md
+++ b/docs/resources/integration_pagerduty.md
@@ -45,8 +45,8 @@ resource "datadog_integration_pagerduty_service_object" "testing_bar" {
 
 ### Required
 
-- `subdomain` (String) Your PagerDuty account’s personalized subdomain name.
 - `api_token` (String, Sensitive) Your PagerDuty API token.
+- `subdomain` (String) Your PagerDuty account’s personalized subdomain name.
 
 ### Optional
 

--- a/docs/resources/integration_pagerduty.md
+++ b/docs/resources/integration_pagerduty.md
@@ -46,10 +46,10 @@ resource "datadog_integration_pagerduty_service_object" "testing_bar" {
 ### Required
 
 - `subdomain` (String) Your PagerDuty account’s personalized subdomain name.
+- `api_token` (String, Sensitive) Your PagerDuty API token.
 
 ### Optional
 
-- `api_token` (String, Sensitive) Your PagerDuty API token.
 - `schedules` (List of String) Array of your schedule URLs.
 
 ### Read-Only


### PR DESCRIPTION
Original PR by @StreamOfRon
> If api_token is not supplied, the API throws a 400 error. Updating the documentation to reflect this as a required argument to avoid future confusion.
> 
> ```
> ---[ REQUEST ]---------------------------------------
> PUT /api/v1/integration/pagerduty HTTP/1.1
> Host: api.datadoghq.com
> User-Agent: terraform-provider-datadog/3.20.0 (terraform 2.10.1; terraform-cli 1.3.7) datadog-api-client-go/go-datadog-api (go go1.18.9; os darwin; arch arm64)
> Content-Length: 44
> Content-Type: application/json
> Dd-Api-Key: *****
> Dd-Application-Key: *****
> Accept-Encoding: gzip
> 
> {
>  "subdomain": "*****",
>  "api_token": ""
> }
> -----------------------------------------------------: timestamp=2023-02-06T10:55:41.838-0800
> 2023-02-06T10:55:42.216-0800 [INFO]  provider.terraform-provider-datadog_v3.20.0: 2023/02/06 10:55:42 [DEBUG] Datadog API Response Details:
> ---[ RESPONSE ]--------------------------------------
> HTTP/1.1 400 Bad Request
> Connection: close
> Transfer-Encoding: chunked
> Cache-Control: no-cache
> Content-Type: application/json
> Date: Mon, 06 Feb 2023 18:55:42 GMT
> Pragma: no-cache
> Strict-Transport-Security: max-age=15724800;
> Vary: Accept-Encoding
> X-Content-Type-Options: nosniff
> X-Frame-Options: SAMEORIGIN
> 
> 30
> {
>  "errors": [
>   "API Token should be of length 20."
>  ]
> }
> 0
> ```

Supercedes https://github.com/DataDog/terraform-provider-datadog/pull/1759, due to title/changelog CI permissions failing