### PR TITLE
Fix permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+  workflows: write
+
 jobs:
   create_release:
     name: Create release


### PR DESCRIPTION
The Create Release job is getting a 403 when trying to create the release. This should give enough permissions for that job to run.