### PR TITLE
[datadog_downtime] Ignore start/end comparison on recurring downtimes

### DIFF
--- a/datadog/resource_datadog_downtime.go
+++ b/datadog/resource_datadog_downtime.go
@@ -311,11 +311,17 @@ func downtimeBoundaryNeedsApply(d *schema.ResourceData, tsFrom string, apiTs, co
 
 	if updating {
 		// when updating, we apply when
-		// * API-returned value is different than configured value
 		// * the config value has changed
-		if apiTs != configTs || d.HasChange(tsFrom) {
+		// * API-returned value is different than configured value and there is no recurrence
+		if d.HasChange(tsFrom) {
 			apply = true
+		} else {
+			_, ok := d.GetOk("active_child_id")
+			if !ok && apiTs != configTs {
+				apply = true
+			}
 		}
+
 	} else {
 		// when creating, we always apply
 		apply = true


### PR DESCRIPTION
We compare with the times of the children, so there is going to be a change after every recurrence. Let's ignore it instead, at the expense of losing UI drifts. This was the intent of the original recurrence support but wasn't done.