### PR TITLE
[datadog_service_level_objective] Fix edge case removing fields that are both optional and computed

### DIFF
--- a/datadog/resource_datadog_service_level_objective.go
+++ b/datadog/resource_datadog_service_level_objective.go
@@ -185,8 +185,6 @@ func resourceDatadogServiceLevelObjective() *schema.Resource {
 
 // ValidateServiceLevelObjectiveTypeString is a ValidateFunc that ensures the SLO is of one of the supported types
 
-// ValidateServiceLevelObjectiveTypeString is a ValidateFunc that ensures the SLO is of one of the supported types
-
 // Use CustomizeDiff to do monitor validation
 func resourceDatadogServiceLevelObjectiveCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 	if validate, ok := diff.GetOkExists("validate"); ok && !validate.(bool) {
@@ -313,20 +311,29 @@ func buildServiceLevelObjectiveStructs(d *schema.ResourceData) (*datadogV1.Servi
 		}
 	}
 
+	plan := d.GetRawConfig()
 	if tf, ok := d.GetOk("timeframe"); ok {
-		slo.SetTimeframe(datadogV1.SLOTimeframe(tf.(string)))
-		slor.SetTimeframe(datadogV1.SLOTimeframe(tf.(string)))
+		if plan.GetAttr("timeframe").IsNull() {
+			d.Set("timeframe", nil)
+		} else {
+			slo.SetTimeframe(datadogV1.SLOTimeframe(tf.(string)))
+			slor.SetTimeframe(datadogV1.SLOTimeframe(tf.(string)))
+		}
 	}
 
 	if targetValue, ok := d.GetOk("target_threshold"); ok {
-		if f, ok := floatOk(targetValue); ok {
+		if plan.GetAttr("target_threshold").IsNull() {
+			d.Set("target_threshold", nil)
+		} else if f, ok := floatOk(targetValue); ok {
 			slo.SetTargetThreshold(f)
 			slor.SetTargetThreshold(f)
 		}
 	}
 
 	if warningValue, ok := d.GetOk("warning_threshold"); ok {
-		if f, ok := floatOk(warningValue); ok {
+		if plan.GetAttr("warning_threshold").IsNull() {
+			d.Set("warning_threshold", nil)
+		} else if f, ok := floatOk(warningValue); ok {
 			slo.SetWarningThreshold(f)
 			slor.SetWarningThreshold(f)
 		}


### PR DESCRIPTION
Uses the sdk's experimental `GetRawConfig()` in order to check if the user is trying to remove a field.
In this case, because the field is optional and computed, removing the field in the config doesn't actually remove it in state - the terraform sdk keeps it around assuming it is computed. This causes issues if other fields conflict with the removed field, and there's no way to tell that the field is supposed to be removed (without checking the raw config) because the sdk reports the field as having not changed.

Resolves #1877 

Todo: check other resources for this interaction, good chance this exists elsewhere as well.