### PR TITLE
[provider] Fix segfault on invalid API URL

### DIFF
--- a/datadog/fwprovider/framework_provider.go
+++ b/datadog/fwprovider/framework_provider.go
@@ -326,7 +326,7 @@ func defaultConfigureFunc(p *FrameworkProvider, request *provider.ConfigureReque
 			return diags
 		}
 		if parsedAPIURL.Host == "" || parsedAPIURL.Scheme == "" {
-			diags.AddError("missing protocol or host", parseErr.Error())
+			diags.AddError("invalid API URL", "API URL missing protocol or host")
 			return diags
 		}
 		// If api url is passed, set and use the api name and protocol on ServerIndex{1}

--- a/datadog/fwprovider/framework_provider.go
+++ b/datadog/fwprovider/framework_provider.go
@@ -326,7 +326,7 @@ func defaultConfigureFunc(p *FrameworkProvider, request *provider.ConfigureReque
 			return diags
 		}
 		if parsedAPIURL.Host == "" || parsedAPIURL.Scheme == "" {
-			diags.AddError("invalid API URL", "API URL missing protocol or host")
+			diags.AddError("invalid API URL", fmt.Sprintf("API URL '%s' missing protocol or host", config.ApiUrl.ValueString()))
 			return diags
 		}
 		// If api url is passed, set and use the api name and protocol on ServerIndex{1}


### PR DESCRIPTION
`parseErr` is always nil if the edited code block is entered, so we cannot call `Error()` on it.

Fixes segfaults when the API url is missing protocol or host, such as `api.datadoghq.com` instead of `https://api.datadoghq.com`