### PR TITLE
Update Dashboard docs to match API docs

### DIFF
--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -738,10 +738,10 @@ resource "datadog_dashboard" "free_dashboard" {
 
 - `dashboard_lists` (Set of Number) A list of dashboard lists this dashboard belongs to. This attribute should not be set if managing the corresponding dashboard lists using Terraform as it causes inconsistent behavior.
 - `description` (String) The description of the dashboard.
-- `is_read_only` (Boolean, Deprecated) Whether this dashboard is read-only. **Deprecated.** Prefer using `restricted_roles` to define which roles are required to edit the dashboard. Defaults to `false`.
+- `is_read_only` (Boolean, Deprecated) Whether this dashboard is read-only. Defaults to `false`. **Deprecated.** Please use `datadog_restriction_policy` to manage authorization.
 - `notify_list` (Set of String) The list of handles for the users to notify when changes are made to this dashboard.
 - `reflow_type` (String) The reflow type of a new dashboard layout. Set this only when layout type is `ordered`. If set to `fixed`, the dashboard expects all widgets to have a layout, and if it's set to `auto`, widgets should not have layouts. Valid values are `auto`, `fixed`.
-- `restricted_roles` (Set of String) UUIDs of roles whose associated users are authorized to edit the dashboard.
+- `restricted_roles` (Set of String) UUIDs of roles whose associated users are authorized to edit the dashboard. **Deprecated.** Please use `datadog_restriction_policy` to manage authorization.
 - `tags` (List of String) A list of tags assigned to the Dashboard. Only team names of the form `team:<name>` are supported.
 - `template_variable` (Block List) The list of template variables for this dashboard. (see [below for nested schema](#nestedblock--template_variable))
 - `template_variable_preset` (Block List) The list of selectable template variable presets for this dashboard. (see [below for nested schema](#nestedblock--template_variable_preset))


### PR DESCRIPTION
Updating the TF docs to reflect deprecation of `is_read_only` and `restricted_roles`, per the API docs - https://docs.datadoghq.com/api/latest/dashboards/