### PR TITLE
[datadog_synthetics_test] Add maximum value in docs for retry and interval

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -597,13 +597,13 @@ func syntheticsTestOptionsRetry() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"count": {
-					Description: "Number of retries needed to consider a location as failed before sending a notification alert.",
+					Description: "Number of retries needed to consider a location as failed before sending a notification alert. Maximum value: `5`.",
 					Type:        schema.TypeInt,
 					Default:     0,
 					Optional:    true,
 				},
 				"interval": {
-					Description: "Interval between a failed test and the next retry in milliseconds.",
+					Description: "Interval between a failed test and the next retry in milliseconds. Maximum value: `5000`.",
 					Type:        schema.TypeInt,
 					Default:     300,
 					Optional:    true,

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -783,8 +783,8 @@ Optional:
 
 Optional:
 
-- `count` (Number) Number of retries needed to consider a location as failed before sending a notification alert. Defaults to `0`.
-- `interval` (Number) Interval between a failed test and the next retry in milliseconds. Defaults to `300`.
+- `count` (Number) Number of retries needed to consider a location as failed before sending a notification alert. Maximum value: `5`. Defaults to `0`.
+- `interval` (Number) Interval between a failed test and the next retry in milliseconds. Maximum value: `5000`. Defaults to `300`.
 
 
 
@@ -1008,8 +1008,8 @@ Optional:
 
 Optional:
 
-- `count` (Number) Number of retries needed to consider a location as failed before sending a notification alert. Defaults to `0`.
-- `interval` (Number) Interval between a failed test and the next retry in milliseconds. Defaults to `300`.
+- `count` (Number) Number of retries needed to consider a location as failed before sending a notification alert. Maximum value: `5`. Defaults to `0`.
+- `interval` (Number) Interval between a failed test and the next retry in milliseconds. Maximum value: `5000`. Defaults to `300`.
 
 
 <a id="nestedblock--options_list--rum_settings"></a>


### PR DESCRIPTION
Update the documentation of Synthetics with maximum values for retry and interval