### PR TITLE
[datadog_integration_gcp_sts] Create a GCP STS Terraform Resource

### DIFF
--- a/datadog/fwprovider/framework_provider.go
+++ b/datadog/fwprovider/framework_provider.go
@@ -41,6 +41,7 @@ var Resources = []func() resource.Resource{
 	NewSensitiveDataScannerGroupOrder,
 	NewSpansMetricResource,
 	NewSyntheticsConcurrencyCapResource,
+	NewDatadogIntegrationGCPSTSResource,
 }
 
 var Datasources = []func() datasource.DataSource{

--- a/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
+++ b/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
@@ -24,7 +24,7 @@ var (
 // datadogIntegrationGCPSTSResource is the resource implementation.
 type datadogIntegrationGCPSTSResource struct {
 	Auth   context.Context
-	GcpApi *datadogV2.GCPIntegrationSTSApi
+	GcpApi *datadogV2.GCPIntegrationApi
 }
 
 // NewDatadogIntegrationGCPSTSResource is a helper function to simplify the provider implementation.
@@ -62,7 +62,7 @@ func (r *datadogIntegrationGCPSTSResource) Configure(_ context.Context, request 
 	}
 
 	r.Auth = providerData.Auth
-	r.GcpApi = providerData.DatadogApiInstances.GetGCPStsIntegrationApiV2()
+	r.GcpApi = providerData.DatadogApiInstances.GetGCPIntegrationApiV2()
 }
 
 // Schema defines the Terraform Resource configuration.
@@ -154,7 +154,7 @@ func (r *datadogIntegrationGCPSTSResource) Create(ctx context.Context, req resou
 		enableCSPM = plan.EnableCspm.ValueBool()
 	}
 
-	saInfo := datadogV2.ServiceAccountToBeCreatedData{
+	saInfo := datadogV2.ServiceAccountCreateRequestData{
 		Data: &datadogV2.ServiceAccountMetadata{
 			Attributes: &datadogV2.AttributeMetadata{
 				ClientEmail:   stringToPointer(plan.ServiceAccountEmail.ValueString()),
@@ -213,7 +213,7 @@ func (r *datadogIntegrationGCPSTSResource) Read(ctx context.Context, req resourc
 	}
 
 	// Find Service Account by ID.
-	var foundAccount *datadogV2.GCPSTSAccounts
+	var foundAccount *datadogV2.GCPSTSAccount
 	for _, accountObject := range stsEnabledAccounts.GetData() {
 		accountUniqueID := accountObject.GetId()
 

--- a/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
+++ b/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
@@ -126,7 +126,7 @@ func (r *datadogIntegrationGCPSTSResource) Create(ctx context.Context, req resou
 	delegateResponse, _, err := r.GcpApi.CreateGCPSTSDelegate(r.Auth, *datadogV2.NewCreateGCPSTSDelegateOptionalParameters())
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating GCP Delegate within Datadog",
-			"Could not create Delegate Service Account, unexpected error:"+err.Error())
+			"Could not create Delegate Service Account, unexpected error: "+err.Error())
 		return
 	}
 
@@ -138,7 +138,7 @@ func (r *datadogIntegrationGCPSTSResource) Create(ctx context.Context, req resou
 	listOfHostFilters, err := attributeListToStringList(ctx, hostFilterPlanElements)
 	if err != nil {
 		resp.Diagnostics.AddError("Error converting attribute list to strings",
-			"Error converting attribute list to strings:"+err.Error())
+			"Error converting attribute list to strings: "+err.Error())
 		return
 	}
 	if len(listOfHostFilters) == 0 {
@@ -191,7 +191,7 @@ func (r *datadogIntegrationGCPSTSResource) Create(ctx context.Context, req resou
 	}
 }
 
-// Read resets the Terraform state using the latest "pulled" data. Read() is called when running Terraform Plans.
+// Read resets the Terraform state using the latest "pulled" data.
 func (r *datadogIntegrationGCPSTSResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	// Get Current State.
 	var state datadogIntegrationGCPSTSResourceModel
@@ -215,7 +215,7 @@ func (r *datadogIntegrationGCPSTSResource) Read(ctx context.Context, req resourc
 	stsEnabledAccounts, _, err := r.GcpApi.ListGCPSTSAccounts(r.Auth)
 	if err != nil {
 		resp.Diagnostics.AddError("Error retrieving STS service accounts",
-			"Error listing GCP STS Accounts:"+err.Error())
+			"Error listing GCP STS Accounts: "+err.Error())
 		return
 	}
 
@@ -231,7 +231,7 @@ func (r *datadogIntegrationGCPSTSResource) Read(ctx context.Context, req resourc
 	}
 	if foundAccount == nil {
 		resp.Diagnostics.AddError("Error finding your service account",
-			"Error couldn't find your service account with ID:"+state.GeneratedSaId.ValueString())
+			"Error couldn't find your service account with ID: "+state.GeneratedSaId.ValueString())
 		return
 	}
 
@@ -247,7 +247,7 @@ func (r *datadogIntegrationGCPSTSResource) Read(ctx context.Context, req resourc
 
 	// The section below handles optional fields in Terraform.
 	// If an optional field is not used, Teraform state stores a nil value.
-	// However, The API always returns a value for these optional fields (an empty list, a false boolean, etc).
+	// However, the API always returns a value for these optional fields (an empty list, a false boolean, etc).
 	// If these optional fields aren't used in Terraform Resources, then these fields should remain nil.
 	if state.HostFilters.IsNull() {
 		if len(currentHostFilters) > 0 {
@@ -306,7 +306,7 @@ func (r *datadogIntegrationGCPSTSResource) Update(ctx context.Context, req resou
 		hostFilters, err := attributeListToStringList(ctx, hostFilterPlanElements)
 		if err != nil {
 			resp.Diagnostics.AddError("Error converting attribute list to strings",
-				"Error converting attribute list to strings:"+err.Error())
+				"Error converting attribute list to strings: "+err.Error())
 			return
 		}
 		listOfHostFilters = hostFilters
@@ -338,7 +338,7 @@ func (r *datadogIntegrationGCPSTSResource) Update(ctx context.Context, req resou
 	updateResponse, _, err := r.GcpApi.UpdateGCPSTSAccount(r.Auth, uniqueAccountID, updatedSAInfo)
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating your service account",
-			"Error:"+err.Error())
+			"Error: "+err.Error())
 		return
 	}
 
@@ -368,7 +368,7 @@ func (r *datadogIntegrationGCPSTSResource) Delete(ctx context.Context, req resou
 	_, err := r.GcpApi.DeleteGCPSTSAccount(r.Auth, state.GeneratedSaId.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting your service account",
-			"Error encountered when attempting to delete your service account from Datadog"+err.Error())
+			"Error encountered when attempting to delete your service account from Datadog: "+err.Error())
 		return
 	}
 }

--- a/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
+++ b/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
@@ -152,9 +152,9 @@ func (r *datadogIntegrationGCPSTSResource) Create(ctx context.Context, req resou
 		enableCSPM = plan.EnableCspm.ValueBool()
 	}
 
-	saInfo := datadogV2.GCPServiceAccountCreateRequestData{
-		Data: &datadogV2.GCPServiceAccountData{
-			Attributes: &datadogV2.GCPServiceAccountAttributes{
+	saInfo := datadogV2.GCPSTSServiceAccountCreateRequest{
+		Data: &datadogV2.GCPSTSServiceAccountData{
+			Attributes: &datadogV2.GCPSTSServiceAccountAttributes{
 				ClientEmail:   stringToPointer(plan.ServiceAccountEmail.ValueString()),
 				Automute:      boolToPointer(enableAutomute),
 				IsCspmEnabled: boolToPointer(enableCSPM),
@@ -298,10 +298,10 @@ func (r *datadogIntegrationGCPSTSResource) Update(ctx context.Context, req resou
 		toEnableAutomute = plan.Automute.ValueBool()
 	}
 
-	updatedSAInfo := datadogV2.GCPServiceAccountUpdateRequest{
-		Data: &datadogV2.GCPServiceAccountUpdateRequestData{
+	updatedSAInfo := datadogV2.GCPSTSServiceAccountUpdateRequest{
+		Data: &datadogV2.GCPSTSServiceAccountUpdateRequestData{
 			Type: datadogV2.GCPSERVICEACCOUNTTYPE_GCP_SERVICE_ACCOUNT.Ptr(),
-			Attributes: &datadogV2.GCPServiceAccountAttributes{
+			Attributes: &datadogV2.GCPSTSServiceAccountAttributes{
 				IsCspmEnabled: boolToPointer(toEnableCSPM),
 				Automute:      boolToPointer(toEnableAutomute),
 				HostFilters:   listOfHostFilters,
@@ -360,7 +360,7 @@ func boolToPointer(b bool) *bool {
 	return &b
 }
 
-func getHostFilters(account *datadogV2.GCPSTSAccount) (basetypes.ListValue, int) {
+func getHostFilters(account *datadogV2.GCPSTSServiceAccount) (basetypes.ListValue, int) {
 	accountAttributes := account.GetAttributes()
 
 	currentHostFilters := accountAttributes.GetHostFilters()
@@ -375,7 +375,7 @@ func getHostFilters(account *datadogV2.GCPSTSAccount) (basetypes.ListValue, int)
 	return outputListValue, len(requiredAttributes)
 }
 
-func extractDelegateAccountEmail(delegateResponse datadogV2.GCPSTSDelegateResponse) (basetypes.StringValue, error) {
+func extractDelegateAccountEmail(delegateResponse datadogV2.GCPSTSDelegateAccountResponse) (basetypes.StringValue, error) {
 	delegateResponseData := delegateResponse.GetData()
 
 	delegateAttributes := delegateResponseData.GetAttributes()
@@ -388,13 +388,13 @@ func extractDelegateAccountEmail(delegateResponse datadogV2.GCPSTSDelegateRespon
 	return types.StringValue(delegateAttributes.GetDelegateAccountEmail()), nil
 }
 
-func findServiceAccountByUniqueID(accounts datadogV2.GCPSTSEnabledAccountData, accountToFindID string) (*datadogV2.GCPSTSAccount, error) {
+func findServiceAccountByUniqueID(accounts datadogV2.GCPSTSServiceAccountsResponse, accountToFindID string) (*datadogV2.GCPSTSServiceAccount, error) {
 	if accountToFindID == "" {
 		idEmptyError := errors.New("Error your service account's unique account ID is empty \"\"")
 		return nil, idEmptyError
 	}
 
-	var foundAccount *datadogV2.GCPSTSAccount
+	var foundAccount *datadogV2.GCPSTSServiceAccount
 
 	for _, accountObject := range accounts.GetData() {
 		accountID := accountObject.GetId()

--- a/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
+++ b/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
@@ -151,7 +151,7 @@ func (r *datadogIntegrationGCPSTSResource) Create(ctx context.Context, req resou
 
 	var enableCSPM bool
 	if !plan.EnableCspm.IsNull() {
-		enableAutomute = plan.EnableCspm.ValueBool()
+		enableCSPM = plan.EnableCspm.ValueBool()
 	}
 
 	saInfo := datadogV2.ServiceAccountToBeCreatedData{
@@ -315,10 +315,10 @@ func (r *datadogIntegrationGCPSTSResource) Update(ctx context.Context, req resou
 		toEnableAutomute = plan.Automute.ValueBool()
 	}
 
-	updatedSAInfo := datadogV2.DataObjectPatch{
+	updatedSAInfo := datadogV2.AccountPatchBody{
 		Data: &datadogV2.ServiceAccountInfoPatch{
 			Type: stringToPointer(defaultType),
-			Attributes: &datadogV2.ServiceAccountInfoPatchAttributes{
+			Attributes: &datadogV2.AccountAttributes{
 				IsCspmEnabled: boolToPointer(toEnableCSPM),
 				Automute:      boolToPointer(toEnableAutomute),
 				HostFilters:   listOfHostFilters,

--- a/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
+++ b/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
@@ -4,11 +4,13 @@ import (
 	"context"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -93,6 +95,9 @@ func (r *datadogIntegrationGCPSTSResource) Schema(_ context.Context, _ resource.
 				ElementType: types.StringType,
 				Description: "Your Datadog Host Filters.",
 				Optional:    true,
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+				},
 			},
 			"automute": schema.BoolAttribute{
 				Description: "Enable Automute.",

--- a/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
+++ b/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
@@ -154,9 +154,9 @@ func (r *datadogIntegrationGCPSTSResource) Create(ctx context.Context, req resou
 		enableCSPM = plan.EnableCspm.ValueBool()
 	}
 
-	saInfo := datadogV2.ServiceAccountCreateRequestData{
-		Data: &datadogV2.ServiceAccountMetadata{
-			Attributes: &datadogV2.AttributeMetadata{
+	saInfo := datadogV2.GCPServiceAccountCreateRequestData{
+		Data: &datadogV2.GCPServiceAccountMetadata{
+			Attributes: &datadogV2.GCPServiceAccountAttributes{
 				ClientEmail:   stringToPointer(plan.ServiceAccountEmail.ValueString()),
 				Automute:      boolToPointer(enableAutomute),
 				IsCspmEnabled: boolToPointer(enableCSPM),
@@ -315,10 +315,10 @@ func (r *datadogIntegrationGCPSTSResource) Update(ctx context.Context, req resou
 		toEnableAutomute = plan.Automute.ValueBool()
 	}
 
-	updatedSAInfo := datadogV2.AccountPatchBody{
-		Data: &datadogV2.ServiceAccountInfoPatch{
+	updatedSAInfo := datadogV2.GCPServiceAccountPatchBody{
+		Data: &datadogV2.GCPServiceAccountInfoPatch{
 			Type: stringToPointer(defaultType),
-			Attributes: &datadogV2.AccountAttributes{
+			Attributes: &datadogV2.GCPServiceAccountAttributes{
 				IsCspmEnabled: boolToPointer(toEnableCSPM),
 				Automute:      boolToPointer(toEnableAutomute),
 				HostFilters:   listOfHostFilters,

--- a/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
+++ b/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
@@ -32,7 +32,6 @@ func NewDatadogIntegrationGCPSTSResource() resource.Resource {
 	return &datadogIntegrationGCPSTSResource{}
 }
 
-// datadogIntegrationGCPSTSResourceModel
 type datadogIntegrationGCPSTSResourceModel struct {
 	ServiceAccountEmail types.String `tfsdk:"service_account_email"`
 	ID                  types.String `tfsdk:"id"`
@@ -46,7 +45,7 @@ const (
 	defaultType = "gcp_service_account"
 )
 
-// Metadata returns the resource type name. Resource Name within Terraform is "datadog_integration_gcp_sts".
+// Metadata returns the resource name.
 func (r *datadogIntegrationGCPSTSResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "integration_gcp_sts"
 }
@@ -66,7 +65,7 @@ func (r *datadogIntegrationGCPSTSResource) Configure(_ context.Context, request 
 	r.GcpApi = providerData.DatadogApiInstances.GetGCPStsIntegrationApiV2()
 }
 
-// Schema defines the configuration used as input within your Terraform Resource.
+// Schema defines the Terraform Resource configuration.
 func (r *datadogIntegrationGCPSTSResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: "Provides a Datadog - Google Cloud Platform STS integration resource. This can be used to create and manage Datadog Google Cloud Platform STS integrations",
@@ -112,10 +111,9 @@ func (r *datadogIntegrationGCPSTSResource) Schema(_ context.Context, _ resource.
 	}
 }
 
-// Create creates the resource and sets the initial Terraform state.
+// Create sets the initial Terraform state.
 func (r *datadogIntegrationGCPSTSResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 
-	// Get current TF state.
 	var plan datadogIntegrationGCPSTSResourceModel
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -123,7 +121,6 @@ func (r *datadogIntegrationGCPSTSResource) Create(ctx context.Context, req resou
 		return
 	}
 
-	// Create a Delegate Service Account within Datadog.
 	delegateResponse, _, err := r.GcpApi.CreateGCPSTSDelegate(r.Auth, *datadogV2.NewCreateGCPSTSDelegateOptionalParameters())
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating GCP Delegate within Datadog",
@@ -131,7 +128,6 @@ func (r *datadogIntegrationGCPSTSResource) Create(ctx context.Context, req resou
 		return
 	}
 
-	// Host filters.
 	var hostFilters []string
 	delegateInfoResponse := delegateResponse.GetData()
 	delegateAttributes := delegateInfoResponse.GetAttributes()
@@ -158,7 +154,6 @@ func (r *datadogIntegrationGCPSTSResource) Create(ctx context.Context, req resou
 		enableAutomute = plan.EnableCspm.ValueBool()
 	}
 
-	// Create an entry within Datadog for your STS enabled service account.
 	saInfo := datadogV2.ServiceAccountToBeCreatedData{
 		Data: &datadogV2.ServiceAccountMetadata{
 			Attributes: &datadogV2.AttributeMetadata{
@@ -184,7 +179,6 @@ func (r *datadogIntegrationGCPSTSResource) Create(ctx context.Context, req resou
 	plan.ID = types.StringValue(createdServiceAccountInfo.GetId())
 	plan.DelegateEmail = types.StringValue(delegateAttributes.GetDelegateAccountEmail())
 
-	// Write state.
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -192,9 +186,8 @@ func (r *datadogIntegrationGCPSTSResource) Create(ctx context.Context, req resou
 	}
 }
 
-// Read resets the Terraform state using the latest "pulled" data.
+// Read re-sets the Terraform state using the latest "pulled" data.
 func (r *datadogIntegrationGCPSTSResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	// Get Current State.
 	var state datadogIntegrationGCPSTSResourceModel
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -202,7 +195,6 @@ func (r *datadogIntegrationGCPSTSResource) Read(ctx context.Context, req resourc
 		return
 	}
 
-	// Get the Delegate email.
 	delegateResponse, _, err := r.GcpApi.GetGCPSTSDelegate(r.Auth, *datadogV2.NewGetGCPSTSDelegateOptionalParameters())
 	if err != nil {
 		resp.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving STS delegate"))
@@ -283,7 +275,7 @@ func (r *datadogIntegrationGCPSTSResource) Read(ctx context.Context, req resourc
 	}
 }
 
-// Update re-sets the Terraform state locally and on the Datadog "backend".
+// Update updates the Terraform state locally and on the Datadog "backend".
 func (r *datadogIntegrationGCPSTSResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 
 	var plan datadogIntegrationGCPSTSResourceModel
@@ -357,7 +349,7 @@ func (r *datadogIntegrationGCPSTSResource) Update(ctx context.Context, req resou
 	}
 }
 
-// Delete deletes the resource, and removes the Terraform state on success.
+// Delete removes the resource from Terraform state.
 func (r *datadogIntegrationGCPSTSResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state datadogIntegrationGCPSTSResourceModel
 	diags := req.State.Get(ctx, &state)

--- a/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
+++ b/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
@@ -1,0 +1,348 @@
+package fwprovider
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+)
+
+var (
+	_ resource.Resource = &datadogIntegrationGCPSTSResource{}
+)
+
+// datadogIntegrationGCPSTSResource is the resource implementation.
+type datadogIntegrationGCPSTSResource struct {
+	Auth   context.Context
+	GcpApi *datadogV2.GCPIntegrationSTSApi
+}
+
+// NewDatadogIntegrationGCPSTSResource is a helper function to simplify the provider implementation.
+func NewDatadogIntegrationGCPSTSResource() resource.Resource {
+	return &datadogIntegrationGCPSTSResource{}
+}
+
+// datadogIntegrationGCPSTSResourceModel
+type datadogIntegrationGCPSTSResourceModel struct {
+	ServiceAccountEmail types.String `tfsdk:"service_account_email"`
+	GeneratedSaId       types.String `tfsdk:"generated_sa_id"`
+	DelegateEmail       types.String `tfsdk:"delegate_email"`
+	Automute            types.Bool   `tfsdk:"automute"`
+	EnableCspm          types.Bool   `tfsdk:"enable_cspm"`
+	HostFilters         types.List   `tfsdk:"host_filters"`
+}
+
+const (
+	defaultType = "gcp_service_account"
+)
+
+// Metadata returns the resource type name. Resource Name within Terraform is "datadog_integration_gcp_sts".
+func (r *datadogIntegrationGCPSTSResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "integration_gcp_sts"
+}
+
+func (r *datadogIntegrationGCPSTSResource) Configure(_ context.Context, request resource.ConfigureRequest, response *resource.ConfigureResponse) {
+	if request.ProviderData == nil {
+		return
+	}
+
+	providerData, ok := request.ProviderData.(*FrameworkProvider)
+	if !ok {
+		response.Diagnostics.AddError("Unexpected Resource Configure Type", "")
+		return
+	}
+
+	r.Auth = providerData.Auth
+	r.GcpApi = providerData.DatadogApiInstances.GetGCPStsIntegrationApiV2()
+}
+
+// Schema defines the configuration used as input within your Terraform Resource.
+func (r *datadogIntegrationGCPSTSResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Provides a Datadog - Google Cloud Platform STS integration resource. This can be used to create and manage Datadog Google Cloud Platform STS integrations",
+		Attributes: map[string]schema.Attribute{
+			"service_account_email": schema.StringAttribute{
+				Description: "Your STS-enabled GCP service account.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"delegate_email": schema.StringAttribute{
+				Description: "Datadog's STS Delegate Email.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"generated_sa_id": schema.StringAttribute{
+				Description: "Datadog's Unique ID generated for your STS-enabled GCP service account.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"host_filters": schema.ListAttribute{
+				ElementType: types.StringType,
+				Description: "Your Datadog Host Filters.",
+				Optional:    true,
+			},
+			"automute": schema.BoolAttribute{
+				Description: "Enable Automute.",
+				Optional:    true,
+			},
+			"enable_cspm": schema.BoolAttribute{
+				Description: "Enable CSPM.",
+				Optional:    true,
+			},
+		},
+	}
+}
+
+// Create creates the resource and sets the initial Terraform state.
+func (r *datadogIntegrationGCPSTSResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+
+	// Get current TF state.
+	var plan datadogIntegrationGCPSTSResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Create a Delegate Service Account within Datadog.
+	delegateResponse, _, err := r.GcpApi.CreateGCPSTSDelegate(r.Auth, *datadogV2.NewCreateGCPSTSDelegateOptionalParameters())
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating GCP Delegate within Datadog",
+			"Could not create Delegate Service Account, unexpected error:"+err.Error())
+		return
+	}
+
+	delegateInfoResponse := delegateResponse.GetData()
+	delegateAttributes := delegateInfoResponse.GetAttributes()
+	hostFilterPlanElements := plan.HostFilters.Elements()
+
+	listOfHostFilters, err := attributeListToStringList(ctx, hostFilterPlanElements)
+	if err != nil {
+		resp.Diagnostics.AddError("Error converting attribute list to strings",
+			"Error converting attribute list to strings:"+err.Error())
+		return
+	}
+
+	// Create an entry wthin Datadog for your STS enabled service account.
+	saInfo := datadogV2.ServiceAccountToBeCreatedData{
+		Data: &datadogV2.ServiceAccountMetadata{
+			Attributes: &datadogV2.AttributeMetadata{
+				ClientEmail:   stringToPointer(plan.ServiceAccountEmail.ValueString()),
+				Automute:      boolToPointer(plan.Automute.ValueBool()),
+				IsCspmEnabled: boolToPointer(plan.EnableCspm.ValueBool()),
+				HostFilters:   listOfHostFilters,
+			},
+			Type: stringToPointer(defaultType),
+		},
+	}
+
+	createResponse, _, err := r.GcpApi.CreateGCPSTSAccount(r.Auth, saInfo)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating STS service account",
+			"Error creating an entry within Datadog for your STS enabled service account: "+err.Error())
+		return
+	}
+
+	createdServiceAccountInfo := createResponse.GetData()
+
+	// Set the "computed" values.
+	plan.GeneratedSaId = types.StringValue(createdServiceAccountInfo.GetId())
+	plan.DelegateEmail = types.StringValue(delegateAttributes.GetDelegateAccountEmail())
+
+	// Write state.
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Read resets the Terraform state using the latest "pulled" data. Read() is called when running Terraform Plans.
+func (r *datadogIntegrationGCPSTSResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// Get Current State.
+	var state datadogIntegrationGCPSTSResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get the Delegate email.
+	delegateResponse, _, err := r.GcpApi.GetGCPSTSDelegate(r.Auth, *datadogV2.NewGetGCPSTSDelegateOptionalParameters())
+	if err != nil {
+		resp.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving STS delegate"))
+		return
+	}
+
+	delegateResponseData := delegateResponse.GetData()
+	delegateAttributes := delegateResponseData.GetAttributes()
+	state.DelegateEmail = types.StringValue(delegateAttributes.GetDelegateAccountEmail())
+
+	stsEnabledAccounts, _, err := r.GcpApi.ListGCPSTSAccounts(r.Auth)
+	if err != nil {
+		resp.Diagnostics.AddError("Error retrieving STS service accounts",
+			"Error listing GCP STS Accounts:"+err.Error())
+		return
+	}
+
+	// Find Service Account by ID.
+	var foundAccount *datadogV2.GCPSTSAccounts
+	for _, accountObject := range stsEnabledAccounts.GetData() {
+		accountUniqueID := accountObject.GetId()
+
+		if accountUniqueID == state.GeneratedSaId.ValueString() {
+			foundAccount = &accountObject
+			break
+		}
+	}
+	if foundAccount == nil {
+		resp.Diagnostics.AddError("Error finding your service account",
+			"Error couldn't find your service account with ID:"+state.GeneratedSaId.ValueString())
+		return
+	}
+
+	// Retrieve Host Filters.
+	accountAttributes := foundAccount.GetAttributes()
+	currentHostFilters := accountAttributes.GetHostFilters()
+
+	var requiredAttributes []attr.Value
+	for _, hostFilter := range currentHostFilters {
+		requiredAttributes = append(requiredAttributes, types.StringValue(hostFilter))
+	}
+	outputListValue, _ := types.ListValue(types.StringType, requiredAttributes)
+
+	state.HostFilters = outputListValue
+	state.Automute = types.BoolValue(accountAttributes.GetAutomute())
+	state.EnableCspm = types.BoolValue(accountAttributes.GetIsCspmEnabled())
+	state.ServiceAccountEmail = types.StringValue(accountAttributes.GetClientEmail())
+
+	diags = resp.State.Set(ctx, state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Update re-sets the Terraform state locally and on the Datadog "backend".
+func (r *datadogIntegrationGCPSTSResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+
+	var plan datadogIntegrationGCPSTSResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var currentState datadogIntegrationGCPSTSResourceModel
+	currentDiagnostics := req.State.Get(ctx, &currentState)
+	if currentDiagnostics.HasError() {
+		return
+	}
+
+	hostFilterPlanElements := plan.HostFilters.Elements()
+	listOfHostFilters, err := attributeListToStringList(ctx, hostFilterPlanElements)
+	if err != nil {
+		resp.Diagnostics.AddError("Error converting attribute list to strings",
+			"Error converting attribute list to strings:"+err.Error())
+		return
+	}
+
+	updatedSAInfo := datadogV2.DataObjectPatch{
+		Data: &datadogV2.ServiceAccountInfoPatch{
+			Type: stringToPointer(defaultType),
+			Attributes: &datadogV2.ServiceAccountInfoPatchAttributes{
+				IsCspmEnabled: boolToPointer(plan.EnableCspm.ValueBool()),
+				Automute:      boolToPointer(plan.Automute.ValueBool()),
+				HostFilters:   listOfHostFilters,
+			},
+		},
+	}
+
+	uniqueAccountID := currentState.GeneratedSaId.ValueString()
+	updateResponse, _, err := r.GcpApi.UpdateGCPSTSAccount(r.Auth, uniqueAccountID, updatedSAInfo)
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating your service account",
+			"Error:"+err.Error())
+		return
+	}
+
+	dataBlock := updateResponse.GetData()
+	blockAttributes := dataBlock.GetAttributes()
+
+	plan.GeneratedSaId = basetypes.NewStringValue(dataBlock.GetId())
+	plan.DelegateEmail = currentState.DelegateEmail
+	plan.ServiceAccountEmail = basetypes.NewStringValue(blockAttributes.GetClientEmail())
+
+	if plan.Automute.IsNull() {
+		plan.Automute = currentState.Automute
+	}
+	if plan.EnableCspm.IsNull() {
+		plan.EnableCspm = currentState.EnableCspm
+	}
+	if plan.HostFilters.IsNull() {
+		plan.HostFilters = currentState.HostFilters
+	}
+
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Delete deletes the resource, and removes the Terraform state on success.
+func (r *datadogIntegrationGCPSTSResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state datadogIntegrationGCPSTSResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := r.GcpApi.DeleteGCPSTSAccount(r.Auth, state.GeneratedSaId.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error deleting your service account",
+			"Error encountered when attempting to delete your service account from Datadog"+err.Error())
+		return
+	}
+}
+
+func stringToPointer(s string) *string {
+	return &s
+}
+
+func boolToPointer(b bool) *bool {
+	return &b
+}
+
+func attributeListToStringList(ctx context.Context, listOfAttributes []attr.Value) ([]string, error) {
+	var listOfHostFilters []string
+
+	// Convert each element into a Go Type, rather than a TF type
+	for _, element := range listOfAttributes {
+		stringElement, err := element.ToTerraformValue(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		var valuePointer string
+		stringElement.Copy().As(&valuePointer)
+
+		listOfHostFilters = append(listOfHostFilters, valuePointer)
+	}
+
+	return listOfHostFilters, nil
+}

--- a/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
+++ b/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
@@ -121,7 +121,7 @@ func (r *datadogIntegrationGCPSTSResource) Create(ctx context.Context, req resou
 		return
 	}
 
-	delegateResponse, _, err := r.GcpApi.CreateGCPSTSDelegate(r.Auth, *datadogV2.NewCreateGCPSTSDelegateOptionalParameters())
+	delegateResponse, _, err := r.GcpApi.MakeDelegateV2(r.Auth, *datadogV2.NewMakeDelegateV2OptionalParameters())
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating GCP Delegate within Datadog",
 			"Could not create Delegate Service Account, unexpected error: "+err.Error())
@@ -166,7 +166,7 @@ func (r *datadogIntegrationGCPSTSResource) Create(ctx context.Context, req resou
 		},
 	}
 
-	createResponse, _, err := r.GcpApi.CreateGCPSTSAccount(r.Auth, saInfo)
+	createResponse, _, err := r.GcpApi.CreateGCPSTSAccountsV2(r.Auth, saInfo)
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating STS service account",
 			"Error creating an entry within Datadog for your STS enabled service account: "+err.Error())
@@ -195,7 +195,7 @@ func (r *datadogIntegrationGCPSTSResource) Read(ctx context.Context, req resourc
 		return
 	}
 
-	delegateResponse, _, err := r.GcpApi.GetGCPSTSDelegate(r.Auth, *datadogV2.NewGetGCPSTSDelegateOptionalParameters())
+	delegateResponse, _, err := r.GcpApi.GetDelegateV2(r.Auth, *datadogV2.NewGetDelegateV2OptionalParameters())
 	if err != nil {
 		resp.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving STS delegate"))
 		return
@@ -205,7 +205,7 @@ func (r *datadogIntegrationGCPSTSResource) Read(ctx context.Context, req resourc
 	delegateAttributes := delegateResponseData.GetAttributes()
 	state.DelegateEmail = types.StringValue(delegateAttributes.GetDelegateAccountEmail())
 
-	stsEnabledAccounts, _, err := r.GcpApi.ListGCPSTSAccounts(r.Auth)
+	stsEnabledAccounts, _, err := r.GcpApi.ListGCPSTSAccountsV2(r.Auth)
 	if err != nil {
 		resp.Diagnostics.AddError("Error retrieving STS service accounts",
 			"Error listing GCP STS Accounts: "+err.Error())
@@ -328,7 +328,7 @@ func (r *datadogIntegrationGCPSTSResource) Update(ctx context.Context, req resou
 
 	uniqueAccountID := currentState.ID.ValueString()
 
-	updateResponse, _, err := r.GcpApi.UpdateGCPSTSAccount(r.Auth, uniqueAccountID, updatedSAInfo)
+	updateResponse, _, err := r.GcpApi.UpdateGCPSTSAccountsV2(r.Auth, uniqueAccountID, updatedSAInfo)
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating your service account",
 			"Error: "+err.Error())
@@ -358,7 +358,7 @@ func (r *datadogIntegrationGCPSTSResource) Delete(ctx context.Context, req resou
 		return
 	}
 
-	_, err := r.GcpApi.DeleteGCPSTSAccount(r.Auth, state.ID.ValueString())
+	_, err := r.GcpApi.DeleteGCPSTSAccountsV2(r.Auth, state.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting your service account",
 			"Error encountered when attempting to delete your service account from Datadog: "+err.Error())

--- a/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
+++ b/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
@@ -281,8 +281,8 @@ func (r *datadogIntegrationGCPSTSResource) Update(ctx context.Context, req resou
 		hostFilterPlanElements := plan.HostFilters.Elements()
 		hostFilters, err := attributeListToStringList(ctx, hostFilterPlanElements)
 		if err != nil {
-			resp.Diagnostics.AddError("Error converting attribute list to strings",
-				"Error converting attribute list to strings: "+err.Error())
+			resp.Diagnostics.AddError("Error converting attribute list to a string list",
+				"Error converting attribute list to a string list: "+err.Error())
 			return
 		}
 		listOfHostFilters = hostFilters
@@ -310,7 +310,6 @@ func (r *datadogIntegrationGCPSTSResource) Update(ctx context.Context, req resou
 	}
 
 	uniqueAccountID := currentState.ID.ValueString()
-
 	updateResponse, _, err := r.GcpApi.UpdateGCPSTSAccount(r.Auth, uniqueAccountID, updatedSAInfo)
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating your service account",

--- a/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
+++ b/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
@@ -6,6 +6,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -371,6 +372,10 @@ func (r *datadogIntegrationGCPSTSResource) Delete(ctx context.Context, req resou
 			"Error encountered when attempting to delete your service account from Datadog: "+err.Error())
 		return
 	}
+}
+
+func (r *datadogIntegrationGCPSTSResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 func stringToPointer(s string) *string {

--- a/datadog/internal/utils/api_instances_helper.go
+++ b/datadog/internal/utils/api_instances_helper.go
@@ -52,7 +52,7 @@ type ApiInstances struct {
 	dashboardListsApiV2        *datadogV2.DashboardListsApi
 	eventsApiV2                *datadogV2.EventsApi
 	fastlyIntegrationApiV2     *datadogV2.FastlyIntegrationApi
-	gcpStsIntegrationApiV2     *datadogV2.GCPIntegrationSTSApi
+	gcpStsIntegrationApiV2     *datadogV2.GCPIntegrationApi
 	incidentServicesApiV2      *datadogV2.IncidentServicesApi
 	incidentTeamsApiV2         *datadogV2.IncidentTeamsApi
 	incidentsApiV2             *datadogV2.IncidentsApi
@@ -366,9 +366,9 @@ func (i *ApiInstances) GetEventsApiV2() *datadogV2.EventsApi {
 }
 
 // GetGCPStsIntegrationApiV2 get instance of GetGCPStsIntegration
-func (i *ApiInstances) GetGCPStsIntegrationApiV2() *datadogV2.GCPIntegrationSTSApi {
+func (i *ApiInstances) GetGCPIntegrationApiV2() *datadogV2.GCPIntegrationApi {
 	if i.gcpStsIntegrationApiV2 == nil {
-		i.gcpStsIntegrationApiV2 = datadogV2.NewGCPIntegrationSTSApi(i.HttpClient)
+		i.gcpStsIntegrationApiV2 = datadogV2.NewGCPIntegrationApi(i.HttpClient)
 	}
 	return i.gcpStsIntegrationApiV2
 }

--- a/datadog/internal/utils/api_instances_helper.go
+++ b/datadog/internal/utils/api_instances_helper.go
@@ -52,6 +52,7 @@ type ApiInstances struct {
 	dashboardListsApiV2        *datadogV2.DashboardListsApi
 	eventsApiV2                *datadogV2.EventsApi
 	fastlyIntegrationApiV2     *datadogV2.FastlyIntegrationApi
+	gcpStsIntegrationApiV2     *datadogV2.GCPIntegrationSTSApi
 	incidentServicesApiV2      *datadogV2.IncidentServicesApi
 	incidentTeamsApiV2         *datadogV2.IncidentTeamsApi
 	incidentsApiV2             *datadogV2.IncidentsApi
@@ -362,6 +363,14 @@ func (i *ApiInstances) GetEventsApiV2() *datadogV2.EventsApi {
 		i.eventsApiV2 = datadogV2.NewEventsApi(i.HttpClient)
 	}
 	return i.eventsApiV2
+}
+
+// GetGCPStsIntegrationApiV2 get instance of GetGCPStsIntegration
+func (i *ApiInstances) GetGCPStsIntegrationApiV2() *datadogV2.GCPIntegrationSTSApi {
+	if i.gcpStsIntegrationApiV2 == nil {
+		i.gcpStsIntegrationApiV2 = datadogV2.NewGCPIntegrationSTSApi(i.HttpClient)
+	}
+	return i.gcpStsIntegrationApiV2
 }
 
 // GetIncidentServicesApiV2 get instance of IncidentServicesApi

--- a/datadog/tests/provider_test.go
+++ b/datadog/tests/provider_test.go
@@ -138,6 +138,7 @@ var testFiles2EndpointTags = map[string]string{
 	"tests/resource_datadog_integration_cloudflare_account_test":             "integration-cloudflare",
 	"tests/resource_datadog_integration_fastly_account_test":                 "integration-fastly-account",
 	"tests/resource_datadog_integration_gcp_test":                            "integration-gcp",
+	"tests/resource_datadog_integration_gcp_sts_test":                        "integration-gcp",
 	"tests/resource_datadog_integration_opsgenie_service_object_test":        "integration-opsgenie-service",
 	"tests/resource_datadog_integration_pagerduty_service_object_test":       "integration-pagerduty",
 	"tests/resource_datadog_integration_pagerduty_test":                      "integration-pagerduty",

--- a/datadog/tests/resource_datadog_integration_gcp_sts_test.go
+++ b/datadog/tests/resource_datadog_integration_gcp_sts_test.go
@@ -79,17 +79,14 @@ func TestGCPSTSIntegrationResourceUpdates(t *testing.T) {
 					resource.TestCheckResourceAttr("datadog_integration_gcp_sts.foo", "enable_cspm", "true"),
 				),
 			},
-			// Verify removing updates works
 			{
 				Config: testBasicGCPSTSResource(uniq),
 				Check: resource.ComposeTestCheckFunc(
 					testGCPIntegrationAccountExists(providers.frameworkProvider),
 					resource.TestCheckResourceAttr(
 						"datadog_integration_gcp_sts.foo", "service_account_email", uniq),
-					// Verify computed values
 					resource.TestCheckResourceAttrSet("datadog_integration_gcp_sts.foo", "delegate_email"),
 					resource.TestCheckResourceAttrSet("datadog_integration_gcp_sts.foo", "id"),
-					// Verify nil values
 					resource.TestCheckNoResourceAttr("datadog_integration_gcp_sts.foo", "host_filters"),
 					resource.TestCheckNoResourceAttr("datadog_integration_gcp_sts.foo", "automute"),
 					resource.TestCheckNoResourceAttr("datadog_integration_gcp_sts.foo", "enable_cspm"),
@@ -100,7 +97,7 @@ func TestGCPSTSIntegrationResourceUpdates(t *testing.T) {
 	})
 }
 
-// Update all configurable fields
+// Update all optional, configurable fields
 func testGCPIntegrationUpdate(uniq string) string {
 	return fmt.Sprintf(`
 	resource "datadog_integration_gcp_sts" "foo" {
@@ -147,7 +144,6 @@ func integrationGCPSTSAccountExistsHelper(auth context.Context, s *terraform.Sta
 }
 
 func testBasicGCPSTSResource(uniq string) string {
-	// Update me to make use of the unique value
 	return fmt.Sprintf(`
 resource "datadog_integration_gcp_sts" "foo" {
     service_account_email = "%s"

--- a/datadog/tests/resource_datadog_integration_gcp_sts_test.go
+++ b/datadog/tests/resource_datadog_integration_gcp_sts_test.go
@@ -1,0 +1,215 @@
+package test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+)
+
+func TestGCPSTSIntegrationBasic(t *testing.T) {
+	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
+	uniq := uniqueEntityName(ctx, t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: accProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testBasicGCPSTSResource(uniq),
+				Check: resource.ComposeTestCheckFunc(
+					testGCPIntegrationAccountExists(providers.frameworkProvider),
+					resource.TestCheckResourceAttr(
+						"datadog_integration_gcp_sts.foo", "service_account_email", uniq),
+					// Verify computed values
+					resource.TestCheckResourceAttrSet("datadog_integration_gcp_sts.foo", "delegate_email"),
+					resource.TestCheckResourceAttrSet("datadog_integration_gcp_sts.foo", "id"),
+					// Verify nil values
+					resource.TestCheckNoResourceAttr("datadog_integration_gcp_sts.foo", "host_filters"),
+					resource.TestCheckNoResourceAttr("datadog_integration_gcp_sts.foo", "automute"),
+					resource.TestCheckNoResourceAttr("datadog_integration_gcp_sts.foo", "enable_cspm"),
+				),
+			},
+		},
+		CheckDestroy: testGCPSTSDestroy(providers.frameworkProvider),
+	})
+}
+
+func TestGCPSTSIntegrationResourceUpdates(t *testing.T) {
+	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
+	uniq := uniqueEntityName(ctx, t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: accProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testBasicGCPSTSResource(uniq),
+				Check: resource.ComposeTestCheckFunc(
+					testGCPIntegrationAccountExists(providers.frameworkProvider),
+					resource.TestCheckResourceAttr(
+						"datadog_integration_gcp_sts.foo", "service_account_email", uniq),
+					// Verify computed values
+					resource.TestCheckResourceAttrSet("datadog_integration_gcp_sts.foo", "delegate_email"),
+					resource.TestCheckResourceAttrSet("datadog_integration_gcp_sts.foo", "id"),
+					// Verify nil values
+					resource.TestCheckNoResourceAttr("datadog_integration_gcp_sts.foo", "host_filters"),
+					resource.TestCheckNoResourceAttr("datadog_integration_gcp_sts.foo", "automute"),
+					resource.TestCheckNoResourceAttr("datadog_integration_gcp_sts.foo", "enable_cspm"),
+				),
+			},
+			{
+				Config: testGCPIntegrationUpdate(uniq),
+				Check: resource.ComposeTestCheckFunc(
+					testGCPIntegrationAccountExists(providers.frameworkProvider),
+					resource.TestCheckResourceAttr(
+						"datadog_integration_gcp_sts.foo", "service_account_email", uniq),
+					// Verify computed values
+					resource.TestCheckResourceAttrSet("datadog_integration_gcp_sts.foo", "delegate_email"),
+					resource.TestCheckResourceAttrSet("datadog_integration_gcp_sts.foo", "id"),
+					// Verify updated values
+					resource.TestCheckResourceAttr("datadog_integration_gcp_sts.foo", "host_filters.0", "filter_one"),
+					resource.TestCheckResourceAttr("datadog_integration_gcp_sts.foo", "host_filters.1", "filter_two"),
+					resource.TestCheckResourceAttr("datadog_integration_gcp_sts.foo", "host_filters.2", "filter_three"),
+					resource.TestCheckResourceAttr("datadog_integration_gcp_sts.foo", "automute", "true"),
+					resource.TestCheckResourceAttr("datadog_integration_gcp_sts.foo", "enable_cspm", "true"),
+				),
+			},
+			// Verify removing updates works
+			{
+				Config: testBasicGCPSTSResource(uniq),
+				Check: resource.ComposeTestCheckFunc(
+					testGCPIntegrationAccountExists(providers.frameworkProvider),
+					resource.TestCheckResourceAttr(
+						"datadog_integration_gcp_sts.foo", "service_account_email", uniq),
+					// Verify computed values
+					resource.TestCheckResourceAttrSet("datadog_integration_gcp_sts.foo", "delegate_email"),
+					resource.TestCheckResourceAttrSet("datadog_integration_gcp_sts.foo", "id"),
+					// Verify nil values
+					resource.TestCheckNoResourceAttr("datadog_integration_gcp_sts.foo", "host_filters"),
+					resource.TestCheckNoResourceAttr("datadog_integration_gcp_sts.foo", "automute"),
+					resource.TestCheckNoResourceAttr("datadog_integration_gcp_sts.foo", "enable_cspm"),
+				),
+			},
+		},
+		CheckDestroy: testGCPSTSDestroy(providers.frameworkProvider),
+	})
+}
+
+// Update all configurable fields
+func testGCPIntegrationUpdate(uniq string) string {
+	return fmt.Sprintf(`
+	resource "datadog_integration_gcp_sts" "foo" {
+		service_account_email = "%s"
+		host_filters = ["filter_one", "filter_two", "filter_three"]
+		automute = true
+		enable_cspm = true
+	}`, uniq)
+}
+
+func testGCPIntegrationAccountExists(accProvider *fwprovider.FrameworkProvider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		apiInstances := accProvider.DatadogApiInstances
+		auth := accProvider.Auth
+
+		if err := integrationGCPSTSAccountExistsHelper(auth, s, apiInstances); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func integrationGCPSTSAccountExistsHelper(auth context.Context, s *terraform.State, apiInstances *utils.ApiInstances) error {
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "datadog_integration_gcp_sts" {
+			continue
+		}
+		id := r.Primary.ID
+
+		accounts, httpResp, err := apiInstances.GetGCPStsIntegrationApiV2().ListGCPSTSAccounts(auth)
+		if err != nil {
+			return utils.TranslateClientError(err, httpResp, "error retrieving STS enabled GCP service account")
+		}
+
+		accountWasFound, err := findGCPAccount(id, accounts)
+		if err != nil {
+			return utils.TranslateClientError(err, httpResp, "error retrieving STS enabled GCP service account")
+		}
+		if !accountWasFound {
+			return errors.New("error finding your account with id:" + id)
+		}
+	}
+	return nil
+}
+
+func testBasicGCPSTSResource(uniq string) string {
+	// Update me to make use of the unique value
+	return fmt.Sprintf(`
+resource "datadog_integration_gcp_sts" "foo" {
+    service_account_email = "%s"
+}`, uniq)
+}
+
+func testGCPSTSDestroy(accProvider *fwprovider.FrameworkProvider) func(*terraform.State) error {
+	return func(s *terraform.State) error {
+		apiInstances := accProvider.DatadogApiInstances
+		auth := accProvider.Auth
+		if err := GCPSTSIntegrationDestroyHelper(auth, s, apiInstances); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func GCPSTSIntegrationDestroyHelper(auth context.Context, s *terraform.State, apiInstances *utils.ApiInstances) error {
+	err := utils.Retry(2, 10, func() error {
+		for _, r := range s.RootModule().Resources {
+			if r.Type != "datadog_integration_gcp_sts" {
+				continue
+			}
+			id := r.Primary.ID
+
+			stsEnabledAccounts, _, err := apiInstances.GetGCPStsIntegrationApiV2().ListGCPSTSAccounts(auth)
+			if err != nil {
+				return &utils.RetryableError{Prob: fmt.Sprintf("error retrieving STS enabled accounts %s", err)}
+			}
+
+			accountWasFound, err := findGCPAccount(id, stsEnabledAccounts)
+			if err != nil {
+				return err
+			}
+
+			if !accountWasFound {
+				return nil
+			}
+
+			return &utils.RetryableError{Prob: "GCP STS account still exists"}
+		}
+		return nil
+	})
+	return err
+}
+
+func findGCPAccount(accountID string, stsEnabledAccounts datadogV2.STSEnabledAccountData) (bool, error) {
+	accounts, ok := stsEnabledAccounts.GetDataOk()
+	if !ok {
+		return false, errors.New("error retrieving Data from GCP accounts")
+	}
+
+	for _, account := range *accounts {
+		id, ok := account.GetIdOk()
+		if !ok {
+			return false, errors.New("error retrieving id from account")
+		}
+
+		if *id == accountID {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/datadog/tests/resource_datadog_integration_gcp_sts_test.go
+++ b/datadog/tests/resource_datadog_integration_gcp_sts_test.go
@@ -127,9 +127,9 @@ func integrationGCPSTSAccountExistsHelper(auth context.Context, s *terraform.Sta
 		}
 		id := r.Primary.ID
 
-		accounts, httpResp, err := apiInstances.GetGCPStsIntegrationApiV2().ListGCPSTSAccounts(auth)
+		accounts, httpResp, err := apiInstances.GetGCPIntegrationApiV2().ListGCPSTSAccounts(auth)
 		if err != nil {
-			return utils.TranslateClientError(err, httpResp, "error retrieving STS enabled GCP service account")
+			return utils.TranslateClientError(err, httpResp, "error listing STS enabled GCP service accounts")
 		}
 
 		accountWasFound, err := findGCPAccount(id, accounts)
@@ -169,7 +169,7 @@ func GCPSTSIntegrationDestroyHelper(auth context.Context, s *terraform.State, ap
 			}
 			id := r.Primary.ID
 
-			stsEnabledAccounts, _, err := apiInstances.GetGCPStsIntegrationApiV2().ListGCPSTSAccounts(auth)
+			stsEnabledAccounts, _, err := apiInstances.GetGCPIntegrationApiV2().ListGCPSTSAccounts(auth)
 			if err != nil {
 				return &utils.RetryableError{Prob: fmt.Sprintf("error retrieving STS enabled accounts %s", err)}
 			}
@@ -190,7 +190,7 @@ func GCPSTSIntegrationDestroyHelper(auth context.Context, s *terraform.State, ap
 	return err
 }
 
-func findGCPAccount(accountID string, stsEnabledAccounts datadogV2.STSEnabledAccountData) (bool, error) {
+func findGCPAccount(accountID string, stsEnabledAccounts datadogV2.GCPSTSServiceAccountsResponse) (bool, error) {
 	accounts, ok := stsEnabledAccounts.GetDataOk()
 	if !ok {
 		return false, errors.New("error retrieving Data from GCP accounts")

--- a/go.mod
+++ b/go.mod
@@ -93,3 +93,5 @@ require (
 )
 
 go 1.19
+
+replace github.com/DataDog/datadog-api-client-go/v2 => /Users/josh.huie/go/src/github.com/datadog-api-client-go

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/datadog-api-client-go/v2 v2.12.1-0.20230519192638-b16a2b9c0c56 h1:wCKbLcKh4yT9Stgd4F/ISBqj23OnOKlAal1sT4PhBXs=
-github.com/DataDog/datadog-api-client-go/v2 v2.12.1-0.20230519192638-b16a2b9c0c56/go.mod h1:kntOqXEh1SmjwSDzW/eJkr9kS7EqttvEkelglWtJRbg=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=


### PR DESCRIPTION
This pull request includes the Go code changes needed to enable a GCP STS Integration Resource. This Terraform resource sets up a GCP STS Integration within Datadog using a customer’s GCP service account.

Included in this PR are the Create, Read, Update, Delete, and Import operations used to create a standard Terraform resource. 

This PR has a few dependencies that aren’t released yet (in the `datadog-api-client-go` and the `datadog-api-spec` repos).
