### PR TITLE
[test_utils] Fix retry logic

### DIFF
--- a/datadog/internal/utils/test_utils.go
+++ b/datadog/internal/utils/test_utils.go
@@ -20,14 +20,14 @@ func Retry(interval time.Duration, count int, call func() error) error {
 		err := call()
 		if err == nil {
 			return nil
-		} else if errors.Is(err, retryErrorType) {
+		} else if errors.As(err, &retryErrorType) {
 			log.Print(err.Error())
 			if os.Getenv("RECORD") == "false" {
 				// Skip sleep in replay mode to go faster
 				continue
 			}
 			time.Sleep(interval)
-		} else if errors.Is(err, fatalErrorType) {
+		} else if errors.As(err, &fatalErrorType) {
 			log.Print(err.Error())
 			return err
 		}


### PR DESCRIPTION
errors.Is never returns true because our error structs don't implement the right `Is(error) bool` method. Changes the function to `errors.As` which doesn't solely rely on that method's implementation to check if error matches.