### PR TITLE
[datadog_dashboard_list] Remove resource from state on 404

### DIFF
--- a/datadog/fwprovider/resource_datadog_dashboard_list.go
+++ b/datadog/fwprovider/resource_datadog_dashboard_list.go
@@ -220,7 +220,7 @@ func (r *dashboardListResource) Read(ctx context.Context, req resource.ReadReque
 	dashList, httpresp, err := r.ApiV1.GetDashboardList(r.Auth, id)
 	if err != nil {
 		if httpresp != nil && httpresp.StatusCode == 404 {
-			state.ID = types.StringNull()
+			resp.State.RemoveResource(ctx)
 			return
 		}
 		resp.Diagnostics.Append(utils.FrameworkErrorDiag(utils.TranslateClientError(err, httpresp, ""), "error getting dashboard list"))


### PR DESCRIPTION
With sdk, we used to set id to nil on 404 with framework we need to remove the resource since ID is treated as an attribute