### PR TITLE
[datadog_downtime] Update downtime boundary on recurrence update

### DIFF
--- a/datadog/resource_datadog_downtime.go
+++ b/datadog/resource_datadog_downtime.go
@@ -313,7 +313,8 @@ func downtimeBoundaryNeedsApply(d *schema.ResourceData, tsFrom string, apiTs, co
 		// when updating, we apply when
 		// * the config value has changed
 		// * API-returned value is different than configured value and there is no recurrence
-		if d.HasChange(tsFrom) {
+		// * Recurrence has changed
+		if d.HasChange(tsFrom) || d.HasChange("recurrence") {
 			apply = true
 		} else {
 			_, ok := d.GetOk("active_child_id")


### PR DESCRIPTION
Updating the recurrence doesn't trigger an update of the start/end values, but the API was changed to expect it to. This fix allows users to modify the recurrence without being blocked by the API.