### PR TITLE
[datadog_dashboard_json] skip prepResource if attrMap is nil

### DIFF
--- a/datadog/resource_datadog_dashboard_json.go
+++ b/datadog/resource_datadog_dashboard_json.go
@@ -233,6 +233,11 @@ func updateDashboardJSONState(d *schema.ResourceData, dashboard map[string]inter
 }
 
 func prepResource(attrMap map[string]interface{}) map[string]interface{} {
+	// This is an edge case where refresh might be called with an empty definition.
+	if attrMap == nil {
+		return attrMap
+	}
+
 	// Remove computed fields when comparing diffs
 	for _, f := range computedFields {
 		delete(attrMap, f)


### PR DESCRIPTION
Handle an edge case where prepResource is called with nil config during refresh. 
Closes: https://github.com/DataDog/terraform-provider-datadog/issues/1897