### PR TITLE
[datadog_application_key] Add deprecation warning for importing datadog_application_key resources

### DIFF
--- a/datadog/fwprovider/resource_datadog_application_key.go
+++ b/datadog/fwprovider/resource_datadog_application_key.go
@@ -33,12 +33,16 @@ type applicationKeyResource struct {
 }
 
 func (r *applicationKeyResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
+	response.Diagnostics.AddWarning(
+		"Deprecated",
+		"The import functionality for datadog_application_key resources is deprecated and will be removed in a future release with prior notice. Securely store your application keys using a secret management system or use the datadog_application_key resource to create and manage new application keys.",
+	)
 	resource.ImportStatePassthroughID(ctx, frameworkPath.Root("id"), request, response)
 }
 
 func (r *applicationKeyResource) Schema(_ context.Context, _ resource.SchemaRequest, response *resource.SchemaResponse) {
 	response.Schema = schema.Schema{
-		Description: "Provides a Datadog Application Key resource. This can be used to create and manage Datadog Application Keys.",
+		Description: "Provides a Datadog Application Key resource. This can be used to create and manage Datadog Application Keys. Import functionality for this resource is deprecated and will be removed in a future release with prior notice. Securely store your application keys using a secret management system or use this resource to create and manage new application keys.",
 		Attributes: map[string]schema.Attribute{
 			"name": schema.StringAttribute{
 				Description: "Name for Application Key.",

--- a/docs/resources/application_key.md
+++ b/docs/resources/application_key.md
@@ -3,12 +3,12 @@
 page_title: "datadog_application_key Resource - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  Provides a Datadog Application Key resource. This can be used to create and manage Datadog Application Keys.
+  Provides a Datadog Application Key resource. This can be used to create and manage Datadog Application Keys. Import functionality for this resource is deprecated and will be removed in a future release with prior notice. Securely store your application keys using a secret management system or use this resource to create and manage new application keys.
 ---
 
 # datadog_application_key (Resource)
 
-Provides a Datadog Application Key resource. This can be used to create and manage Datadog Application Keys.
+Provides a Datadog Application Key resource. This can be used to create and manage Datadog Application Keys. Import functionality for this resource is deprecated and will be removed in a future release with prior notice. Securely store your application keys using a secret management system or use this resource to create and manage new application keys.
 
 ## Example Usage
 


### PR DESCRIPTION
Add a new deprecation warning that Import will no longer be supported for application keys.

```
=> terraform plan
datadog_application_key.jackakeller-foo-application-import: Preparing import... [id=ed3f601f-94e0-463d-bd37-3867ce24a063]
datadog_application_key.jackakeller-foo-application-import: Refreshing state... [id=ed3f601f-94e0-463d-bd37-3867ce24a063]

Terraform will perform the following actions:

  # datadog_application_key.jackakeller-foo-application-import will be imported
    resource "datadog_application_key" "jackakeller-foo-application-import" {
        id   = "ed3f601f-94e0-463d-bd37-3867ce24a063"
        key  = (sensitive value)
        name = "jackakeller-foo-application-import"
    }

Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.
╷
│ Warning: Deprecated
│
│ The import functionality for datadog_application_key resources is deprecated and will be removed in a future release with prior notice. Securely store your application keys using
│ a secret management system or use the datadog_application_key resource to create and manage new application keys.
╵
```

See https://developer.hashicorp.com/terraform/language/import