### PR TITLE
[datadog_logs_archive] Make project id optional in GCS destination

### DIFF
--- a/datadog/resource_datadog_logs_archive.go
+++ b/datadog/resource_datadog_logs_archive.go
@@ -72,7 +72,7 @@ func resourceDatadogLogsArchive() *schema.Resource {
 							"bucket":       {Description: "Name of your GCS bucket.", Type: schema.TypeString, Required: true},
 							"path":         {Description: "Path where the archive is stored.", Type: schema.TypeString, Optional: true},
 							"client_email": {Description: "Your client email.", Type: schema.TypeString, Required: true},
-							"project_id":   {Description: "Your project id.", Type: schema.TypeString, Required: true},
+							"project_id":   {Description: "Your project id.", Type: schema.TypeString, Optional: true},
 						},
 					},
 				},

--- a/docs/resources/logs_archive.md
+++ b/docs/resources/logs_archive.md
@@ -68,11 +68,11 @@ Required:
 
 - `bucket` (String) Name of your GCS bucket.
 - `client_email` (String) Your client email.
-- `project_id` (String) Your project id.
 
 Optional:
 
 - `path` (String) Path where the archive is stored.
+- `project_id` (String) Your project id.
 
 
 <a id="nestedblock--s3_archive"></a>


### PR DESCRIPTION
[LOGSAC-468](https://datadoghq.atlassian.net/browse/LOGSAC-468)
## Description

Quick PR to reflect the public api change and make the project id an optional field in terraform as well
https://github.com/DataDog/datadog-api-spec/pull/2686

[LOGSAC-468]: https://datadoghq.atlassian.net/browse/LOGSAC-468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ