### PR TITLE
[data_source_datadog_service_level_objectives] Add ability to query slo with multiple tags

### DIFF
--- a/datadog/data_source_datadog_service_level_objectives.go
+++ b/datadog/data_source_datadog_service_level_objectives.go
@@ -42,6 +42,17 @@ func dataSourceDatadogServiceLevelObjectives() *schema.Resource {
 					Type:        schema.TypeString,
 					Optional:    true,
 				},
+				"error_on_no_results": {
+					Description: "Throw an error if no results are found.",
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Default:     true,
+				},
+				"q": {
+					Description: "The query string to filter results based on SLO names. Some examples of queries include service:<service-name> and <slo-name>. If you specify this parameter, the name_query, tags_query, and metrics_query parameters are ignored.",
+					Type:        schema.TypeString,
+					Optional:    true,
+				},
 
 				// Computed values
 				"slos": {
@@ -75,71 +86,152 @@ func dataSourceDatadogServiceLevelObjectives() *schema.Resource {
 
 func dataSourceDatadogServiceLevelObjectivesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConf := meta.(*ProviderConfiguration)
-	apiInstances := providerConf.DatadogApiInstances
-	auth := providerConf.Auth
 
-	var idsPtr *string
-	var nameQueryPtr *string
-	var tagsQueryPtr *string
-	var metricsQueryPtr *string
+	var resourceID string
+	var slos []map[string]interface{}
+	var diags diag.Diagnostics
 
-	reqParams := datadogV1.NewListSLOsOptionalParameters()
-	if v, ok := d.GetOk("ids"); ok {
-		ids := strings.Join(expandStringList(v.([]interface{})), ",")
-		idsPtr = &ids
-		reqParams.WithIds(ids)
-	}
-	if v, ok := d.GetOk("name_query"); ok {
-		nameQuery := v.(string)
-		nameQueryPtr = &nameQuery
-		reqParams.WithQuery(nameQuery)
-	}
-	if v, ok := d.GetOk("tags_query"); ok {
-		tagsQuery := v.(string)
-		tagsQueryPtr = &tagsQuery
-		reqParams.WithTagsQuery(tagsQuery)
-	}
-	if v, ok := d.GetOk("metrics_query"); ok {
-		metricsQuery := v.(string)
-		metricsQueryPtr = &metricsQuery
-		reqParams.WithMetricsQuery(metricsQuery)
+	errorOnNoResults := true
+
+	if v, ok := d.GetOk("error_on_no_results"); ok {
+		errorOnNoResults = v.(bool)
 	}
 
-	slosResp, httpresp, err := apiInstances.GetServiceLevelObjectivesApiV1().ListSLOs(auth, *reqParams)
-	if err != nil {
-		return utils.TranslateClientErrorDiag(err, httpresp, "error querying service level objectives")
+	if v, ok := d.GetOk("q"); ok {
+		var qPtr *string
+		q := v.(string)
+		qPtr = &q
+		// q take precedence over other query parameters if specified
+
+		reqParams := datadogV1.NewSearchSLOOptionalParameters()
+		reqParams.WithQuery(q)
+
+		diags, slos = searchSLO(reqParams, providerConf)
+
+		if diags.HasError() {
+			return diags
+		}
+
+		resourceID = computeSLOsDataSourceIDbySearchEndpointCall(qPtr)
+	} else {
+		var idsPtr *string
+		var nameQueryPtr *string
+		var tagsQueryPtr *string
+		var metricsQueryPtr *string
+
+		reqParams := datadogV1.NewListSLOsOptionalParameters()
+		if v, ok := d.GetOk("ids"); ok {
+			ids := strings.Join(expandStringList(v.([]interface{})), ",")
+			idsPtr = &ids
+			reqParams.WithIds(ids)
+		}
+		if v, ok := d.GetOk("name_query"); ok {
+			nameQuery := v.(string)
+			nameQueryPtr = &nameQuery
+			reqParams.WithQuery(nameQuery)
+		}
+		if v, ok := d.GetOk("tags_query"); ok {
+			tagsQuery := v.(string)
+			tagsQueryPtr = &tagsQuery
+			reqParams.WithTagsQuery(tagsQuery)
+		}
+		if v, ok := d.GetOk("metrics_query"); ok {
+			metricsQuery := v.(string)
+			metricsQueryPtr = &metricsQuery
+			reqParams.WithMetricsQuery(metricsQuery)
+		}
+
+		diags, slos = listSLO(reqParams, providerConf)
+
+		if diags.HasError() {
+			return diags
+		}
+
+		resourceID = computeSLOsDataSourceIDByListEndpointCall(idsPtr, nameQueryPtr, tagsQueryPtr, metricsQueryPtr)
 	}
-	if len(slosResp.GetData()) == 0 {
+
+	if len(slos) == 0 && errorOnNoResults {
 		return diag.Errorf("your query returned no result, please try a less specific search criteria")
 	}
 
-	diags := diag.Diagnostics{}
-	slos := make([]map[string]interface{}, 0, len(slosResp.GetData()))
-	for _, slo := range slosResp.GetData() {
-		if err := utils.CheckForUnparsed(slo); err != nil {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Warning,
-				Summary:  fmt.Sprintf("skipping service level objective with id: %s", slo.GetId()),
-				Detail:   fmt.Sprintf("service level objective contains unparsed object: %v", err),
-			})
-			continue
-		}
-
-		slos = append(slos, map[string]interface{}{
-			"id":   slo.GetId(),
-			"name": slo.GetName(),
-			"type": slo.GetType(),
-		})
-	}
 	if err := d.Set("slos", slos); err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(computeSLOsDataSourceID(idsPtr, nameQueryPtr, tagsQueryPtr, metricsQueryPtr))
+	d.SetId(resourceID)
 
 	return diags
 }
 
-func computeSLOsDataSourceID(ids *string, nameQuery *string, tagsQuery *string, metricsQuery *string) string {
+func searchSLO(reqParams *datadogV1.SearchSLOOptionalParameters, providerConf *ProviderConfiguration) (diag.Diagnostics, []map[string]interface{}) {
+	apiInstances := providerConf.DatadogApiInstances
+	auth := providerConf.Auth
+
+	reqParams.WithPageSize(100)
+
+	pageNumber := int64(0)
+	numberOfSLOs := int64(0)
+
+	allSlosPages := make([][]map[string]interface{}, 0)
+
+	diags := diag.Diagnostics{}
+
+	for {
+		reqParams.WithPageNumber(pageNumber)
+		slosResp, httpresp, err := apiInstances.GetServiceLevelObjectivesApiV1().SearchSLO(auth, *reqParams)
+		if err != nil {
+			return utils.TranslateClientErrorDiag(err, httpresp, "error querying service level objectives"), nil
+		}
+
+		slosPage := make([]map[string]interface{}, 0, len(slosResp.GetData().Attributes.Slos))
+		for _, slo := range slosResp.GetData().Attributes.Slos {
+			if err := utils.CheckForUnparsed(slo); err != nil {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  fmt.Sprintf("skipping service level objective with id: %s", *slo.GetData().Id),
+					Detail:   fmt.Sprintf("service level objective contains unparsed object: %v", err),
+				})
+				continue
+			}
+
+			slosPage = append(slosPage, map[string]interface{}{
+				"id":   *slo.GetData().Id,
+				"name": slo.GetData().Attributes.GetName(),
+				"type": slo.GetData().Attributes.GetSloType(),
+			})
+		}
+
+		allSlosPages = append(allSlosPages, slosPage)
+		numberOfSLOs += int64(len(slosPage))
+
+		if *slosResp.GetMeta().Pagination.LastNumber <= pageNumber {
+			break
+		}
+		pageNumber++
+	}
+
+	// Flatten all pages of slos into a single list
+	slos := make([]map[string]interface{}, 0, numberOfSLOs)
+	for _, slosPage := range allSlosPages {
+		slos = append(slos, slosPage...)
+	}
+
+	return diags, slos
+}
+
+func listSLO(reqParams *datadogV1.ListSLOsOptionalParameters, providerConf *ProviderConfiguration) (diag.Diagnostics, []map[string]interface{}) {
+	return nil, nil
+}
+
+func computeSLOsDataSourceIDbySearchEndpointCall(q *string) string {
+	// Key for hashing
+	h := sha256.New()
+	log.Println("HASHKEY", q)
+	h.Write([]byte(*q))
+
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func computeSLOsDataSourceIDByListEndpointCall(ids *string, nameQuery *string, tagsQuery *string, metricsQuery *string) string {
 	// Key for hashing
 	var b strings.Builder
 	if ids != nil {

--- a/docs/data-sources/service_level_objectives.md
+++ b/docs/data-sources/service_level_objectives.md
@@ -23,9 +23,11 @@ data "datadog_service_level_objectives" "ft_foo_slos" {
 
 ### Optional
 
+- `error_on_no_results` (Boolean) Throw an error if no results are found.
 - `ids` (List of String) An array of SLO IDs to limit the search.
 - `metrics_query` (String) Filter results based on SLO numerator and denominator.
 - `name_query` (String) Filter results based on SLO names.
+- `q` (String) The query string to filter results based on SLO names. Some examples of queries include service:<service-name> and <slo-name>. If you specify this parameter, the name_query, tags_query, and metrics_query parameters are ignored.
 - `tags_query` (String) Filter results based on a single SLO tag.
 
 ### Read-Only


### PR DESCRIPTION
# Datadog Service Level Objectives data source

## What is the goal?

Actually, the `datadog_service_level_objectives` data source return a list of slos in the `slos` attribute.

We can query the data source with:
* ids (List of String) An array of SLO IDs to limit the search.
* metrics_query: (String) Filter results based on SLO numerator and denominator.
* name_query: (String) Filter results based on SLO names.
* tags_query: (String) Filter results based on a **single** SLO tag.

Here is the problem with the `tags_query` parameter. It's not possible to query multiple tags.

If there is no slos, an error is returned.

## Why is this important?

It's not possible to query with multiple tags on the `datadog_service_level_objectives` data source. So we can't use this data source to get a list of slos by `env` and `service` for example.

If there is no slos, an error is returned. It's not possible to get an empty list of slos if we expect to have no slos.

## How can we solve it?

The **single** tag limitation is due to the limitation of the api endpoint of listing slo `GET api/v1/slo` (https://docs.datadoghq.com/fr/api/latest/service-level-objectives/#get-all-slos). We have to change the api endpoint and use the `GET api/v1/slo/search`. In this case, we have work with pagination.

In order to allow to get an empty list of slos, we have to change the behavior of the data source. If there is no slos, we have to return the empty list.

## Implementation details

I propose to change the behavior of the `datadog_service_level_objectives` data source by using the `GET api/v1/slo/search` endpoint and replace parameters by only one parameter `query`.

This allow to combine multiple tags and name filter in the same query.

This implementation manage pagination and call the api endpoint until there is no more slos (100 by 100).

## Breaking changes

### Parameters

1. The `ids`, `metrics_query`, `name_query` and `tags_query` parameters are removed.
2. The `query` parameter is added.

NOTE: `query` parameter will not replace the `ids` and `metrics_query` parameters, but we can use the `query` parameter to replace the `name_query` and `tags_query` parameters.

NOTE: the second data source `datadog_service_level_objective` is not impacted by this change.

### No slos returned

If there is no slos, an empty list is returned instead of an error.

---

I hope this proposal is clear enough. If you have any questions, don't hesitate to ask me.

Have a nice day!

👋
