### PR TITLE
[datadog_synthetics_test] Allow synthetics web basicauth without password set

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -1586,7 +1586,7 @@ func completeSyntheticsTestRequest(request datadogV1.SyntheticsTestRequest, requ
 
 	if len(basicAuth) > 0 {
 		if requestBasicAuth, ok := basicAuth[0].(map[string]interface{}); ok {
-			if requestBasicAuth["type"] == "web" && requestBasicAuth["username"] != "" && requestBasicAuth["password"] != "" {
+			if requestBasicAuth["type"] == "web" && requestBasicAuth["username"] != "" {
 				basicAuth := datadogV1.NewSyntheticsBasicAuthWebWithDefaults()
 				basicAuth.SetPassword(requestBasicAuth["password"].(string))
 				basicAuth.SetUsername(requestBasicAuth["username"].(string))


### PR DESCRIPTION
Synthetics tests with basic web auth work properly without a password set, but not when username is missing. Changes the requirement to only require username.

The password field is defined as required, but not nullable, so we can safely omit it and it will default to empty string on the go sdk side.