### PR TITLE
[resource_monitor_json] Avoid restricted role diffs with restriction_policy

### DIFF
--- a/datadog/tests/cassettes/TestAccDatadogMonitorJSONBasic.yaml
+++ b/datadog/tests/cassettes/TestAccDatadogMonitorJSONBasic.yaml
@@ -73,7 +73,7 @@ interactions:
         headers:
             Content-Type:
                 - application/json
-        url: https://api.datadoghq.com/api/v1/monitor/142875735
+        url: https://api.datadoghq.com/api/v1/monitor/142875735?with_restricted_roles=false
         method: GET
       response:
         proto: HTTP/1.1
@@ -85,7 +85,7 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"id":142875735,"org_id":321813,"type":"service check","name":"tf-TestAccDatadogMonitorJSONBasic-local-1712694310","message":"Change the message triggers if any host's clock goes out of sync with the time given by NTP. The offset threshold is configured in the Agent's 'ntp.yaml' file.\n\nSee [Troubleshooting NTP Offset issues](https://docs.datadoghq.com/agent/troubleshooting/ntp for more details on cause and resolution.","tags":[],"query":"\"ntp.in_sync\".by(\"*\").last(2).count_by_status()","options":{"include_tags":true,"new_host_delay":150,"notify_audit":false,"notify_no_data":false,"thresholds":{"warning":1,"ok":1,"critical":1},"silenced":{}},"multi":true,"created_at":1712694311000,"created":"2024-04-09T20:25:11.421316+00:00","modified":"2024-04-09T20:25:11.421316+00:00","deleted":null,"restricted_roles":null,"priority":null,"overall_state_modified":null,"overall_state":"No Data","creator":{"name":null,"email":"frog@datadoghq.com","handle":"frog@datadoghq.com","id":1445416}}
+            {"id":142875735,"org_id":321813,"type":"service check","name":"tf-TestAccDatadogMonitorJSONBasic-local-1712694310","message":"Change the message triggers if any host's clock goes out of sync with the time given by NTP. The offset threshold is configured in the Agent's 'ntp.yaml' file.\n\nSee [Troubleshooting NTP Offset issues](https://docs.datadoghq.com/agent/troubleshooting/ntp for more details on cause and resolution.","tags":[],"query":"\"ntp.in_sync\".by(\"*\").last(2).count_by_status()","options":{"include_tags":true,"new_host_delay":150,"notify_audit":false,"notify_no_data":false,"thresholds":{"warning":1,"ok":1,"critical":1},"silenced":{}},"multi":true,"created_at":1712694311000,"created":"2024-04-09T20:25:11.421316+00:00","modified":"2024-04-09T20:25:11.421316+00:00","deleted":null,"priority":null,"overall_state_modified":null,"overall_state":"No Data","creator":{"name":null,"email":"frog@datadoghq.com","handle":"frog@datadoghq.com","id":1445416}}
         headers:
             Content-Type:
                 - application/json
@@ -108,7 +108,7 @@ interactions:
         headers:
             Content-Type:
                 - application/json
-        url: https://api.datadoghq.com/api/v1/monitor/142875735
+        url: https://api.datadoghq.com/api/v1/monitor/142875735?with_restricted_roles=false
         method: GET
       response:
         proto: HTTP/1.1
@@ -120,7 +120,7 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"id":142875735,"org_id":321813,"type":"service check","name":"tf-TestAccDatadogMonitorJSONBasic-local-1712694310","message":"Change the message triggers if any host's clock goes out of sync with the time given by NTP. The offset threshold is configured in the Agent's 'ntp.yaml' file.\n\nSee [Troubleshooting NTP Offset issues](https://docs.datadoghq.com/agent/troubleshooting/ntp for more details on cause and resolution.","tags":[],"query":"\"ntp.in_sync\".by(\"*\").last(2).count_by_status()","options":{"include_tags":true,"new_host_delay":150,"notify_audit":false,"notify_no_data":false,"thresholds":{"warning":1,"ok":1,"critical":1},"silenced":{}},"multi":true,"created_at":1712694311000,"created":"2024-04-09T20:25:11.421316+00:00","modified":"2024-04-09T20:25:11.421316+00:00","deleted":null,"restricted_roles":null,"priority":null,"overall_state_modified":null,"overall_state":"No Data","creator":{"name":null,"email":"frog@datadoghq.com","handle":"frog@datadoghq.com","id":1445416}}
+            {"id":142875735,"org_id":321813,"type":"service check","name":"tf-TestAccDatadogMonitorJSONBasic-local-1712694310","message":"Change the message triggers if any host's clock goes out of sync with the time given by NTP. The offset threshold is configured in the Agent's 'ntp.yaml' file.\n\nSee [Troubleshooting NTP Offset issues](https://docs.datadoghq.com/agent/troubleshooting/ntp for more details on cause and resolution.","tags":[],"query":"\"ntp.in_sync\".by(\"*\").last(2).count_by_status()","options":{"include_tags":true,"new_host_delay":150,"notify_audit":false,"notify_no_data":false,"thresholds":{"warning":1,"ok":1,"critical":1},"silenced":{}},"multi":true,"created_at":1712694311000,"created":"2024-04-09T20:25:11.421316+00:00","modified":"2024-04-09T20:25:11.421316+00:00","deleted":null,"priority":null,"overall_state_modified":null,"overall_state":"No Data","creator":{"name":null,"email":"frog@datadoghq.com","handle":"frog@datadoghq.com","id":1445416}}
         headers:
             Content-Type:
                 - application/json
@@ -199,7 +199,7 @@ interactions:
         headers:
             Content-Type:
                 - application/json
-        url: https://api.datadoghq.com/api/v1/monitor/142875735
+        url: https://api.datadoghq.com/api/v1/monitor/142875735?with_restricted_roles=false
         method: GET
       response:
         proto: HTTP/1.1
@@ -211,7 +211,7 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"id":142875735,"org_id":321813,"type":"service check","name":"tf-TestAccDatadogMonitorJSONBasic-local-1712694310-updated","message":"Change the message triggers if any host's clock goes out of sync with the time given by NTP. The offset threshold is configured in the Agent's 'ntp.yaml' file.\n\nSee [Troubleshooting NTP Offset issues](https://docs.datadoghq.com/agent/troubleshooting/ntp for more details on cause and resolution.","tags":[],"query":"\"ntp.in_sync\".by(\"*\").last(2).count_by_status()","options":{"include_tags":true,"new_host_delay":150,"notify_audit":false,"notify_no_data":false,"thresholds":{"warning":1,"ok":1,"critical":1},"silenced":{}},"multi":true,"created_at":1712694311000,"created":"2024-04-09T20:25:11.421316+00:00","modified":"2024-04-09T20:25:13.564041+00:00","deleted":null,"restricted_roles":null,"priority":null,"overall_state_modified":null,"overall_state":"No Data","creator":{"name":null,"email":"frog@datadoghq.com","handle":"frog@datadoghq.com","id":1445416}}
+            {"id":142875735,"org_id":321813,"type":"service check","name":"tf-TestAccDatadogMonitorJSONBasic-local-1712694310-updated","message":"Change the message triggers if any host's clock goes out of sync with the time given by NTP. The offset threshold is configured in the Agent's 'ntp.yaml' file.\n\nSee [Troubleshooting NTP Offset issues](https://docs.datadoghq.com/agent/troubleshooting/ntp for more details on cause and resolution.","tags":[],"query":"\"ntp.in_sync\".by(\"*\").last(2).count_by_status()","options":{"include_tags":true,"new_host_delay":150,"notify_audit":false,"notify_no_data":false,"thresholds":{"warning":1,"ok":1,"critical":1},"silenced":{}},"multi":true,"created_at":1712694311000,"created":"2024-04-09T20:25:11.421316+00:00","modified":"2024-04-09T20:25:13.564041+00:00","deleted":null,"priority":null,"overall_state_modified":null,"overall_state":"No Data","creator":{"name":null,"email":"frog@datadoghq.com","handle":"frog@datadoghq.com","id":1445416}}
         headers:
             Content-Type:
                 - application/json

--- a/datadog/tests/cassettes/TestAccDatadogMonitorJSONImport.yaml
+++ b/datadog/tests/cassettes/TestAccDatadogMonitorJSONImport.yaml
@@ -73,7 +73,7 @@ interactions:
         headers:
             Content-Type:
                 - application/json
-        url: https://api.datadoghq.com/api/v1/monitor/142875736
+        url: https://api.datadoghq.com/api/v1/monitor/142875736?with_restricted_roles=false
         method: GET
       response:
         proto: HTTP/1.1
@@ -85,7 +85,7 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"id":142875736,"org_id":321813,"type":"service check","name":"tf-TestAccDatadogMonitorJSONImport-local-1712694310","message":"Change the message triggers if any host's clock goes out of sync with the time given by NTP. The offset threshold is configured in the Agent's 'ntp.yaml' file.\n\nSee [Troubleshooting NTP Offset issues](https://docs.datadoghq.com/agent/troubleshooting/ntp for more details on cause and resolution.","tags":[],"query":"\"ntp.in_sync\".by(\"*\").last(2).count_by_status()","options":{"include_tags":true,"new_host_delay":150,"notify_audit":false,"notify_no_data":false,"thresholds":{"warning":1,"ok":1,"critical":1},"silenced":{}},"multi":true,"created_at":1712694311000,"created":"2024-04-09T20:25:11.434214+00:00","modified":"2024-04-09T20:25:11.434214+00:00","deleted":null,"restricted_roles":null,"priority":null,"overall_state_modified":null,"overall_state":"No Data","creator":{"name":null,"email":"frog@datadoghq.com","handle":"frog@datadoghq.com","id":1445416}}
+            {"id":142875736,"org_id":321813,"type":"service check","name":"tf-TestAccDatadogMonitorJSONImport-local-1712694310","message":"Change the message triggers if any host's clock goes out of sync with the time given by NTP. The offset threshold is configured in the Agent's 'ntp.yaml' file.\n\nSee [Troubleshooting NTP Offset issues](https://docs.datadoghq.com/agent/troubleshooting/ntp for more details on cause and resolution.","tags":[],"query":"\"ntp.in_sync\".by(\"*\").last(2).count_by_status()","options":{"include_tags":true,"new_host_delay":150,"notify_audit":false,"notify_no_data":false,"thresholds":{"warning":1,"ok":1,"critical":1},"silenced":{}},"multi":true,"created_at":1712694311000,"created":"2024-04-09T20:25:11.434214+00:00","modified":"2024-04-09T20:25:11.434214+00:00","deleted":null,"priority":null,"overall_state_modified":null,"overall_state":"No Data","creator":{"name":null,"email":"frog@datadoghq.com","handle":"frog@datadoghq.com","id":1445416}}
         headers:
             Content-Type:
                 - application/json
@@ -108,7 +108,7 @@ interactions:
         headers:
             Content-Type:
                 - application/json
-        url: https://api.datadoghq.com/api/v1/monitor/142875736
+        url: https://api.datadoghq.com/api/v1/monitor/142875736?with_restricted_roles=false
         method: GET
       response:
         proto: HTTP/1.1
@@ -120,7 +120,7 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"id":142875736,"org_id":321813,"type":"service check","name":"tf-TestAccDatadogMonitorJSONImport-local-1712694310","message":"Change the message triggers if any host's clock goes out of sync with the time given by NTP. The offset threshold is configured in the Agent's 'ntp.yaml' file.\n\nSee [Troubleshooting NTP Offset issues](https://docs.datadoghq.com/agent/troubleshooting/ntp for more details on cause and resolution.","tags":[],"query":"\"ntp.in_sync\".by(\"*\").last(2).count_by_status()","options":{"include_tags":true,"new_host_delay":150,"notify_audit":false,"notify_no_data":false,"thresholds":{"warning":1,"ok":1,"critical":1},"silenced":{}},"multi":true,"created_at":1712694311000,"created":"2024-04-09T20:25:11.434214+00:00","modified":"2024-04-09T20:25:11.434214+00:00","deleted":null,"restricted_roles":null,"priority":null,"overall_state_modified":null,"overall_state":"No Data","creator":{"name":null,"email":"frog@datadoghq.com","handle":"frog@datadoghq.com","id":1445416}}
+            {"id":142875736,"org_id":321813,"type":"service check","name":"tf-TestAccDatadogMonitorJSONImport-local-1712694310","message":"Change the message triggers if any host's clock goes out of sync with the time given by NTP. The offset threshold is configured in the Agent's 'ntp.yaml' file.\n\nSee [Troubleshooting NTP Offset issues](https://docs.datadoghq.com/agent/troubleshooting/ntp for more details on cause and resolution.","tags":[],"query":"\"ntp.in_sync\".by(\"*\").last(2).count_by_status()","options":{"include_tags":true,"new_host_delay":150,"notify_audit":false,"notify_no_data":false,"thresholds":{"warning":1,"ok":1,"critical":1},"silenced":{}},"multi":true,"created_at":1712694311000,"created":"2024-04-09T20:25:11.434214+00:00","modified":"2024-04-09T20:25:11.434214+00:00","deleted":null,"priority":null,"overall_state_modified":null,"overall_state":"No Data","creator":{"name":null,"email":"frog@datadoghq.com","handle":"frog@datadoghq.com","id":1445416}}
         headers:
             Content-Type:
                 - application/json


### PR DESCRIPTION
This hacks around this (already hacky) resource having conflicts with the restricted_roles attribute when the restriction_policy resource is used to manage permissions on monitors. The general strategy is to ignore roles sent back from the API if roles are not explicitly defined in the monitor. Note: This resource should be converted to a framework provider resource, that should provide much easier access to what the user configured and make this handling consistent and esaier to reason about.

Scenarios tested:
* create monitor and restriction_policy (with and without roles), there should be no diff when running subsequent plans
* modify the monitor and restricton policy, e.g. add/remove a role, there should be no diffs when running subsequent plans

Open questions:
* what does this do to existing monitor_json resources when a user updates?