### PR TITLE
[datadog_monitor] Change enable_samples to optional

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -332,7 +332,7 @@ func resourceDatadogMonitor() *schema.Resource {
 				"enable_samples": {
 					Description: "Whether or not a list of samples which triggered the alert is included. This is only used by CI Test and Pipeline monitors.",
 					Type:        schema.TypeBool,
-					Computed:    true,
+					Optional:    true,
 				},
 				"force_delete": {
 					Description: "A boolean indicating whether this monitor can be deleted even if it’s referenced by other resources (e.g. SLO, composite monitor).",

--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -1088,6 +1088,12 @@ func updateMonitorState(d *schema.ResourceData, meta interface{}, m *datadogV1.M
 		}
 	}
 
+	if m.GetType() == datadogV1.MONITORTYPE_CI_PIPELINES_ALERT || m.GetType() == datadogV1.MONITORTYPE_CI_TESTS_ALERT {
+		if err := d.Set("enable_samples", m.Options.GetEnableSamples()); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	if err := d.Set("notify_by", m.Options.GetNotifyBy()); err != nil {
 		return diag.FromErr(err)
 	}

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -49,6 +49,7 @@ Email notifications can be sent to specific users by using the same `@username` 
 ### Optional
 
 - `enable_logs_sample` (Boolean) A boolean indicating whether or not to include a list of log values which triggered the alert. This is only used by log monitors. Defaults to `false`.
+- `enable_samples` (Boolean) Whether or not a list of samples which triggered the alert is included. This is only used by CI Test and Pipeline monitors.
 - `escalation_message` (String) A message to include with a re-notification. Supports the `@username` notification allowed elsewhere.
 - `evaluation_delay` (Number) (Only applies to metric alert) Time (in seconds) to delay evaluation, as a non-negative integer.
 
@@ -86,7 +87,6 @@ We recommend at least 2x the monitor timeframe for metric alerts or 2 minutes fo
 
 ### Read-Only
 
-- `enable_samples` (Boolean) Whether or not a list of samples which triggered the alert is included. This is only used by CI Test and Pipeline monitors.
 - `id` (String) The ID of this resource.
 
 <a id="nestedblock--monitor_threshold_windows"></a>


### PR DESCRIPTION
Resolves https://github.com/DataDog/terraform-provider-datadog/issues/2679

This value should be optional, defaulted to false. It should not be marked as computed.