### PR TITLE
[datadog_integration_aws_*] remove access_key_id note

### DIFF
--- a/datadog/resource_datadog_integration_aws_lambda_arn.go
+++ b/datadog/resource_datadog_integration_aws_lambda_arn.go
@@ -32,7 +32,7 @@ func resourceDatadogIntegrationAwsLambdaArn() *schema.Resource {
 		SchemaFunc: func() map[string]*schema.Schema {
 			return map[string]*schema.Schema{
 				"account_id": {
-					Description: "Your AWS Account ID without dashes. If your account is a GovCloud or China account, specify the `access_key_id` here.",
+					Description: "Your AWS Account ID without dashes.",
 					Type:        schema.TypeString,
 					Required:    true,
 					ForceNew:    true, // waits for update API call support

--- a/datadog/resource_datadog_integration_aws_log_collection.go
+++ b/datadog/resource_datadog_integration_aws_log_collection.go
@@ -25,7 +25,7 @@ func resourceDatadogIntegrationAwsLogCollection() *schema.Resource {
 		SchemaFunc: func() map[string]*schema.Schema {
 			return map[string]*schema.Schema{
 				"account_id": {
-					Description: "Your AWS Account ID without dashes. If your account is a GovCloud or China account, specify the `access_key_id` here.",
+					Description: "Your AWS Account ID without dashes.",
 					Type:        schema.TypeString,
 					Required:    true,
 					ForceNew:    true,

--- a/datadog/resource_datadog_integration_aws_tag_filter.go
+++ b/datadog/resource_datadog_integration_aws_tag_filter.go
@@ -26,7 +26,7 @@ func resourceDatadogIntegrationAwsTagFilter() *schema.Resource {
 		SchemaFunc: func() map[string]*schema.Schema {
 			return map[string]*schema.Schema{
 				"account_id": {
-					Description: "Your AWS Account ID without dashes. If your account is a GovCloud or China account, specify the `access_key_id` here.",
+					Description: "Your AWS Account ID without dashes.",
 					Type:        schema.TypeString,
 					Required:    true,
 				},

--- a/docs/resources/integration_aws_lambda_arn.md
+++ b/docs/resources/integration_aws_lambda_arn.md
@@ -28,7 +28,7 @@ resource "datadog_integration_aws_lambda_arn" "main_collector" {
 
 ### Required
 
-- `account_id` (String) Your AWS Account ID without dashes. If your account is a GovCloud or China account, specify the `access_key_id` here.
+- `account_id` (String) Your AWS Account ID without dashes.
 - `lambda_arn` (String) The ARN of the Datadog forwarder Lambda.
 
 ### Read-Only

--- a/docs/resources/integration_aws_log_collection.md
+++ b/docs/resources/integration_aws_log_collection.md
@@ -25,7 +25,7 @@ resource "datadog_integration_aws_log_collection" "main" {
 
 ### Required
 
-- `account_id` (String) Your AWS Account ID without dashes. If your account is a GovCloud or China account, specify the `access_key_id` here.
+- `account_id` (String) Your AWS Account ID without dashes.
 - `services` (List of String) A list of services to collect logs from. See the [api docs](https://docs.datadoghq.com/api/v1/aws-logs-integration/#get-list-of-aws-log-ready-services) for more details on which services are supported.
 
 ### Read-Only

--- a/docs/resources/integration_aws_tag_filter.md
+++ b/docs/resources/integration_aws_tag_filter.md
@@ -26,7 +26,7 @@ resource "datadog_integration_aws_tag_filter" "foo" {
 
 ### Required
 
-- `account_id` (String) Your AWS Account ID without dashes. If your account is a GovCloud or China account, specify the `access_key_id` here.
+- `account_id` (String) Your AWS Account ID without dashes.
 - `namespace` (String) The namespace associated with the tag filter entry. Valid values are `elb`, `application_elb`, `sqs`, `rds`, `custom`, `network_elb`, `lambda`.
 - `tag_filter_str` (String) The tag filter string.
 


### PR DESCRIPTION
`access_key_id` is no longer returned as `account_id` when creating AWS account using it. Lets update the documentation wording to make sure future users do not pass the `access_key_id` here