### PR TITLE
[datadog_synthetics_test] Add comment regarding browser step available auths

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -2215,12 +2215,12 @@ func buildDatadogSyntheticsBrowserTest(d *schema.ResourceData) *datadogV1.Synthe
 			request.SetQuery(query)
 		}
 	}
-
 	if username, ok := d.GetOk("request_basicauth.0.username"); ok {
 		if password, ok := d.GetOk("request_basicauth.0.password"); ok {
 			basicAuth := datadogV1.NewSyntheticsBasicAuthWebWithDefaults()
 			basicAuth.SetPassword(password.(string))
 			basicAuth.SetUsername(username.(string))
+			// Works for Web Basic Auth, NTLM and Digest as they all use `username` + `password`
 			request.SetBasicAuth(datadogV1.SyntheticsBasicAuthWebAsSyntheticsBasicAuth(basicAuth))
 		}
 	}


### PR DESCRIPTION
### Description

Initially, we wanted to implement all auth methods used by api tests for browser tests in terraform. Turns out that dogweb only supports web basic auth for browser tests, and as a side effect, also NTLM and Digest which also use `username` and `password`.  We thus added a comment to explain that in terraform.