### PR TITLE
[datadog_spans_metric] Normalize tag value

### DIFF
--- a/datadog/fwprovider/resource_datadog_spans_metric.go
+++ b/datadog/fwprovider/resource_datadog_spans_metric.go
@@ -92,7 +92,7 @@ func (r *spansMetricResource) Schema(_ context.Context, _ resource.SchemaRequest
 							Computed:    true,
 							Description: "Eventual name of the tag that gets created. By default, the path attribute is used as the tag name.",
 							PlanModifiers: []planmodifier.String{
-								planmodifiers.NormalizaTag(),
+								planmodifiers.NormalizeTag(),
 							},
 						},
 					},

--- a/datadog/fwprovider/resource_datadog_spans_metric.go
+++ b/datadog/fwprovider/resource_datadog_spans_metric.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
+	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/planmodifiers"
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 )
 
@@ -90,6 +91,9 @@ func (r *spansMetricResource) Schema(_ context.Context, _ resource.SchemaRequest
 							Optional:    true,
 							Computed:    true,
 							Description: "Eventual name of the tag that gets created. By default, the path attribute is used as the tag name.",
+							PlanModifiers: []planmodifier.String{
+								planmodifiers.NormalizaTag(),
+							},
 						},
 					},
 				},

--- a/datadog/internal/planmodifiers/types_string_tag_normalizer.go
+++ b/datadog/internal/planmodifiers/types_string_tag_normalizer.go
@@ -8,7 +8,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 )
 
-func NormalizaTag() planmodifier.String {
+func NormalizeTag() planmodifier.String {
 	return normalizeTagModifier{}
 }
 

--- a/datadog/internal/planmodifiers/types_string_tag_normalizer.go
+++ b/datadog/internal/planmodifiers/types_string_tag_normalizer.go
@@ -1,0 +1,32 @@
+package planmodifiers
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+)
+
+func NormalizaTag() planmodifier.String {
+	return normalizeTagModifier{}
+}
+
+type normalizeTagModifier struct{}
+
+func (m normalizeTagModifier) Description(_ context.Context) string {
+	return "Normalize tag value."
+}
+
+func (m normalizeTagModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m normalizeTagModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
+		return
+	}
+
+	val := req.ConfigValue.ValueString()
+	resp.PlanValue = types.StringValue(utils.NormalizeTag(val))
+}


### PR DESCRIPTION
Add normalize tag plan modifier to handle diff caused by normalization in the backend.

Closes: https://github.com/DataDog/terraform-provider-datadog/issues/2052