### PR TITLE
[datadog_monitor] Omit recurrence start field if its an empty string

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -627,7 +627,7 @@ func buildMonitorStruct(d utils.Resource) (*datadogV1.Monitor, *datadogV1.Monito
 					if rrule, ok := firstRecurrence["rrule"].(string); ok {
 						recurrence.SetRrule(rrule)
 					}
-					if start, ok := firstRecurrence["start"].(string); ok {
+					if start, ok := firstRecurrence["start"].(string); ok && start != "" {
 						recurrence.SetStart(start)
 					}
 					if timezone, ok := firstRecurrence["timezone"].(string); ok {


### PR DESCRIPTION
empty string is default for fields omitted in hcl, but that's not valid for the backend.