### PR TITLE
[datadog_synthetics_test] Handle both example and secure missing from variables

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -2798,12 +2798,12 @@ func updateSyntheticsBrowserTestLocalState(d *schema.ResourceData, syntheticsTes
 		}
 		if v, ok := variable.GetExampleOk(); ok {
 			localVariable["example"] = *v
-		} else if localVariable["secure"].(bool) {
+		} else if v, ok := localVariable["secure"].(bool); ok && v {
 			localVariable["example"] = d.Get(fmt.Sprintf("browser_variable.%d.example", i))
 		}
 		if v, ok := variable.GetPatternOk(); ok {
 			localVariable["pattern"] = *v
-		} else if localVariable["secure"].(bool) {
+		} else if v, ok := localVariable["secure"].(bool); ok && v {
 			localVariable["pattern"] = d.Get(fmt.Sprintf("browser_variable.%d.pattern", i))
 		}
 		localBrowserVariables[i] = localVariable
@@ -3004,12 +3004,12 @@ func updateSyntheticsAPITestLocalState(d *schema.ResourceData, syntheticsTest *d
 		if configVariable.GetType() != "global" {
 			if v, ok := configVariable.GetExampleOk(); ok {
 				localVariable["example"] = *v
-			} else if localVariable["secure"].(bool) {
+			} else if v, ok := localVariable["secure"].(bool); ok && v {
 				localVariable["example"] = d.Get(fmt.Sprintf("config_variable.%d.example", i))
 			}
 			if v, ok := configVariable.GetPatternOk(); ok {
 				localVariable["pattern"] = *v
-			} else if localVariable["secure"].(bool) {
+			} else if v, ok := localVariable["secure"].(bool); ok && v {
 				localVariable["pattern"] = d.Get(fmt.Sprintf("config_variable.%d.pattern", i))
 			}
 		}


### PR DESCRIPTION
If the example is not set on a test config variable, it gets the secure field unconditionally and it can crash. This fixes it by checking the boolean cast properly.

Fixes #1958