### PR TITLE
[datadog_user] Re-order role updates

### DIFF
--- a/datadog/resource_datadog_user.go
+++ b/datadog/resource_datadog_user.go
@@ -130,17 +130,6 @@ func updateRoles(meta interface{}, userID string, oldRoles *schema.Set, newRoles
 	rolesToRemove := oldRoles.Difference(newRoles)
 	rolesToAdd := newRoles.Difference(oldRoles)
 
-	for _, roleI := range rolesToRemove.List() {
-		role := roleI.(string)
-		userRelation := datadogV2.NewRelationshipToUserWithDefaults()
-		userRelationData := datadogV2.NewRelationshipToUserDataWithDefaults()
-		userRelationData.SetId(userID)
-		userRelation.SetData(*userRelationData)
-		_, httpResponse, err := apiInstances.GetRolesApiV2().RemoveUserFromRole(auth, role, *userRelation)
-		if err != nil {
-			return utils.TranslateClientErrorDiag(err, httpResponse, "error removing user from role")
-		}
-	}
 	for _, roleI := range rolesToAdd.List() {
 		role := roleI.(string)
 		roleRelation := datadogV2.NewRelationshipToUserWithDefaults()
@@ -150,6 +139,17 @@ func updateRoles(meta interface{}, userID string, oldRoles *schema.Set, newRoles
 		_, httpResponse, err := apiInstances.GetRolesApiV2().AddUserToRole(auth, role, *roleRelation)
 		if err != nil {
 			return utils.TranslateClientErrorDiag(err, httpResponse, "error adding user to role")
+		}
+	}
+	for _, roleI := range rolesToRemove.List() {
+		role := roleI.(string)
+		userRelation := datadogV2.NewRelationshipToUserWithDefaults()
+		userRelationData := datadogV2.NewRelationshipToUserDataWithDefaults()
+		userRelationData.SetId(userID)
+		userRelation.SetData(*userRelationData)
+		_, httpResponse, err := apiInstances.GetRolesApiV2().RemoveUserFromRole(auth, role, *userRelation)
+		if err != nil {
+			return utils.TranslateClientErrorDiag(err, httpResponse, "error removing user from role")
 		}
 	}
 


### PR DESCRIPTION
This PR proposes that we re-order role updates for datadog_user, so additions happen before removals.

I was testing `datadog_user` and ran into a funny case. If you're modifying yourself, for example to change from
```
[ datadog_role.old_admin_role.id ]
```
to
```
[ datadog_role.new_admin_role.id ]
```
... then if we do removals first, then additions, we'll get locked out and won't be able to finish the operation. It seems safer to first add all the new roles, then remove any old roles.

Note: it's still possible to delete your own role and lock yourself out, but only if the target list of roles doesn't contain the user_access_manage permission.
