### PR TITLE
Add team relationship support to AuthNMappings resource

### DIFF
--- a/datadog/fwprovider/resource_datadog_apm_retention_filter.go
+++ b/datadog/fwprovider/resource_datadog_apm_retention_filter.go
@@ -263,10 +263,10 @@ func (r *ApmRetentionFilterResource) buildRetentionFilterCreateRequestBody(ctx c
 
 func (r *ApmRetentionFilterResource) buildApmRetentionFilterUpdateRequestBody(ctx context.Context, state *ApmRetentionFilterModel) (*datadogV2.RetentionFilterUpdateRequest, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
-	attributes := datadogV2.NewRetentionFilterCreateAttributesWithDefaults()
+	attributes := datadogV2.NewRetentionFilterUpdateAttributesWithDefaults()
 
 	attributes.SetName(state.Name.ValueString())
-	attributes.SetFilterType(datadogV2.RetentionFilterType(state.FilterType.ValueString()))
+	attributes.SetFilterType(datadogV2.RetentionFilterAllType(state.FilterType.ValueString()))
 	fValue, err := strconv.ParseFloat(state.Rate.ValueString(), 64)
 	if err != nil {
 		diags.AddError("rate", fmt.Sprintf("error parsing rate: %s", err))

--- a/datadog/fwprovider/resource_datadog_security_monitoring_suppression.go
+++ b/datadog/fwprovider/resource_datadog_security_monitoring_suppression.go
@@ -191,7 +191,8 @@ func (r *securityMonitoringSuppressionResource) buildCreateSecurityMonitoringSup
 		return nil, err
 	}
 
-	attributes := datadogV2.NewSecurityMonitoringSuppressionCreateAttributes(enabled, name, ruleQuery, suppressionQuery)
+	attributes := datadogV2.NewSecurityMonitoringSuppressionCreateAttributes(enabled, name, ruleQuery)
+	attributes.SetSuppressionQuery(suppressionQuery)
 	attributes.Description = description
 	attributes.ExpirationDate = expirationDate
 

--- a/datadog/resource_datadog_authn_mapping.go
+++ b/datadog/resource_datadog_authn_mapping.go
@@ -39,7 +39,12 @@ func resourceDatadogAuthnMapping() *schema.Resource {
 				"role": {
 					Description: "The ID of a role to attach to all users with the corresponding key and value.",
 					Type:        schema.TypeString,
-					Required:    true,
+					Optional:    true,
+				},
+				"team": {
+					Description: "The ID of a team to add all users with the corresponding key and value to.",
+					Type:        schema.TypeString,
+					Optional:    true,
 				},
 			}
 		},

--- a/datadog/resource_datadog_authn_mapping.go
+++ b/datadog/resource_datadog_authn_mapping.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 )
 
 func resourceDatadogAuthnMapping() *schema.Resource {
@@ -157,19 +157,29 @@ func buildAuthNMappingCreateRequest(d *schema.ResourceData) *datadogV2.AuthNMapp
 	authNMappingCreateRequest := datadogV2.NewAuthNMappingCreateRequestWithDefaults()
 	authNMappingCreateData := datadogV2.NewAuthNMappingCreateDataWithDefaults()
 	authNMappingCreateAttrs := datadogV2.NewAuthNMappingCreateAttributesWithDefaults()
-	authNMappingRelations := datadogV2.NewAuthNMappingCreateRelationshipsWithDefaults()
 
 	// Set AuthN mapping Attributes
 	authNMappingCreateAttrs.SetAttributeKey(d.Get("key").(string))
 	authNMappingCreateAttrs.SetAttributeValue(d.Get("value").(string))
 
 	// Set AuthN mapping Relationships
-	roleRelations := buildRoleRelations(d)
-	authNMappingRelations.SetRole(*roleRelations)
+	relationships := datadogV2.AuthNMappingCreateRelationships{}
+	roleRelation := buildRoleRelations(d)
+	teamRelation := buildTeamRelations(d)
+	if roleRelation != nil {
+		relationshipToRole := datadogV2.NewAuthNMappingRelationshipToRoleWithDefaults()
+		relationshipToRole.SetRole(*roleRelation)
+		relationships.AuthNMappingRelationshipToRole = relationshipToRole
+	}
+	if teamRelation != nil {
+		relationshipToTeam := datadogV2.NewAuthNMappingRelationshipToTeamWithDefaults()
+		relationshipToTeam.SetTeam(*teamRelation)
+		relationships.AuthNMappingRelationshipToTeam = relationshipToTeam
+	}
 
 	// Set AuthN mapping create data
 	authNMappingCreateData.SetAttributes(*authNMappingCreateAttrs)
-	authNMappingCreateData.SetRelationships(*authNMappingRelations)
+	authNMappingCreateData.SetRelationships(relationships)
 
 	// Set AuthN mapping create request
 	authNMappingCreateRequest.SetData(*authNMappingCreateData)
@@ -180,19 +190,29 @@ func buildAuthNMappingUpdateRequest(d *schema.ResourceData) *datadogV2.AuthNMapp
 	authNMappingUpdateRequest := datadogV2.NewAuthNMappingUpdateRequestWithDefaults()
 	authNMappingUpdateData := datadogV2.NewAuthNMappingUpdateDataWithDefaults()
 	authNMappingUpdateAttrs := datadogV2.NewAuthNMappingUpdateAttributesWithDefaults()
-	authNMappingRelations := datadogV2.NewAuthNMappingUpdateRelationshipsWithDefaults()
 
 	// Set AuthN mapping Attributes
 	authNMappingUpdateAttrs.SetAttributeKey(d.Get("key").(string))
 	authNMappingUpdateAttrs.SetAttributeValue(d.Get("value").(string))
 
 	// Set AuthN mapping Relationships
-	roleRelations := buildRoleRelations(d)
-	authNMappingRelations.SetRole(*roleRelations)
+	relationships := datadogV2.AuthNMappingUpdateRelationships{}
+	roleRelation := buildRoleRelations(d)
+	teamRelation := buildTeamRelations(d)
+	if roleRelation != nil {
+		relationshipToRole := datadogV2.NewAuthNMappingRelationshipToRoleWithDefaults()
+		relationshipToRole.SetRole(*roleRelation)
+		relationships.AuthNMappingRelationshipToRole = relationshipToRole
+	}
+	if teamRelation != nil {
+		relationshipToTeam := datadogV2.NewAuthNMappingRelationshipToTeamWithDefaults()
+		relationshipToTeam.SetTeam(*teamRelation)
+		relationships.AuthNMappingRelationshipToTeam = relationshipToTeam
+	}
 
 	// Set AuthN mapping update data
 	authNMappingUpdateData.SetAttributes(*authNMappingUpdateAttrs)
-	authNMappingUpdateData.SetRelationships(*authNMappingRelations)
+	authNMappingUpdateData.SetRelationships(relationships)
 	authNMappingUpdateData.SetId(d.Id())
 
 	// Set AuthN mapping update request
@@ -203,7 +223,27 @@ func buildAuthNMappingUpdateRequest(d *schema.ResourceData) *datadogV2.AuthNMapp
 func buildRoleRelations(d *schema.ResourceData) *datadogV2.RelationshipToRole {
 	roleRelations := datadogV2.NewRelationshipToRoleWithDefaults()
 	roleRelationsData := datadogV2.NewRelationshipToRoleDataWithDefaults()
-	roleRelationsData.SetId(d.Get("role").(string))
+
+	role := d.Get("role")
+	if role == nil {
+		return nil
+	}
+
+	roleRelationsData.SetId(role.(string))
 	roleRelations.SetData(*roleRelationsData)
 	return roleRelations
+}
+
+func buildTeamRelations(d *schema.ResourceData) *datadogV2.RelationshipToTeam {
+	teamRelations := datadogV2.NewRelationshipToTeamWithDefaults()
+	teamRelationsData := datadogV2.NewRelationshipToTeamDataWithDefaults()
+
+	team := d.Get("team")
+	if team == nil {
+		return nil
+	}
+
+	teamRelationsData.SetId(team.(string))
+	teamRelations.SetData(*teamRelationsData)
+	return teamRelations
 }

--- a/datadog/resource_datadog_authn_mapping.go
+++ b/datadog/resource_datadog_authn_mapping.go
@@ -226,13 +226,13 @@ func buildAuthNMappingUpdateRequest(d *schema.ResourceData) *datadogV2.AuthNMapp
 }
 
 func buildRoleRelations(d *schema.ResourceData) *datadogV2.RelationshipToRole {
-	roleRelations := datadogV2.NewRelationshipToRoleWithDefaults()
-	roleRelationsData := datadogV2.NewRelationshipToRoleDataWithDefaults()
-
 	role := d.Get("role")
-	if role == nil {
+	if role == nil || role == "" {
 		return nil
 	}
+
+	roleRelations := datadogV2.NewRelationshipToRoleWithDefaults()
+	roleRelationsData := datadogV2.NewRelationshipToRoleDataWithDefaults()
 
 	roleRelationsData.SetId(role.(string))
 	roleRelations.SetData(*roleRelationsData)
@@ -240,13 +240,13 @@ func buildRoleRelations(d *schema.ResourceData) *datadogV2.RelationshipToRole {
 }
 
 func buildTeamRelations(d *schema.ResourceData) *datadogV2.RelationshipToTeam {
-	teamRelations := datadogV2.NewRelationshipToTeamWithDefaults()
-	teamRelationsData := datadogV2.NewRelationshipToTeamDataWithDefaults()
-
 	team := d.Get("team")
-	if team == nil {
+	if team == nil || team == "" {
 		return nil
 	}
+
+	teamRelations := datadogV2.NewRelationshipToTeamWithDefaults()
+	teamRelationsData := datadogV2.NewRelationshipToTeamDataWithDefaults()
 
 	teamRelationsData.SetId(team.(string))
 	teamRelations.SetData(*teamRelationsData)

--- a/datadog/tests/resource_datadog_authn_mapping_test.go
+++ b/datadog/tests/resource_datadog_authn_mapping_test.go
@@ -5,28 +5,26 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
+	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccDatadogAuthNMapping_CreateUpdate(t *testing.T) {
 	t.Parallel()
-	_, accProviders := testAccProviders(context.Background(), t)
-	accProvider := testAccProvider(t, accProviders)
+	_, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
+	// uniq := strings.ToLower(uniqueEntityName(ctx, t))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: accProviders,
-		CheckDestroy:      testAccCheckDatadogAuthNMappingDestroy(accProvider),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: accProviders,
+		CheckDestroy:             testAccCheckDatadogAuthNMappingDestroy(providers.frameworkProvider),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDatadogAuthNMappingConfig("key_1", "value_1"),
+				Config: testAccCheckDatadogAuthNMappingRoleConfig("key_1", "value_1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDatadogAuthNMappingExists(accProvider, "datadog_authn_mapping.foo"),
+					testAccCheckDatadogAuthNMappingExists(providers.frameworkProvider, "datadog_authn_mapping.foo"),
 					resource.TestCheckResourceAttr("datadog_authn_mapping.foo", "key", "key_1"),
 					resource.TestCheckResourceAttr("datadog_authn_mapping.foo", "value", "value_1"),
 					testCheckAuthNMappingHasRole("datadog_authn_mapping.foo", "data.datadog_role.ro_role"),
@@ -35,7 +33,7 @@ func TestAccDatadogAuthNMapping_CreateUpdate(t *testing.T) {
 			{
 				Config: testAccCheckDatadogAuthNMappingConfigUpdated("key_2", "value_2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDatadogAuthNMappingExists(accProvider, "datadog_authn_mapping.foo"),
+					testAccCheckDatadogAuthNMappingExists(providers.frameworkProvider, "datadog_authn_mapping.foo"),
 					resource.TestCheckResourceAttr("datadog_authn_mapping.foo", "key", "key_2"),
 					resource.TestCheckResourceAttr("datadog_authn_mapping.foo", "value", "value_2"),
 					testCheckAuthNMappingHasRole("datadog_authn_mapping.foo", "data.datadog_role.standard_role"),
@@ -47,16 +45,15 @@ func TestAccDatadogAuthNMapping_CreateUpdate(t *testing.T) {
 
 func TestAccDatadogAuthNMapping_import(t *testing.T) {
 	t.Parallel()
-	_, accProviders := testAccProviders(context.Background(), t)
-	accProvider := testAccProvider(t, accProviders)
+	_, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: accProviders,
-		CheckDestroy:      testAccCheckDatadogAuthNMappingDestroy(accProvider),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: accProviders,
+		CheckDestroy:             testAccCheckDatadogAuthNMappingDestroy(providers.frameworkProvider),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDatadogAuthNMappingConfig("key_1", "value_1"),
+				Config: testAccCheckDatadogAuthNMappingRoleConfig("key_1", "value_1"),
 			},
 			{
 				ResourceName:      "datadog_authn_mapping.foo",
@@ -67,8 +64,8 @@ func TestAccDatadogAuthNMapping_import(t *testing.T) {
 	})
 }
 
-// Create Terraform Config for AuthN Mapping
-func testAccCheckDatadogAuthNMappingConfig(key string, val string) string {
+// Create Terraform Config for AuthN Mapping with role
+func testAccCheckDatadogAuthNMappingRoleConfig(key string, val string) string {
 	return fmt.Sprintf(`
 	data "datadog_role" "ro_role" {
 		filter = "Datadog Read Only Role"
@@ -80,6 +77,23 @@ func testAccCheckDatadogAuthNMappingConfig(key string, val string) string {
 	  value = "%s"
 	  role  = data.datadog_role.ro_role.id
 	}`, key, val)
+}
+
+// Create Terraform Config for AuthN Mapping with team
+func testAccCheckDatadogAuthNMappingTeamConfig(uniq, key string, val string) string {
+	return fmt.Sprintf(`
+	resource "datadog_team" "foo" {
+		description = "Example team"
+		handle      = "%s"
+		name        = "%s"
+	}
+	  
+	# Create a new AuthN mapping
+	resource "datadog_authn_mapping" "foo" {
+	  key   = "%s"
+	  value = "%s"
+	  team  = data.datadog_team.foo.id
+	}`, uniq, uniq, key, val)
 }
 
 // Update Terraform Config for AuthN Mapping
@@ -97,12 +111,10 @@ func testAccCheckDatadogAuthNMappingConfigUpdated(key string, val string) string
 }
 
 // Check if AuthN Mapping Exists
-func testAccCheckDatadogAuthNMappingExists(accProvider func() (*schema.Provider, error), authNMappingName string) resource.TestCheckFunc {
+func testAccCheckDatadogAuthNMappingExists(accProvider *fwprovider.FrameworkProvider, authNMappingName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		provider, _ := accProvider()
-		providerConf := provider.Meta().(*datadog.ProviderConfiguration)
-		apiInstances := providerConf.DatadogApiInstances
-		auth := providerConf.Auth
+		apiInstances := accProvider.DatadogApiInstances
+		auth := accProvider.Auth
 
 		id := s.RootModule().Resources[authNMappingName].Primary.ID
 		_, httpresp, err := apiInstances.GetAuthNMappingsApiV2().GetAuthNMapping(auth, id)
@@ -114,12 +126,10 @@ func testAccCheckDatadogAuthNMappingExists(accProvider func() (*schema.Provider,
 }
 
 // Verify that AuthNMapping is destroyed after test run
-func testAccCheckDatadogAuthNMappingDestroy(accProvider func() (*schema.Provider, error)) func(*terraform.State) error {
+func testAccCheckDatadogAuthNMappingDestroy(accProvider *fwprovider.FrameworkProvider) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		provider, _ := accProvider()
-		providerConf := provider.Meta().(*datadog.ProviderConfiguration)
-		apiInstances := providerConf.DatadogApiInstances
-		auth := providerConf.Auth
+		apiInstances := accProvider.DatadogApiInstances
+		auth := accProvider.Auth
 
 		for _, r := range s.RootModule().Resources {
 			if r.Type != "datadog_authn_mapping" {

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-datadog
 
 require (
-	github.com/DataDog/datadog-api-client-go/v2 v2.24.1-0.20240404143448-85da29fb6313
+	github.com/DataDog/datadog-api-client-go/v2 v2.25.0
 	github.com/DataDog/dd-sdk-go-testing v0.0.0-20211116174033-1cd082e322ad
 	github.com/google/uuid v1.5.0
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/datadog-api-client-go/v2 v2.24.1-0.20240404143448-85da29fb6313 h1:IBoqCyARfZ6oXBVpe7jsq8JSR1NuRXqI+VJ/WOpeCDA=
-github.com/DataDog/datadog-api-client-go/v2 v2.24.1-0.20240404143448-85da29fb6313/go.mod h1:QKOu6vscsh87fMY1lHfLEmNSunyXImj8BUaUWJXOehc=
+github.com/DataDog/datadog-api-client-go/v2 v2.25.0 h1:9Zq42D6M3U///VDxjx2SS1g+EW55WhZYZFHtzM+cO4k=
+github.com/DataDog/datadog-api-client-go/v2 v2.25.0/go.mod h1:QKOu6vscsh87fMY1lHfLEmNSunyXImj8BUaUWJXOehc=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=


### PR DESCRIPTION
Additional changes are to upgrade the golang SDK to incorporate breaking changes required to make this happen.

The AuthNMapping resource can now take a role or a team as a relationship to accommodate the relatively new team SAML mapping feature.