### PR TITLE
Adds the monitor ID as a available 

### DIFF
--- a/datadog/data_source_datadog_monitor.go
+++ b/datadog/data_source_datadog_monitor.go
@@ -39,6 +39,12 @@ func dataSourceDatadogMonitor() *schema.Resource {
 					Optional:    true,
 					Elem:        &schema.Schema{Type: schema.TypeString},
 				},
+				"monitor_id": {
+					Description: "The ID of the monitor.",
+					Type:        schema.TypeString,
+					Optional:    true,
+					Elem:        &schema.Schema{Type: schema.TypeString},
+				},
 
 				// Computed values
 				"name": {
@@ -327,6 +333,9 @@ func dataSourceDatadogMonitorRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	monitors, httpresp, err := apiInstances.GetMonitorsApiV1().ListMonitors(auth, *optionalParams)
+	if v, ok := d.GetOk("monitor_id"); ok {
+		monitors = fitlerByMonitorId(fmt.Sprint(v), monitors)
+	}
 	if len(monitors) > 1 {
 		return diag.Errorf("your query returned more than one result, please try a more specific search criteria")
 	}
@@ -464,6 +473,19 @@ func dataSourceDatadogMonitorRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	return nil
+}
+
+func fitlerByMonitorId(monitorId string, monitors []datadogV1.Monitor) []datadogV1.Monitor {
+	var filteredMonitiors []datadogV1.Monitor
+
+	for index, monitor := range monitors {
+		currentMonitorId := fmt.Sprint(monitor.GetId())
+
+		if currentMonitorId == monitorId {
+			filteredMonitiors = append(filteredMonitiors, monitors[index])
+		}
+	}
+	return filteredMonitiors
 }
 
 func expandStringList(configured []interface{}) []string {

--- a/docs/data-sources/monitor.md
+++ b/docs/data-sources/monitor.md
@@ -24,6 +24,7 @@ data "datadog_monitor" "test" {
 
 ### Optional
 
+- `monitor_id` (String) The ID of the monitor.
 - `monitor_tags_filter` (List of String) A list of monitor tags to limit the search. This filters on the tags set on the monitor itself.
 - `name_filter` (String) A monitor name to limit the search.
 - `tags_filter` (List of String) A list of tags to limit the search. This filters on the monitor scope.


### PR DESCRIPTION
This PR will add support for a `monitor_id` filter for the the `datadog_monitor` data resource. 