### PR TITLE
Fix typo `millseconds` -> `milliseconds`

### DIFF
--- a/docs/resources/metric_metadata.md
+++ b/docs/resources/metric_metadata.md
@@ -17,7 +17,7 @@ Provides a Datadog metric_metadata resource. This can be used to manage a metric
 resource "datadog_metric_metadata" "request_time" {
   metric      = "request.time"
   short_name  = "Request time"
-  description = "99th percentile request time in millseconds"
+  description = "99th percentile request time in milliseconds"
   type        = "gauge"
   unit        = "millisecond"
 }

--- a/examples/resources/datadog_metric_metadata/resource.tf
+++ b/examples/resources/datadog_metric_metadata/resource.tf
@@ -2,7 +2,7 @@
 resource "datadog_metric_metadata" "request_time" {
   metric      = "request.time"
   short_name  = "Request time"
-  description = "99th percentile request time in millseconds"
+  description = "99th percentile request time in milliseconds"
   type        = "gauge"
   unit        = "millisecond"
 }


### PR DESCRIPTION
Fixing a small typo in the documentation.