### PR TITLE
[provider] Remove request logger transport

### DIFF
--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -296,7 +296,6 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	}
 
 	c := cleanhttp.DefaultClient()
-	c.Transport = logging.NewLoggingHTTPTransport(c.Transport)
 	communityClient.ExtraHeader["User-Agent"] = utils.GetUserAgent(fmt.Sprintf(
 		"datadog-api-client-go/%s (go %s; os %s; arch %s)",
 		"go-datadog-api",

--- a/datadog/tests/framework_provider_test.go
+++ b/datadog/tests/framework_provider_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	datadogCommunity "github.com/zorkian/go-datadog-api"
 	ddhttp "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
@@ -129,7 +128,6 @@ func initHttpClient(ctx context.Context, t *testing.T) (context.Context, *http.C
 	ctx = testSpan(ctx, t)
 	rec := initRecorder(t)
 	httpClient := cleanhttp.DefaultClient()
-	httpClient.Transport = logging.NewTransport("Datadog", rec)
 	t.Cleanup(func() {
 		rec.Stop()
 	})

--- a/datadog/tests/provider_test.go
+++ b/datadog/tests/provider_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/dnaeon/go-vcr/recorder"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -626,8 +625,6 @@ func testAccProviders(ctx context.Context, t *testing.T) (context.Context, map[s
 	rec := initRecorder(t)
 	ctx = context.WithValue(ctx, clockContextKey("clock"), testClock(t))
 	c := cleanhttp.DefaultClient()
-	loggingTransport := logging.NewTransport("Datadog", rec)
-	c.Transport = loggingTransport
 	p := testAccProvidersWithHTTPClient(ctx, t, c)
 	t.Cleanup(func() {
 		rec.Stop()
@@ -649,7 +646,6 @@ func TestProvider(t *testing.T) {
 	defer rec.Stop()
 
 	c := cleanhttp.DefaultClient()
-	c.Transport = logging.NewTransport("Datadog", rec)
 	accProvider := initAccProvider(context.Background(), t, c)
 
 	if err := accProvider.InternalValidate(); err != nil {


### PR DESCRIPTION
The underlying go client already outputs debug logs around requests and responses. This removes the potential duplicate logs when running tests as well as the logging of the entire request response object without proper sanitization 