### PR TITLE
[data_source_datadog_service_account] fix exact_match pointer bug

### DIFF
--- a/datadog/fwprovider/data_source_datadog_service_account.go
+++ b/datadog/fwprovider/data_source_datadog_service_account.go
@@ -122,7 +122,7 @@ func (d *datadogServiceAccountDatasource) Read(ctx context.Context, req datasour
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	var userData *datadogV2.User
+	var userData datadogV2.User
 	if !state.ID.IsNull() {
 		serviceAccountID := state.ID.ValueString()
 		ddResp, _, err := d.Api.GetUser(d.Auth, serviceAccountID)
@@ -135,7 +135,7 @@ func (d *datadogServiceAccountDatasource) Read(ctx context.Context, req datasour
 			resp.Diagnostics.AddError("Obtained entity was not a service account", "")
 			return
 		}
-		userData = ddResp.Data
+		userData = *ddResp.Data
 	} else {
 		optionalParams := datadogV2.ListUsersOptionalParameters{}
 		filter := state.Filter.ValueString()
@@ -166,17 +166,17 @@ func (d *datadogServiceAccountDatasource) Read(ctx context.Context, req datasour
 			resp.Diagnostics.AddError("filter keyword returned no results", "")
 			return
 		}
-		userData = &serviceAccounts[0]
+		userData = serviceAccounts[0]
 		if isExactMatch {
 			matchCount := 0
 			for _, serviceAccount := range serviceAccounts {
 				if *serviceAccount.GetAttributes().Email == filter {
-					userData = &serviceAccount
+					userData = serviceAccount
 					matchCount++
 					continue
 				}
 				if *serviceAccount.GetAttributes().Name.Get() == filter {
-					userData = &serviceAccount
+					userData = serviceAccount
 					matchCount++
 					continue
 				}
@@ -191,7 +191,7 @@ func (d *datadogServiceAccountDatasource) Read(ctx context.Context, req datasour
 			}
 		}
 	}
-	d.updateState(ctx, &state, userData)
+	d.updateState(ctx, &state, &userData)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 


### PR DESCRIPTION
Fixes #2571 

TL;DR: select the correct item when specifying an exact_match filter on the service_account data source

Passes the test added in the previous PR

Longer explanation: when iterating over multiple service account objects returned by the API, the `userData` variable is assigned to the pointer of the iterator `serviceAccount`. The underlying value keeps changing as we iterate over all items. It always ends up pointing to the last item in the collection, even if we did hit an exact match (`matchCount == 1`).