### PR TITLE
[restriction_policy] Update restriction_policy resource documentation

### DIFF
--- a/datadog/fwprovider/resource_datadog_restriction_policy.go
+++ b/datadog/fwprovider/resource_datadog_restriction_policy.go
@@ -52,11 +52,11 @@ func (r *RestrictionPolicyResource) Metadata(_ context.Context, request resource
 
 func (r *RestrictionPolicyResource) Schema(_ context.Context, _ resource.SchemaRequest, response *resource.SchemaResponse) {
 	response.Schema = schema.Schema{
-		Description: "Provides a Datadog RestrictionPolicy resource. This can be used to create and manage Datadog restriction policies. See this page for more details https://docs.datadoghq.com/api/latest/restriction-policies/#supported-relations-for-resources.",
+		Description: "Provides a Datadog RestrictionPolicy resource. This can be used to create and manage Datadog restriction policies.",
 		Attributes: map[string]schema.Attribute{
 			"resource_id": schema.StringAttribute{
 				Required:    true,
-				Description: "Identifier for the resource, formatted as resource_type:resource_id.",
+				Description: "Identifier for the resource, formatted as resource_type:resource_id.\n\nNote: dashboard resource is currently not supported",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -68,11 +68,11 @@ func (r *RestrictionPolicyResource) Schema(_ context.Context, _ resource.SchemaR
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"relation": schema.StringAttribute{
-							Optional:    true,
-							Description: "The role/level of access.",
+							Required:    true,
+							Description: "The role/level of access. See this page for more details https://docs.datadoghq.com/api/latest/restriction-policies/#supported-relations-for-resources",
 						},
 						"principals": schema.SetAttribute{
-							Optional:    true,
+							Required:    true,
 							Description: "An array of principals. A principal is a subject or group of subjects. Each principal is formatted as `type:id`. Supported types: `role` and `org`. The org ID can be obtained through the api/v2/users API.",
 							ElementType: types.StringType,
 						},

--- a/docs/resources/restriction_policy.md
+++ b/docs/resources/restriction_policy.md
@@ -3,12 +3,12 @@
 page_title: "datadog_restriction_policy Resource - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  Provides a Datadog RestrictionPolicy resource. This can be used to create and manage Datadog restriction policies. See this page for more details https://docs.datadoghq.com/api/latest/restriction-policies/#supported-relations-for-resources.
+  Provides a Datadog RestrictionPolicy resource. This can be used to create and manage Datadog restriction policies.
 ---
 
 # datadog_restriction_policy (Resource)
 
-Provides a Datadog RestrictionPolicy resource. This can be used to create and manage Datadog restriction policies. See this page for more details https://docs.datadoghq.com/api/latest/restriction-policies/#supported-relations-for-resources.
+Provides a Datadog RestrictionPolicy resource. This can be used to create and manage Datadog restriction policies.
 
 ## Example Usage
 
@@ -36,6 +36,8 @@ resource "datadog_restriction_policy" "foo" {
 
 - `resource_id` (String) Identifier for the resource, formatted as resource_type:resource_id.
 
+Note: dashboard resource is currently not supported
+
 ### Optional
 
 - `bindings` (Block Set) (see [below for nested schema](#nestedblock--bindings))
@@ -47,10 +49,10 @@ resource "datadog_restriction_policy" "foo" {
 <a id="nestedblock--bindings"></a>
 ### Nested Schema for `bindings`
 
-Optional:
+Required:
 
 - `principals` (Set of String) An array of principals. A principal is a subject or group of subjects. Each principal is formatted as `type:id`. Supported types: `role` and `org`. The org ID can be obtained through the api/v2/users API.
-- `relation` (String) The role/level of access.
+- `relation` (String) The role/level of access. See this page for more details https://docs.datadoghq.com/api/latest/restriction-policies/#supported-relations-for-resources
 
 ## Import
 


### PR DESCRIPTION
* Update the documentation for restriction_policy resource to specify the required fields within `binding` object and other links
* Marked the `relation` and `principal` attribute as required for binding
* Added the note that dashboard resource type is not supported
* This is how the doc will look like for customers -> https://github.com/DataDog/terraform-provider-datadog/blob/sanjay.thakkar/GRACE-RP-Fix-Doc/docs/resources/restriction_policy.md