### PR TITLE
[datadog_ip_ranges] Fix test to actually test values in state

### DIFF
--- a/datadog/tests/data_source_datadog_ip_ranges_test.go
+++ b/datadog/tests/data_source_datadog_ip_ranges_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -10,7 +11,7 @@ import (
 func TestAccDatadogIpRangesDatasource_existing(t *testing.T) {
 	t.Parallel()
 	_, _, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
-
+	nonZeroRe := regexp.MustCompile(`[1-9]+`)
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: accProviders,
 		Steps: []resource.TestStep{
@@ -20,27 +21,28 @@ func TestAccDatadogIpRangesDatasource_existing(t *testing.T) {
 				`,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					//ipv4
-					resource.TestCheckResourceAttrSet("data.datadog_ip_ranges.test", "agents_ipv4.#"),
-					resource.TestCheckResourceAttrSet("data.datadog_ip_ranges.test", "api_ipv4.#"),
-					resource.TestCheckResourceAttrSet("data.datadog_ip_ranges.test", "apm_ipv4.#"),
-					resource.TestCheckResourceAttrSet("data.datadog_ip_ranges.test", "global_ipv4.#"),
-					resource.TestCheckResourceAttrSet("data.datadog_ip_ranges.test", "logs_ipv4.#"),
-					resource.TestCheckResourceAttrSet("data.datadog_ip_ranges.test", "orchestrator_ipv4.#"),
-					resource.TestCheckResourceAttrSet("data.datadog_ip_ranges.test", "process_ipv4.#"),
-					resource.TestCheckResourceAttrSet("data.datadog_ip_ranges.test", "synthetics_ipv4.#"),
-					resource.TestCheckResourceAttrSet("data.datadog_ip_ranges.test", "synthetics_ipv4_by_location.%"),
-					resource.TestCheckResourceAttrSet("data.datadog_ip_ranges.test", "webhooks_ipv4.#"),
+					resource.TestMatchResourceAttr("data.datadog_ip_ranges.test", "agents_ipv4.#", nonZeroRe),
+					resource.TestMatchResourceAttr("data.datadog_ip_ranges.test", "api_ipv4.#", nonZeroRe),
+					resource.TestMatchResourceAttr("data.datadog_ip_ranges.test", "apm_ipv4.#", nonZeroRe),
+					resource.TestMatchResourceAttr("data.datadog_ip_ranges.test", "global_ipv4.#", nonZeroRe),
+					resource.TestMatchResourceAttr("data.datadog_ip_ranges.test", "logs_ipv4.#", nonZeroRe),
+					resource.TestMatchResourceAttr("data.datadog_ip_ranges.test", "orchestrator_ipv4.#", nonZeroRe),
+					resource.TestMatchResourceAttr("data.datadog_ip_ranges.test", "process_ipv4.#", nonZeroRe),
+					resource.TestMatchResourceAttr("data.datadog_ip_ranges.test", "synthetics_ipv4.#", nonZeroRe),
+					resource.TestMatchResourceAttr("data.datadog_ip_ranges.test", "synthetics_ipv4_by_location.%", nonZeroRe),
+					resource.TestMatchResourceAttr("data.datadog_ip_ranges.test", "webhooks_ipv4.#", nonZeroRe),
 					//ipv6
-					resource.TestCheckResourceAttrSet("data.datadog_ip_ranges.test", "agents_ipv6.#"),
-					resource.TestCheckResourceAttrSet("data.datadog_ip_ranges.test", "api_ipv6.#"),
-					resource.TestCheckResourceAttrSet("data.datadog_ip_ranges.test", "apm_ipv6.#"),
-					resource.TestCheckResourceAttrSet("data.datadog_ip_ranges.test", "global_ipv6.#"),
-					resource.TestCheckResourceAttrSet("data.datadog_ip_ranges.test", "logs_ipv6.#"),
-					resource.TestCheckResourceAttrSet("data.datadog_ip_ranges.test", "orchestrator_ipv6.#"),
-					resource.TestCheckResourceAttrSet("data.datadog_ip_ranges.test", "process_ipv6.#"),
-					resource.TestCheckResourceAttrSet("data.datadog_ip_ranges.test", "synthetics_ipv6.#"),
-					resource.TestCheckResourceAttrSet("data.datadog_ip_ranges.test", "synthetics_ipv6_by_location.%"),
-					resource.TestCheckResourceAttrSet("data.datadog_ip_ranges.test", "webhooks_ipv6.#"),
+					resource.TestMatchResourceAttr("data.datadog_ip_ranges.test", "agents_ipv6.#", nonZeroRe),
+					resource.TestMatchResourceAttr("data.datadog_ip_ranges.test", "api_ipv6.#", nonZeroRe),
+					resource.TestMatchResourceAttr("data.datadog_ip_ranges.test", "apm_ipv6.#", nonZeroRe),
+					resource.TestMatchResourceAttr("data.datadog_ip_ranges.test", "global_ipv6.#", nonZeroRe),
+					resource.TestMatchResourceAttr("data.datadog_ip_ranges.test", "logs_ipv6.#", nonZeroRe),
+					resource.TestMatchResourceAttr("data.datadog_ip_ranges.test", "orchestrator_ipv6.#", nonZeroRe),
+					resource.TestMatchResourceAttr("data.datadog_ip_ranges.test", "process_ipv6.#", nonZeroRe),
+					// These fields have no ip ranges set, this may change in the future.
+					// resource.TestMatchResourceAttr("data.datadog_ip_ranges.test", "synthetics_ipv6.#", nonZeroRe),
+					// resource.TestMatchResourceAttr("data.datadog_ip_ranges.test", "synthetics_ipv6_by_location.%", nonZeroRe),
+					// resource.TestMatchResourceAttr("data.datadog_ip_ranges.test", "webhooks_ipv6.#", nonZeroRe),
 				),
 			},
 		},


### PR DESCRIPTION
it wasn't possible for the old test to fail, the data source always creates an empty list/map for all fields, so testing if they exist is redundant.