### PR TITLE
[datadog_integration_azure] Fix docs for app_service_plan_filters

### DIFF
--- a/datadog/resource_datadog_integration_azure.go
+++ b/datadog/resource_datadog_integration_azure.go
@@ -49,7 +49,7 @@ func resourceDatadogIntegrationAzure() *schema.Resource {
 					Optional:    true,
 				},
 				"app_service_plan_filters": {
-					Description: "This comma-separated list of tags (in the form `key:value`) defines a filter that Datadog uses when collecting metrics from Azure App Service Plans. Only App Service Plans that match one of the defined tags are imported into Datadog. The rest, including the apps and functions running on them, are ignored. This also filters the metrics for any App or Function running on the App Service Plan(s).",
+					Description: "This comma-separated list of tags (in the form `key:value,key:value`) defines a filter that Datadog uses when collecting metrics from Azure App Service Plans. Only App Service Plans that match one of the defined tags are imported into Datadog. The rest, including the apps and functions running on them, are ignored. This also filters the metrics for any App or Function running on the App Service Plan(s).",
 					Type:        schema.TypeString,
 					Optional:    true,
 				},

--- a/datadog/resource_datadog_integration_azure.go
+++ b/datadog/resource_datadog_integration_azure.go
@@ -49,7 +49,7 @@ func resourceDatadogIntegrationAzure() *schema.Resource {
 					Optional:    true,
 				},
 				"app_service_plan_filters": {
-					Description: "String of app service plan tag(s) (in the form `key:value,key:value`) defines a filter that Datadog uses when collecting metrics from Azure. Limit the Azure instances that are pulled into Datadog by using tags. Only hosts that match one of the defined tags are imported into Datadog. For example, `env:production,deploymentgroup:red`.",
+					Description: "This comma separated list of tags (in the form key:value) defines a filter that we will use when collecting metrics from Azure App Service Plans. Only App Service Plans that match one of the defined tags will be imported into Datadog. The rest, including the apps and functions running on them, will be ignored. Note that this will also filter the metrics for any App or Function running on the App Service Plan(s).",
 					Type:        schema.TypeString,
 					Optional:    true,
 				},

--- a/datadog/resource_datadog_integration_azure.go
+++ b/datadog/resource_datadog_integration_azure.go
@@ -49,7 +49,7 @@ func resourceDatadogIntegrationAzure() *schema.Resource {
 					Optional:    true,
 				},
 				"app_service_plan_filters": {
-					Description: "This comma separated list of tags (in the form key:value) defines a filter that we will use when collecting metrics from Azure App Service Plans. Only App Service Plans that match one of the defined tags will be imported into Datadog. The rest, including the apps and functions running on them, will be ignored. Note that this will also filter the metrics for any App or Function running on the App Service Plan(s).",
+					Description: "This comma-separated list of tags (in the form `key:value`) defines a filter that Datadog uses when collecting metrics from Azure App Service Plans. Only App Service Plans that match one of the defined tags are imported into Datadog. The rest, including the apps and functions running on them, are ignored. This also filters the metrics for any App or Function running on the App Service Plan(s).",
 					Type:        schema.TypeString,
 					Optional:    true,
 				},

--- a/docs/resources/integration_azure.md
+++ b/docs/resources/integration_azure.md
@@ -37,7 +37,7 @@ resource "datadog_integration_azure" "sandbox" {
 
 ### Optional
 
-- `app_service_plan_filters` (String) This comma-separated list of tags (in the form `key:value`) defines a filter that Datadog uses when collecting metrics from Azure App Service Plans. Only App Service Plans that match one of the defined tags are imported into Datadog. The rest, including the apps and functions running on them, are ignored. This also filters the metrics for any App or Function running on the App Service Plan(s).
+- `app_service_plan_filters` (String) This comma-separated list of tags (in the form `key:value,key:value`) defines a filter that Datadog uses when collecting metrics from Azure App Service Plans. Only App Service Plans that match one of the defined tags are imported into Datadog. The rest, including the apps and functions running on them, are ignored. This also filters the metrics for any App or Function running on the App Service Plan(s).
 - `automute` (Boolean) Silence monitors for expected Azure VM shutdowns.
 - `cspm_enabled` (Boolean) Enable Cloud Security Management Misconfigurations for your organization.
 - `custom_metrics_enabled` (Boolean) Enable custom metrics for your organization.

--- a/docs/resources/integration_azure.md
+++ b/docs/resources/integration_azure.md
@@ -37,7 +37,7 @@ resource "datadog_integration_azure" "sandbox" {
 
 ### Optional
 
-- `app_service_plan_filters` (String) String of app service plan tag(s) (in the form `key:value,key:value`) defines a filter that Datadog uses when collecting metrics from Azure. Limit the Azure instances that are pulled into Datadog by using tags. Only hosts that match one of the defined tags are imported into Datadog. For example, `env:production,deploymentgroup:red`.
+- `app_service_plan_filters` (String) This comma separated list of tags (in the form key:value) defines a filter that we will use when collecting metrics from Azure App Service Plans. Only App Service Plans that match one of the defined tags will be imported into Datadog. The rest, including the apps and functions running on them, will be ignored. Note that this will also filter the metrics for any App or Function running on the App Service Plan(s).
 - `automute` (Boolean) Silence monitors for expected Azure VM shutdowns.
 - `cspm_enabled` (Boolean) Enable Cloud Security Management Misconfigurations for your organization.
 - `custom_metrics_enabled` (Boolean) Enable custom metrics for your organization.

--- a/docs/resources/integration_azure.md
+++ b/docs/resources/integration_azure.md
@@ -37,7 +37,7 @@ resource "datadog_integration_azure" "sandbox" {
 
 ### Optional
 
-- `app_service_plan_filters` (String) This comma separated list of tags (in the form key:value) defines a filter that we will use when collecting metrics from Azure App Service Plans. Only App Service Plans that match one of the defined tags will be imported into Datadog. The rest, including the apps and functions running on them, will be ignored. Note that this will also filter the metrics for any App or Function running on the App Service Plan(s).
+- `app_service_plan_filters` (String) This comma-separated list of tags (in the form `key:value`) defines a filter that Datadog uses when collecting metrics from Azure App Service Plans. Only App Service Plans that match one of the defined tags are imported into Datadog. The rest, including the apps and functions running on them, are ignored. This also filters the metrics for any App or Function running on the App Service Plan(s).
 - `automute` (Boolean) Silence monitors for expected Azure VM shutdowns.
 - `cspm_enabled` (Boolean) Enable Cloud Security Management Misconfigurations for your organization.
 - `custom_metrics_enabled` (Boolean) Enable custom metrics for your organization.


### PR DESCRIPTION
We realized the doc comment for app_service_plan_filters in terraform has a typo, and could be generally improved by changing it to the doc we already use in the tile.