### PR TITLE
[datadog_user] Omitting `roles` from `datadog_user` no longer unassigns all roles 

### DIFF
--- a/datadog/resource_datadog_user.go
+++ b/datadog/resource_datadog_user.go
@@ -235,7 +235,7 @@ func resourceDatadogUserCreate(ctx context.Context, d *schema.ResourceData, meta
 			return diag.FromErr(err)
 		}
 
-		// Update roles
+		// Update roles if provided
 		if _, ok := d.GetOk("roles"); ok {
 			_, newRolesI := d.GetChange("roles")
 			newRoles := newRolesI.(*schema.Set)

--- a/datadog/resource_datadog_user.go
+++ b/datadog/resource_datadog_user.go
@@ -45,7 +45,6 @@ func resourceDatadogUser() *schema.Resource {
 					Type:        schema.TypeSet,
 					Optional:    true,
 					Elem:        &schema.Schema{Type: schema.TypeString},
-					Deprecated:  "`roles` has been deprecated in favor of the new `datadog_user_role` resource.",
 				},
 				"send_user_invitation": {
 					Description: "Whether an invitation email should be sent when the user is created.",

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -37,7 +37,7 @@ resource "datadog_user" "foo" {
 
 - `disabled` (Boolean) Whether the user is disabled. Defaults to `false`.
 - `name` (String) Name for user.
-- `roles` (Set of String, Deprecated) A list a role IDs to assign to the user. **Deprecated.** `roles` has been deprecated in favor of the new `datadog_user_role` resource.
+- `roles` (Set of String) A list a role IDs to assign to the user.
 - `send_user_invitation` (Boolean) Whether an invitation email should be sent when the user is created. Defaults to `true`.
 
 ### Read-Only

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -37,7 +37,7 @@ resource "datadog_user" "foo" {
 
 - `disabled` (Boolean) Whether the user is disabled. Defaults to `false`.
 - `name` (String) Name for user.
-- `roles` (Set of String) A list a role IDs to assign to the user.
+- `roles` (Set of String, Deprecated) A list a role IDs to assign to the user. **Deprecated.** `roles` has been deprecated in favor of the new `datadog_user_role` resource.
 - `send_user_invitation` (Boolean) Whether an invitation email should be sent when the user is created. Defaults to `true`.
 
 ### Read-Only


### PR DESCRIPTION
update `datadog_user` Terraform resource such that:
- if `roles` is omitted/unspecified, do not update existing roles (currently: unassigns all roles)
- if `roles=[]`, unassign all roles

https://github.com/DataDog/terraform-provider-datadog/assets/62684843/f0a1e6f6-5682-40bb-ae6f-292b8ec4d922

