### PR TITLE
[datadog_synthetics_test] Update docs and validation of tick_every field

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -574,7 +574,7 @@ func syntheticsTestOptionsList() *schema.Schema {
 				"allow_insecure":   syntheticsAllowInsecureOption(),
 				"follow_redirects": syntheticsFollowRedirectsOption(),
 				"tick_every": {
-					Description:  "How often the test should run (in seconds).",
+					Description:  "How often the test should run (in seconds). Must be between `300` and `604,800`.",
 					Type:         schema.TypeInt,
 					Required:     true,
 					ValidateFunc: validation.IntBetween(300, 604800),

--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -577,7 +577,7 @@ func syntheticsTestOptionsList() *schema.Schema {
 					Description:  "How often the test should run (in seconds).",
 					Type:         schema.TypeInt,
 					Required:     true,
-					ValidateFunc: validation.IntBetween(30, 604800),
+					ValidateFunc: validation.IntBetween(300, 604800),
 				},
 				"scheduling": syntheticsTestAdvancedScheduling(),
 				"accept_self_signed": {

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -655,7 +655,7 @@ Optional:
 
 Required:
 
-- `tick_every` (Number) How often the test should run (in seconds).
+- `tick_every` (Number) How often the test should run (in seconds). Must be between `300` and `604,800`.
 
 Optional:
 


### PR DESCRIPTION
This updates the `tick_every` field's validation to only accept values between 300 and 604800 (5min to 1week). This matches the backend validation.