### PR TITLE
[datadog_dashboard] Add note about tf managed dashboard lists when using `dashboard_lists` resource

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -120,7 +120,7 @@ func resourceDatadogDashboard() *schema.Resource {
 			"dashboard_lists": {
 				Type:        schema.TypeSet,
 				Optional:    true,
-				Description: "A list of dashboard lists this dashboard belongs to.",
+				Description: "A list of dashboard lists this dashboard belongs to. This attribute should not be set if managing the corresponding dashboard lists using terraform as it will cause inconsistent results.",
 				Elem:        &schema.Schema{Type: schema.TypeInt},
 			},
 			"dashboard_lists_removed": {

--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -120,7 +120,7 @@ func resourceDatadogDashboard() *schema.Resource {
 			"dashboard_lists": {
 				Type:        schema.TypeSet,
 				Optional:    true,
-				Description: "A list of dashboard lists this dashboard belongs to. This attribute should not be set if managing the corresponding dashboard lists using terraform as it will cause inconsistent results.",
+				Description: "A list of dashboard lists this dashboard belongs to. This attribute should not be set if managing the corresponding dashboard lists using Terraform as it causes inconsistent behavior.",
 				Elem:        &schema.Schema{Type: schema.TypeInt},
 			},
 			"dashboard_lists_removed": {

--- a/datadog/resource_datadog_dashboard_json.go
+++ b/datadog/resource_datadog_dashboard_json.go
@@ -68,7 +68,7 @@ func resourceDatadogDashboardJSON() *schema.Resource {
 			"dashboard_lists": {
 				Type:        schema.TypeSet,
 				Optional:    true,
-				Description: "The list of dashboard lists this dashboard belongs to.",
+				Description: "A list of dashboard lists this dashboard belongs to. This attribute should not be set if managing the corresponding dashboard lists using terraform as it will cause inconsistent results.",
 				Elem:        &schema.Schema{Type: schema.TypeInt},
 			},
 			"dashboard_lists_removed": {

--- a/datadog/resource_datadog_dashboard_json.go
+++ b/datadog/resource_datadog_dashboard_json.go
@@ -68,7 +68,7 @@ func resourceDatadogDashboardJSON() *schema.Resource {
 			"dashboard_lists": {
 				Type:        schema.TypeSet,
 				Optional:    true,
-				Description: "A list of dashboard lists this dashboard belongs to. This attribute should not be set if managing the corresponding dashboard lists using terraform as it will cause inconsistent results.",
+				Description: "A list of dashboard lists this dashboard belongs to. This attribute should not be set if managing the corresponding dashboard lists using Terraform as it causes inconsistent behavior.",
 				Elem:        &schema.Schema{Type: schema.TypeInt},
 			},
 			"dashboard_lists_removed": {

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -689,7 +689,7 @@ resource "datadog_dashboard" "free_dashboard" {
 
 ### Optional
 
-- `dashboard_lists` (Set of Number) A list of dashboard lists this dashboard belongs to.
+- `dashboard_lists` (Set of Number) A list of dashboard lists this dashboard belongs to. This attribute should not be set if managing the corresponding dashboard lists using terraform as it will cause inconsistent results.
 - `description` (String) The description of the dashboard.
 - `is_read_only` (Boolean, Deprecated) Whether this dashboard is read-only. **Deprecated.** Prefer using `restricted_roles` to define which roles are required to edit the dashboard.
 - `notify_list` (Set of String) The list of handles for the users to notify when changes are made to this dashboard.

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -689,7 +689,7 @@ resource "datadog_dashboard" "free_dashboard" {
 
 ### Optional
 
-- `dashboard_lists` (Set of Number) A list of dashboard lists this dashboard belongs to. This attribute should not be set if managing the corresponding dashboard lists using terraform as it will cause inconsistent results.
+- `dashboard_lists` (Set of Number) A list of dashboard lists this dashboard belongs to. This attribute should not be set if managing the corresponding dashboard lists using Terraform as it causes inconsistent behavior.
 - `description` (String) The description of the dashboard.
 - `is_read_only` (Boolean, Deprecated) Whether this dashboard is read-only. **Deprecated.** Prefer using `restricted_roles` to define which roles are required to edit the dashboard.
 - `notify_list` (Set of String) The list of handles for the users to notify when changes are made to this dashboard.

--- a/docs/resources/dashboard_json.md
+++ b/docs/resources/dashboard_json.md
@@ -514,7 +514,7 @@ EOF
 
 ### Optional
 
-- `dashboard_lists` (Set of Number) The list of dashboard lists this dashboard belongs to.
+- `dashboard_lists` (Set of Number) A list of dashboard lists this dashboard belongs to. This attribute should not be set if managing the corresponding dashboard lists using terraform as it will cause inconsistent results.
 - `url` (String) The URL of the dashboard.
 
 ### Read-Only

--- a/docs/resources/dashboard_json.md
+++ b/docs/resources/dashboard_json.md
@@ -514,7 +514,7 @@ EOF
 
 ### Optional
 
-- `dashboard_lists` (Set of Number) A list of dashboard lists this dashboard belongs to. This attribute should not be set if managing the corresponding dashboard lists using terraform as it will cause inconsistent results.
+- `dashboard_lists` (Set of Number) A list of dashboard lists this dashboard belongs to. This attribute should not be set if managing the corresponding dashboard lists using Terraform as it causes inconsistent behavior.
 - `url` (String) The URL of the dashboard.
 
 ### Read-Only


### PR DESCRIPTION
This is a follow up to: https://github.com/DataDog/terraform-provider-datadog/issues/1974

Users should not combine usage of `dashboard_lists` reosurce and `dashboard_lists` attribute in dashboard resources as it will cause inconsistent behavior unless they are explicitly setup to ensure both values match. To avoid inconsistencies, users, should use either/or. 