### PR TITLE
[datadog_security_monitoring_default_rule] Update deprecation warning for security monitoring rule

### DIFF
--- a/datadog/resource_datadog_security_monitoring_default_rule.go
+++ b/datadog/resource_datadog_security_monitoring_default_rule.go
@@ -113,10 +113,10 @@ func securityMonitoringRuleDeprecationWarning(rule securityMonitoringRuleRespons
 			Severity: diag.Warning,
 			Summary:  fmt.Sprintf("Rule will be deprecated on %s.", deprecation.Format("Jan _2 2006")),
 			Detail: "Please consider deleting the associated resource." +
-			"After the depreciation date, the rule will stop triggering signals." +
-			" Moreover, the API will reject any call to update the rule, which might break your Terraform pipeline." + 
-			"The Datadog team performs regular audit of all detection rules to maintain high fidelity signal quality." +
-			"We will be replacing this rule with an improved third party detection rule after the depreciation date." ,
+				"After the depreciation date, the rule will stop triggering signals." +
+				" Moreover, the API will reject any call to update the rule, which might break your Terraform pipeline." +
+				"The Datadog team performs regular audit of all detection rules to maintain high fidelity signal quality." +
+				"We will be replacing this rule with an improved third party detection rule after the depreciation date.",
 		}
 
 		diags = append(diags, warning)

--- a/datadog/resource_datadog_security_monitoring_default_rule.go
+++ b/datadog/resource_datadog_security_monitoring_default_rule.go
@@ -112,9 +112,11 @@ func securityMonitoringRuleDeprecationWarning(rule securityMonitoringRuleRespons
 		warning := diag.Diagnostic{
 			Severity: diag.Warning,
 			Summary:  fmt.Sprintf("Rule will be deprecated on %s.", deprecation.Format("Jan _2 2006")),
-			Detail: "Please consider deleting the associated resource. " +
-				"After the deprecation date, the rule will stop triggering signals. " +
-				"Moreover, the API will reject any call to update the rule, which might break your Terraform pipeline.",
+			Detail: "Please consider deleting the associated resource." +
+			"After the depreciation date, the rule will stop triggering signals." +
+			" Moreover, the API will reject any call to update the rule, which might break your Terraform pipeline." + 
+			"The Datadog team performs regular audit of all detection rules to maintain high fidelity signal quality." +
+			"We will be replacing this rule with an improved third party detection rule after the depreciation date." ,
 		}
 
 		diags = append(diags, warning)


### PR DESCRIPTION
Update terraform warning message detail on default rule depreciation for more clarity per [the following issue](https://datadoghq.atlassian.net/jira/software/c/projects/SEC/boards/1549?modal=detail&selectedIssue=SEC-7439): 