### PR TITLE
[datadog_cloudflare] Remove default and update doc

### DIFF
--- a/datadog/fwprovider/resource_datadog_integration_cloudflare_account.go
+++ b/datadog/fwprovider/resource_datadog_integration_cloudflare_account.go
@@ -4,12 +4,10 @@ import (
 	"context"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	frameworkPath "github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -74,8 +72,7 @@ func (r *integrationCloudflareAccountResource) Schema(_ context.Context, _ resou
 				ElementType: types.StringType,
 				Optional:    true,
 				Computed:    true,
-				Description: "An allowlist of resources to restrict pulling metrics for including `web`, `dns`, `lb` (load balancer), `worker`)",
-				Default:     listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{})),
+				Description: "An allowlist of resources to pull metrics for. Including, `web`, `dns`, `lb` (load balancer), and `worker`).",
 			},
 		},
 	}

--- a/docs/resources/integration_cloudflare_account.md
+++ b/docs/resources/integration_cloudflare_account.md
@@ -33,7 +33,7 @@ resource "datadog_integration_cloudflare_account" "foo" {
 ### Optional
 
 - `email` (String) The email associated with the Cloudflare account. If an API key is provided (and not a token), this field is also required.
-- `resources` (List of String) An allowlist of resources to restrict pulling metrics for including `web`, `dns`, `lb` (load balancer), `worker`)
+- `resources` (List of String) An allowlist of resources to pull metrics for. Including, `web`, `dns`, `lb` (load balancer), and `worker`).
 
 ### Read-Only
 


### PR DESCRIPTION
Lets remove the default to avoid overriding remote current resources config as well as update the doc to clarify it. Followup to https://github.com/DataDog/terraform-provider-datadog/issues/2656