### PR TITLE
[datadog_downtime_schedule] GA the resource

### DIFF
--- a/datadog/fwprovider/resource_datadog_downtime_schedule.go
+++ b/datadog/fwprovider/resource_datadog_downtime_schedule.go
@@ -80,7 +80,7 @@ func (r *DowntimeScheduleResource) Metadata(_ context.Context, request resource.
 
 func (r *DowntimeScheduleResource) Schema(_ context.Context, _ resource.SchemaRequest, response *resource.SchemaResponse) {
 	response.Schema = schema.Schema{
-		Description: "Provides a Datadog DowntimeSchedule resource. This can be used to create and manage Datadog downtimes. **NOTE:** Currently in private beta. To request access, contact Support at support@datadoghq.com.",
+		Description: "Provides a Datadog DowntimeSchedule resource. This can be used to create and manage Datadog downtimes.",
 		Attributes: map[string]schema.Attribute{
 			"display_timezone": schema.StringAttribute{
 				Optional:    true,

--- a/datadog/resource_datadog_downtime.go
+++ b/datadog/resource_datadog_downtime.go
@@ -108,11 +108,12 @@ func (d *downtimeChild) GetMuteFirstRecoveryNotification() bool {
 
 func resourceDatadogDowntime() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Provides a Datadog downtime resource. This can be used to create and manage Datadog downtimes.",
-		CreateContext: resourceDatadogDowntimeCreate,
-		ReadContext:   resourceDatadogDowntimeRead,
-		UpdateContext: resourceDatadogDowntimeUpdate,
-		DeleteContext: resourceDatadogDowntimeDelete,
+		Description:        "This resource is deprecated — use the `datadog_downtime_schedule resource` instead. Provides a Datadog downtime resource. This can be used to create and manage Datadog downtimes.",
+		DeprecationMessage: "This resource is deprecated — use the datadog_downtime_schedule resource instead.",
+		CreateContext:      resourceDatadogDowntimeCreate,
+		ReadContext:        resourceDatadogDowntimeRead,
+		UpdateContext:      resourceDatadogDowntimeUpdate,
+		DeleteContext:      resourceDatadogDowntimeDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/docs/resources/downtime.md
+++ b/docs/resources/downtime.md
@@ -3,12 +3,12 @@
 page_title: "datadog_downtime Resource - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  Provides a Datadog downtime resource. This can be used to create and manage Datadog downtimes.
+  This resource is deprecated — use the datadog_downtime_schedule resource instead. Provides a Datadog downtime resource. This can be used to create and manage Datadog downtimes.
 ---
 
 # datadog_downtime (Resource)
 
-Provides a Datadog downtime resource. This can be used to create and manage Datadog downtimes.
+This resource is deprecated — use the `datadog_downtime_schedule resource` instead. Provides a Datadog downtime resource. This can be used to create and manage Datadog downtimes.
 
 ## Example Usage
 

--- a/docs/resources/downtime_schedule.md
+++ b/docs/resources/downtime_schedule.md
@@ -3,12 +3,12 @@
 page_title: "datadog_downtime_schedule Resource - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  Provides a Datadog DowntimeSchedule resource. This can be used to create and manage Datadog downtimes. NOTE: Currently in private beta. To request access, contact Support at support@datadoghq.com.
+  Provides a Datadog DowntimeSchedule resource. This can be used to create and manage Datadog downtimes.
 ---
 
 # datadog_downtime_schedule (Resource)
 
-Provides a Datadog DowntimeSchedule resource. This can be used to create and manage Datadog downtimes. **NOTE:** Currently in private beta. To request access, contact Support at support@datadoghq.com.
+Provides a Datadog DowntimeSchedule resource. This can be used to create and manage Datadog downtimes.
 
 ## Example Usage
 


### PR DESCRIPTION
**Don't merge until Downtime V2 is enabled in us1.prod (targeted for 9/8/2023)**

Downtimes V2 will be enabled in all DCs by end of next week. This PR removes the unstable denotation for these endpoints.