### PR TITLE
[datadog_service_definition_yaml] Keep `ci-pipeline-fingerprints` sorted in state

### DIFF
--- a/datadog/resource_datadog_service_definition_yaml.go
+++ b/datadog/resource_datadog_service_definition_yaml.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -208,7 +207,7 @@ func prepServiceDefinitionResource(attrMap map[string]interface{}) map[string]in
 			for _, fingerprint := range ci_pipeline_fingerprints {
 				sortedFingerprints = append(sortedFingerprints, fingerprint.(string))
 			}
-			slices.Sort(sortedFingerprints)
+			sort.Strings(sortedFingerprints)
 			attrMap["ci-pipeline-fingerprints"] = sortedFingerprints
 		}
 	}

--- a/datadog/resource_datadog_service_definition_yaml.go
+++ b/datadog/resource_datadog_service_definition_yaml.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -199,6 +200,19 @@ func prepServiceDefinitionResource(attrMap map[string]interface{}) map[string]in
 			delete(attrMap, "integrations")
 		}
 	}
+	if ci_pipeline_fingerprints, ok := attrMap["ci-pipeline-fingerprints"].([]interface{}); ok {
+		if len(ci_pipeline_fingerprints) == 0 {
+			delete(attrMap, "ci-pipeline-fingerprints")
+		} else {
+			sortedFingerprints := make([]string, 0)
+			for _, fingerprint := range ci_pipeline_fingerprints {
+				sortedFingerprints = append(sortedFingerprints, fingerprint.(string))
+			}
+			slices.Sort(sortedFingerprints)
+			attrMap["ci-pipeline-fingerprints"] = sortedFingerprints
+		}
+	}
+
 	return attrMap
 }
 


### PR DESCRIPTION
the order of the ci-pipeline-fingerprints isn't static, so keep the list sorted in state to prevent drift
Closes: #2117 