### PR TITLE
[datadog_metric_metadata] correct consistency of type

### DIFF
--- a/datadog/resource_datadog_metric_metadata.go
+++ b/datadog/resource_datadog_metric_metadata.go
@@ -30,7 +30,7 @@ func resourceDatadogMetricMetadata() *schema.Resource {
 					Required:    true,
 				},
 				"type": {
-					Description: "Metric type such as `gauge` or `rate`.",
+					Description: "Metric type such as `count`, `gauge`, or `rate`. Updating a metric of type `distribution` is not supported. If you would like to see the `distribution` type returned, please contact Datadog support.",
 					Type:        schema.TypeString,
 					Optional:    true,
 				},

--- a/datadog/resource_datadog_metric_metadata.go
+++ b/datadog/resource_datadog_metric_metadata.go
@@ -95,8 +95,10 @@ func resourceDatadogMetricMetadataCreate(ctx context.Context, d *schema.Resource
 }
 
 func updateMetricMetadataState(d *schema.ResourceData, metadata *datadogV1.MetricMetadata) diag.Diagnostics {
-	if err := d.Set("type", metadata.GetType()); err != nil {
-		return diag.FromErr(err)
+	if _, ok := d.GetOk("type"); !ok || metadata.GetType() != "distribution" {
+		if err := d.Set("type", metadata.GetType()); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 	if err := d.Set("description", metadata.GetDescription()); err != nil {
 		return diag.FromErr(err)

--- a/datadog/resource_datadog_metric_metadata.go
+++ b/datadog/resource_datadog_metric_metadata.go
@@ -30,7 +30,7 @@ func resourceDatadogMetricMetadata() *schema.Resource {
 					Required:    true,
 				},
 				"type": {
-					Description: "Metric type such as `count`, `gauge`, or `rate`. Updating a metric of type `distribution` is not supported. If you would like to see the `distribution` type returned, please contact Datadog support.",
+					Description: "Metric type such as `count`, `gauge`, or `rate`. Updating a metric of type `distribution` is not supported. If you would like to see the `distribution` type returned, contact [Datadog support](https://docs.datadoghq.com/help/).",
 					Type:        schema.TypeString,
 					Optional:    true,
 				},

--- a/docs/resources/metric_metadata.md
+++ b/docs/resources/metric_metadata.md
@@ -36,7 +36,7 @@ resource "datadog_metric_metadata" "request_time" {
 - `per_unit` (String) Per unit of the metric such as `second` in `bytes per second`.
 - `short_name` (String) A short name of the metric.
 - `statsd_interval` (Number) If applicable, statsd flush interval in seconds for the metric.
-- `type` (String) Metric type such as `gauge` or `rate`.
+- `type` (String) Metric type such as `count`, `gauge`, or `rate`. Updating a metric of type `distribution` is not supported. If you would like to see the `distribution` type returned, please contact Datadog support.
 - `unit` (String) Primary unit of the metric such as `byte` or `operation`.
 
 ### Read-Only

--- a/docs/resources/metric_metadata.md
+++ b/docs/resources/metric_metadata.md
@@ -36,7 +36,7 @@ resource "datadog_metric_metadata" "request_time" {
 - `per_unit` (String) Per unit of the metric such as `second` in `bytes per second`.
 - `short_name` (String) A short name of the metric.
 - `statsd_interval` (Number) If applicable, statsd flush interval in seconds for the metric.
-- `type` (String) Metric type such as `count`, `gauge`, or `rate`. Updating a metric of type `distribution` is not supported. If you would like to see the `distribution` type returned, please contact Datadog support.
+- `type` (String) Metric type such as `count`, `gauge`, or `rate`. Updating a metric of type `distribution` is not supported. If you would like to see the `distribution` type returned, contact [Datadog support](https://docs.datadoghq.com/help/).
 - `unit` (String) Primary unit of the metric such as `byte` or `operation`.
 
 ### Read-Only


### PR DESCRIPTION
Motivation
---------
It appears that metric API has enable the distribution type on metric metadata but the result between the `PUT` and the `GET` method is not consistent:

```bash
$ export metric_name=name_of_metric_distribution
$ curl -X PUT "https://api.datadoghq.com/api/v1/metrics/${metric_name}" \
-H "Accept: application/json" \
-H "Content-Type: application/json" \
-H "DD-API-KEY: ***" \
-H "DD-APPLICATION-KEY: ***" \
-d @- << EOF
{"type":"gauge"}
EOF
{"description":null,"short_name":null,"type":"gauge","unit":null,"per_unit":null,"statsd_interval":null,"integration":null}
and then the get:
$ curl -X GET "https://api.datadoghq.com/api/v1/metrics/${metric_name}" \
-H "Accept: application/json" \
-H "DD-API-KEY: ***" \
-H "DD-APPLICATION-KEY: ***" \
{"description":null,"short_name":null,"type":"distribution","unit":null,"per_unit":null,"statsd_interval":null,"integration":null}
```

this make metric type always being marked has a diff:
```
terraform plan
~ resource "datadog_metric_metadata" "metric_name" {
        id              = "metric_name"
      ~ type            = "distribution" -> "gauge"
        # (5 unchanged attributes hidden)
    }
```

Scope
----
Set metric type to gauge in terraform state when type return by API is distribution

Test
----
Test no diff locally
```bash
make build
cd terraformdir
terraform plan
...
No changes. Your infrastructure matches the configuration.
```