### PR TITLE
[datadog_dashboards] Bump limit for allowed graphs in split graph widget

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -8126,9 +8126,10 @@ func getSplitConfigSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"split_dimensions": getSplitDimensionSchema(),
 		"limit": {
-			Description: "Maximum number of graphs to display in the widget.",
-			Type:        schema.TypeInt,
-			Optional:    true,
+			Description:  "Maximum number of graphs to display in the widget.",
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ValidateFunc: validation.IntBetween(1, 500),
 		},
 		"sort":          getSplitSortSchema(),
 		"static_splits": getStaticSplitsSchema(),
@@ -8201,7 +8202,7 @@ func getStaticSplitsSchema() *schema.Schema {
 		Description: "The property by which the graph splits",
 		Type:        schema.TypeList,
 		Optional:    true,
-		MaxItems:    100,
+		MaxItems:    500,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"split_vector": getSplitVectorSchema(),

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -12790,7 +12790,7 @@ Required:
 Optional:
 
 - `limit` (Number) Maximum number of graphs to display in the widget.
-- `static_splits` (Block List, Max: 100) The property by which the graph splits (see [below for nested schema](#nestedblock--widget--group_definition--widget--split_graph_definition--split_config--static_splits))
+- `static_splits` (Block List, Max: 500) The property by which the graph splits (see [below for nested schema](#nestedblock--widget--group_definition--widget--split_graph_definition--split_config--static_splits))
 
 <a id="nestedblock--widget--group_definition--widget--split_graph_definition--split_config--sort"></a>
 ### Nested Schema for `widget.group_definition.widget.split_graph_definition.split_config.sort`
@@ -24365,7 +24365,7 @@ Required:
 Optional:
 
 - `limit` (Number) Maximum number of graphs to display in the widget.
-- `static_splits` (Block List, Max: 100) The property by which the graph splits (see [below for nested schema](#nestedblock--widget--split_graph_definition--split_config--static_splits))
+- `static_splits` (Block List, Max: 500) The property by which the graph splits (see [below for nested schema](#nestedblock--widget--split_graph_definition--split_config--static_splits))
 
 <a id="nestedblock--widget--split_graph_definition--split_config--sort"></a>
 ### Nested Schema for `widget.split_graph_definition.split_config.sort`


### PR DESCRIPTION
This pull request increases limit for allowed graphs in split graph widget. 
It used to be 100, now 500