### PR TITLE
[datadog_authn_mapping] Only allow one of role and team to be set

### DIFF
--- a/datadog/resource_datadog_authn_mapping.go
+++ b/datadog/resource_datadog_authn_mapping.go
@@ -37,14 +37,16 @@ func resourceDatadogAuthnMapping() *schema.Resource {
 					Required:    true,
 				},
 				"role": {
-					Description: "The ID of a role to attach to all users with the corresponding key and value.",
-					Type:        schema.TypeString,
-					Optional:    true,
+					Description:  "The ID of a role to attach to all users with the corresponding key and value.",
+					Type:         schema.TypeString,
+					Optional:     true,
+					ExactlyOneOf: []string{"role", "team"},
 				},
 				"team": {
-					Description: "The ID of a team to add all users with the corresponding key and value to.",
-					Type:        schema.TypeString,
-					Optional:    true,
+					Description:  "The ID of a team to add all users with the corresponding key and value to.",
+					Type:         schema.TypeString,
+					Optional:     true,
+					ExactlyOneOf: []string{"role", "team"},
 				},
 			}
 		},

--- a/datadog/resource_datadog_authn_mapping.go
+++ b/datadog/resource_datadog_authn_mapping.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
@@ -37,13 +38,13 @@ func resourceDatadogAuthnMapping() *schema.Resource {
 					Required:    true,
 				},
 				"role": {
-					Description:  "The ID of a role to attach to all users with the corresponding key and value.",
+					Description:  "The ID of a role to attach to all users with the corresponding key and value. Cannot be used in conjunction with `team`.",
 					Type:         schema.TypeString,
 					Optional:     true,
 					ExactlyOneOf: []string{"role", "team"},
 				},
 				"team": {
-					Description:  "The ID of a team to add all users with the corresponding key and value to.",
+					Description:  "The ID of a team to add all users with the corresponding key and value to. Cannot be used in conjunction with `role`.",
 					Type:         schema.TypeString,
 					Optional:     true,
 					ExactlyOneOf: []string{"role", "team"},

--- a/datadog/tests/resource_datadog_authn_mapping_test.go
+++ b/datadog/tests/resource_datadog_authn_mapping_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 )

--- a/docs/resources/authn_mapping.md
+++ b/docs/resources/authn_mapping.md
@@ -36,8 +36,8 @@ resource "datadog_authn_mapping" "dev_ro_role_mapping" {
 
 ### Optional
 
-- `role` (String) The ID of a role to attach to all users with the corresponding key and value.
-- `team` (String) The ID of a team to add all users with the corresponding key and value to.
+- `role` (String) The ID of a role to attach to all users with the corresponding key and value. Cannot be used in conjunction with `team`.
+- `team` (String) The ID of a team to add all users with the corresponding key and value to. Cannot be used in conjunction with `role`.
 
 ### Read-Only
 


### PR DESCRIPTION
Based on our testing, only one of `role` and `team` should be provided for the resource to work as intended (https://github.com/DataDog/terraform-provider-datadog/issues/2148#issuecomment-2085167742).

This PR adds some validation to fix this.

Note that I have not tested this change, as I don't have a datadog org to test with.