### PR TITLE
[datadog_ip_allowlist] fix ip_allowlist code example error

### DIFF
--- a/docs/resources/ip_allowlist.md
+++ b/docs/resources/ip_allowlist.md
@@ -17,12 +17,12 @@ resource "datadog_ip_allowlist" "example" {
   enabled = false
 
   entry {
-    cidr_block = "172.0.0.1/32"
+    cidr_block = "127.0.0.0/32"
     note       = "1st Example IP Range"
   }
 
   entry {
-    cidr_block = "127.0.0.0/32"
+    cidr_block = "192.0.2.0/24"
     note       = "2nd Example IP Range"
   }
 }

--- a/examples/resources/datadog_ip_allowlist/resource.tf
+++ b/examples/resources/datadog_ip_allowlist/resource.tf
@@ -2,12 +2,12 @@ resource "datadog_ip_allowlist" "example" {
   enabled = false
 
   entry {
-    cidr_block = "172.0.0.1/32"
+    cidr_block = "127.0.0.0/32"
     note       = "1st Example IP Range"
   }
 
   entry {
-    cidr_block = "127.0.0.0/32"
+    cidr_block = "192.0.2.0/24"
     note       = "2nd Example IP Range"
   }
 }


### PR DESCRIPTION
I added an example to the ip_allowlist terraform docs that accidentally used a real IP address. This PR fixes the issue.