### PR TITLE
[datadog_integration_pagerduty_service_object] Add importer

### DIFF
--- a/datadog/resource_datadog_integration_pagerduty_service_object.go
+++ b/datadog/resource_datadog_integration_pagerduty_service_object.go
@@ -19,8 +19,13 @@ func resourceDatadogIntegrationPagerdutySO() *schema.Resource {
 		ReadContext:   resourceDatadogIntegrationPagerdutySORead,
 		UpdateContext: resourceDatadogIntegrationPagerdutySOUpdate,
 		DeleteContext: resourceDatadogIntegrationPagerdutySODelete,
-		// since the API never returns service_key, it's impossible to meaningfully import resources
-		Importer: nil,
+		// The API never returns service_key, importing this resource can be used
+		// to avoid recreating an existing one, but the lifecycle of the `service_key`
+		// won't be manageable through it and should probably be in an `ignore_changes`
+		// block.
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
 			return map[string]*schema.Schema{

--- a/docs/resources/integration_pagerduty_service_object.md
+++ b/docs/resources/integration_pagerduty_service_object.md
@@ -35,3 +35,12 @@ resource "datadog_integration_pagerduty_service_object" "testing_bar" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# Pagerduty service object can be imported using the service_name, while the service_key should be passed by setting the environment variable SERVICE_KEY
+SERVICE_KEY=${service_key} terraform import datadog_integration_pagerduty_service_object.foo ${service_name}
+```

--- a/examples/resources/datadog_integration_pagerduty_service_object/import.sh
+++ b/examples/resources/datadog_integration_pagerduty_service_object/import.sh
@@ -1,0 +1,2 @@
+# Pagerduty service object can be imported using the service_name, while the service_key should be passed by setting the environment variable SERVICE_KEY
+SERVICE_KEY=${service_key} terraform import datadog_integration_pagerduty_service_object.foo ${service_name}


### PR DESCRIPTION
Adds an importer for `datadog_integration_pagerduty_service_object`.

As a way to get unstuck when there's an existing resource that is not reflected in the state.

With this, one can do:

```
terraform import datadog_integration_pagerduty_service_object.<name of the resource> "<service name>"
```

And get rid of `400 Bad Request` errors that might happen when applying on top of an already existing service with the same name.

Fixes #513 and #1822 (which shouldn't be closed, IMHO).