### PR TITLE
[SYNTH-15394] use new SyntheticsGlobalVariableRequest in global variable terraform resource

### DIFF
--- a/datadog/resource_datadog_synthetics_global_variable.go
+++ b/datadog/resource_datadog_synthetics_global_variable.go
@@ -156,8 +156,8 @@ func resourceDatadogSyntheticsGlobalVariableCreate(ctx context.Context, d *schem
 	apiInstances := providerConf.DatadogApiInstances
 	auth := providerConf.Auth
 
-	syntheticsGlobalRequestVariable := buildSyntheticsGlobalVariableRequestStruct(d)
-	createdSyntheticsGlobalVariable, httpResponse, err := apiInstances.GetSyntheticsApiV1().CreateGlobalVariable(auth, *syntheticsGlobalRequestVariable)
+	syntheticsGlobalVariableRequest := buildSyntheticsGlobalVariableRequestStruct(d)
+	createdSyntheticsGlobalVariable, httpResponse, err := apiInstances.GetSyntheticsApiV1().CreateGlobalVariable(auth, *syntheticsGlobalVariableRequest)
 	if err != nil {
 		// Note that Id won't be set, so no state will be saved.
 		return utils.TranslateClientErrorDiag(err, httpResponse, "error creating synthetics global variable")

--- a/datadog/resource_datadog_synthetics_global_variable.go
+++ b/datadog/resource_datadog_synthetics_global_variable.go
@@ -156,8 +156,8 @@ func resourceDatadogSyntheticsGlobalVariableCreate(ctx context.Context, d *schem
 	apiInstances := providerConf.DatadogApiInstances
 	auth := providerConf.Auth
 
-	syntheticsGlobalVariable := buildSyntheticsGlobalVariableStruct(d)
-	createdSyntheticsGlobalVariable, httpResponse, err := apiInstances.GetSyntheticsApiV1().CreateGlobalVariable(auth, *syntheticsGlobalVariable)
+	syntheticsGlobalRequestVariable := buildSyntheticsGlobalVariableRequestStruct(d)
+	createdSyntheticsGlobalVariable, httpResponse, err := apiInstances.GetSyntheticsApiV1().CreateGlobalVariable(auth, *syntheticsGlobalRequestVariable)
 	if err != nil {
 		// Note that Id won't be set, so no state will be saved.
 		return utils.TranslateClientErrorDiag(err, httpResponse, "error creating synthetics global variable")
@@ -220,8 +220,8 @@ func resourceDatadogSyntheticsGlobalVariableUpdate(ctx context.Context, d *schem
 	apiInstances := providerConf.DatadogApiInstances
 	auth := providerConf.Auth
 
-	syntheticsGlobalVariable := buildSyntheticsGlobalVariableStruct(d)
-	if _, httpResponse, err := apiInstances.GetSyntheticsApiV1().EditGlobalVariable(auth, d.Id(), *syntheticsGlobalVariable); err != nil {
+	syntheticsGlobalVariableRequest := buildSyntheticsGlobalVariableRequestStruct(d)
+	if _, httpResponse, err := apiInstances.GetSyntheticsApiV1().EditGlobalVariable(auth, d.Id(), *syntheticsGlobalVariableRequest); err != nil {
 		// If the Update callback returns with or without an error, the full state is saved.
 		utils.TranslateClientErrorDiag(err, httpResponse, "error updating synthetics global variable")
 	}
@@ -244,13 +244,13 @@ func resourceDatadogSyntheticsGlobalVariableDelete(ctx context.Context, d *schem
 	return nil
 }
 
-func buildSyntheticsGlobalVariableStruct(d *schema.ResourceData) *datadogV1.SyntheticsGlobalVariable {
-	syntheticsGlobalVariable := datadogV1.NewSyntheticsGlobalVariableWithDefaults()
+func buildSyntheticsGlobalVariableRequestStruct(d *schema.ResourceData) *datadogV1.SyntheticsGlobalVariableRequest {
+	syntheticsGlobalVariableRequest := datadogV1.NewSyntheticsGlobalVariableRequestWithDefaults()
 
-	syntheticsGlobalVariable.SetName(d.Get("name").(string))
+	syntheticsGlobalVariableRequest.SetName(d.Get("name").(string))
 
 	if description, ok := d.GetOk("description"); ok {
-		syntheticsGlobalVariable.SetDescription(description.(string))
+		syntheticsGlobalVariableRequest.SetDescription(description.(string))
 	}
 
 	tags := make([]string, 0)
@@ -259,7 +259,7 @@ func buildSyntheticsGlobalVariableStruct(d *schema.ResourceData) *datadogV1.Synt
 			tags = append(tags, s.(string))
 		}
 	}
-	syntheticsGlobalVariable.SetTags(tags)
+	syntheticsGlobalVariableRequest.SetTags(tags)
 
 	syntheticsGlobalVariableValue := datadogV1.SyntheticsGlobalVariableValue{}
 
@@ -279,11 +279,11 @@ func buildSyntheticsGlobalVariableStruct(d *schema.ResourceData) *datadogV1.Synt
 		syntheticsGlobalVariableValue.SetOptions(variableOptions)
 	}
 
-	syntheticsGlobalVariable.SetValue(syntheticsGlobalVariableValue)
+	syntheticsGlobalVariableRequest.SetValue(syntheticsGlobalVariableValue)
 
 	if parseTestID, ok := d.GetOk("parse_test_id"); ok {
 		if _, ok := d.GetOk("parse_test_options.0"); ok {
-			syntheticsGlobalVariable.SetParseTestPublicId(parseTestID.(string))
+			syntheticsGlobalVariableRequest.SetParseTestPublicId(parseTestID.(string))
 
 			parseTestOptions := datadogV1.SyntheticsGlobalVariableParseTestOptions{}
 			parseTestOptions.SetType(datadogV1.SyntheticsGlobalVariableParseTestOptionsType(d.Get("parse_test_options.0.type").(string)))
@@ -307,7 +307,7 @@ func buildSyntheticsGlobalVariableStruct(d *schema.ResourceData) *datadogV1.Synt
 				parseTestOptions.SetLocalVariableName(localVariableName.(string))
 			}
 
-			syntheticsGlobalVariable.SetParseTestOptions(parseTestOptions)
+			syntheticsGlobalVariableRequest.SetParseTestOptions(parseTestOptions)
 		}
 	}
 
@@ -316,10 +316,10 @@ func buildSyntheticsGlobalVariableStruct(d *schema.ResourceData) *datadogV1.Synt
 		attributes := datadogV1.SyntheticsGlobalVariableAttributes{
 			RestrictedRoles: *restrictedRoles,
 		}
-		syntheticsGlobalVariable.SetAttributes(attributes)
+		syntheticsGlobalVariableRequest.SetAttributes(attributes)
 	}
 
-	return syntheticsGlobalVariable
+	return syntheticsGlobalVariableRequest
 }
 
 func updateSyntheticsGlobalVariableLocalState(d *schema.ResourceData, syntheticsGlobalVariable *datadogV1.SyntheticsGlobalVariable) diag.Diagnostics {

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-datadog
 
 require (
-	github.com/DataDog/datadog-api-client-go/v2 v2.29.0
+	github.com/DataDog/datadog-api-client-go/v2 v2.29.1-0.20240821183809-7b88ddcf13e7
 	github.com/DataDog/dd-sdk-go-testing v0.0.0-20211116174033-1cd082e322ad
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/datadog-api-client-go/v2 v2.29.0 h1:b0vTasEPUc7FuCKaRFqbJB+88IdWL/f7LdKcasMV8Vo=
-github.com/DataDog/datadog-api-client-go/v2 v2.29.0/go.mod h1:QKOu6vscsh87fMY1lHfLEmNSunyXImj8BUaUWJXOehc=
+github.com/DataDog/datadog-api-client-go/v2 v2.29.1-0.20240821183809-7b88ddcf13e7 h1:VSigb7pzWYmfuknBzmPcxIvs1bycIKYD9T9PnvBYGm8=
+github.com/DataDog/datadog-api-client-go/v2 v2.29.1-0.20240821183809-7b88ddcf13e7/go.mod h1:QKOu6vscsh87fMY1lHfLEmNSunyXImj8BUaUWJXOehc=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=


### PR DESCRIPTION
This PR follows the latest change in datadog-api-spec, and use `syntheticsGlobalRequestVariable` instead of `syntheticsGlobalVariable`, the former being introduced by https://github.com/DataDog/datadog-api-spec/pull/2904.