### PR TITLE
[datadog_sensitive_data_scanner_group] Mark resource as missing when not found

### DIFF
--- a/datadog/resource_datadog_sensitive_data_scanner_group.go
+++ b/datadog/resource_datadog_sensitive_data_scanner_group.go
@@ -138,6 +138,8 @@ func resourceDatadogSensitiveDataScannerGroupRead(ctx context.Context, d *schema
 
 	if groupFound := findSensitiveDataScannerGroupHelper(groupId, resp); groupFound != nil {
 		return updateSensitiveDataScannerGroupState(d, groupFound.Attributes)
+	} else {
+		d.SetId("")
 	}
 
 	return nil


### PR DESCRIPTION
fix the resource ignoring when the group is deleted on the backend