### PR TITLE
[CWS-2164] - Put the cloud workload security resources as deprecated

### DIFF
--- a/datadog/data_source_datadog_cloud_workload_security_agent_rules.go
+++ b/datadog/data_source_datadog_cloud_workload_security_agent_rules.go
@@ -12,7 +12,7 @@ import (
 
 func dataSourceDatadogCloudWorkloadSecurityAgentRules() *schema.Resource {
 	return &schema.Resource{
-		Description: "Use this data source to retrieve information about existing Cloud Workload Security Agent Rules for use in other resources.",
+		Description: "Use this data source to retrieve information about existing Cloud Workload Security Agent Rules for use in other resources (this resource is going to be deprecated soon).",
 		ReadContext: dataSourceDatadogCloudWorkloadSecurityAgentRulesRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {

--- a/datadog/data_source_datadog_cloud_workload_security_agent_rules.go
+++ b/datadog/data_source_datadog_cloud_workload_security_agent_rules.go
@@ -12,7 +12,7 @@ import (
 
 func dataSourceDatadogCloudWorkloadSecurityAgentRules() *schema.Resource {
 	return &schema.Resource{
-		Description: "Use this data source to retrieve information about existing Cloud Workload Security Agent Rules for use in other resources (this data source is going to be deprecated soon).",
+		Description: "Use this data source to retrieve information about existing Cloud Workload Security Agent Rules for use in other resources. Deprecated, use CSM Threats Agent Rules instead: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/data-sources/csm_threats_agent_rules",
 		ReadContext: dataSourceDatadogCloudWorkloadSecurityAgentRulesRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {

--- a/datadog/data_source_datadog_cloud_workload_security_agent_rules.go
+++ b/datadog/data_source_datadog_cloud_workload_security_agent_rules.go
@@ -12,7 +12,7 @@ import (
 
 func dataSourceDatadogCloudWorkloadSecurityAgentRules() *schema.Resource {
 	return &schema.Resource{
-		Description: "Use this data source to retrieve information about existing Cloud Workload Security Agent Rules for use in other resources (this resource is going to be deprecated soon).",
+		Description: "Use this data source to retrieve information about existing Cloud Workload Security Agent Rules for use in other resources (this data source is going to be deprecated soon).",
 		ReadContext: dataSourceDatadogCloudWorkloadSecurityAgentRulesRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {

--- a/datadog/resource_datadog_cloud_workload_security_agent_rule.go
+++ b/datadog/resource_datadog_cloud_workload_security_agent_rule.go
@@ -12,7 +12,7 @@ import (
 
 func resourceDatadogCloudWorkloadSecurityAgentRule() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Provides a Datadog Cloud Workload Security Agent Rule API resource for agent rules.",
+		Description:   "Provides a Datadog Cloud Workload Security Agent Rule API resource for agent rules (this resource is going to be deprecated soon).",
 		CreateContext: resourceDatadogCloudWorkloadSecurityAgentRuleCreate,
 		ReadContext:   resourceDatadogCloudWorkloadSecurityAgentRuleRead,
 		UpdateContext: resourceDatadogCloudWorkloadSecurityAgentRuleUpdate,

--- a/datadog/resource_datadog_cloud_workload_security_agent_rule.go
+++ b/datadog/resource_datadog_cloud_workload_security_agent_rule.go
@@ -12,7 +12,7 @@ import (
 
 func resourceDatadogCloudWorkloadSecurityAgentRule() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Provides a Datadog Cloud Workload Security Agent Rule API resource for agent rules (this resource is going to be deprecated soon).",
+		Description:   "Provides a Datadog Cloud Workload Security Agent Rule API resource for agent rules. Deprecated, use CSM Threats Agent Rule instead: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/csm_threats_agent_rule",
 		CreateContext: resourceDatadogCloudWorkloadSecurityAgentRuleCreate,
 		ReadContext:   resourceDatadogCloudWorkloadSecurityAgentRuleRead,
 		UpdateContext: resourceDatadogCloudWorkloadSecurityAgentRuleUpdate,

--- a/docs/data-sources/cloud_workload_security_agent_rules.md
+++ b/docs/data-sources/cloud_workload_security_agent_rules.md
@@ -3,12 +3,12 @@
 page_title: "datadog_cloud_workload_security_agent_rules Data Source - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  Use this data source to retrieve information about existing Cloud Workload Security Agent Rules for use in other resources.
+  Use this data source to retrieve information about existing Cloud Workload Security Agent Rules for use in other resources (this resource is going to be deprecated soon).
 ---
 
 # datadog_cloud_workload_security_agent_rules (Data Source)
 
-Use this data source to retrieve information about existing Cloud Workload Security Agent Rules for use in other resources.
+Use this data source to retrieve information about existing Cloud Workload Security Agent Rules for use in other resources (this resource is going to be deprecated soon).
 
 ## Example Usage
 

--- a/docs/data-sources/cloud_workload_security_agent_rules.md
+++ b/docs/data-sources/cloud_workload_security_agent_rules.md
@@ -3,12 +3,12 @@
 page_title: "datadog_cloud_workload_security_agent_rules Data Source - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  Use this data source to retrieve information about existing Cloud Workload Security Agent Rules for use in other resources (this data source is going to be deprecated soon).
+  Use this data source to retrieve information about existing Cloud Workload Security Agent Rules for use in other resources. Deprecated, use CSM Threats Agent Rules instead: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/data-sources/csmthreatsagent_rules
 ---
 
 # datadog_cloud_workload_security_agent_rules (Data Source)
 
-Use this data source to retrieve information about existing Cloud Workload Security Agent Rules for use in other resources (this data source is going to be deprecated soon).
+Use this data source to retrieve information about existing Cloud Workload Security Agent Rules for use in other resources. Deprecated, use CSM Threats Agent Rules instead: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/data-sources/csm_threats_agent_rules
 
 ## Example Usage
 

--- a/docs/data-sources/cloud_workload_security_agent_rules.md
+++ b/docs/data-sources/cloud_workload_security_agent_rules.md
@@ -3,12 +3,12 @@
 page_title: "datadog_cloud_workload_security_agent_rules Data Source - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  Use this data source to retrieve information about existing Cloud Workload Security Agent Rules for use in other resources (this resource is going to be deprecated soon).
+  Use this data source to retrieve information about existing Cloud Workload Security Agent Rules for use in other resources (this data source is going to be deprecated soon).
 ---
 
 # datadog_cloud_workload_security_agent_rules (Data Source)
 
-Use this data source to retrieve information about existing Cloud Workload Security Agent Rules for use in other resources (this resource is going to be deprecated soon).
+Use this data source to retrieve information about existing Cloud Workload Security Agent Rules for use in other resources (this data source is going to be deprecated soon).
 
 ## Example Usage
 

--- a/docs/resources/cloud_workload_security_agent_rule.md
+++ b/docs/resources/cloud_workload_security_agent_rule.md
@@ -3,12 +3,12 @@
 page_title: "datadog_cloud_workload_security_agent_rule Resource - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  Provides a Datadog Cloud Workload Security Agent Rule API resource for agent rules (this resource is going to be deprecated soon).
+  Provides a Datadog Cloud Workload Security Agent Rule API resource for agent rules. Deprecated, use CSM Threats Agent Rule instead: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/csmthreatsagent_rule
 ---
 
 # datadog_cloud_workload_security_agent_rule (Resource)
 
-Provides a Datadog Cloud Workload Security Agent Rule API resource for agent rules (this resource is going to be deprecated soon).
+Provides a Datadog Cloud Workload Security Agent Rule API resource for agent rules. Deprecated, use CSM Threats Agent Rule instead: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/csm_threats_agent_rule
 
 ## Example Usage
 

--- a/docs/resources/cloud_workload_security_agent_rule.md
+++ b/docs/resources/cloud_workload_security_agent_rule.md
@@ -3,12 +3,12 @@
 page_title: "datadog_cloud_workload_security_agent_rule Resource - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  Provides a Datadog Cloud Workload Security Agent Rule API resource for agent rules.
+  Provides a Datadog Cloud Workload Security Agent Rule API resource for agent rules (this resource is going to be deprecated soon).
 ---
 
 # datadog_cloud_workload_security_agent_rule (Resource)
 
-Provides a Datadog Cloud Workload Security Agent Rule API resource for agent rules.
+Provides a Datadog Cloud Workload Security Agent Rule API resource for agent rules (this resource is going to be deprecated soon).
 
 ## Example Usage
 


### PR DESCRIPTION
We want to surface the customers the `cloud_workload_security` resources are going to be deprecated soon, this PR updates the description to mention this.