### PR TITLE
[datadog_synthetics_test] Update and standardize example tests

### DIFF
--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -41,98 +41,142 @@ url = https://{{ LOCAL_VAR }}
 ```terraform
 # Example Usage (Synthetics API test)
 # Create a new Datadog Synthetics API/HTTP test on https://www.example.org
-resource "datadog_synthetics_test" "test_api" {
+resource "datadog_synthetics_test" "test_uptime" {
+  name    = "An Uptime test on example.org"
   type    = "api"
   subtype = "http"
+  status = "live"
+  message = "Notify @pagerduty"
+  locations = ["aws:eu-central-1"]
+  tags    = ["foo:bar", "foo", "env:test"]
+
   request_definition {
     method = "GET"
     url    = "https://www.example.org"
   }
+
   request_headers = {
     Content-Type   = "application/json"
-    Authentication = "Token: 1234566789"
   }
+
   assertion {
     type     = "statusCode"
     operator = "is"
     target   = "200"
   }
-  locations = ["aws:eu-central-1"]
+
   options_list {
     tick_every = 900
-
     retry {
       count    = 2
       interval = 300
     }
-
     monitor_options {
       renotify_interval = 120
     }
   }
-  name    = "An API test on example.org"
-  message = "Notify @pagerduty"
-  tags    = ["foo:bar", "foo", "env:test"]
+}
 
-  status = "live"
+
+# Example Usage (Authenticated API test)
+# Create a new Datadog Synthetics API/HTTP test on https://www.example.org
+resource "datadog_synthetics_test" "test_api" {
+  name      = "An API test on example.org"
+  type      = "api"
+  subtype   = "http"
+  status    = "live"
+  message   = "Notify @pagerduty"
+  locations = ["aws:eu-central-1"]
+  tags      = ["foo:bar", "foo", "env:test"]
+
+  request_definition {
+    method = "GET"
+    url    = "https://www.example.org"
+  }
+
+  request_headers = {
+    Content-Type   = "application/json"
+    Authentication = "Token: 1234566789"
+  }
+
+  assertion {
+    type     = "statusCode"
+    operator = "is"
+    target   = "200"
+  }
+
+  options_list {
+    tick_every = 900
+    retry {
+      count    = 2
+      interval = 300
+    }
+    monitor_options {
+      renotify_interval = 120
+    }
+  }
 }
 
 
 # Example Usage (Synthetics SSL test)
 # Create a new Datadog Synthetics API/SSL test on example.org
 resource "datadog_synthetics_test" "test_ssl" {
+  name    = "An API test on example.org"
   type    = "api"
   subtype = "ssl"
+  status = "live"
+  message = "Notify @pagerduty"
+  locations = ["aws:eu-central-1"]
+  tags    = ["foo:bar", "foo", "env:test"]
+
   request_definition {
     host = "example.org"
     port = 443
   }
+
   assertion {
     type     = "certificate"
     operator = "isInMoreThan"
     target   = 30
   }
-  locations = ["aws:eu-central-1"]
+
   options_list {
     tick_every         = 900
     accept_self_signed = true
   }
-  name    = "An API test on example.org"
-  message = "Notify @pagerduty"
-  tags    = ["foo:bar", "foo", "env:test"]
-
-  status = "live"
 }
 
 
 # Example Usage (Synthetics TCP test)
 # Create a new Datadog Synthetics API/TCP test on example.org
 resource "datadog_synthetics_test" "test_tcp" {
-  type    = "api"
-  subtype = "tcp"
+  name      = "An API test on example.org"
+  type      = "api"
+  subtype   = "tcp"
+  status    = "live"
+  message   = "Notify @pagerduty"
+  locations = ["aws:eu-central-1"]
+  tags      = ["foo:bar", "foo", "env:test"]
+
   request_definition {
     host = "example.org"
     port = 443
   }
+
   assertion {
     type     = "responseTime"
     operator = "lessThan"
     target   = 2000
   }
-  locations = ["aws:eu-central-1"]
-  options_list {
-    tick_every = 900
-  }
-  name    = "An API test on example.org"
-  message = "Notify @pagerduty"
-  tags    = ["foo:bar", "foo", "env:test"]
-
-  status = "live"
 
   config_variable {
     type = "global"
     name = "MY_GLOBAL_VAR"
     id   = "76636cd1-82e2-4aeb-9cfe-51366a8198a2"
+  }
+
+  options_list {
+    tick_every = 900
   }
 }
 
@@ -140,37 +184,40 @@ resource "datadog_synthetics_test" "test_tcp" {
 # Example Usage (Synthetics DNS test)
 # Create a new Datadog Synthetics API/DNS test on example.org
 resource "datadog_synthetics_test" "test_dns" {
-  type    = "api"
-  subtype = "dns"
+  name      = "An API test on example.org"
+  type      = "api"
+  subtype   = "dns"
+  status    = "live"
+  message   = "Notify @pagerduty"
+  locations = ["aws:eu-central-1"]
+  tags      = ["foo:bar", "foo", "env:test"]
+
   request_definition {
     host = "example.org"
   }
+
   assertion {
     type     = "recordSome"
     operator = "is"
     property = "A"
     target   = "0.0.0.0"
   }
-  locations = ["aws:eu-central-1"]
+
   options_list {
     tick_every = 900
   }
-  name    = "An API test on example.org"
-  message = "Notify @pagerduty"
-  tags    = ["foo:bar", "foo", "env:test"]
-
-  status = "live"
 }
 
 
 # Example Usage (Synthetics Multistep API test)
 # Create a new Datadog Synthetics Multistep API test
-resource "datadog_synthetics_test" "test" {
+resource "datadog_synthetics_test" "test_multi_step" {
   name      = "Multistep API test"
   type      = "api"
   subtype   = "multi"
   status    = "live"
   locations = ["aws:eu-central-1"]
+  tags      = ["foo:bar", "foo", "env:test"]
 
   api_step {
     name    = "An API test on example.org"
@@ -219,25 +266,18 @@ resource "datadog_synthetics_test" "test" {
 # Example Usage (Synthetics Browser test)
 # Create a new Datadog Synthetics Browser test starting on https://www.example.org
 resource "datadog_synthetics_test" "test_browser" {
-  type = "browser"
+  name       = "A Browser test on example.org"
+  type       = "browser"
+  status     = "paused"
+  message    = "Notify @qa"
+  device_ids = ["laptop_large"]
+  locations  = ["aws:eu-central-1"]
+  tags       = []
 
   request_definition {
     method = "GET"
     url    = "https://app.datadoghq.com"
   }
-
-  device_ids = ["laptop_large"]
-  locations  = ["aws:eu-central-1"]
-
-  options_list {
-    tick_every = 3600
-  }
-
-  name    = "A Browser test on example.org"
-  message = "Notify @qa"
-  tags    = []
-
-  status = "paused"
 
   browser_step {
     name = "Check current url"
@@ -266,6 +306,10 @@ resource "datadog_synthetics_test" "test_browser" {
     type = "global"
     name = "MY_GLOBAL_VAR"
     id   = "76636cd1-82e2-4aeb-9cfe-51366a8198a2"
+  }
+
+  options_list {
+    tick_every = 3600
   }
 }
 ```

--- a/examples/resources/datadog_synthetics_test/resource.tf
+++ b/examples/resources/datadog_synthetics_test/resource.tf
@@ -1,97 +1,141 @@
 # Example Usage (Synthetics API test)
 # Create a new Datadog Synthetics API/HTTP test on https://www.example.org
-resource "datadog_synthetics_test" "test_api" {
+resource "datadog_synthetics_test" "test_uptime" {
+  name    = "An Uptime test on example.org"
   type    = "api"
   subtype = "http"
+  status = "live"
+  message = "Notify @pagerduty"
+  locations = ["aws:eu-central-1"]
+  tags    = ["foo:bar", "foo", "env:test"]
+
   request_definition {
     method = "GET"
     url    = "https://www.example.org"
   }
+
   request_headers = {
     Content-Type   = "application/json"
-    Authentication = "Token: 1234566789"
   }
+
   assertion {
     type     = "statusCode"
     operator = "is"
     target   = "200"
   }
-  locations = ["aws:eu-central-1"]
+
   options_list {
     tick_every = 900
-
     retry {
       count    = 2
       interval = 300
     }
-
     monitor_options {
       renotify_interval = 120
     }
   }
-  name    = "An API test on example.org"
-  message = "Notify @pagerduty"
-  tags    = ["foo:bar", "foo", "env:test"]
+}
 
-  status = "live"
+
+# Example Usage (Authenticated API test)
+# Create a new Datadog Synthetics API/HTTP test on https://www.example.org
+resource "datadog_synthetics_test" "test_api" {
+  name      = "An API test on example.org"
+  type      = "api"
+  subtype   = "http"
+  status    = "live"
+  message   = "Notify @pagerduty"
+  locations = ["aws:eu-central-1"]
+  tags      = ["foo:bar", "foo", "env:test"]
+
+  request_definition {
+    method = "GET"
+    url    = "https://www.example.org"
+  }
+
+  request_headers = {
+    Content-Type   = "application/json"
+    Authentication = "Token: 1234566789"
+  }
+
+  assertion {
+    type     = "statusCode"
+    operator = "is"
+    target   = "200"
+  }
+
+  options_list {
+    tick_every = 900
+    retry {
+      count    = 2
+      interval = 300
+    }
+    monitor_options {
+      renotify_interval = 120
+    }
+  }
 }
 
 
 # Example Usage (Synthetics SSL test)
 # Create a new Datadog Synthetics API/SSL test on example.org
 resource "datadog_synthetics_test" "test_ssl" {
+  name    = "An API test on example.org"
   type    = "api"
   subtype = "ssl"
+  status = "live"
+  message = "Notify @pagerduty"
+  locations = ["aws:eu-central-1"]
+  tags    = ["foo:bar", "foo", "env:test"]
+
   request_definition {
     host = "example.org"
     port = 443
   }
+
   assertion {
     type     = "certificate"
     operator = "isInMoreThan"
     target   = 30
   }
-  locations = ["aws:eu-central-1"]
+
   options_list {
     tick_every         = 900
     accept_self_signed = true
   }
-  name    = "An API test on example.org"
-  message = "Notify @pagerduty"
-  tags    = ["foo:bar", "foo", "env:test"]
-
-  status = "live"
 }
 
 
 # Example Usage (Synthetics TCP test)
 # Create a new Datadog Synthetics API/TCP test on example.org
 resource "datadog_synthetics_test" "test_tcp" {
-  type    = "api"
-  subtype = "tcp"
+  name      = "An API test on example.org"
+  type      = "api"
+  subtype   = "tcp"
+  status    = "live"
+  message   = "Notify @pagerduty"
+  locations = ["aws:eu-central-1"]
+  tags      = ["foo:bar", "foo", "env:test"]
+
   request_definition {
     host = "example.org"
     port = 443
   }
+
   assertion {
     type     = "responseTime"
     operator = "lessThan"
     target   = 2000
   }
-  locations = ["aws:eu-central-1"]
-  options_list {
-    tick_every = 900
-  }
-  name    = "An API test on example.org"
-  message = "Notify @pagerduty"
-  tags    = ["foo:bar", "foo", "env:test"]
-
-  status = "live"
 
   config_variable {
     type = "global"
     name = "MY_GLOBAL_VAR"
     id   = "76636cd1-82e2-4aeb-9cfe-51366a8198a2"
+  }
+
+  options_list {
+    tick_every = 900
   }
 }
 
@@ -99,37 +143,40 @@ resource "datadog_synthetics_test" "test_tcp" {
 # Example Usage (Synthetics DNS test)
 # Create a new Datadog Synthetics API/DNS test on example.org
 resource "datadog_synthetics_test" "test_dns" {
-  type    = "api"
-  subtype = "dns"
+  name      = "An API test on example.org"
+  type      = "api"
+  subtype   = "dns"
+  status    = "live"
+  message   = "Notify @pagerduty"
+  locations = ["aws:eu-central-1"]
+  tags      = ["foo:bar", "foo", "env:test"]
+
   request_definition {
     host = "example.org"
   }
+
   assertion {
     type     = "recordSome"
     operator = "is"
     property = "A"
     target   = "0.0.0.0"
   }
-  locations = ["aws:eu-central-1"]
+
   options_list {
     tick_every = 900
   }
-  name    = "An API test on example.org"
-  message = "Notify @pagerduty"
-  tags    = ["foo:bar", "foo", "env:test"]
-
-  status = "live"
 }
 
 
 # Example Usage (Synthetics Multistep API test)
 # Create a new Datadog Synthetics Multistep API test
-resource "datadog_synthetics_test" "test" {
+resource "datadog_synthetics_test" "test_multi_step" {
   name      = "Multistep API test"
   type      = "api"
   subtype   = "multi"
   status    = "live"
   locations = ["aws:eu-central-1"]
+  tags      = ["foo:bar", "foo", "env:test"]
 
   api_step {
     name    = "An API test on example.org"
@@ -178,25 +225,18 @@ resource "datadog_synthetics_test" "test" {
 # Example Usage (Synthetics Browser test)
 # Create a new Datadog Synthetics Browser test starting on https://www.example.org
 resource "datadog_synthetics_test" "test_browser" {
-  type = "browser"
+  name       = "A Browser test on example.org"
+  type       = "browser"
+  status     = "paused"
+  message    = "Notify @qa"
+  device_ids = ["laptop_large"]
+  locations  = ["aws:eu-central-1"]
+  tags       = []
 
   request_definition {
     method = "GET"
     url    = "https://app.datadoghq.com"
   }
-
-  device_ids = ["laptop_large"]
-  locations  = ["aws:eu-central-1"]
-
-  options_list {
-    tick_every = 3600
-  }
-
-  name    = "A Browser test on example.org"
-  message = "Notify @qa"
-  tags    = []
-
-  status = "paused"
 
   browser_step {
     name = "Check current url"
@@ -225,5 +265,9 @@ resource "datadog_synthetics_test" "test_browser" {
     type = "global"
     name = "MY_GLOBAL_VAR"
     id   = "76636cd1-82e2-4aeb-9cfe-51366a8198a2"
+  }
+
+  options_list {
+    tick_every = 3600
   }
 }


### PR DESCRIPTION
- Add missing uptime test example
- Standardise example blocks

When implementing datadog, I noticed there was no explicit example for an uptime test, which caused me to accidentally configure all uptime tests as `browser` tests instead of `api` tests.

Additionally, I noticed that some of the examples listed things like name, locations, and status towards the top, and others didn't. This caused me to write badly formatted code which I later had to go and correct once I realised what was possible.

This PR exemplifies good quality, readable, standardised code, and also adds a much needed example for uptime tests.