### PR TITLE
[datadog_spans_metric] Convert `group_by` to set

### DIFF
--- a/datadog/fwprovider/resource_datadog_spans_metric.go
+++ b/datadog/fwprovider/resource_datadog_spans_metric.go
@@ -78,7 +78,7 @@ func (r *SpansMetricResource) Schema(_ context.Context, _ resource.SchemaRequest
 			"id": utils.ResourceIDAttribute(),
 		},
 		Blocks: map[string]schema.Block{
-			"group_by": schema.ListNestedBlock{
+			"group_by": schema.SetNestedBlock{
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"path": schema.StringAttribute{

--- a/datadog/tests/resource_datadog_spans_metric_test.go
+++ b/datadog/tests/resource_datadog_spans_metric_test.go
@@ -221,12 +221,12 @@ func testAccCheckDatadogSpansMetricTestingCountGroupBys(uniq string) string {
 				query = "@http.status_code:200 service:my-service"
 			}
 			group_by {
-				path     = "resource_name1"
-				tag_name = "my_resource1"
-			}
-			group_by {
 				path     = "resource_name2"
 				tag_name = "my_resource2"
+			}
+			group_by {
+				path     = "resource_name1"
+				tag_name = "my_resource1"
 			}
 		}
 	`, uniq)

--- a/docs/resources/spans_metric.md
+++ b/docs/resources/spans_metric.md
@@ -43,7 +43,7 @@ resource "datadog_spans_metric" "testing_spans_metric" {
 
 - `compute` (Block, Optional) (see [below for nested schema](#nestedblock--compute))
 - `filter` (Block, Optional) (see [below for nested schema](#nestedblock--filter))
-- `group_by` (Block List) (see [below for nested schema](#nestedblock--group_by))
+- `group_by` (Block Set) (see [below for nested schema](#nestedblock--group_by))
 
 ### Read-Only
 


### PR DESCRIPTION
group_by elements are sorted on the backend side so using a list forces you to order the elements on client side.