### PR TITLE
[datadog_api_key][datadog_application_key] Add exact_match option to data sources

### DIFF
--- a/datadog/fwprovider/data_source_datadog_api_key.go
+++ b/datadog/fwprovider/data_source_datadog_api_key.go
@@ -121,6 +121,10 @@ func (d *apiKeyDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 				resp.Diagnostics.AddError("your query returned more than one exact match, please try a more specific search criteria", "")
 				return
 			}
+			if exact_matches == 0 {
+				resp.Diagnostics.AddError("your query returned no exact matches, please try a less specific search criteria", "")
+				return
+			}
 		} else {
 			id := apiKeysData[0].GetId()
 			ddResp, _, err := d.Api.GetAPIKey(d.Auth, id)

--- a/datadog/fwprovider/data_source_datadog_api_key.go
+++ b/datadog/fwprovider/data_source_datadog_api_key.go
@@ -27,14 +27,14 @@ type apiKeyDataSourceModel struct {
 }
 
 type apiKeyDataSource struct {
-	Api  *datadogV2.KeyManagementApi
-	Auth context.Context
+	api  *datadogV2.KeyManagementApi
+	auth context.Context
 }
 
 func (r *apiKeyDataSource) Configure(_ context.Context, request datasource.ConfigureRequest, response *datasource.ConfigureResponse) {
 	providerData, _ := request.ProviderData.(*FrameworkProvider)
-	r.Api = providerData.DatadogApiInstances.GetKeyManagementApiV2()
-	r.Auth = providerData.Auth
+	r.api = providerData.DatadogApiInstances.GetKeyManagementApiV2()
+	r.auth = providerData.Auth
 }
 
 func (d *apiKeyDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -74,7 +74,7 @@ func (d *apiKeyDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	}
 
 	if !state.ID.IsNull() {
-		ddResp, _, err := d.Api.GetAPIKey(d.Auth, state.ID.ValueString())
+		ddResp, _, err := d.api.GetAPIKey(d.auth, state.ID.ValueString())
 		if err != nil {
 			resp.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error getting api key"))
 			return
@@ -85,7 +85,7 @@ func (d *apiKeyDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		optionalParams := datadogV2.NewListAPIKeysOptionalParameters()
 		optionalParams.WithFilter(state.Name.ValueString())
 
-		apiKeysResponse, _, err := d.Api.ListAPIKeys(d.Auth, *optionalParams)
+		apiKeysResponse, _, err := d.api.ListAPIKeys(d.auth, *optionalParams)
 		if err != nil {
 			resp.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error getting api keys"))
 			return
@@ -108,7 +108,7 @@ func (d *apiKeyDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 				if state.Name.ValueString() == apiKeyAttributes.GetName() {
 					exact_matches++
 					id := apiKeyPartialData.GetId()
-					ddResp, _, err := d.Api.GetAPIKey(d.Auth, id)
+					ddResp, _, err := d.api.GetAPIKey(d.auth, id)
 					if err != nil {
 						resp.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error getting api key"))
 						return
@@ -127,7 +127,7 @@ func (d *apiKeyDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 			}
 		} else {
 			id := apiKeysData[0].GetId()
-			ddResp, _, err := d.Api.GetAPIKey(d.Auth, id)
+			ddResp, _, err := d.api.GetAPIKey(d.auth, id)
 			if err != nil {
 				resp.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error getting api key"))
 				return

--- a/datadog/fwprovider/data_source_datadog_api_key.go
+++ b/datadog/fwprovider/data_source_datadog_api_key.go
@@ -27,14 +27,14 @@ type apiKeyDataSourceModel struct {
 }
 
 type apiKeyDataSource struct {
-	api  *datadogV2.KeyManagementApi
-	auth context.Context
+	Api  *datadogV2.KeyManagementApi
+	Auth context.Context
 }
 
 func (r *apiKeyDataSource) Configure(_ context.Context, request datasource.ConfigureRequest, response *datasource.ConfigureResponse) {
 	providerData, _ := request.ProviderData.(*FrameworkProvider)
-	r.api = providerData.DatadogApiInstances.GetKeyManagementApiV2()
-	r.auth = providerData.Auth
+	r.Api = providerData.DatadogApiInstances.GetKeyManagementApiV2()
+	r.Auth = providerData.Auth
 }
 
 func (d *apiKeyDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -74,7 +74,7 @@ func (d *apiKeyDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	}
 
 	if !state.ID.IsNull() {
-		ddResp, _, err := d.api.GetAPIKey(d.auth, state.ID.ValueString())
+		ddResp, _, err := d.Api.GetAPIKey(d.Auth, state.ID.ValueString())
 		if err != nil {
 			resp.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error getting api key"))
 			return
@@ -85,7 +85,7 @@ func (d *apiKeyDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		optionalParams := datadogV2.NewListAPIKeysOptionalParameters()
 		optionalParams.WithFilter(state.Name.ValueString())
 
-		apiKeysResponse, _, err := d.api.ListAPIKeys(d.auth, *optionalParams)
+		apiKeysResponse, _, err := d.Api.ListAPIKeys(d.Auth, *optionalParams)
 		if err != nil {
 			resp.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error getting api keys"))
 			return
@@ -108,7 +108,7 @@ func (d *apiKeyDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 				if state.Name.ValueString() == apiKeyAttributes.GetName() {
 					exact_matches++
 					id := apiKeyPartialData.GetId()
-					ddResp, _, err := d.api.GetAPIKey(d.auth, id)
+					ddResp, _, err := d.Api.GetAPIKey(d.Auth, id)
 					if err != nil {
 						resp.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error getting api key"))
 						return
@@ -127,7 +127,7 @@ func (d *apiKeyDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 			}
 		} else {
 			id := apiKeysData[0].GetId()
-			ddResp, _, err := d.api.GetAPIKey(d.auth, id)
+			ddResp, _, err := d.Api.GetAPIKey(d.Auth, id)
 			if err != nil {
 				resp.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error getting api key"))
 				return

--- a/datadog/fwprovider/data_source_datadog_api_key.go
+++ b/datadog/fwprovider/data_source_datadog_api_key.go
@@ -103,6 +103,7 @@ func (d *apiKeyDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		}
 		if state.ExactMatch.ValueBool() {
 			exact_matches := 0
+			var apiKeyData datadogV2.FullAPIKey
 			for _, apiKeyPartialData := range apiKeysData {
 				apiKeyAttributes := apiKeyPartialData.GetAttributes()
 				if state.Name.ValueString() == apiKeyAttributes.GetName() {
@@ -113,8 +114,7 @@ func (d *apiKeyDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 						resp.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error getting api key"))
 						return
 					}
-					apiKeyData := ddResp.GetData()
-					d.updateState(&state, &apiKeyData)
+					apiKeyData = ddResp.GetData()
 				}
 			}
 			if exact_matches > 1 {
@@ -125,6 +125,7 @@ func (d *apiKeyDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 				resp.Diagnostics.AddError("your query returned no exact matches, please try a less specific search criteria", "")
 				return
 			}
+			d.updateState(&state, &apiKeyData)
 		} else {
 			id := apiKeysData[0].GetId()
 			ddResp, _, err := d.Api.GetAPIKey(d.Auth, id)

--- a/datadog/fwprovider/data_source_datadog_application_key.go
+++ b/datadog/fwprovider/data_source_datadog_application_key.go
@@ -118,6 +118,10 @@ func (d *applicationKeyDataSource) Read(ctx context.Context, req datasource.Read
 				resp.Diagnostics.AddError("your query returned more than one exact match, please try a more specific search criteria", "")
 				return
 			}
+			if exact_matches == 0 {
+				resp.Diagnostics.AddError("your query returned no exact matches, please try a less specific search criteria", "")
+				return
+			}
 		} else {
 			id := applicationKeysData[0].GetId()
 			applicationKeyResponse, _, err := d.Api.GetCurrentUserApplicationKey(d.Auth, id)

--- a/datadog/fwprovider/data_source_datadog_application_key.go
+++ b/datadog/fwprovider/data_source_datadog_application_key.go
@@ -100,6 +100,7 @@ func (d *applicationKeyDataSource) Read(ctx context.Context, req datasource.Read
 		}
 		if state.ExactMatch.ValueBool() {
 			exact_matches := 0
+			var applicationKeyData datadogV2.FullApplicationKey
 			for _, appKeyPartialData := range applicationKeysData {
 				appKeyAttributes := appKeyPartialData.GetAttributes()
 				if state.Name.ValueString() == appKeyAttributes.GetName() {
@@ -110,8 +111,7 @@ func (d *applicationKeyDataSource) Read(ctx context.Context, req datasource.Read
 						resp.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error getting application key"))
 						return
 					}
-					appKeyData := ddResp.GetData()
-					d.updateState(&state, &appKeyData)
+					applicationKeyData = ddResp.GetData()
 				}
 			}
 			if exact_matches > 1 {
@@ -122,6 +122,7 @@ func (d *applicationKeyDataSource) Read(ctx context.Context, req datasource.Read
 				resp.Diagnostics.AddError("your query returned no exact matches, please try a less specific search criteria", "")
 				return
 			}
+			d.updateState(&state, &applicationKeyData)
 		} else {
 			id := applicationKeysData[0].GetId()
 			applicationKeyResponse, _, err := d.Api.GetCurrentUserApplicationKey(d.Auth, id)

--- a/datadog/tests/data_source_datadog_api_key_test.go
+++ b/datadog/tests/data_source_datadog_api_key_test.go
@@ -61,6 +61,33 @@ func TestAccDatadogApiKeyDatasource_matchName(t *testing.T) {
 	})
 }
 
+func TestAccDatadogApiKeyDatasource_exactMatchName(t *testing.T) {
+	t.Parallel()
+	if isRecording() || isReplaying() {
+		t.Skip("This test doesn't support recording or replaying")
+	}
+	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
+	apiKeyName := uniqueEntityName(ctx, t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: accProviders,
+		CheckDestroy:             testAccCheckDatadogApiKeyDestroy(providers.frameworkProvider),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceApiKeyExactMatch(apiKeyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogApiKeyExists(providers.frameworkProvider, "datadog_api_key.api_key_1"),
+					resource.TestCheckResourceAttr("datadog_api_key.api_key_1", "name", apiKeyName),
+					resource.TestCheckResourceAttr("datadog_api_key.api_key_2", "name", fmt.Sprintf("%s 2", apiKeyName)),
+					resource.TestCheckResourceAttr("data.datadog_api_key.api_key", "name", apiKeyName),
+					resource.TestCheckResourceAttrPair("data.datadog_api_key.api_key", "id", "datadog_api_key.api_key_1", "id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDatadogApiKeyDatasource_matchIdError(t *testing.T) {
 	t.Parallel()
 	if isRecording() || isReplaying() {
@@ -170,7 +197,26 @@ data "datadog_api_key" "api_key" {
 }
 
 func testAccDatasourceApiKeyMissingParametersConfig() string {
-	return fmt.Sprintf(`
+	return `
 data "datadog_api_key" "api_key" {
-}`)
+}`
+}
+
+func testAccDatasourceApiKeyExactMatch(uniq string) string {
+	return fmt.Sprintf(`
+resource "datadog_api_key" "api_key_1" {
+  name = "%s"
+}
+
+resource "datadog_api_key" "api_key_2" {
+  name = "%s 2"
+}
+data "datadog_api_key" "api_key" {
+  depends_on = [
+    datadog_api_key.api_key_1,
+    datadog_api_key.api_key_2,
+  ]
+  exact_match = true
+  name = "%s"
+}`, uniq, uniq, uniq)
 }

--- a/docs/data-sources/api_key.md
+++ b/docs/data-sources/api_key.md
@@ -23,6 +23,7 @@ data "datadog_api_key" "foo" {
 
 ### Optional
 
+- `exact_match` (Boolean) Whether to use exact match when searching by name.
 - `id` (String) The ID of this resource.
 - `name` (String) Name for API Key.
 

--- a/docs/data-sources/application_key.md
+++ b/docs/data-sources/application_key.md
@@ -23,6 +23,7 @@ data "datadog_application_key" "foo" {
 
 ### Optional
 
+- `exact_match` (Boolean) Whether to use exact match when searching by name.
 - `id` (String) Id for Application Key.
 - `name` (String) Name for Application Key.
 


### PR DESCRIPTION
If exact_match is true, searches the returned list of key names for an exact match instead of erroring out due to multiple results.