### PR TITLE
[datadog_service_account][datadog_user] Fix typo in service_account and user

### DIFF
--- a/datadog/fwprovider/resource_datadog_service_account.go
+++ b/datadog/fwprovider/resource_datadog_service_account.go
@@ -70,7 +70,7 @@ func (r *serviceAccountResource) Schema(_ context.Context, _ resource.SchemaRequ
 				Required:    true,
 			},
 			"roles": schema.SetAttribute{
-				Description: "A list a role IDs to assign to the service account.",
+				Description: "A list of role IDs to assign to the service account.",
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,

--- a/datadog/resource_datadog_user.go
+++ b/datadog/resource_datadog_user.go
@@ -41,7 +41,7 @@ func resourceDatadogUser() *schema.Resource {
 					Optional:    true,
 				},
 				"roles": {
-					Description: "A list a role IDs to assign to the user.",
+					Description: "A list of role IDs to assign to the user.",
 					Type:        schema.TypeSet,
 					Optional:    true,
 					Computed:    true,

--- a/docs/resources/service_account.md
+++ b/docs/resources/service_account.md
@@ -36,7 +36,7 @@ resource "datadog_service_account" "bar" {
 
 - `disabled` (Boolean) Whether the service account is disabled. Defaults to `false`.
 - `name` (String) Name for the service account.
-- `roles` (Set of String) A list a role IDs to assign to the service account.
+- `roles` (Set of String) A list of role IDs to assign to the service account.
 
 ### Read-Only
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -37,7 +37,7 @@ resource "datadog_user" "foo" {
 
 - `disabled` (Boolean) Whether the user is disabled. Defaults to `false`.
 - `name` (String) Name for user.
-- `roles` (Set of String) A list a role IDs to assign to the user.
+- `roles` (Set of String) A list of role IDs to assign to the user.
 - `send_user_invitation` (Boolean) Whether an invitation email should be sent when the user is created. Defaults to `true`.
 
 ### Read-Only


### PR DESCRIPTION
`A list a role IDs` => `A list of role IDs`
 I searched accross all repo files for this specific typo and edited all changes