### PR TITLE
[provider] Add helper to validate normalized tags

### DIFF
--- a/datadog/internal/validators/tags_set_is_nomalized.go
+++ b/datadog/internal/validators/tags_set_is_nomalized.go
@@ -10,20 +10,20 @@ import (
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 )
 
-func StringSetTagsAreNormalized() stringSetTagsAreNormalized {
-	return stringSetTagsAreNormalized{}
+func TagsSetIsNormalized() tagsSetIsNormalized {
+	return tagsSetIsNormalized{}
 }
 
-type stringSetTagsAreNormalized struct{}
+type tagsSetIsNormalized struct{}
 
-func (v stringSetTagsAreNormalized) Description(_ context.Context) string {
+func (v tagsSetIsNormalized) Description(_ context.Context) string {
 	return "Tags must be normalized. See docs https://docs.datadoghq.com/getting_started/tagging/#define-tags"
 }
-func (v stringSetTagsAreNormalized) MarkdownDescription(ctx context.Context) string {
+func (v tagsSetIsNormalized) MarkdownDescription(ctx context.Context) string {
 	return v.Description(ctx)
 }
 
-func (v stringSetTagsAreNormalized) ValidateSet(ctx context.Context, req validator.SetRequest, resp *validator.SetResponse) {
+func (v tagsSetIsNormalized) ValidateSet(ctx context.Context, req validator.SetRequest, resp *validator.SetResponse) {
 	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
 		return
 	}

--- a/datadog/internal/validators/tags_string_set_nomalized.go
+++ b/datadog/internal/validators/tags_string_set_nomalized.go
@@ -1,0 +1,48 @@
+package validators
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+)
+
+func StringSetTagsAreNormalized() stringSetTagsAreNormalized {
+	return stringSetTagsAreNormalized{}
+}
+
+type stringSetTagsAreNormalized struct{}
+
+func (v stringSetTagsAreNormalized) Description(_ context.Context) string {
+	return "Tags must be normalized. See docs https://docs.datadoghq.com/getting_started/tagging/#define-tags"
+}
+func (v stringSetTagsAreNormalized) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v stringSetTagsAreNormalized) ValidateSet(ctx context.Context, req validator.SetRequest, resp *validator.SetResponse) {
+	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
+		return
+	}
+
+	for _, i := range req.ConfigValue.Elements() {
+		var val types.String
+		diags := tfsdk.ValueAs(ctx, i, &val)
+		resp.Diagnostics.Append(diags...)
+		if diags.HasError() {
+			return
+		}
+
+		normalizedVal := utils.NormalizeTag(val.ValueString())
+		if val.ValueString() != normalizedVal {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				v.Description(ctx),
+				fmt.Sprintf("'%s' should be '%s'", val.ValueString(), normalizedVal),
+			)
+		}
+	}
+}


### PR DESCRIPTION
Add helper that validate tags are normalized.

We previously dealt with such normalizations using the `DiffSuppressFunc` but this is currently not possible with the framework sdk. See issue: https://github.com/hashicorp/terraform-plugin-framework/issues/70
