### PR TITLE
[repository] Enable ci for merge queue branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       - master
   schedule:
     - cron: "0 1 * * *"
+  push:
+    branches:
+      - mq-working-branch-master-**
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}-test


### PR DESCRIPTION
merge queue didn't know what to do because CI checks weren't allowed to run on the temporary branches it created