### PR TITLE
[datadog_metric_tag_configuration] Fix tag validation for metric tags configs

### DIFF
--- a/datadog/resource_datadog_metric_tag_configuration.go
+++ b/datadog/resource_datadog_metric_tag_configuration.go
@@ -87,7 +87,7 @@ func resourceDatadogMetricTagConfiguration() *schema.Resource {
 				Type:        schema.TypeSet,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.All(validation.StringMatch(regexp.MustCompile(`^[A-Za-z][A-Za-z0-9\.\-\_:\/]*[^:]$`), "tags must be valid"), validation.StringLenBetween(1, 200)),
+					ValidateFunc: validation.All(validation.StringMatch(regexp.MustCompile(`^[A-Za-z](?:[A-Za-z0-9\.\-\_:\/]*[A-Za-z0-9\.\-\_\/])*$`), "tags must be valid"), validation.StringLenBetween(1, 200)),
 				},
 				Required: true,
 			},

--- a/datadog/resource_datadog_metric_tag_configuration.go
+++ b/datadog/resource_datadog_metric_tag_configuration.go
@@ -87,7 +87,7 @@ func resourceDatadogMetricTagConfiguration() *schema.Resource {
 				Type:        schema.TypeSet,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.All(validation.StringMatch(regexp.MustCompile(`^[A-Za-z](?:[A-Za-z0-9\.\-\_:\/]*[A-Za-z0-9\.\-\_\/])*$`), "tags must be valid"), validation.StringLenBetween(1, 200)),
+					ValidateFunc: validation.All(validation.StringMatch(regexp.MustCompile(`^[A-Za-z][A-Za-z0-9\.\-\_:\/]*$`), "tags must be valid"), validation.StringLenBetween(1, 200)),
 				},
 				Required: true,
 			},


### PR DESCRIPTION
`key:value` end of string parsing with `[^:]` is too loose, allows special characters that aren't allowed in tags
Tags are allowed to end in `:`, so this relaxes that validation and fixes the above issue