### PR TITLE
[datadog_csm_threats_agent_rules] Add a by resource lock to prevent 409s

### DIFF
--- a/datadog/fwprovider/resource_datadog_csm_threats_agent_rule.go
+++ b/datadog/fwprovider/resource_datadog_csm_threats_agent_rule.go
@@ -122,9 +122,6 @@ func (r *csmThreatsAgentRuleResource) Read(ctx context.Context, request resource
 		return
 	}
 
-	csmThreatsMutex.Lock()
-	defer csmThreatsMutex.Unlock()
-
 	agentRuleId := state.Id.ValueString()
 	res, httpResponse, err := r.api.GetCSMThreatsAgentRule(r.auth, agentRuleId)
 	if err != nil {


### PR DESCRIPTION
Previous [PR](https://github.com/DataDog/terraform-provider-datadog/pull/2316), added the new csm_agent_threats resource. Thing is, sometimes we got 409s from the backend because of requests accessing the same resource. 
This PR removes this possibility by introducing a lock by resource.