### PR TITLE
[datadog_integration_gcp] Mark resource as deprecated

### DIFF
--- a/datadog/resource_datadog_integration_gcp.go
+++ b/datadog/resource_datadog_integration_gcp.go
@@ -16,11 +16,12 @@ var integrationGcpMutex = sync.Mutex{}
 
 func resourceDatadogIntegrationGcp() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.",
-		CreateContext: resourceDatadogIntegrationGcpCreate,
-		ReadContext:   resourceDatadogIntegrationGcpRead,
-		UpdateContext: resourceDatadogIntegrationGcpUpdate,
-		DeleteContext: resourceDatadogIntegrationGcpDelete,
+		Description:        "Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.",
+		DeprecationMessage: "This resource is deprecated. Instead use the datadog_integration_gcp_sts resource.",
+		CreateContext:      resourceDatadogIntegrationGcpCreate,
+		ReadContext:        resourceDatadogIntegrationGcpRead,
+		UpdateContext:      resourceDatadogIntegrationGcpUpdate,
+		DeleteContext:      resourceDatadogIntegrationGcpDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/datadog/resource_datadog_integration_gcp.go
+++ b/datadog/resource_datadog_integration_gcp.go
@@ -16,8 +16,8 @@ var integrationGcpMutex = sync.Mutex{}
 
 func resourceDatadogIntegrationGcp() *schema.Resource {
 	return &schema.Resource{
-		Description:        "Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.",
-		DeprecationMessage: "This resource is deprecated. Instead use the datadog_integration_gcp_sts resource.",
+		Description:        "This resource is deprecated — use the gcp_sts resource instead. Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.",
+		DeprecationMessage: "This resource is deprecated — use the datadog_integration_gcp_sts resource instead.",
 		CreateContext:      resourceDatadogIntegrationGcpCreate,
 		ReadContext:        resourceDatadogIntegrationGcpRead,
 		UpdateContext:      resourceDatadogIntegrationGcpUpdate,

--- a/datadog/resource_datadog_integration_gcp.go
+++ b/datadog/resource_datadog_integration_gcp.go
@@ -16,7 +16,7 @@ var integrationGcpMutex = sync.Mutex{}
 
 func resourceDatadogIntegrationGcp() *schema.Resource {
 	return &schema.Resource{
-		Description:        "This resource is deprecated — use the datadog_integration_gcp_sts resource instead. Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.",
+		Description:        "This resource is deprecated — use the `datadog_integration_gcp_sts resource` instead. Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.",
 		DeprecationMessage: "This resource is deprecated — use the datadog_integration_gcp_sts resource instead.",
 		CreateContext:      resourceDatadogIntegrationGcpCreate,
 		ReadContext:        resourceDatadogIntegrationGcpRead,

--- a/datadog/resource_datadog_integration_gcp.go
+++ b/datadog/resource_datadog_integration_gcp.go
@@ -16,7 +16,7 @@ var integrationGcpMutex = sync.Mutex{}
 
 func resourceDatadogIntegrationGcp() *schema.Resource {
 	return &schema.Resource{
-		Description:        "This resource is deprecated — use the gcp_sts resource instead. Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.",
+		Description:        "This resource is deprecated — use the datadog_integration_gcp_sts resource instead. Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.",
 		DeprecationMessage: "This resource is deprecated — use the datadog_integration_gcp_sts resource instead.",
 		CreateContext:      resourceDatadogIntegrationGcpCreate,
 		ReadContext:        resourceDatadogIntegrationGcpRead,

--- a/docs/resources/integration_gcp.md
+++ b/docs/resources/integration_gcp.md
@@ -3,12 +3,12 @@
 page_title: "datadog_integration_gcp Resource - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  This resource is deprecated — use the datadogintegrationgcp_sts resource instead. Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.
+  This resource is deprecated — use the datadog_integration_gcp_sts resource instead. Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.
 ---
 
 # datadog_integration_gcp (Resource)
 
-This resource is deprecated — use the datadog_integration_gcp_sts resource instead. Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.
+This resource is deprecated — use the `datadog_integration_gcp_sts resource` instead. Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.
 
 ## Example Usage
 

--- a/docs/resources/integration_gcp.md
+++ b/docs/resources/integration_gcp.md
@@ -3,12 +3,12 @@
 page_title: "datadog_integration_gcp Resource - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  This resource is deprecated — use the gcp_sts resource instead. Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.
+  This resource is deprecated — use the datadogintegrationgcp_sts resource instead. Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.
 ---
 
 # datadog_integration_gcp (Resource)
 
-This resource is deprecated — use the gcp_sts resource instead. Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.
+This resource is deprecated — use the datadog_integration_gcp_sts resource instead. Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.
 
 ## Example Usage
 

--- a/docs/resources/integration_gcp.md
+++ b/docs/resources/integration_gcp.md
@@ -3,12 +3,12 @@
 page_title: "datadog_integration_gcp Resource - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.
+  This resource is deprecated — use the gcp_sts resource instead. Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.
 ---
 
 # datadog_integration_gcp (Resource)
 
-Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.
+This resource is deprecated — use the gcp_sts resource instead. Provides a Datadog - Google Cloud Platform integration resource. This can be used to create and manage Datadog - Google Cloud Platform integration.
 
 ## Example Usage
 


### PR DESCRIPTION
Updates the GCP Integration Terraform Resource. We want to mark it as deprecated because of the newly created gcp_sts resource.