### PR TITLE
[datadog_integration_aws_tag_filter] include `step_functions` as valid enum for v1 AWS tag filter 

### DIFF
--- a/docs/resources/integration_aws_tag_filter.md
+++ b/docs/resources/integration_aws_tag_filter.md
@@ -27,7 +27,7 @@ resource "datadog_integration_aws_tag_filter" "foo" {
 ### Required
 
 - `account_id` (String) Your AWS Account ID without dashes.
-- `namespace` (String) The namespace associated with the tag filter entry. Valid values are `elb`, `application_elb`, `sqs`, `rds`, `custom`, `network_elb`, `lambda`.
+- `namespace` (String) The namespace associated with the tag filter entry. Valid values are `elb`, `application_elb`, `sqs`, `rds`, `custom`, `network_elb`, `lambda`, `step_functions`.
 - `tag_filter_str` (String) The tag filter string.
 
 ### Read-Only

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-datadog
 
 require (
-	github.com/DataDog/datadog-api-client-go/v2 v2.33.0
+	github.com/DataDog/datadog-api-client-go/v2 v2.33.1-0.20241114153206-4637c31fedcf
 	github.com/DataDog/dd-sdk-go-testing v0.0.0-20211116174033-1cd082e322ad
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/datadog-api-client-go/v2 v2.33.0 h1:OI6kDnJeQmkjfGzxmP0XUQUxMD4tp6oAPXnnJ4VpgUM=
-github.com/DataDog/datadog-api-client-go/v2 v2.33.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
+github.com/DataDog/datadog-api-client-go/v2 v2.33.1-0.20241114153206-4637c31fedcf h1:ev4nydbonZI3p8JrKanDp2AfK6sScWgKgPoJ9OEDvvY=
+github.com/DataDog/datadog-api-client-go/v2 v2.33.1-0.20241114153206-4637c31fedcf/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=


### PR DESCRIPTION
bump go client to include the changes in https://github.com/DataDog/datadog-api-client-go/pull/2788

address https://github.com/DataDog/terraform-provider-datadog/issues/2669