### PR TITLE
[datadog_synthetics_test] Refactor options for Synthetics tests

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -2481,6 +2481,124 @@ func buildLocalExtractedValues(extractedValues []datadogV1.SyntheticsParsingOpti
 	return localExtractedValues
 }
 
+func buildLocalOptions(actualOptions datadogV1.SyntheticsTestOptions) []map[string]interface{} {
+	localOptionsList := make(map[string]interface{})
+
+	if actualOptions.HasFollowRedirects() {
+		localOptionsList["follow_redirects"] = actualOptions.GetFollowRedirects()
+	}
+	if actualOptions.HasMinFailureDuration() {
+		localOptionsList["min_failure_duration"] = actualOptions.GetMinFailureDuration()
+	}
+	if actualOptions.HasMinLocationFailed() {
+		localOptionsList["min_location_failed"] = actualOptions.GetMinLocationFailed()
+	}
+	if actualOptions.HasTickEvery() {
+		localOptionsList["tick_every"] = actualOptions.GetTickEvery()
+	}
+	if actualOptions.HasHttpVersion() {
+		localOptionsList["http_version"] = actualOptions.GetHttpVersion()
+	}
+	if actualOptions.HasAcceptSelfSigned() {
+		localOptionsList["accept_self_signed"] = actualOptions.GetAcceptSelfSigned()
+	}
+	if actualOptions.HasCheckCertificateRevocation() {
+		localOptionsList["check_certificate_revocation"] = actualOptions.GetCheckCertificateRevocation()
+	}
+	if actualOptions.HasAllowInsecure() {
+		localOptionsList["allow_insecure"] = actualOptions.GetAllowInsecure()
+	}
+
+	if actualOptions.HasScheduling() {
+		scheduling := actualOptions.GetScheduling()
+		timeFrames := scheduling.GetTimeframes()
+		optionsListScheduling := make(map[string]interface{})
+		optionsListSchedulingTimeframes := make([]map[string]interface{}, 0, len(timeFrames))
+		for _, tf := range timeFrames {
+			timeframe := make(map[string]interface{})
+			timeframe["from"] = tf.GetFrom()
+			timeframe["day"] = tf.GetDay()
+			timeframe["to"] = tf.GetTo()
+			optionsListSchedulingTimeframes = append(optionsListSchedulingTimeframes, timeframe)
+		}
+		optionsListScheduling["timeframes"] = optionsListSchedulingTimeframes
+		optionsListScheduling["timezone"] = scheduling.GetTimezone()
+		optionsListSchedulingList := []map[string]interface{}{optionsListScheduling}
+		localOptionsList["scheduling"] = optionsListSchedulingList
+	}
+
+	if actualOptions.HasRetry() {
+		retry := actualOptions.GetRetry()
+		optionsListRetry := make(map[string]interface{})
+		optionsListRetry["count"] = retry.GetCount()
+
+		if interval, ok := retry.GetIntervalOk(); ok {
+			optionsListRetry["interval"] = interval
+		}
+
+		localOptionsList["retry"] = []map[string]interface{}{optionsListRetry}
+	}
+	if actualOptions.HasMonitorOptions() {
+		actualMonitorOptions := actualOptions.GetMonitorOptions()
+		renotifyInterval := actualMonitorOptions.GetRenotifyInterval()
+
+		optionsListMonitorOptions := make(map[string]int64)
+		optionsListMonitorOptions["renotify_interval"] = renotifyInterval
+		localOptionsList["monitor_options"] = []map[string]int64{optionsListMonitorOptions}
+	}
+	if actualOptions.HasNoScreenshot() {
+		localOptionsList["no_screenshot"] = actualOptions.GetNoScreenshot()
+	}
+	if actualOptions.HasMonitorName() {
+		localOptionsList["monitor_name"] = actualOptions.GetMonitorName()
+	}
+	if actualOptions.HasMonitorPriority() {
+		localOptionsList["monitor_priority"] = actualOptions.GetMonitorPriority()
+	}
+	if actualOptions.HasRestrictedRoles() {
+		localOptionsList["restricted_roles"] = actualOptions.GetRestrictedRoles()
+	}
+	if actualOptions.HasCi() {
+		actualCi := actualOptions.GetCi()
+		ciOptions := make(map[string]interface{})
+		ciOptions["execution_rule"] = actualCi.GetExecutionRule()
+
+		localOptionsList["ci"] = []map[string]interface{}{ciOptions}
+	}
+
+	if rumSettings, ok := actualOptions.GetRumSettingsOk(); ok {
+		localRumSettings := make(map[string]interface{})
+		localRumSettings["is_enabled"] = rumSettings.GetIsEnabled()
+
+		if rumSettings.HasApplicationId() {
+			localRumSettings["application_id"] = rumSettings.GetApplicationId()
+		}
+
+		if rumSettings.HasClientTokenId() {
+			localRumSettings["client_token_id"] = rumSettings.GetClientTokenId()
+		}
+
+		localOptionsList["rum_settings"] = []map[string]interface{}{localRumSettings}
+	}
+	if actualOptions.HasIgnoreServerCertificateError() {
+		localOptionsList["ignore_server_certificate_error"] = actualOptions.GetIgnoreServerCertificateError()
+	}
+	if actualOptions.HasDisableCsp() {
+		localOptionsList["disable_csp"] = actualOptions.GetDisableCsp()
+	}
+	if actualOptions.HasDisableCors() {
+		localOptionsList["disable_cors"] = actualOptions.GetDisableCors()
+	}
+	if actualOptions.HasInitialNavigationTimeout() {
+		localOptionsList["initial_navigation_timeout"] = actualOptions.GetInitialNavigationTimeout()
+	}
+
+	localOptionsLists := make([]map[string]interface{}, 1)
+	localOptionsLists[0] = localOptionsList
+
+	return localOptionsLists
+}
+
 func updateSyntheticsBrowserTestLocalState(d *schema.ResourceData, syntheticsTest *datadogV1.SyntheticsBrowserTest) diag.Diagnostics {
 	if err := d.Set("type", syntheticsTest.GetType()); err != nil {
 		return diag.FromErr(err)
@@ -2626,113 +2744,8 @@ func updateSyntheticsBrowserTestLocalState(d *schema.ResourceData, syntheticsTes
 		return diag.FromErr(err)
 	}
 
-	actualOptions := syntheticsTest.GetOptions()
-	localOptionsList := make(map[string]interface{})
-	if actualOptions.HasFollowRedirects() {
-		localOptionsList["follow_redirects"] = actualOptions.GetFollowRedirects()
-	}
-	if actualOptions.HasMinFailureDuration() {
-		localOptionsList["min_failure_duration"] = actualOptions.GetMinFailureDuration()
-	}
-	if actualOptions.HasMinLocationFailed() {
-		localOptionsList["min_location_failed"] = actualOptions.GetMinLocationFailed()
-	}
-	if actualOptions.HasTickEvery() {
-		localOptionsList["tick_every"] = actualOptions.GetTickEvery()
-	}
-	if actualOptions.HasAcceptSelfSigned() {
-		localOptionsList["accept_self_signed"] = actualOptions.GetAcceptSelfSigned()
-	}
-	if actualOptions.HasAllowInsecure() {
-		localOptionsList["allow_insecure"] = actualOptions.GetAllowInsecure()
-	}
+	localOptionsLists := buildLocalOptions(syntheticsTest.GetOptions())
 
-	if actualOptions.HasScheduling() {
-		scheduling := actualOptions.GetScheduling()
-		timeFrames := scheduling.GetTimeframes()
-		optionsListScheduling := make(map[string]interface{})
-		optionsListSchedulingTimeframes := make([]map[string]interface{}, 0, len(timeFrames))
-		for _, tf := range timeFrames {
-			timeframe := make(map[string]interface{})
-			timeframe["from"] = tf.GetFrom()
-			timeframe["day"] = tf.GetDay()
-			timeframe["to"] = tf.GetTo()
-			optionsListSchedulingTimeframes = append(optionsListSchedulingTimeframes, timeframe)
-		}
-		optionsListScheduling["timeframes"] = optionsListSchedulingTimeframes
-		optionsListScheduling["timezone"] = scheduling.GetTimezone()
-		optionsListSchedulingList := []map[string]interface{}{optionsListScheduling}
-		localOptionsList["scheduling"] = optionsListSchedulingList
-	}
-
-	if actualOptions.HasRetry() {
-		retry := actualOptions.GetRetry()
-		optionsListRetry := make(map[string]interface{})
-		optionsListRetry["count"] = retry.GetCount()
-
-		if interval, ok := retry.GetIntervalOk(); ok {
-			optionsListRetry["interval"] = interval
-		}
-
-		localOptionsList["retry"] = []map[string]interface{}{optionsListRetry}
-	}
-	if actualOptions.HasMonitorOptions() {
-		actualMonitorOptions := actualOptions.GetMonitorOptions()
-		renotifyInterval := actualMonitorOptions.GetRenotifyInterval()
-
-		optionsListMonitorOptions := make(map[string]int64)
-		optionsListMonitorOptions["renotify_interval"] = renotifyInterval
-		localOptionsList["monitor_options"] = []map[string]int64{optionsListMonitorOptions}
-	}
-	if actualOptions.HasNoScreenshot() {
-		localOptionsList["no_screenshot"] = actualOptions.GetNoScreenshot()
-	}
-	if actualOptions.HasMonitorName() {
-		localOptionsList["monitor_name"] = actualOptions.GetMonitorName()
-	}
-	if actualOptions.HasMonitorPriority() {
-		localOptionsList["monitor_priority"] = actualOptions.GetMonitorPriority()
-	}
-	if actualOptions.HasRestrictedRoles() {
-		localOptionsList["restricted_roles"] = actualOptions.GetRestrictedRoles()
-	}
-	if actualOptions.HasCi() {
-		actualCi := actualOptions.GetCi()
-		ciOptions := make(map[string]interface{})
-		ciOptions["execution_rule"] = actualCi.GetExecutionRule()
-
-		localOptionsList["ci"] = []map[string]interface{}{ciOptions}
-	}
-
-	if rumSettings, ok := actualOptions.GetRumSettingsOk(); ok {
-		localRumSettings := make(map[string]interface{})
-		localRumSettings["is_enabled"] = rumSettings.GetIsEnabled()
-
-		if rumSettings.HasApplicationId() {
-			localRumSettings["application_id"] = rumSettings.GetApplicationId()
-		}
-
-		if rumSettings.HasClientTokenId() {
-			localRumSettings["client_token_id"] = rumSettings.GetClientTokenId()
-		}
-
-		localOptionsList["rum_settings"] = []map[string]interface{}{localRumSettings}
-	}
-	if actualOptions.HasIgnoreServerCertificateError() {
-		localOptionsList["ignore_server_certificate_error"] = actualOptions.GetIgnoreServerCertificateError()
-	}
-	if actualOptions.HasDisableCsp() {
-		localOptionsList["disable_csp"] = actualOptions.GetDisableCsp()
-	}
-	if actualOptions.HasDisableCors() {
-		localOptionsList["disable_cors"] = actualOptions.GetDisableCors()
-	}
-	if actualOptions.HasInitialNavigationTimeout() {
-		localOptionsList["initial_navigation_timeout"] = actualOptions.GetInitialNavigationTimeout()
-	}
-
-	localOptionsLists := make([]map[string]interface{}, 1)
-	localOptionsLists[0] = localOptionsList
 	if err := d.Set("options_list", localOptionsLists); err != nil {
 		return diag.FromErr(err)
 	}
@@ -3025,92 +3038,8 @@ func updateSyntheticsAPITestLocalState(d *schema.ResourceData, syntheticsTest *d
 		return diag.FromErr(err)
 	}
 
-	actualOptions := syntheticsTest.GetOptions()
-	localOptionsList := make(map[string]interface{})
-	if actualOptions.HasFollowRedirects() {
-		localOptionsList["follow_redirects"] = actualOptions.GetFollowRedirects()
-	}
-	if actualOptions.HasMinFailureDuration() {
-		localOptionsList["min_failure_duration"] = actualOptions.GetMinFailureDuration()
-	}
-	if actualOptions.HasMinLocationFailed() {
-		localOptionsList["min_location_failed"] = actualOptions.GetMinLocationFailed()
-	}
-	if actualOptions.HasTickEvery() {
-		localOptionsList["tick_every"] = actualOptions.GetTickEvery()
-	}
-	if actualOptions.HasHttpVersion() {
-		localOptionsList["http_version"] = actualOptions.GetHttpVersion()
-	}
-	if actualOptions.HasAcceptSelfSigned() {
-		localOptionsList["accept_self_signed"] = actualOptions.GetAcceptSelfSigned()
-	}
-	if actualOptions.HasCheckCertificateRevocation() {
-		localOptionsList["check_certificate_revocation"] = actualOptions.GetCheckCertificateRevocation()
-	}
-	if actualOptions.HasAllowInsecure() {
-		localOptionsList["allow_insecure"] = actualOptions.GetAllowInsecure()
-	}
-	if actualOptions.HasRetry() {
-		retry := actualOptions.GetRetry()
-		optionsListRetry := make(map[string]interface{})
-		optionsListRetry["count"] = retry.GetCount()
+	localOptionsLists := buildLocalOptions(syntheticsTest.GetOptions())
 
-		if interval, ok := retry.GetIntervalOk(); ok {
-			optionsListRetry["interval"] = interval
-		}
-
-		localOptionsList["retry"] = []map[string]interface{}{optionsListRetry}
-	}
-	if actualOptions.HasMonitorOptions() {
-		actualMonitorOptions := actualOptions.GetMonitorOptions()
-		renotifyInterval := actualMonitorOptions.GetRenotifyInterval()
-
-		optionsListMonitorOptions := make(map[string]int64)
-		optionsListMonitorOptions["renotify_interval"] = renotifyInterval
-		localOptionsList["monitor_options"] = []map[string]int64{optionsListMonitorOptions}
-	}
-	if actualOptions.HasMonitorName() {
-		localOptionsList["monitor_name"] = actualOptions.GetMonitorName()
-	}
-	if actualOptions.HasMonitorPriority() {
-		localOptionsList["monitor_priority"] = actualOptions.GetMonitorPriority()
-	}
-	if actualOptions.HasRestrictedRoles() {
-		localOptionsList["restricted_roles"] = actualOptions.GetRestrictedRoles()
-	}
-	if actualOptions.HasCi() {
-		actualCi := actualOptions.GetCi()
-		ciOptions := make(map[string]interface{})
-		ciOptions["execution_rule"] = actualCi.GetExecutionRule()
-
-		localOptionsList["ci"] = []map[string]interface{}{ciOptions}
-	}
-
-	if actualOptions.HasScheduling() {
-		scheduling := actualOptions.GetScheduling()
-		timeFrames := scheduling.GetTimeframes()
-		optionsListScheduling := make(map[string]interface{})
-		optionsListSchedulingTimeframes := make([]map[string]interface{}, 0, len(timeFrames))
-		for _, tf := range timeFrames {
-			timeframe := make(map[string]interface{})
-			timeframe["from"] = tf.GetFrom()
-			timeframe["day"] = tf.GetDay()
-			timeframe["to"] = tf.GetTo()
-			optionsListSchedulingTimeframes = append(optionsListSchedulingTimeframes, timeframe)
-		}
-		optionsListScheduling["timeframes"] = optionsListSchedulingTimeframes
-		optionsListScheduling["timezone"] = scheduling.GetTimezone()
-		optionsListSchedulingList := []map[string]interface{}{optionsListScheduling}
-		localOptionsList["scheduling"] = optionsListSchedulingList
-	}
-
-	if actualOptions.HasIgnoreServerCertificateError() {
-		localOptionsList["ignore_server_certificate_error"] = actualOptions.GetIgnoreServerCertificateError()
-	}
-
-	localOptionsLists := make([]map[string]interface{}, 1)
-	localOptionsLists[0] = localOptionsList
 	if err := d.Set("options_list", localOptionsLists); err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
This PR puts in common the code used to set the options on Synthetics tests as well as the building of the local state for options. Currently this is done separately for api and browser tests, and this has led to several issues in the past where an option was added somewhere but forgotten in the other type.