### PR TITLE
Skip AWS log collection tests which use `access_key_id`

### DIFF
--- a/datadog/tests/resource_datadog_integration_aws_lambda_arn_test.go
+++ b/datadog/tests/resource_datadog_integration_aws_lambda_arn_test.go
@@ -44,6 +44,10 @@ resource "datadog_integration_aws_lambda_arn" "main_collector" {
 
 func TestAccDatadogIntegrationAWSLambdaArnAccessKey(t *testing.T) {
 	t.Parallel()
+	if !isReplaying() {
+		t.Skip("Account ID is not returned with invalid AWS accounts using access_key_id")
+		return
+	}
 	ctx, accProviders := testAccProviders(context.Background(), t)
 	accessKeyID := uniqueAWSAccessKeyID(ctx, t)
 	accProvider := testAccProvider(t, accProviders)


### PR DESCRIPTION
Skip these tests as account id is not returned for new invalid AWS accounts which use `access_key_id`.