### PR TITLE
[datadog_api_key] Add deprecation warning to datadog_api_key data source

### DIFF
--- a/docs/data-sources/api_key.md
+++ b/docs/data-sources/api_key.md
@@ -3,12 +3,12 @@
 page_title: "datadog_api_key Data Source - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  Use this data source to retrieve information about an existing api key.
+  Use this data source to retrieve information about an existing api key. Deprecated. This will be removed in a future release with prior notice. Securely store your API keys using a secret management system or use the datadogapikey resource to manage API keys in your Datadog account.
 ---
 
 # datadog_api_key (Data Source)
 
-Use this data source to retrieve information about an existing api key.
+Use this data source to retrieve information about an existing api key. Deprecated. This will be removed in a future release with prior notice. Securely store your API keys using a secret management system or use the datadog_api_key resource to manage API keys in your Datadog account.
 
 ## Example Usage
 


### PR DESCRIPTION
Add new deprecation message to datadog_api_key data source.

Followed these guidelines: https://developer.hashicorp.com/terraform/plugin/framework/deprecations#provider-data-source-or-resource-removal

Tested locally.

**Warning when deprecated data source is used**:
```sh
data.datadog_api_key.ddiner_test: Reading...
data.datadog_api_key.ddiner_test: Read complete after 1s [id=b4371e76-3361-4034-9b48-f15e7514587f]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
╷
│ Warning: Deprecated
│
│   with data.datadog_api_key.ddiner_test,
│   on main.tf line 15, in data "datadog_api_key" "ddiner_test":
│   15: data "datadog_api_key" "ddiner_test" {
│
│ Deprecated. This will be removed in a future release with prior notice. Securely store your API keys using a secret
│ management system or use the datadog_api_key resource to manage API keys in your Datadog account.
```

This also is printed for terraform refresh and terraform apply. On either refresh or apply the key is still stored in Terraform state.

**Error when deprecated source is used and application key is not provided from the datadog API**:
```sh
data.datadog_api_key.ddiner_test: Reading...

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Warning: Deprecated
│
│   with data.datadog_api_key.ddiner_test,
│   on main.tf line 15, in data "datadog_api_key" "ddiner_test":
│   15: data "datadog_api_key" "ddiner_test" {
│
│ Deprecated. This will be removed in a future release with prior notice. Securely store your API keys using a secret
│ management system or use the datadog_api_key resource to manage API keys in your Datadog account.
│
│ (and one more similar warning elsewhere)
╵
╷
│ Error: Deprecated
│
│   with data.datadog_api_key.ddiner_test,
│   on main.tf line 15, in data "datadog_api_key" "ddiner_test":
│   15: data "datadog_api_key" "ddiner_test" {
│
│ The datadog_api_key data source is deprecated and will be removed in a future release. Securely store your API key using a
│ secret management system or use the datadog_api_key resource to manage API keys in your Datadog account.
```

This also is printed for terraform refresh and terraform apply.

**Testing note**:

If in the future we stop returning the key field, then the integration tests will start failing. This is okay because at that point the data source is no longer functional and the tests can be removed.