### PR TITLE
[datadog_synthetics_test] Ensure tags are non-empty and castable

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -111,7 +111,10 @@ func resourceDatadogSyntheticsTest() *schema.Resource {
 					Description: "A list of tags to associate with your synthetics test. This can help you categorize and filter tests in the manage synthetics page of the UI. Default is an empty list (`[]`).",
 					Type:        schema.TypeList,
 					Optional:    true,
-					Elem:        &schema.Schema{Type: schema.TypeString},
+					Elem: &schema.Schema{
+						Type:             schema.TypeString,
+						ValidateDiagFunc: validators.ValidateNonEmptyStrings,
+					},
 				},
 				"status": {
 					Description:      "Define whether you want to start (`live`) or pause (`paused`) a Synthetic test.",

--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -2286,7 +2286,9 @@ func buildSyntheticsBrowserTestStruct(d *schema.ResourceData) *datadogV1.Synthet
 	tags := make([]string, 0)
 	if attr, ok := d.GetOk("tags"); ok {
 		for _, s := range attr.([]interface{}) {
-			tags = append(tags, s.(string))
+			if tag, ok := s.(string); ok {
+				tags = append(tags, tag)
+			}
 		}
 	}
 	syntheticsTest.SetTags(tags)


### PR DESCRIPTION
SSIA, bugfix in response to customer ticket