### PR TITLE
[datadog_sensitive_data_scanner_group] Add ordering constraints to tests

### DIFF
--- a/datadog/tests/data_source_datadog_sensitive_data_scanner_group_order_test.go
+++ b/datadog/tests/data_source_datadog_sensitive_data_scanner_group_order_test.go
@@ -30,7 +30,9 @@ func TestAccDatadogSDSGroupOrderDatasource(t *testing.T) {
 
 func testAccDatasourceDatadogSDSGroupOrderWithGroupConfig(uniq string) string {
 	return fmt.Sprintf(`
-data "datadog_sensitive_data_scanner_group_order" "foo" {}
+data "datadog_sensitive_data_scanner_group_order" "foo" {
+	depends_on = [datadog_sensitive_data_scanner_group.mygroup]
+}
 
 resource "datadog_sensitive_data_scanner_group" "mygroup" {
 	name        = "%s"

--- a/datadog/tests/resource_datadog_sensitive_data_scanner_group_order_test.go
+++ b/datadog/tests/resource_datadog_sensitive_data_scanner_group_order_test.go
@@ -18,6 +18,7 @@ resource "datadog_sensitive_data_scanner_group_order" "foo" {
 }
 
 resource "datadog_sensitive_data_scanner_group" "mygroup" {
+	depends_on = [data.datadog_sensitive_data_scanner_group_order.foo]
 	name        = "%s"
 	description = "A relevant description"
 	filter {


### PR DESCRIPTION
Fix flakiness when a data source is initialized with no groups in the system, and making sure a data source is initialized before trying to re-order groups