### PR TITLE
[datadog_synthetics_test] Fix http2 pseudo-headers not accepted

### DIFF
--- a/datadog/internal/validators/validators.go
+++ b/datadog/internal/validators/validators.go
@@ -308,8 +308,8 @@ func Float64Between(min, max float64) validator.String {
 func ValidateHttpRequestHeader(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(map[string]interface{})
 	for headerField, headerValue := range value {
-		if !isValidToken(headerField) {
-			errors = append(errors, fmt.Errorf("invalid value for %s (header field must be a valid token)", k))
+		if !isValidToken(headerField) && !isRequestPseudoHeader(headerField) {
+			errors = append(errors, fmt.Errorf("invalid value for %s (header field must be a valid token or a http/2 request pseudo-header)", k))
 			return
 		}
 		headerStringValue, ok := headerValue.(string)
@@ -326,6 +326,11 @@ func ValidateHttpRequestHeader(v interface{}, k string) (ws []string, errors []e
 		}
 	}
 	return
+}
+
+func isRequestPseudoHeader(header string) bool {
+	// :status is a response pseudo-header, and :protocol may only be used internally in websockets
+	return header == ":method" || header == ":scheme" || header == ":authority" || header == ":path"
 }
 
 func isValidToken(token string) bool {

--- a/datadog/internal/validators/validators_test.go
+++ b/datadog/internal/validators/validators_test.go
@@ -216,3 +216,52 @@ func TestValidateFloat64Between(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateHttpRequestHeader(t *testing.T) {
+	cases := []struct {
+		Value    map[string]interface{}
+		ErrCount int
+	}{
+		{
+			Value:    map[string]interface{}{"foo": "bar"},
+			ErrCount: 0,
+		},
+		{
+			Value:    map[string]interface{}{"content-length": "1"},
+			ErrCount: 0,
+		},
+		{
+			Value:    map[string]interface{}{":authority": "example.com"},
+			ErrCount: 0,
+		},
+		{
+			Value:    map[string]interface{}{"foo": "\t"},
+			ErrCount: 0,
+		},
+		{
+			Value:    map[string]interface{}{"not?token": "any"},
+			ErrCount: 1,
+		},
+		{
+			Value:    map[string]interface{}{":unknown": "any"},
+			ErrCount: 1,
+		},
+		{
+			Value:    map[string]interface{}{"foo": "\r"},
+			ErrCount: 1,
+		},
+		{
+			Value:    map[string]interface{}{"foo": "\n"},
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := ValidateHttpRequestHeader(tc.Value, "request_headers")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected http request header validation to trigger %d error(s) for value %q - instead saw %d",
+				tc.ErrCount, tc.Value, len(errors))
+		}
+	}
+}


### PR DESCRIPTION
After https://github.com/DataDog/terraform-provider-datadog/pull/2469, the following Terraform definition:

```tf
resource "datadog_synthetics_test" "test" {
  [...]
  request_headers = {
    ":authority" = "example.com"
  }
  [...]
}
```

Is failing with:

```
│ Error: invalid value for request_headers (header field must be a valid token)
│
│ with datadog_synthetics_test.test,
│ on modules/uptime-monitoring/main.tf line 51, in resource "datadog_synthetics_test" "test":
│ 51: request_headers = {
│ 52: ":authority" = "example.com"
│ 54: }
```