### PR TITLE
[datadog_api_key] Stop overwriting key values in state when the API omits the key

### DIFF
--- a/datadog/fwprovider/resource_datadog_api_key.go
+++ b/datadog/fwprovider/resource_datadog_api_key.go
@@ -162,5 +162,7 @@ func (r *apiKeyResource) buildDatadogApiKeyUpdateV2Struct(state *apiKeyResourceM
 func (r *apiKeyResource) updateState(state *apiKeyResourceModel, apiKeyData *datadogV2.FullAPIKey) {
 	apiKeyAttributes := apiKeyData.GetAttributes()
 	state.Name = types.StringValue(apiKeyAttributes.GetName())
-	state.Key = types.StringValue(apiKeyAttributes.GetKey())
+	if apiKeyAttributes.HasKey() {
+		state.Key = types.StringValue(apiKeyAttributes.GetKey())
+	}
 }

--- a/datadog/tests/resource_datadog_api_key_test.go
+++ b/datadog/tests/resource_datadog_api_key_test.go
@@ -21,6 +21,7 @@ func TestAccDatadogApiKey_Update(t *testing.T) {
 	apiKeyName := uniqueEntityName(ctx, t)
 	apiKeyNameUpdate := apiKeyName + "-2"
 	resourceName := "datadog_api_key.foo"
+	var apiKey string
 
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: accProviders,
@@ -31,7 +32,16 @@ func TestAccDatadogApiKey_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatadogApiKeyExists(providers.frameworkProvider, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", apiKeyName),
-					testAccCheckDatadogApiKeyValueMatches(providers.frameworkProvider, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "key"),
+					func(s *terraform.State) error {
+						resource, ok := s.RootModule().Resources[resourceName]
+						if !ok {
+							return fmt.Errorf("Resource not found: %s", resourceName)
+						}
+
+						apiKey = resource.Primary.Attributes["key"]
+						return nil
+					},
 				),
 			},
 			{
@@ -39,7 +49,18 @@ func TestAccDatadogApiKey_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatadogApiKeyExists(providers.frameworkProvider, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", apiKeyNameUpdate),
-					testAccCheckDatadogApiKeyValueMatches(providers.frameworkProvider, resourceName),
+					func(s *terraform.State) error {
+						resource, ok := s.RootModule().Resources[resourceName]
+						if !ok {
+							return fmt.Errorf("Resource not found: %s", resourceName)
+						}
+
+						stateAPIKey := resource.Primary.Attributes["key"]
+						if stateAPIKey != apiKey {
+							return fmt.Errorf("API key (%s) does not match expected value (%s)", stateAPIKey, apiKey)
+						}
+						return nil
+					},
 				),
 			},
 		},
@@ -95,33 +116,6 @@ func datadogApiKeyExistsHelper(ctx context.Context, s *terraform.State, apiInsta
 	id := s.RootModule().Resources[name].Primary.ID
 	if _, _, err := apiInstances.GetKeyManagementApiV2().GetAPIKey(ctx, id); err != nil {
 		return fmt.Errorf("received an error retrieving api key %s", err)
-	}
-	return nil
-}
-
-func testAccCheckDatadogApiKeyValueMatches(accProvider *fwprovider.FrameworkProvider, n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		apiInstances := accProvider.DatadogApiInstances
-		auth := accProvider.Auth
-
-		if err := datadogApiKeyValueMatches(auth, s, apiInstances, n); err != nil {
-			return err
-		}
-		return nil
-	}
-}
-
-func datadogApiKeyValueMatches(ctx context.Context, s *terraform.State, apiInstances *utils.ApiInstances, name string) error {
-	primaryResource := s.RootModule().Resources[name].Primary
-	id := primaryResource.ID
-	expectedKey := primaryResource.Attributes["key"]
-	resp, _, err := apiInstances.GetKeyManagementApiV2().GetAPIKey(ctx, id)
-	if err != nil {
-		return fmt.Errorf("received an error retrieving api key %s", err)
-	}
-	actualKey := resp.Data.Attributes.GetKey()
-	if expectedKey != actualKey {
-		return fmt.Errorf("api key value does not match")
 	}
 	return nil
 }


### PR DESCRIPTION
When updating or importing API key resources, if the Datadog API does not include the optional computed key field, then the field is overwritten with an empty string in terraform state. The key is immutable so it does not need to be updated once it has been initially set.

Added a check to ensure the field is set before writing it into the response.

Tested manually via integration test against API responses with and without the key field. Updated unit test to match new behavior and not depend on the API returning an optional field.