### PR TITLE
fix is_column_break and x and y widget layout schema descriptions

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -1548,12 +1548,12 @@ func buildTerraformSourceWidgetDefinition(datadogSourceWidgetDefinition *datadog
 func getWidgetLayoutSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"x": {
-			Description: "The position of the widget on the x (horizontal) axis. Should be greater than or equal to 0.",
+			Description: "The position of the widget on the x (horizontal) axis. Must be greater than or equal to 0.",
 			Type:        schema.TypeInt,
 			Required:    true,
 		},
 		"y": {
-			Description: "The position of the widget on the y (vertical) axis. Should be greater than or equal to 0.",
+			Description: "The position of the widget on the y (vertical) axis. Must be greater than or equal to 0.",
 			Type:        schema.TypeInt,
 			Required:    true,
 		},
@@ -1568,7 +1568,7 @@ func getWidgetLayoutSchema() map[string]*schema.Schema {
 			Required:    true,
 		},
 		"is_column_break": {
-			Description: "Whether the widget should be the first one on the second column in high density or not. Only for the new dashboard layout and only one widget in the dashboard should have this property set to `true`.",
+			Description: "Whether the widget should be the first one on the second column in high density or not. Only one widget in the dashboard should have this property set to `true`.",
 			Type:        schema.TypeBool,
 			Optional:    true,
 		},

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -14865,12 +14865,12 @@ Required:
 
 - `height` (Number) The height of the widget.
 - `width` (Number) The width of the widget.
-- `x` (Number) The position of the widget on the x (horizontal) axis. Should be greater than or equal to 0.
-- `y` (Number) The position of the widget on the y (vertical) axis. Should be greater than or equal to 0.
+- `x` (Number) The position of the widget on the x (horizontal) axis. Must be greater than or equal to 0.
+- `y` (Number) The position of the widget on the y (vertical) axis. Must be greater than or equal to 0.
 
 Optional:
 
-- `is_column_break` (Boolean) Whether the widget should be the first one on the second column in high density or not. Only for the new dashboard layout and only one widget in the dashboard should have this property set to `true`.
+- `is_column_break` (Boolean) Whether the widget should be the first one on the second column in high density or not. Only one widget in the dashboard should have this property set to `true`.
 
 
 
@@ -26134,12 +26134,12 @@ Required:
 
 - `height` (Number) The height of the widget.
 - `width` (Number) The width of the widget.
-- `x` (Number) The position of the widget on the x (horizontal) axis. Should be greater than or equal to 0.
-- `y` (Number) The position of the widget on the y (vertical) axis. Should be greater than or equal to 0.
+- `x` (Number) The position of the widget on the x (horizontal) axis. Must be greater than or equal to 0.
+- `y` (Number) The position of the widget on the y (vertical) axis. Must be greater than or equal to 0.
 
 Optional:
 
-- `is_column_break` (Boolean) Whether the widget should be the first one on the second column in high density or not. Only for the new dashboard layout and only one widget in the dashboard should have this property set to `true`.
+- `is_column_break` (Boolean) Whether the widget should be the first one on the second column in high density or not. Only one widget in the dashboard should have this property set to `true`.
 
 ## Import
 

--- a/docs/resources/powerpack.md
+++ b/docs/resources/powerpack.md
@@ -37,12 +37,12 @@ Required:
 
 - `height` (Number) The height of the widget.
 - `width` (Number) The width of the widget.
-- `x` (Number) The position of the widget on the x (horizontal) axis. Should be greater than or equal to 0.
-- `y` (Number) The position of the widget on the y (vertical) axis. Should be greater than or equal to 0.
+- `x` (Number) The position of the widget on the x (horizontal) axis. Must be greater than or equal to 0.
+- `y` (Number) The position of the widget on the y (vertical) axis. Must be greater than or equal to 0.
 
 Optional:
 
-- `is_column_break` (Boolean) Whether the widget should be the first one on the second column in high density or not. Only for the new dashboard layout and only one widget in the dashboard should have this property set to `true`.
+- `is_column_break` (Boolean) Whether the widget should be the first one on the second column in high density or not. Only one widget in the dashboard should have this property set to `true`.
 
 
 <a id="nestedblock--template_variables"></a>
@@ -2109,9 +2109,9 @@ Required:
 
 - `height` (Number) The height of the widget.
 - `width` (Number) The width of the widget.
-- `x` (Number) The position of the widget on the x (horizontal) axis. Should be greater than or equal to 0.
-- `y` (Number) The position of the widget on the y (vertical) axis. Should be greater than or equal to 0.
+- `x` (Number) The position of the widget on the x (horizontal) axis. Must be greater than or equal to 0.
+- `y` (Number) The position of the widget on the y (vertical) axis. Must be greater than or equal to 0.
 
 Optional:
 
-- `is_column_break` (Boolean) Whether the widget should be the first one on the second column in high density or not. Only for the new dashboard layout and only one widget in the dashboard should have this property set to `true`.
+- `is_column_break` (Boolean) Whether the widget should be the first one on the second column in high density or not. Only one widget in the dashboard should have this property set to `true`.


### PR DESCRIPTION
Follow up to 2 docs comments on https://github.com/DataDog/terraform-provider-datadog/pull/2158: [comment 1](https://github.com/DataDog/terraform-provider-datadog/pull/2173#discussion_r1387367706) and [comment 2](https://github.com/DataDog/terraform-provider-datadog/pull/2173#discussion_r1391455698) to add clarity to 3 widget layout schema descriptions:
- x: The position of the widget on the x (horizontal) axis. Must be greater than or equal to 0.
- y: The position of the widget on the y (vertical) axis. Must be greater than or equal to 0.
- is_column_break: Whether the widget should be the first one on the second column in high density or not. Only one widget in the dashboard should have this property set to `true`.

