### PR TITLE
[datadog_synthetics_test] Handle secure `config_variables` on import

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -2936,8 +2936,11 @@ func buildTerraformConfigVariables(configVariables []datadogV1.SyntheticsConfigV
 			// If the variable is secure, the example and pattern are not returned by the API,
 			// so we need to keep the values from the terraform config.
 			if v, ok := localVariable["secure"].(bool); ok && v {
-				localVariable["example"] = oldConfigVariables[i].(map[string]interface{})["example"].(string)
-				localVariable["pattern"] = oldConfigVariables[i].(map[string]interface{})["pattern"].(string)
+				// There is no previous state to fallback on during import
+				if i < len(oldConfigVariables) && oldConfigVariables[i] != nil {
+					localVariable["example"] = oldConfigVariables[i].(map[string]interface{})["example"].(string)
+					localVariable["pattern"] = oldConfigVariables[i].(map[string]interface{})["pattern"].(string)
+				}
 			} else {
 				if v, ok := configVariable.GetExampleOk(); ok {
 					localVariable["example"] = *v


### PR DESCRIPTION
On import, previous state does not exist so we cannot rely on the previous state to set the old values in state for example and pattern. 

Stack trace:
```
➜  ~/Documents/terraform terraform plan -generate-config-out=generated3.tf
datadog_synthetics_test.test_integration_installation: Preparing import... [id=123]
datadog_synthetics_test.test_integration_installation: Refreshing state... [id=123]

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Plugin did not respond
│ 
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ReadResource call. The plugin logs may contain more details.
╵

Stack trace from the terraform-provider-datadog_v3.46.0 plugin:

panic: runtime error: index out of range [0] with length 0

goroutine 134 [running]:
github.com/terraform-providers/terraform-provider-datadog/datadog.buildTerraformConfigVariables({0x14000b3e140, 0x2, 0x9?}, {0x105113b40, 0x0, 0x0?})
        github.com/terraform-providers/terraform-provider-datadog/datadog/resource_datadog_synthetics_test_.go:2939 +0x5f0
````