### PR TITLE
[datadog_synthetics_test] Fix docs for `browser_step.params.email`

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -958,7 +958,7 @@ func syntheticsBrowserStepParams() schema.Schema {
 					Optional:    true,
 				},
 				"element": {
-					Description: "Element to use for the step, json encoded string.",
+					Description: "Element to use for the step, JSON encoded string.",
 					Type:        schema.TypeString,
 					Optional:    true,
 					DiffSuppressFunc: func(key, old, new string, d *schema.ResourceData) bool {
@@ -1015,7 +1015,7 @@ func syntheticsBrowserStepParams() schema.Schema {
 					},
 				},
 				"email": {
-					Description: `Details of the email for an "assert email" step.`,
+					Description: `Details of the email for an "assert email" step, JSON encoded string.`,
 					Type:        schema.TypeString,
 					Optional:    true,
 				},
@@ -1028,7 +1028,7 @@ func syntheticsBrowserStepParams() schema.Schema {
 					},
 				},
 				"files": {
-					Description: `Details of the files for an "upload files" step, json encoded string.`,
+					Description: `Details of the files for an "upload files" step, JSON encoded string.`,
 					Type:        schema.TypeString,
 					Optional:    true,
 				},

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -719,7 +719,7 @@ Optional:
 - `delay` (Number) Delay between each key stroke for a "type test" step.
 - `element` (String) Element to use for the step, json encoded string.
 - `element_user_locator` (Block List, Max: 1) Custom user selector to use for the step. (see [below for nested schema](#nestedblock--browser_step--params--element_user_locator))
-- `email` (String) Details of the email for an "assert email" step.
+- `email` (String) Details of the email for an "assert email" step, json encoded string.
 - `file` (String) JSON encoded string used for an "assert download" step. Refer to the examples for a usage example showing the schema.
 - `files` (String) Details of the files for an "upload files" step, json encoded string.
 - `modifiers` (List of String) Modifier to use for a "press key" step.

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -717,11 +717,11 @@ Optional:
 - `click_type` (String) Type of click to use for a "click" step.
 - `code` (String) Javascript code to use for the step.
 - `delay` (Number) Delay between each key stroke for a "type test" step.
-- `element` (String) Element to use for the step, json encoded string.
+- `element` (String) Element to use for the step, JSON encoded string.
 - `element_user_locator` (Block List, Max: 1) Custom user selector to use for the step. (see [below for nested schema](#nestedblock--browser_step--params--element_user_locator))
-- `email` (String) Details of the email for an "assert email" step, json encoded string.
+- `email` (String) Details of the email for an "assert email" step, JSON encoded string.
 - `file` (String) JSON encoded string used for an "assert download" step. Refer to the examples for a usage example showing the schema.
-- `files` (String) Details of the files for an "upload files" step, json encoded string.
+- `files` (String) Details of the files for an "upload files" step, JSON encoded string.
 - `modifiers` (List of String) Modifier to use for a "press key" step.
 - `playing_tab_id` (String) ID of the tab to play the subtest.
 - `request` (String) Request for an API step.


### PR DESCRIPTION
It was not specified the parameter `browser_step.params.email` must be a JSON encoded string, as I discovered on my own.