### PR TITLE
[restriction_policy] Update restriction_policy resource documentation for private beta dashboard support

### DIFF
--- a/datadog/fwprovider/resource_datadog_restriction_policy.go
+++ b/datadog/fwprovider/resource_datadog_restriction_policy.go
@@ -56,7 +56,7 @@ func (r *RestrictionPolicyResource) Schema(_ context.Context, _ resource.SchemaR
 		Attributes: map[string]schema.Attribute{
 			"resource_id": schema.StringAttribute{
 				Required:    true,
-				Description: "Identifier for the resource, formatted as resource_type:resource_id.\n\nNote: dashboard resource is currently not supported",
+				Description: "Identifier for the resource, formatted as resource_type:resource_id.\n\nNote: Dashboards support is in private beta and requires upgrading to version 3.27.0. Reach out to your Datadog contact or support to enable this",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},

--- a/docs/resources/restriction_policy.md
+++ b/docs/resources/restriction_policy.md
@@ -36,7 +36,7 @@ resource "datadog_restriction_policy" "foo" {
 
 - `resource_id` (String) Identifier for the resource, formatted as resource_type:resource_id.
 
-Note: dashboard resource is currently not supported
+Note: Dashboards support is in private beta and requires upgrading to version 3.27.0. Reach out to your Datadog contact or support to enable this
 
 ### Optional
 


### PR DESCRIPTION
* For `datadog_restriction_policy` resource, updated the note to specify that we now support dashboard resource type in private beta
* This is how the doc will look like for customers -> https://github.com/DataDog/terraform-provider-datadog/blob/sanjay.thakkar/GRACE-RP-Fix-Doc-2/docs/resources/restriction_policy.md