### PR TITLE
[repo] block sdkv2 resources

### DIFF
--- a/.github/sdkv2-warning.yml
+++ b/.github/sdkv2-warning.yml
@@ -1,0 +1,7 @@
+comment:
+  on-update: recreate
+  snippets:
+    - id: post-deprecation-warning
+      body: |
+        > [!WARNING]
+        > It looks like you're adding a new `terraform-plugin-sdkv2` resource. If so, this is deprecated - going forward, all new resources must use the `terraform-plugin-framework`. If you are a Datadog employee and need guidance on this process, reach out to us at #api-clients.

--- a/.github/sdkv2-warning.yml
+++ b/.github/sdkv2-warning.yml
@@ -2,6 +2,8 @@ comment:
   on-update: recreate
   snippets:
     - id: post-deprecation-warning
+      files:
+        - 'datadog/*.go' # The actual check for new files is done in the workflow
       body: |
         > [!WARNING]
         > It looks like you're adding a new `terraform-plugin-sdkv2` resource. If so, this is deprecated - going forward, all new resources must use the `terraform-plugin-framework`. If you are a Datadog employee and need guidance on this process, reach out to us at #api-clients.

--- a/.github/workflows/sdkv2_deprecation.yaml
+++ b/.github/workflows/sdkv2_deprecation.yaml
@@ -1,12 +1,24 @@
+name: SDKv2 Deprecation Check
+
 on:
   pull_request:
-    paths:
-      - 'datadog/provider.go'
+    branches:
+      - main
+
 jobs:
-  post-deprecation:
+  check-sdkv2:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
+      - uses: actions/checkout@v4
+      - name: Get changed files
+        id: new-resources
+        uses: tj-actions/changed-files@v45
+        with:
+          files: "datadog/*.go"
       - uses: actions/github-script@v6
+        if: steps.new-resources.outputs.added_files_count != '0'
         with:
           script: |
             github.rest.issues.createComment({
@@ -16,3 +28,4 @@ jobs:
               body: '👋 it looks like the `terraform-plugin-sdkv2` provider definition was changed (`datadog/provider.go`) - are you adding a new SDKv2 resource? If so, this is deprecated - going forward, all new resources must use the terraform-plugin-framework. If you are a Datadog employee and need guidance on this process, reach out to us at #api-clients.'
             })
       - run: exit 1
+        if: steps.new-resources.outputs.added_files_count != '0'

--- a/.github/workflows/sdkv2_deprecation.yaml
+++ b/.github/workflows/sdkv2_deprecation.yaml
@@ -12,20 +12,17 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
       - name: Get changed files
         id: new-resources
         uses: tj-actions/changed-files@v45
         with:
           files: "datadog/*.go"
-      - uses: actions/github-script@v6
+      - uses: exercism/pr-commenter-action@v1.5.1
         if: steps.new-resources.outputs.added_files_count != '0'
         with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '👋 it looks like the `terraform-plugin-sdkv2` provider definition was changed (`datadog/provider.go`) - are you adding a new SDKv2 resource? If so, this is deprecated - going forward, all new resources must use the terraform-plugin-framework. If you are a Datadog employee and need guidance on this process, reach out to us at #api-clients.'
-            })
+          github-token: "${{ github.token }}"
+          config-file: ".github/sdkv2-warning.yml"
       - run: exit 1
         if: steps.new-resources.outputs.added_files_count != '0'

--- a/.github/workflows/sdkv2_deprecation.yaml
+++ b/.github/workflows/sdkv2_deprecation.yaml
@@ -1,0 +1,18 @@
+on:
+  pull_request:
+    paths:
+      - 'datadog/provider.go'
+jobs:
+  post-deprecation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '👋 it looks like the `terraform-plugin-sdkv2` provider definition was changed (`datadog/provider.go`) - are you adding a new SDKv2 resource? If so, this is deprecated - going forward, all new resources must use the terraform-plugin-framework. If you are a Datadog employee and need guidance on this process, reach out to us at #api-clients.'
+            })
+      - run: exit 1

--- a/.github/workflows/sdkv2_deprecation.yaml
+++ b/.github/workflows/sdkv2_deprecation.yaml
@@ -9,7 +9,7 @@ jobs:
   check-sdkv2:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Get changed files

--- a/.github/workflows/sdkv2_deprecation.yaml
+++ b/.github/workflows/sdkv2_deprecation.yaml
@@ -3,7 +3,7 @@ name: SDKv2 Deprecation Check
 on:
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   check-sdkv2:

--- a/datadog/resource_something_new.go
+++ b/datadog/resource_something_new.go
@@ -1,3 +1,0 @@
-package datadog
-
-// i made a new thing!

--- a/datadog/resource_something_new.go
+++ b/datadog/resource_something_new.go
@@ -1,0 +1,3 @@
+package datadog
+
+// i made a new thing!


### PR DESCRIPTION
Check for new sdkv2, failing any new `.go` files in the `datadog/` directory