### PR TITLE
[datadog_service_account] Implement exact match filtering

### DIFF
--- a/datadog/fwprovider/data_source_datadog_service_account.go
+++ b/datadog/fwprovider/data_source_datadog_service_account.go
@@ -24,6 +24,7 @@ type datadogServiceAccountDatasourceModel struct {
 	ID           types.String `tfsdk:"id"`
 	Filter       types.String `tfsdk:"filter"`
 	FilterStatus types.String `tfsdk:"filter_status"`
+	ExactMatch   types.Bool   `tfsdk:"exact_match"`
 	// Results
 	Disabled types.Bool   `tfsdk:"disabled"`
 	Email    types.String `tfsdk:"email"`
@@ -67,6 +68,10 @@ func (d *datadogServiceAccountDatasource) Schema(_ context.Context, _ datasource
 			},
 			"filter_status": schema.StringAttribute{
 				Description: "Filter on status attribute. Comma separated list, with possible values `Active`, `Pending`, and `Disabled`.",
+				Optional:    true,
+			},
+			"exact_match": schema.BoolAttribute{
+				Description: "When true, `filter` string is exact matched against the user's `email`, followed by `name` attribute.",
 				Optional:    true,
 			},
 			// Computed values
@@ -133,7 +138,8 @@ func (d *datadogServiceAccountDatasource) Read(ctx context.Context, req datasour
 		userData = ddResp.Data
 	} else {
 		optionalParams := datadogV2.ListUsersOptionalParameters{}
-		optionalParams.WithFilter(state.Filter.ValueString())
+		filter := state.Filter.ValueString()
+		optionalParams.WithFilter(filter)
 		if !state.FilterStatus.IsNull() {
 			optionalParams.WithFilterStatus(state.FilterStatus.ValueString())
 		}
@@ -151,7 +157,8 @@ func (d *datadogServiceAccountDatasource) Read(ctx context.Context, req datasour
 				serviceAccounts = append(serviceAccounts, user)
 			}
 		}
-		if len(serviceAccounts) > 1 {
+		isExactMatch := state.ExactMatch.ValueBool()
+		if len(serviceAccounts) > 1 && !isExactMatch {
 			resp.Diagnostics.AddError("filter keyword returned more than one result, use more specific search criteria", "")
 			return
 		}
@@ -160,6 +167,29 @@ func (d *datadogServiceAccountDatasource) Read(ctx context.Context, req datasour
 			return
 		}
 		userData = &serviceAccounts[0]
+		if isExactMatch {
+			matchCount := 0
+			for _, serviceAccount := range serviceAccounts {
+				if *serviceAccount.GetAttributes().Email == filter {
+					userData = &serviceAccount
+					matchCount++
+					continue
+				}
+				if *serviceAccount.GetAttributes().Name.Get() == filter {
+					userData = &serviceAccount
+					matchCount++
+					continue
+				}
+			}
+			if matchCount > 1 {
+				resp.Diagnostics.AddError("your query returned more than one result for filter with exact match, please try a more specific search criteria", "")
+				return
+			}
+			if matchCount == 0 {
+				resp.Diagnostics.AddError("didn't find any service account matching filter string with exact match", "")
+				return
+			}
+		}
 	}
 	d.updateState(ctx, &state, userData)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)

--- a/docs/data-sources/service_account.md
+++ b/docs/data-sources/service_account.md
@@ -17,6 +17,7 @@ Use this data source to retrieve information about an existing Datadog service a
 
 ### Optional
 
+- `exact_match` (Boolean) When true, `filter` string is exact matched against the user's `email`, followed by `name` attribute.
 - `filter` (String) Filter all users and service accounts by name, email, or role.
 - `filter_status` (String) Filter on status attribute. Comma separated list, with possible values `Active`, `Pending`, and `Disabled`.
 - `id` (String) The service account's ID.


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/ACCESS-2606

I modeled this off of the existing exact match filtering in `data_source_datadog_user`

Not sure whether I should match by name or email first, or whether it really even matters.

It didn't make sense to me to exact match by role, even if the filter string will filter for roles...