### PR TITLE
[provider] Update API key validation call to use official SDK

### DIFF
--- a/datadog/fwprovider/framework_provider.go
+++ b/datadog/fwprovider/framework_provider.go
@@ -2,9 +2,7 @@ package fwprovider
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"log"
 	"net/url"
 	"runtime"
 	"strconv"
@@ -374,6 +372,7 @@ func defaultConfigureFunc(p *FrameworkProvider, request *provider.ConfigureReque
 	p.DatadogApiInstances = &utils.ApiInstances{HttpClient: datadogClient}
 	p.Auth = auth
 
+	/*  Commented out due to duplicate validation in SDK provider - remove after Framework migration is complete.
 	if validate {
 		log.Println("[INFO] Datadog client successfully initialized, now validating...")
 		resp, _, err := p.DatadogApiInstances.GetAuthenticationApiV1().Validate(auth)
@@ -391,5 +390,6 @@ func defaultConfigureFunc(p *FrameworkProvider, request *provider.ConfigureReque
 		log.Println("[INFO] Skipping key validation (validate = false)")
 	}
 	log.Printf("[INFO] Datadog Client successfully validated.")
+	*/
 	return nil
 }

--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -87,7 +87,7 @@ func Provider() *schema.Provider {
 			"validate": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Description:  "Enables validation of the provided API and APP keys during provider initialization. Valid values are [`true`, `false`]. Default is true. When false, api_key and app_key won't be checked.",
+				Description:  "Enables validation of the provided API key during provider initialization. Valid values are [`true`, `false`]. Default is true. When false, api_key won't be checked.",
 				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, true),
 			},
 			"http_client_retry_enabled": {
@@ -302,22 +302,6 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	))
 	communityClient.HttpClient = c
 
-	if validate {
-		log.Println("[INFO] Datadog client successfully initialized, now validating...")
-		ok, err := communityClient.Validate()
-		if err != nil {
-			log.Printf("[ERROR] Datadog Client validation error: %v", err)
-			return nil, diag.FromErr(err)
-		} else if !ok {
-			err := errors.New(`Invalid or missing credentials provided to the Datadog Provider. Please confirm your API and APP keys are valid and are for the correct region, see https://www.terraform.io/docs/providers/datadog/ for more information on providing credentials for the Datadog Provider`)
-			log.Printf("[ERROR] Datadog Client validation error: %v", err)
-			return nil, diag.FromErr(err)
-		}
-	} else {
-		log.Println("[INFO] Skipping key validation (validate = false)")
-	}
-	log.Printf("[INFO] Datadog Client successfully validated.")
-
 	// Initialize the official Datadog V1 API client
 	auth := context.WithValue(
 		context.Background(),
@@ -416,10 +400,28 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	}
 
 	datadogClient := datadog.NewAPIClient(config)
+	apiInstances := &utils.ApiInstances{HttpClient: datadogClient}
+	if validate {
+		log.Println("[INFO] Datadog client successfully initialized, now validating...")
+		resp, _, err := apiInstances.GetAuthenticationApiV1().Validate(auth)
+		if err != nil {
+			log.Printf("[ERROR] Datadog Client validation error: %v", err)
+			return nil, diag.FromErr(err)
+		}
+		valid, ok := resp.GetValidOk()
+		if (ok && !*valid) || !ok {
+			err := errors.New(`Invalid or missing credentials provided to the Datadog Provider. Please confirm your API and APP keys are valid and are for the correct region, see https://www.terraform.io/docs/providers/datadog/ for more information on providing credentials for the Datadog Provider`)
+			log.Printf("[ERROR] Datadog Client validation error: %v", err)
+			return nil, diag.FromErr(err)
+		}
+	} else {
+		log.Println("[INFO] Skipping key validation (validate = false)")
+	}
+	log.Printf("[INFO] Datadog Client successfully validated.")
 
 	return &ProviderConfiguration{
 		CommunityClient:     communityClient,
-		DatadogApiInstances: &utils.ApiInstances{HttpClient: datadogClient},
+		DatadogApiInstances: apiInstances,
 		Auth:                auth,
 
 		Now: time.Now,

--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -292,7 +292,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	}
 
 	c := cleanhttp.DefaultClient()
-	c.Transport = logging.NewTransport("Datadog", c.Transport)
+	c.Transport = logging.NewLoggingHTTPTransport(c.Transport)
 	communityClient.ExtraHeader["User-Agent"] = utils.GetUserAgent(fmt.Sprintf(
 		"datadog-api-client-go/%s (go %s; os %s; arch %s)",
 		"go-datadog-api",

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,4 +57,4 @@ provider "datadog" {
 - `http_client_retry_enabled` (String) Enables request retries on HTTP status codes 429 and 5xx. Valid values are [`true`, `false`]. Defaults to `true`.
 - `http_client_retry_max_retries` (Number) The HTTP request maximum retry number. Defaults to 3.
 - `http_client_retry_timeout` (Number) The HTTP request retry timeout period. Defaults to 60 seconds.
-- `validate` (String) Enables validation of the provided API and APP keys during provider initialization. Valid values are [`true`, `false`]. Default is true. When false, api_key and app_key won't be checked.
+- `validate` (String) Enables validation of the provided API key during provider initialization. Valid values are [`true`, `false`]. Default is true. When false, api_key won't be checked.


### PR DESCRIPTION
The old community client would leak keys when in debug mode when it tried to validate keys. This removes that call and replaces it with the official datadog go client, which properly redacts those keys. It also replaces the deprecated `NewTransport` because it logs http req/resp without regard for secrets.

Also updates docs to no longer mention that APP keys are validated. This is because the validate endpoint only validates the API key.