### PR TITLE
[datadog_api_key] Add deprecation warning for importing datadog_api_key resources

### DIFF
--- a/datadog/fwprovider/resource_datadog_api_key.go
+++ b/datadog/fwprovider/resource_datadog_api_key.go
@@ -44,7 +44,7 @@ func (r *apiKeyResource) Metadata(_ context.Context, request resource.MetadataRe
 
 func (r *apiKeyResource) Schema(_ context.Context, _ resource.SchemaRequest, response *resource.SchemaResponse) {
 	response.Schema = schema.Schema{
-		Description: "Provides a Datadog API Key resource. This can be used to create and manage Datadog API Keys.",
+		Description: "Provides a Datadog API Key resource. This can be used to create and manage Datadog API Keys. Import functionality for this resource is deprecated and will be removed in a future release with prior notice. Securely store your API keys using a secret management system or use this resource to create and manage new API keys.",
 		Attributes: map[string]schema.Attribute{
 			"name": schema.StringAttribute{
 				Description: "Name for API Key.",
@@ -140,6 +140,10 @@ func (r *apiKeyResource) Delete(ctx context.Context, request resource.DeleteRequ
 }
 
 func (r *apiKeyResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
+	response.Diagnostics.AddWarning(
+		"Deprecated",
+		"The import functionality for datadog_api_key resources is deprecated and will be removed in a future release with prior notice. Securely store your API keys using a secret management system or use the datadog_api_key resource to create and manage new API keys.",
+	)
 	resource.ImportStatePassthroughID(ctx, frameworkPath.Root("id"), request, response)
 }
 

--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -3,12 +3,12 @@
 page_title: "datadog_api_key Resource - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  Provides a Datadog API Key resource. This can be used to create and manage Datadog API Keys.
+  Provides a Datadog API Key resource. This can be used to create and manage Datadog API Keys. Import functionality for this resource is deprecated and will be removed in a future release with prior notice. Securely store your API keys using a secret management system or use this resource to create and manage new API keys.
 ---
 
 # datadog_api_key (Resource)
 
-Provides a Datadog API Key resource. This can be used to create and manage Datadog API Keys.
+Provides a Datadog API Key resource. This can be used to create and manage Datadog API Keys. Import functionality for this resource is deprecated and will be removed in a future release with prior notice. Securely store your API keys using a secret management system or use this resource to create and manage new API keys.
 
 ## Example Usage
 


### PR DESCRIPTION
Add a new deprecation warning that Import will no longer be supported for application keys.
```sh
datadog_api_key.ddiner_test: Preparing import... [id=b4371e76-3361-4034-9b48-f15e7514587f]
datadog_api_key.ddiner_test: Refreshing state... [id=b4371e76-3361-4034-9b48-f15e7514587f]

Terraform will perform the following actions:

  # datadog_api_key.ddiner_test will be imported
    resource "datadog_api_key" "ddiner_test" {
        id   = "b4371e76-3361-4034-9b48-f15e7514587f"
        key  = (sensitive value)
        name = "ddiner-test"
    }

Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.
╷
│ Warning: Deprecated
│
│ The import functionality for datadog_api_key resources is deprecated and will be removed in a future release with prior
│ notice. Securely store your API keys using a secret management system or use the datadog_api_key resource to create and
│ manage new API keys.
╵
```