### PR TITLE
[MRI-115] Do not set empty list for restricted_roles unless it is intentionally cleared

### DIFF
--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -262,8 +262,9 @@ type ProviderConfiguration struct {
 	Auth                context.Context
 	DefaultTags         map[string]interface{}
 
-	// 
-	ResourceContext map[string]interface{}
+	// To allow passing values between lifecycle hooks that are only needed for provider-internal
+	// logic and don't represent part of the resource's state
+	Metadata map[string]interface{}
 
 	Now func() time.Time
 }
@@ -444,6 +445,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		DatadogApiInstances: apiInstances,
 		Auth:                auth,
 
+        Metadata: make(map[string]interface{}),
 		Now: time.Now,
 	}
 	if v, ok := d.GetOk("default_tags"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {

--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -262,6 +262,9 @@ type ProviderConfiguration struct {
 	Auth                context.Context
 	DefaultTags         map[string]interface{}
 
+	// 
+	ResourceContext map[string]interface{}
+
 	Now func() time.Time
 }
 

--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -23,7 +23,7 @@ import (
 
 const defaultNoDataTimeframeMinutes = 10
 
-const internalClearRestrictedRolesIndicator = "INTERNAL_CLEAR_RESTRICTED_ROLES_INDICATOR"
+const restrictedRolesClearedKey = "restricted_roles_cleared"
 
 var retryTimeout = time.Minute
 
@@ -34,7 +34,7 @@ func resourceDatadogMonitor() *schema.Resource {
 		ReadContext:   resourceDatadogMonitorRead,
 		UpdateContext: resourceDatadogMonitorUpdate,
 		DeleteContext: resourceDatadogMonitorDelete,
-		CustomizeDiff: customdiff.All(resourceDatadogMonitorCustomizeDiff, tagDiff),
+		CustomizeDiff: customdiff.All(resourceDatadogMonitorCustomizeDiff, detectChangesInRestrictedRoles, tagDiff),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -559,7 +559,7 @@ func getMonitorFormulaQuerySchema() *schema.Schema {
 	}
 }
 
-func buildMonitorStruct(d utils.Resource) (*datadogV1.Monitor, *datadogV1.MonitorUpdateRequest) {
+func buildMonitorStruct(d utils.Resource, meta interface{}) (*datadogV1.Monitor, *datadogV1.MonitorUpdateRequest) {
 	var thresholds datadogV1.MonitorThresholds
 
 	if r, ok := d.GetOk("monitor_thresholds.0.ok"); ok {
@@ -791,9 +791,23 @@ func buildMonitorStruct(d utils.Resource) (*datadogV1.Monitor, *datadogV1.Monito
 		}
 		sort.Strings(roles)
 	}
-	// Only delete if it's marked for delete
-	m.SetRestrictedRoles(roles)
-	u.SetRestrictedRoles(roles)
+	// Setting an empty list for restricted roles will delete any associated
+	// restriction policy (if one exists). Therefore, we should only set
+	// an empty list if it represents an intentional removal of existing
+	// restricted roles, rather than an unchanged empty value.
+	providerConf := meta.(*ProviderConfiguration)
+
+	// TMP TO CHECK THIS IS BEING SET
+	_, ok := providerConf.Metadata[restrictedRolesClearedKey]
+	if !ok {
+		panic("metadata not being set")
+	}
+
+	restrictedRolesCleared := len(roles) == 0 && providerConf.Metadata[restrictedRolesClearedKey]
+	if len(roles) > 0 || restrictedRolesCleared {
+		m.SetRestrictedRoles(roles)
+		u.SetRestrictedRoles(roles)
+	}
 
 	tags := make([]string, 0)
 	if attr, ok := d.GetOk("tags"); ok {
@@ -878,21 +892,8 @@ func buildMonitorFormulaAndFunctionEventQuery(data map[string]interface{}) *data
 	return &definition
 }
 
+// Use CustomizeDiff to do monitor validation
 func resourceDatadogMonitorCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
-	err := doRestrictedRolesChangeDetection(ctx, diff, meta)
-	if err != nil {
-		return err
-	}
-	return validateMonitor(ctx, diff, meta)
-}
-
-func doRestrictedRolesChangeDetection(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
-	oldVal, newVal := diff.GetChange("restricted_roles")
-
-	return nil
-}
-
-func validateMonitor(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 	if _, ok := diff.GetOk("query"); !ok {
 		// If "query" depends on other resources, we can't validate as the variables may not be interpolated yet.
 		return nil
@@ -933,12 +934,23 @@ func validateMonitor(ctx context.Context, diff *schema.ResourceDiff, meta interf
 	})
 }
 
+func detectChangesInRestrictedRoles(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+	providerConf := meta.(*ProviderConfiguration)
+	oldVal, newVal := diff.GetChange("restricted_roles")
+	if len(oldVal) > 0 && len(newVal) == 0 {
+		providerConf.Metadata[restrictedRolesClearedKey] = true
+	} else {
+		providerConf.Metadata[restrictedRolesClearedKey] = false
+	}
+	return nil
+}
+
 func resourceDatadogMonitorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConf := meta.(*ProviderConfiguration)
 	apiInstances := providerConf.DatadogApiInstances
 	auth := providerConf.Auth
 
-	m, _ := buildMonitorStruct(d)
+	m, _ := buildMonitorStruct(d, meta)
 	mCreated, httpResponse, err := apiInstances.GetMonitorsApiV1().CreateMonitor(auth, *m)
 	if err != nil {
 		return utils.TranslateClientErrorDiag(err, httpResponse, "error creating monitor")
@@ -1280,7 +1292,7 @@ func resourceDatadogMonitorUpdate(ctx context.Context, d *schema.ResourceData, m
 	apiInstances := providerConf.DatadogApiInstances
 	auth := providerConf.Auth
 
-	_, m := buildMonitorStruct(d)
+	_, m := buildMonitorStruct(d, meta)
 	i, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
Update `resource_datadog_monitor` to only set an empty list for `restricted_roles` if the list is intentionally being cleared, but not if it represents an unchanged empty state