### PR TITLE
[datadog_application_key] Stop overwriting key values in state when the API omits the key

### DIFF
--- a/datadog/fwprovider/resource_datadog_application_key.go
+++ b/datadog/fwprovider/resource_datadog_application_key.go
@@ -160,5 +160,7 @@ func (r *applicationKeyResource) buildDatadogApplicationKeyUpdateV2Struct(state 
 func (r *applicationKeyResource) updateState(state *applicationKeyResourceModel, applicationKeyData *datadogV2.FullApplicationKey) {
 	applicationKeyAttributes := applicationKeyData.GetAttributes()
 	state.Name = types.StringValue(applicationKeyAttributes.GetName())
-	state.Key = types.StringValue(applicationKeyAttributes.GetKey())
+	if applicationKeyAttributes.HasKey() {
+		state.Key = types.StringValue(applicationKeyAttributes.GetKey())
+	}
 }


### PR DESCRIPTION
When updating or importing application key resources, if the Datadog API does not include the optional computed `key` field, then the field is overwritten with an empty string in terraform state. The key is immutable so it does not need to be updated once it has been initially set.

Added a check to ensure the field is set before writing it into the response. 

Tested manually via integration test against API responses with and without the key field. Updated unit test to match new behavior and not depend on the API returning an optional field.