### PR TITLE
[resource_integration_fastly_service] update import docs

### DIFF
--- a/docs/resources/integration_fastly_service.md
+++ b/docs/resources/integration_fastly_service.md
@@ -47,5 +47,5 @@ resource "datadog_integration_fastly_service" "foo" {
 Import is supported using the following syntax:
 
 ```shell
-terraform import datadog_integration_fastly_service.new_list "service-id"
+terraform import datadog_integration_fastly_service.new_list "account-id:service-id"
 ```

--- a/examples/resources/datadog_integration_fastly_service/import.sh
+++ b/examples/resources/datadog_integration_fastly_service/import.sh
@@ -1,1 +1,1 @@
-terraform import datadog_integration_fastly_service.new_list "service-id"
+terraform import datadog_integration_fastly_service.new_list "account-id:service-id"


### PR DESCRIPTION
Fix import docs because fastly importing follows the `account-id:service-id` format