### PR TITLE
Check exit code instead of log output during terraform fmt

### DIFF
--- a/scripts/fmtcheck.sh
+++ b/scripts/fmtcheck.sh
@@ -16,7 +16,7 @@ fi
 
 # Check the example terraform files pass terraform fmt
 echo "==> Checking that examples pass with terraform fmt requirements"
-(unset TF_LOG; terraform_fmt=$(terraform fmt -recursive -check -diff examples 2>&1))
+terraform_fmt=$(unset TF_LOG; terraform fmt -recursive -check -diff examples 2>&1)
 if [[ -n ${terraform_fmt}  ]]; then
     echo "Files in the \`example\` folder aren't terraform formatted"
     echo "You can use the command \`make fmt\` to reformat the following:"

--- a/scripts/fmtcheck.sh
+++ b/scripts/fmtcheck.sh
@@ -16,8 +16,8 @@ fi
 
 # Check the example terraform files pass terraform fmt
 echo "==> Checking that examples pass with terraform fmt requirements"
-terraform_fmt=$(unset TF_LOG; terraform fmt -recursive -check -diff examples 2>&1)
-if [[ -n ${terraform_fmt}  ]]; then
+terraform_fmt=$(terraform fmt -recursive -check -diff examples 2>&1)
+if [[ $? -ne 0 ]]; then
     echo "Files in the \`example\` folder aren't terraform formatted"
     echo "You can use the command \`make fmt\` to reformat the following:"
     echo "${terraform_fmt}"

--- a/scripts/fmtcheck.sh
+++ b/scripts/fmtcheck.sh
@@ -16,7 +16,7 @@ fi
 
 # Check the example terraform files pass terraform fmt
 echo "==> Checking that examples pass with terraform fmt requirements"
-terraform_fmt=$(terraform fmt -recursive -check -diff examples 2>&1)
+(unset TF_LOG; terraform_fmt=$(terraform fmt -recursive -check -diff examples 2>&1))
 if [[ -n ${terraform_fmt}  ]]; then
     echo "Files in the \`example\` folder aren't terraform formatted"
     echo "You can use the command \`make fmt\` to reformat the following:"


### PR DESCRIPTION
Check `exit code != 0` instead of log output being non-empty during terraform fmt
This fixes build failures due to `fmtcheck.sh` misinterpreting `terraform fmt`'s log output.
