### PR TITLE
Docs: update with valid values for sythetics_test renotify_interval

### DIFF
--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -680,7 +680,7 @@ Optional:
 
 Optional:
 
-- `renotify_interval` (Number) Specify a renotification frequency.
+- `renotify_interval` (Number) Specify a renotification frequency. Valid values are `0`, `10`, `20`, `30`, `40`, `50`, `60`, `90`, `120`, `180`, `240`, `300`, `360`, `720`, `1440`.
 
 
 <a id="nestedblock--options_list--retry"></a>


### PR DESCRIPTION
Recently ran into an error using this provider:

```
│ Error: error updating synthetics API test from https://api.datadoghq.com/api/v1/synthetics/tests/api/qn8-4rv-gge: 400 Bad Request: {"errors":["properties.options.properties.monitor_options.properties.renotify_interval.enum: 5 is not one of [0, 10, 20, 30, 40, 50, 60, 90, 120, 180, 240, 300, 360, 720, 1440]
```

This PR updates the documentation to more explicitly list the valid values for the `sythetics_test` `renotify_interval` values.