### PR TITLE
[datadog_metric_metadata] don't send `type` field for distribution metrics

### DIFF
--- a/datadog/resource_datadog_metric_metadata.go
+++ b/datadog/resource_datadog_metric_metadata.go
@@ -81,6 +81,14 @@ func resourceDatadogMetricMetadataCreate(ctx context.Context, d *schema.Resource
 	auth := providerConf.Auth
 
 	id, m := buildMetricMetadataStruct(d)
+
+	// Datadog API only has partial supports for the distribution type in metrics endpoints,
+	// and sending the distribution type field in the request payload will result in a 400 error.
+	// This is an interium workaround so that users can still initialize resources with distribution metric.
+	if m.GetType() == "distribution" {
+		m.SetType("")
+	}
+
 	createdMetadata, httpResponse, err := apiInstances.GetMetricsApiV1().UpdateMetricMetadata(auth, id, *m)
 	if err != nil {
 		return utils.TranslateClientErrorDiag(err, httpResponse, "error creating metric metadata")
@@ -148,7 +156,10 @@ func resourceDatadogMetricMetadataUpdate(ctx context.Context, d *schema.Resource
 	m := &datadogV1.MetricMetadata{}
 	id := d.Get("metric").(string)
 
-	if attr, ok := d.GetOk("type"); ok {
+	// Datadog API only has partial supports for the distribution type in metrics endpoints,
+	// and sending the distribution type field in the request payload will result in a 400 error.
+	// This is an interium workaround so that users can still update other fields of distribution metric metadata.
+	if attr, ok := d.GetOk("type"); ok && attr.(string) != "distribution" {
 		m.SetType(attr.(string))
 	}
 	if attr, ok := d.GetOk("description"); ok {

--- a/datadog/resource_datadog_metric_metadata.go
+++ b/datadog/resource_datadog_metric_metadata.go
@@ -82,9 +82,9 @@ func resourceDatadogMetricMetadataCreate(ctx context.Context, d *schema.Resource
 
 	id, m := buildMetricMetadataStruct(d)
 
-	// Datadog API only has partial supports for the distribution type in metrics endpoints,
-	// and sending the distribution type field in the request payload will result in a 400 error.
-	// This is an interium workaround so that users can still initialize resources with distribution metric.
+	// The Datadog API returns type `distribution` for distribution metrics only when a feature flag is enabled.
+	// The API currently only partially supports recieving the distribution type in the request payload, so we skip
+	// sending the type to avoid a 400 error. For users without the feature flag, this shouldn't affect anything.
 	if m.GetType() == "distribution" {
 		m.SetType("")
 	}
@@ -156,9 +156,9 @@ func resourceDatadogMetricMetadataUpdate(ctx context.Context, d *schema.Resource
 	m := &datadogV1.MetricMetadata{}
 	id := d.Get("metric").(string)
 
-	// Datadog API only has partial supports for the distribution type in metrics endpoints,
-	// and sending the distribution type field in the request payload will result in a 400 error.
-	// This is an interium workaround so that users can still update other fields of distribution metric metadata.
+	// The Datadog API returns type `distribution` for distribution metrics only when a feature flag is enabled.
+	// The API currently only partially supports recieving the distribution type in the request payload, so we skip
+	// sending the type to avoid a 400 error. For users without the feature flag, this shouldn't affect anything.
 	if attr, ok := d.GetOk("type"); ok && attr.(string) != "distribution" {
 		m.SetType(attr.(string))
 	}


### PR DESCRIPTION
This is similar to https://github.com/DataDog/terraform-provider-datadog/pull/2222

We've enabled the feature flag on our account, but because Datadog APIs don't allow including the `type: "distribution"` in the request payload anyway, update operations could end up with 400 bad request errors due to the upstream API validation.

This PR adds an interim workaround so that the provider doesn't include the `type` filed at all for any `distribution` metrics.