### PR TITLE
Remove docs team from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,6 @@
 # All your base
 *                                         @DataDog/integrations-tools-and-libraries
 
-/docs/                                    @DataDog/integrations-tools-and-libraries @DataDog/documentation
-
 # Terraform plugin sdk resources/data-sources
 datadog/*datadog_dashboard*               @DataDog/integrations-tools-and-libraries @DataDog/dashboards
 datadog/*datadog_downtime*                @DataDog/integrations-tools-and-libraries @DataDog/monitor-app


### PR DESCRIPTION
From [this PR](https://github.com/DataDog/terraform-provider-datadog/pull/2015#issuecomment-1647448846), after a docs review one of the code-owners responded that the docs are auto-generated, so they can't make changes:

> Thanks for your suggestions. However, the documentation is automatically generated and CI fails if there is any discrepancy between the documentation on the branch and the generated one. Please contact [@DataDog/integrations-tools-and-libraries](https://github.com/orgs/DataDog/teams/integrations-tools-and-libraries) team if you have suggestions to make regarding the way the documentation is generated

Are all files in this folder auto generated or just a few?
