### PR TITLE
[datadog_webhook] Fix panic on missing encode_as field

### DIFF
--- a/datadog/fwprovider/resource_datadog_webhook.go
+++ b/datadog/fwprovider/resource_datadog_webhook.go
@@ -241,9 +241,8 @@ func (r *webhookResource) buildWebhookRequestBody(ctx context.Context, state *we
 	if !state.CustomHeaders.IsNull() {
 		attributes.SetCustomHeaders(state.CustomHeaders.ValueString())
 	}
-	if !state.EncodeAs.IsNull() {
+	if !state.EncodeAs.IsNull() && !state.EncodeAs.IsUnknown() {
 		encoding, _ := datadogV1.NewWebhooksIntegrationEncodingFromValue(state.EncodeAs.ValueString())
-
 		attributes.SetEncodeAs(*encoding)
 	}
 


### PR DESCRIPTION
SSIA, the field is computed, so it can be non-null while still not having a valid value for the enum.