### PR TITLE
[datadog_service_account_application_key] Improve service account application key error messages

### DIFF
--- a/datadog/fwprovider/resource_datadog_service_account_application_key.go
+++ b/datadog/fwprovider/resource_datadog_service_account_application_key.go
@@ -145,7 +145,7 @@ func (r *serviceAccountApplicationKeyResource) Create(ctx context.Context, reque
 
 	resp, _, err := r.Api.CreateServiceAccountApplicationKey(r.Auth, serviceAccountId, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving ServiceAccountApplicationKey"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating ServiceAccountApplicationKey"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {
@@ -177,7 +177,7 @@ func (r *serviceAccountApplicationKeyResource) Update(ctx context.Context, reque
 
 	resp, _, err := r.Api.UpdateServiceAccountApplicationKey(r.Auth, serviceAccountId, id, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving ServiceAccountApplicationKey"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating ServiceAccountApplicationKey"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {


### PR DESCRIPTION
I got a bit confused about what had happened when apply errored and the error messages indicated it failed retrieving the key.