### PR TITLE
[datadog_sensitive_data_scanner_rule] Handle empty string for `excluded_namespaces`

### DIFF
--- a/datadog/resource_datadog_sensitive_data_scanner_rule.go
+++ b/datadog/resource_datadog_sensitive_data_scanner_rule.go
@@ -225,7 +225,13 @@ func buildSensitiveDataScannerRuleAttributes(d *schema.ResourceData) *datadogV2.
 
 	excludedNamespaces := []string{}
 	for _, s := range d.Get("excluded_namespaces").([]interface{}) {
-		excludedNamespaces = append(excludedNamespaces, s.(string))
+		if s == nil {
+			// sdkv2 treats empty strings in list as nils so
+			// append an empty string
+			excludedNamespaces = append(excludedNamespaces, "")
+		} else {
+			excludedNamespaces = append(excludedNamespaces, s.(string))
+		}
 	}
 	attributes.SetExcludedNamespaces(excludedNamespaces)
 


### PR DESCRIPTION
Closes: https://github.com/DataDog/terraform-provider-datadog/issues/2040