### PR TITLE
[datadog_dashboard] Fix handling of nil notify_by list

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -677,6 +677,10 @@ func buildDatadogNotifyList(terraformNotifyList *schema.Set) *[]string {
 }
 
 func buildTerraformNotifyList(datadogNotifyList *[]string) *[]string {
+	if datadogNotifyList == nil {
+		terraformNotifyList := make([]string, 0)
+		return &terraformNotifyList
+	}
 	terraformNotifyList := make([]string, len(*datadogNotifyList))
 	for i, authorHandle := range *datadogNotifyList {
 		terraformNotifyList[i] = authorHandle


### PR DESCRIPTION
Backend can reset it to null when editing a dasboard.

Closes #2045