### PR TITLE
[datadog_security_monitoring_default_rule] Add spaces to deprecation message

### DIFF
--- a/datadog/resource_datadog_security_monitoring_default_rule.go
+++ b/datadog/resource_datadog_security_monitoring_default_rule.go
@@ -112,11 +112,11 @@ func securityMonitoringRuleDeprecationWarning(rule securityMonitoringRuleRespons
 		warning := diag.Diagnostic{
 			Severity: diag.Warning,
 			Summary:  fmt.Sprintf("Rule will be deprecated on %s.", deprecation.Format("Jan _2 2006")),
-			Detail: "Please consider deleting the associated resource." +
-				"After the depreciation date, the rule will stop triggering signals." +
-				" Moreover, the API will reject any call to update the rule, which might break your Terraform pipeline." +
-				"The Datadog team performs regular audit of all detection rules to maintain high fidelity signal quality." +
-				"We will be replacing this rule with an improved third party detection rule after the depreciation date.",
+			Detail: "Please consider deleting the associated resource. " +
+				"After the depreciation date, the rule will stop triggering signals. " +
+				" Moreover, the API will reject any call to update the rule, which might break your Terraform pipeline. " +
+				"The Datadog team performs regular audit of all detection rules to maintain high fidelity signal quality. " +
+				"We will be replacing this rule with an improved third party detection rule after the depreciation date. ",
 		}
 
 		diags = append(diags, warning)

--- a/datadog/resource_datadog_security_monitoring_default_rule.go
+++ b/datadog/resource_datadog_security_monitoring_default_rule.go
@@ -116,7 +116,7 @@ func securityMonitoringRuleDeprecationWarning(rule securityMonitoringRuleRespons
 				"After the depreciation date, the rule will stop triggering signals. " +
 				" Moreover, the API will reject any call to update the rule, which might break your Terraform pipeline. " +
 				"The Datadog team performs regular audit of all detection rules to maintain high fidelity signal quality. " +
-				"We will be replacing this rule with an improved third party detection rule after the depreciation date. ",
+				"We will be replacing this rule with an improved third party detection rule after the depreciation date.",
 		}
 
 		diags = append(diags, warning)


### PR DESCRIPTION
Revision from [this PR](https://github.com/DataDog/terraform-provider-datadog/pull/1827) to add spaces at the end of each sentence. 