### PR TITLE
[datadog_security_monitoring_suppression] Fix API calls returning 409

### DIFF
--- a/datadog/fwprovider/resource_datadog_security_monitoring_suppression.go
+++ b/datadog/fwprovider/resource_datadog_security_monitoring_suppression.go
@@ -2,6 +2,7 @@ package fwprovider
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
@@ -33,6 +34,8 @@ type securityMonitoringSuppressionResource struct {
 	api  *datadogV2.SecurityMonitoringApi
 	auth context.Context
 }
+
+var suppressionWriteMutex = sync.Mutex{}
 
 func NewSecurityMonitoringSuppressionResource() resource.Resource {
 	return &securityMonitoringSuppressionResource{}
@@ -103,6 +106,9 @@ func (r *securityMonitoringSuppressionResource) Create(ctx context.Context, requ
 		return
 	}
 
+	suppressionWriteMutex.Lock()
+	defer suppressionWriteMutex.Unlock()
+
 	res, _, err := r.api.CreateSecurityMonitoringSuppression(r.auth, *suppressionPayload)
 	if err != nil {
 		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating security monitoring suppression"))
@@ -158,6 +164,9 @@ func (r *securityMonitoringSuppressionResource) Update(ctx context.Context, requ
 		return
 	}
 
+	suppressionWriteMutex.Lock()
+	defer suppressionWriteMutex.Unlock()
+
 	res, _, err := r.api.UpdateSecurityMonitoringSuppression(r.auth, state.Id.ValueString(), *suppressionPayload)
 	if err != nil {
 		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating security monitoring suppression"))
@@ -180,6 +189,9 @@ func (r *securityMonitoringSuppressionResource) Delete(ctx context.Context, requ
 	}
 
 	id := state.Id.ValueString()
+
+	suppressionWriteMutex.Lock()
+	defer suppressionWriteMutex.Unlock()
 
 	httpResp, err := r.api.DeleteSecurityMonitoringSuppression(r.auth, id)
 	if err != nil {


### PR DESCRIPTION
Add a lock for Security Monitoring suppressions API calls to avoid conflicts; only affects write endpoints.