### PR TITLE
[datadog_dashboard] Handle empty section in template variables

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -420,6 +420,9 @@ func getTemplateVariableSchema() map[string]*schema.Schema {
 func buildDatadogTemplateVariables(terraformTemplateVariables *[]interface{}) *[]datadogV1.DashboardTemplateVariable {
 	datadogTemplateVariables := make([]datadogV1.DashboardTemplateVariable, len(*terraformTemplateVariables))
 	for i, ttv := range *terraformTemplateVariables {
+		if ttv == nil {
+			continue
+		}
 		terraformTemplateVariable := ttv.(map[string]interface{})
 		var datadogTemplateVariable datadogV1.DashboardTemplateVariable
 		if v, ok := terraformTemplateVariable["name"].(string); ok && len(v) != 0 {
@@ -544,6 +547,9 @@ func buildDatadogTemplateVariablePresets(terraformTemplateVariablePresets *[]int
 			datadogTemplateVariablePresetValues := make([]datadogV1.DashboardTemplateVariablePresetValue, len(templateVariablePresetValues))
 
 			for j, tvp := range templateVariablePresetValues {
+				if tvp == nil {
+					continue
+				}
 				templateVariablePresetValue := tvp.(map[string]interface{})
 				var datadogTemplateVariablePresetValue datadogV1.DashboardTemplateVariablePresetValue
 

--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -530,6 +530,9 @@ func buildDatadogTemplateVariablePresets(terraformTemplateVariablePresets *[]int
 	datadogTemplateVariablePresets := make([]datadogV1.DashboardTemplateVariablePreset, len(*terraformTemplateVariablePresets))
 
 	for i, tvp := range *terraformTemplateVariablePresets {
+		if tvp == nil {
+			continue
+		}
 		templateVariablePreset := tvp.(map[string]interface{})
 		var datadogTemplateVariablePreset datadogV1.DashboardTemplateVariablePreset
 


### PR DESCRIPTION
This can cause a crash, if we don't check for nil structs.

Closes #1841 