### PR TITLE
[datadog_application_key] Add deprecation warning to datadog_application_key data source

### DIFF
--- a/datadog/tests/data_source_datadog_application_key_test.go
+++ b/datadog/tests/data_source_datadog_application_key_test.go
@@ -17,7 +17,6 @@ func TestAccDatadogApplicationKeyDatasource_matchId(t *testing.T) {
 	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
 
 	applicationKeyName := uniqueEntityName(ctx, t)
-	nonEmptyStringRegex := `[\S\s]+[\S]+`
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV5ProviderFactories: accProviders,
@@ -30,7 +29,6 @@ func TestAccDatadogApplicationKeyDatasource_matchId(t *testing.T) {
 					resource.TestCheckResourceAttr("datadog_application_key.app_key_1", "name", fmt.Sprintf("%s 1", applicationKeyName)),
 					resource.TestCheckResourceAttr("datadog_application_key.app_key_2", "name", fmt.Sprintf("%s 2", applicationKeyName)),
 					resource.TestCheckResourceAttr("data.datadog_application_key.app_key", "name", fmt.Sprintf("%s 1", applicationKeyName)),
-					resource.TestMatchResourceAttr("data.datadog_application_key.app_key", "key", regexp.MustCompile(nonEmptyStringRegex)),
 					resource.TestCheckResourceAttrSet("data.datadog_application_key.app_key", "id"),
 				),
 			},
@@ -46,7 +44,6 @@ func TestAccDatadogApplicationKeyDatasource_matchName(t *testing.T) {
 	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
 	applicationKeyName := uniqueEntityName(ctx, t)
 
-	nonEmptyStringRegex := `[\S\s]+[\S]+`
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV5ProviderFactories: accProviders,
@@ -59,7 +56,6 @@ func TestAccDatadogApplicationKeyDatasource_matchName(t *testing.T) {
 					resource.TestCheckResourceAttr("datadog_application_key.app_key_1", "name", fmt.Sprintf("%s 1", applicationKeyName)),
 					resource.TestCheckResourceAttr("datadog_application_key.app_key_2", "name", fmt.Sprintf("%s 2", applicationKeyName)),
 					resource.TestCheckResourceAttr("data.datadog_application_key.app_key", "name", fmt.Sprintf("%s 1", applicationKeyName)),
-					resource.TestMatchResourceAttr("data.datadog_application_key.app_key", "key", regexp.MustCompile(nonEmptyStringRegex)),
 					resource.TestCheckResourceAttrSet("data.datadog_application_key.app_key", "id"),
 				),
 			},
@@ -70,7 +66,6 @@ func TestAccDatadogApplicationKeyDatasource_matchName(t *testing.T) {
 					resource.TestCheckResourceAttr("datadog_application_key.app_key_1", "name", applicationKeyName),
 					resource.TestCheckResourceAttr("datadog_application_key.app_key_2", "name", fmt.Sprintf("%s 2", applicationKeyName)),
 					resource.TestCheckResourceAttr("data.datadog_application_key.app_key", "name", applicationKeyName),
-					resource.TestMatchResourceAttr("data.datadog_application_key.app_key", "key", regexp.MustCompile(nonEmptyStringRegex)),
 					resource.TestCheckResourceAttrSet("data.datadog_application_key.app_key", "id"),
 				),
 			},
@@ -86,7 +81,6 @@ func TestAccDatadogApplicationKeyDatasource_exactMatchName(t *testing.T) {
 	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
 	applicationKeyName := uniqueEntityName(ctx, t)
 
-	nonEmptyStringRegex := `[\S\s]+[\S]+`
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV5ProviderFactories: accProviders,
@@ -99,7 +93,6 @@ func TestAccDatadogApplicationKeyDatasource_exactMatchName(t *testing.T) {
 					resource.TestCheckResourceAttr("datadog_application_key.app_key_1", "name", applicationKeyName),
 					resource.TestCheckResourceAttr("datadog_application_key.app_key_2", "name", fmt.Sprintf("%s 2", applicationKeyName)),
 					resource.TestCheckResourceAttr("data.datadog_application_key.app_key", "name", applicationKeyName),
-					resource.TestMatchResourceAttr("data.datadog_application_key.app_key", "key", regexp.MustCompile(nonEmptyStringRegex)),
 					resource.TestCheckResourceAttrSet("data.datadog_application_key.app_key", "id"),
 				),
 			},

--- a/docs/data-sources/application_key.md
+++ b/docs/data-sources/application_key.md
@@ -3,12 +3,12 @@
 page_title: "datadog_application_key Data Source - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  Use this data source to retrieve information about an existing application key.
+  Use this data source to retrieve information about an existing application key. Deprecated. This will be removed in a future release with prior notice. Securely store your application keys using a secret management system or use the datadogapplicationkey resource to manage application keys in your Datadog account.
 ---
 
 # datadog_application_key (Data Source)
 
-Use this data source to retrieve information about an existing application key.
+Use this data source to retrieve information about an existing application key. Deprecated. This will be removed in a future release with prior notice. Securely store your application keys using a secret management system or use the datadog_application_key resource to manage application keys in your Datadog account.
 
 ## Example Usage
 


### PR DESCRIPTION
Add new deprecation message to datadog_application_key data source.

Followed these guidelines: https://developer.hashicorp.com/terraform/plugin/framework/deprecations#provider-data-source-or-resource-removal

Tested locally.

**Warning when deprecated data source is used:**

```
=> terraform plan
datadog_application_key.jackakeller-foo: Refreshing state... [id=ad77b716-c871-4e94-bb53-cef5ed244551]
data.datadog_application_key.foo: Reading...
data.datadog_application_key.foo: Read complete after 0s [id=ad77b716-c871-4e94-bb53-cef5ed244551]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
╷
│ Warning: Deprecated
│
│   with data.datadog_application_key.foo,
│   on main.tf line 24, in data "datadog_application_key" "foo":
│   24: data "datadog_application_key" "foo" {
│
│ The datadog_application_key data source is deprecated and will be removed in a future release with prior notice. Securely store your application key using a secret management
│ system or use the datadog_application_key resource to manage application keys in your Datadog account.
│
```

This also is printed for `terraform refresh` and `terraform apply`. On either `refresh` or `apply` the key is still stored in Terraform state.

**Error when deprecated source is used and application key is not provided from the datadog API:**

```
=> terraform plan
data.datadog_application_key.foo: Reading...
datadog_application_key.jackakeller-foo: Refreshing state... [id=ad77b716-c871-4e94-bb53-cef5ed244551]

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Warning: Deprecated
│
│   with data.datadog_application_key.foo,
│   on main.tf line 24, in data "datadog_application_key" "foo":
│   24: data "datadog_application_key" "foo" {
│
│ The datadog_application_key data source is deprecated and will be removed in a future release with prior notice. Securely store your application key using a secret management
│ system or use the datadog_application_key resource to manage application keys in your Datadog account.
│
│ (and one more similar warning elsewhere)
╵
╷
│ Error: Deprecated
│
│   with data.datadog_application_key.foo,
│   on main.tf line 24, in data "datadog_application_key" "foo":
│   24: data "datadog_application_key" "foo" {
│
│ The datadog_application_key data source is deprecated and will be removed in a future release. Securely store your application key using a secret management system or use the
│ datadog_application_key resource to manage application keys in your Datadog account.
```

This also is printed for `terraform refresh` and `terraform apply`.

**Testing note:**

If in the future we stop returning the `key` field, then the integration tests will start failing. This is okay because at that point the data source is no longer functional and the tests can be removed.

**Note:**

We are _not_  going to simply preserve pre-existing data sources by not overwriting the key value like for the [resource here](https://datadoghq.atlassian.net/browse/AUTHN-4201).

Right now, if you configure a data source based on the name, then it reads the current state from that name and overwrites key and UUID. In other words, it's always up to date with Datadog.

This means if you delete an app key that is already configured as a data source, and then create a new one with the same name, you'll get the new app key UUID and key.

If we preserve the original key's raw value, you could get the new UUID but have the old key value. Similarly, if we were to stop updating both UUID and key, then the name also wouldn't match current state. This would cause state drift.

(This is not a problem for imported resources because those import based solely on UUID, and name can still be read on future refreshes even without the key field)