### PR TITLE
[datadog_synthetics_test] Remove required from jsonpath and xpath targetvalue fields

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -458,6 +458,7 @@ func syntheticsAPIAssertion() *schema.Schema {
 							"targetvalue": {
 								Description: "Expected matching value.",
 								Type:        schema.TypeString,
+								Optional:    true,
 							},
 						},
 					},
@@ -482,6 +483,7 @@ func syntheticsAPIAssertion() *schema.Schema {
 							"targetvalue": {
 								Description: "Expected matching value.",
 								Type:        schema.TypeString,
+								Optional:    true,
 							},
 						},
 					},

--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -458,7 +458,6 @@ func syntheticsAPIAssertion() *schema.Schema {
 							"targetvalue": {
 								Description: "Expected matching value.",
 								Type:        schema.TypeString,
-								Required:    true,
 							},
 						},
 					},
@@ -483,7 +482,6 @@ func syntheticsAPIAssertion() *schema.Schema {
 							"targetvalue": {
 								Description: "Expected matching value.",
 								Type:        schema.TypeString,
-								Required:    true,
 							},
 						},
 					},

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -349,6 +349,9 @@ Required:
 
 - `jsonpath` (String) The JSON path to assert.
 - `operator` (String) The specific operator to use on the path.
+
+Optional:
+
 - `targetvalue` (String) Expected matching value.
 
 
@@ -358,8 +361,11 @@ Required:
 Required:
 
 - `operator` (String) The specific operator to use on the path.
-- `targetvalue` (String) Expected matching value.
 - `xpath` (String) The xpath to assert.
+
+Optional:
+
+- `targetvalue` (String) Expected matching value.
 
 
 
@@ -516,6 +522,9 @@ Required:
 
 - `jsonpath` (String) The JSON path to assert.
 - `operator` (String) The specific operator to use on the path.
+
+Optional:
+
 - `targetvalue` (String) Expected matching value.
 
 
@@ -525,8 +534,11 @@ Required:
 Required:
 
 - `operator` (String) The specific operator to use on the path.
-- `targetvalue` (String) Expected matching value.
 - `xpath` (String) The xpath to assert.
+
+Optional:
+
+- `targetvalue` (String) Expected matching value.
 
 
 


### PR DESCRIPTION
Some operators, for example `isUndefined` don't use the `targetvalue` field, but the field is marked as required in the terraform schema. This PR removes the required flag.