### PR TITLE
[synthetics_test] handle when state does not exist

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -2877,9 +2877,12 @@ func buildDatadogBodyFiles(attr []interface{}) []datadogV1.SyntheticsTestRequest
 func buildTerraformBodyFiles(actualBodyFiles *[]datadogV1.SyntheticsTestRequestBodyFile, oldLocalBodyFiles []map[string]interface{}) (localBodyFiles []map[string]interface{}) {
 	localBodyFiles = make([]map[string]interface{}, len(*actualBodyFiles))
 	for i, file := range *actualBodyFiles {
-		// The file content is kept from the existing localFile from the state,
-		// as the response from the backend contains the bucket key rather than the content.
-		localFile := oldLocalBodyFiles[i]
+		localFile := make(map[string]interface{})
+		if i < len(oldLocalBodyFiles) && oldLocalBodyFiles[i] != nil {
+			// The file content is kept from the existing localFile from the state,
+			// as the response from the backend contains the bucket key rather than the content.
+			localFile = oldLocalBodyFiles[i]
+		}
 		localFile["name"] = file.GetName()
 		localFile["original_file_name"] = file.GetOriginalFileName()
 		localFile["type"] = file.GetType()


### PR DESCRIPTION
During imports or manual edits of the synthetics test, the request_file content might not be in the state. To avoid panics, check if the map or map item is nil first.

Example stack trace:
```
Stack trace from the terraform-provider-datadog plugin:

panic: runtime error: index out of range [0] with length 0

goroutine 146 [running]:
github.com/terraform-providers/terraform-provider-datadog/datadog.buildTerraformBodyFiles(0x1400041a0a0, {0x102f02d20, 0x0, 0x1?})
	/dd/terraform-provider-datadog/datadog/resource_datadog_synthetics_test_.go:2882 +0x3bc
github.com/terraform-providers/terraform-provider-datadog/datadog.updateSyntheticsAPITestLocalState(0x14000bc4100, 0x1400041ab40)
	/dd/terraform-provider-datadog/datadog/resource_datadog_synthetics_test_.go:1867 +0x2264
github.com/terraform-providers/terraform-provider-datadog/datadog.resourceDatadogSyntheticsTestRead({0x10204e698?, 0x140008cb050?}, 0x14000bc4100, {0x101be8800?, 0x14000868750?})
	/dd/terraform-provider-datadog/datadog/resource_datadog_synthetics_test_.go:1470 +0x7e4
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0x14000341ce0, {0x10204e698, 0x140008cb050}, 0x14000bc4100, {0x101be8800, 0x14000868750})
```