### PR TITLE
[datadog_dashboards] Docs update for event_size field in dashboard list_stream_definition

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -5212,7 +5212,7 @@ func getListStreamRequestSchema() map[string]*schema.Schema {
 						Optional:    true,
 					},
 					"event_size": {
-						Description:      "Size of events displayed in widget.",
+						Description:      "Size of events displayed in widget. Required if `data_source` is `event_stream`.",
 						Type:             schema.TypeString,
 						Optional:         true,
 						ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewWidgetEventSizeFromValue),

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -4544,7 +4544,7 @@ Required:
 
 Optional:
 
-- `event_size` (String) Size of events displayed in widget. Valid values are `s`, `l`.
+- `event_size` (String) Size of events displayed in widget. Required if `data_source` is `event_stream`. Valid values are `s`, `l`.
 - `indexes` (List of String) List of indexes.
 - `query_string` (String) Widget query.
 - `storage` (String) Storage location (private beta).
@@ -10018,7 +10018,7 @@ Required:
 
 Optional:
 
-- `event_size` (String) Size of events displayed in widget. Valid values are `s`, `l`.
+- `event_size` (String) Size of events displayed in widget. Required if `data_source` is `event_stream`. Valid values are `s`, `l`.
 - `indexes` (List of String) List of indexes.
 - `query_string` (String) Widget query.
 - `storage` (String) Storage location (private beta).


### PR DESCRIPTION
Adds note that `event_size` is required when using a list stream with the `event_stream` data source