### PR TITLE
[provider] Introduce a non-enriched enum validator for enum edge cases

### DIFF
--- a/datadog/fwprovider/resource_datadog_team_permission_setting.go
+++ b/datadog/fwprovider/resource_datadog_team_permission_setting.go
@@ -70,9 +70,9 @@ func (r *teamPermissionSettingResource) Schema(_ context.Context, _ resource.Sch
 			},
 			"value": schema.StringAttribute{
 				Required:    true,
-				Description: "The action value.",
+				Description: "The action value. Valid values are dependent on the action. `manage_membership` action allows `admins`, `members`, `organization`, `user_access_manage` values. `edit` action allows `admins`, `members`, `teams_manage` values.",
 				Validators: []validator.String{
-					validators.NewEnumValidator[validator.String](datadogV2.NewTeamPermissionSettingValueFromValue),
+					validators.NewEnumValidatorSkipEnrichSchema[validator.String](datadogV2.NewTeamPermissionSettingValueFromValue),
 				},
 			},
 			"id": utils.ResourceIDAttribute(),

--- a/datadog/internal/fwutils/fw_enrich_schema.go
+++ b/datadog/internal/fwutils/fw_enrich_schema.go
@@ -61,6 +61,10 @@ func buildEnrichedSchemaDescription(rv reflect.Value) {
 	if validators.IsValid() && !validators.IsNil() && validators.Len() > 0 {
 		for i := 0; i < validators.Len(); i++ {
 			if strings.HasPrefix(validators.Index(i).Elem().Type().Name(), "enumValidator") {
+				enrichSchema := validators.Index(i).Elem().FieldByName("enrichSchema").Bool()
+				if !enrichSchema {
+					continue
+				}
 				allowedValues := validators.Index(i).Elem().FieldByName("AllowedEnumValues")
 				v := reflect.ValueOf(allowedValues.Interface())
 				validValuesMsg := ""

--- a/datadog/internal/validators/enum_validator.go
+++ b/datadog/internal/validators/enum_validator.go
@@ -16,12 +16,20 @@ func NewEnumValidator[T any](i interface{}) enumValidator[T] {
 	return enumValidator[T]{
 		enumFunc:          i,
 		AllowedEnumValues: allowedValues,
+		enrichSchema:      true,
 	}
+}
+
+func NewEnumValidatorSkipEnrichSchema[T any](i interface{}) enumValidator[T] {
+	validator := NewEnumValidator[T](i)
+	validator.enrichSchema = false
+	return validator
 }
 
 type enumValidator[T any] struct {
 	enumFunc          interface{}
 	AllowedEnumValues interface{}
+	enrichSchema      bool
 }
 
 func (v enumValidator[T]) Description(ctx context.Context) string {

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -415,11 +415,11 @@ resource "datadog_synthetics_test" "grpc" {
   type    = "api"
   subtype = "grpc"
   request_definition {
-    method           = "GET"
-    host             = "google.com"
-    port             = 50050
-    service          = "helloworld.Greeter"
-    message          = ""
+    method  = "GET"
+    host    = "google.com"
+    port    = 50050
+    service = "helloworld.Greeter"
+    message = ""
   }
   assertion {
     type     = "responseTime"

--- a/docs/resources/team_permission_setting.md
+++ b/docs/resources/team_permission_setting.md
@@ -33,7 +33,7 @@ resource "datadog_team_permission_setting" "foo" {
 
 - `action` (String) The identifier for the action. Valid values are `manage_membership`, `edit`.
 - `team_id` (String) ID of the team the team permission setting is associated with.
-- `value` (String) The action value. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`.
+- `value` (String) The action value. Valid values are dependent on the action. `manage_membership` action allows `admins`, `members`, `organization`, `user_access_manage` values. `edit` action allows `admins`, `members`, `teams_manage` values.
 
 ### Read-Only
 

--- a/examples/resources/datadog_synthetics_test/resource.tf
+++ b/examples/resources/datadog_synthetics_test/resource.tf
@@ -374,11 +374,11 @@ resource "datadog_synthetics_test" "grpc" {
   type    = "api"
   subtype = "grpc"
   request_definition {
-    method           = "GET"
-    host             = "google.com"
-    port             = 50050
-    service          = "helloworld.Greeter"
-    message          = ""
+    method  = "GET"
+    host    = "google.com"
+    port    = 50050
+    service = "helloworld.Greeter"
+    message = ""
   }
   assertion {
     type     = "responseTime"


### PR DESCRIPTION
Allows us to skip automatically generating the valid values list for enums in descriptions, for cases where extra context is needed.
Resolves: #2446 