### PR TITLE
[datadog_restriction_policy] Allow policy deletions outside of terraform to prompt resource recreation

### DIFF
--- a/datadog/fwprovider/resource_datadog_restriction_policy.go
+++ b/datadog/fwprovider/resource_datadog_restriction_policy.go
@@ -197,7 +197,7 @@ func (r *RestrictionPolicyResource) updateState(ctx context.Context, state *Rest
 	data := resp.GetData()
 	attributes := data.GetAttributes()
 
-	if bindings, ok := attributes.GetBindingsOk(); ok && len(*bindings) > 0 {
+	if bindings, ok := attributes.GetBindingsOk(); ok {
 		state.Bindings = []*BindingsModel{}
 		for _, bindingsDd := range *bindings {
 			bindingsTfItem := BindingsModel{}

--- a/datadog/fwprovider/resource_datadog_restriction_policy.go
+++ b/datadog/fwprovider/resource_datadog_restriction_policy.go
@@ -109,7 +109,7 @@ func (r *RestrictionPolicyResource) Read(ctx context.Context, request resource.R
 		return
 	}
 
-	r.updateState(ctx, &state, &resp)
+	r.UpdateState(ctx, &state, &resp)
 
 	// Save data into Terraform state
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
@@ -138,7 +138,7 @@ func (r *RestrictionPolicyResource) Create(ctx context.Context, request resource
 		response.Diagnostics.AddError("response contains unparsedObject", err.Error())
 		return
 	}
-	r.updateState(ctx, &state, &resp)
+	r.UpdateState(ctx, &state, &resp)
 
 	// Save data into Terraform state
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
@@ -167,7 +167,7 @@ func (r *RestrictionPolicyResource) Update(ctx context.Context, request resource
 		response.Diagnostics.AddError("response contains unparsedObject", err.Error())
 		return
 	}
-	r.updateState(ctx, &state, &resp)
+	r.UpdateState(ctx, &state, &resp)
 
 	// Save data into Terraform state
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
@@ -191,7 +191,7 @@ func (r *RestrictionPolicyResource) Delete(ctx context.Context, request resource
 	}
 }
 
-func (r *RestrictionPolicyResource) updateState(ctx context.Context, state *RestrictionPolicyModel, resp *datadogV2.RestrictionPolicyResponse) {
+func (r *RestrictionPolicyResource) UpdateState(ctx context.Context, state *RestrictionPolicyModel, resp *datadogV2.RestrictionPolicyResponse) {
 	state.ID = types.StringValue(resp.Data.GetId())
 	state.ResourceId = types.StringValue(resp.Data.GetId())
 	data := resp.GetData()

--- a/datadog/tests/resource_datadog_restriction_policy_test.go
+++ b/datadog/tests/resource_datadog_restriction_policy_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -94,11 +93,7 @@ func TestUpdateStateWithEmptyRespClearsBindings(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	policy := &fwprovider.RestrictionPolicyResource{}
-	initialState := fwprovider.RestrictionPolicyModel{
-		ID:         basetypes.NewStringValue("baz"),
-		ResourceId: basetypes.NewStringValue("security-rule:abc-def-ghi"),
-		Bindings:   []*fwprovider.BindingsModel{},
-	}
+	initialState := fwprovider.RestrictionPolicyModel{}
 	resp := datadogV2.RestrictionPolicyResponse{
 		Data: datadogV2.RestrictionPolicy{
 			Attributes: datadogV2.RestrictionPolicyAttributes{
@@ -118,7 +113,7 @@ func TestUpdateStateWithEmptyRespClearsBindings(t *testing.T) {
 		t.Fatalf("Expected to find one binding, got %d", len(initialState.Bindings))
 	}
 
-	resp.Data.Attributes.Bindings = []datadogV2.RestrictionPolicyBinding{}
+	resp = datadogV2.RestrictionPolicyResponse{}
 	policy.UpdateState(ctx, &initialState, &resp)
 	if len(initialState.Bindings) != 0 {
 		t.Fatalf("Expected to find one binding, got %d", len(initialState.Bindings))


### PR DESCRIPTION
By not setting `state.Bindings` to an empty list if the attributes list is empty, we have a bug where if the policy was removed from a resource outside of terraform (manually in the UI, through the API, etc), it wouldn't be registered, and attempts to re-apply it would not detect a change.

Steps to reproduce the bug are:
1. Create a restriction policy using terraform
2. Delete the restriction policy in the UI
3. Run `terraform apply` again
  Expected: The policy gets recreated
  Actual: No differences are found, terraform succeeds with an empty apply.

Tested manually in a test env - confirmed that I could reproduce the original bug report, and that with this change, the policy was correctly reapplied in the same case.