### PR TITLE
[provider_test] skip a bunch of failing tests

### DIFF
--- a/datadog/tests/data_source_datadog_application_key_test.go
+++ b/datadog/tests/data_source_datadog_application_key_test.go
@@ -9,96 +9,96 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAccDatadogApplicationKeyDatasource_matchId(t *testing.T) {
-	if isRecording() || isReplaying() {
-		t.Skip("This test doesn't support recording or replaying")
-	}
-	t.Parallel()
-	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
+// func TestAccDatadogApplicationKeyDatasource_matchId(t *testing.T) {
+// 	if isRecording() || isReplaying() {
+// 		t.Skip("This test doesn't support recording or replaying")
+// 	}
+// 	t.Parallel()
+// 	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
 
-	applicationKeyName := uniqueEntityName(ctx, t)
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV5ProviderFactories: accProviders,
-		CheckDestroy:             testAccCheckDatadogApplicationKeyDestroy(providers.frameworkProvider),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDatasourceApplicationKeyIdConfig(applicationKeyName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDatadogApplicationKeyExists(providers.frameworkProvider, "datadog_application_key.app_key_1"),
-					resource.TestCheckResourceAttr("datadog_application_key.app_key_1", "name", fmt.Sprintf("%s 1", applicationKeyName)),
-					resource.TestCheckResourceAttr("datadog_application_key.app_key_2", "name", fmt.Sprintf("%s 2", applicationKeyName)),
-					resource.TestCheckResourceAttr("data.datadog_application_key.app_key", "name", fmt.Sprintf("%s 1", applicationKeyName)),
-					resource.TestCheckResourceAttrSet("data.datadog_application_key.app_key", "id"),
-				),
-			},
-		},
-	})
-}
+// 	applicationKeyName := uniqueEntityName(ctx, t)
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:                 func() { testAccPreCheck(t) },
+// 		ProtoV5ProviderFactories: accProviders,
+// 		CheckDestroy:             testAccCheckDatadogApplicationKeyDestroy(providers.frameworkProvider),
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccDatasourceApplicationKeyIdConfig(applicationKeyName),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckDatadogApplicationKeyExists(providers.frameworkProvider, "datadog_application_key.app_key_1"),
+// 					resource.TestCheckResourceAttr("datadog_application_key.app_key_1", "name", fmt.Sprintf("%s 1", applicationKeyName)),
+// 					resource.TestCheckResourceAttr("datadog_application_key.app_key_2", "name", fmt.Sprintf("%s 2", applicationKeyName)),
+// 					resource.TestCheckResourceAttr("data.datadog_application_key.app_key", "name", fmt.Sprintf("%s 1", applicationKeyName)),
+// 					resource.TestCheckResourceAttrSet("data.datadog_application_key.app_key", "id"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func TestAccDatadogApplicationKeyDatasource_matchName(t *testing.T) {
-	if isRecording() || isReplaying() {
-		t.Skip("This test doesn't support recording or replaying")
-	}
-	t.Parallel()
-	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
-	applicationKeyName := uniqueEntityName(ctx, t)
+// func TestAccDatadogApplicationKeyDatasource_matchName(t *testing.T) {
+// 	if isRecording() || isReplaying() {
+// 		t.Skip("This test doesn't support recording or replaying")
+// 	}
+// 	t.Parallel()
+// 	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
+// 	applicationKeyName := uniqueEntityName(ctx, t)
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV5ProviderFactories: accProviders,
-		CheckDestroy:             testAccCheckDatadogApplicationKeyDestroy(providers.frameworkProvider),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDatasourceApplicationKeyNameConfig(applicationKeyName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDatadogApplicationKeyExists(providers.frameworkProvider, "datadog_application_key.app_key_1"),
-					resource.TestCheckResourceAttr("datadog_application_key.app_key_1", "name", fmt.Sprintf("%s 1", applicationKeyName)),
-					resource.TestCheckResourceAttr("datadog_application_key.app_key_2", "name", fmt.Sprintf("%s 2", applicationKeyName)),
-					resource.TestCheckResourceAttr("data.datadog_application_key.app_key", "name", fmt.Sprintf("%s 1", applicationKeyName)),
-					resource.TestCheckResourceAttrSet("data.datadog_application_key.app_key", "id"),
-				),
-			},
-			{
-				Config: testAccDatasourceAppKeyExactMatch(applicationKeyName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDatadogApplicationKeyExists(providers.frameworkProvider, "datadog_application_key.app_key_1"),
-					resource.TestCheckResourceAttr("datadog_application_key.app_key_1", "name", applicationKeyName),
-					resource.TestCheckResourceAttr("datadog_application_key.app_key_2", "name", fmt.Sprintf("%s 2", applicationKeyName)),
-					resource.TestCheckResourceAttr("data.datadog_application_key.app_key", "name", applicationKeyName),
-					resource.TestCheckResourceAttrSet("data.datadog_application_key.app_key", "id"),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:                 func() { testAccPreCheck(t) },
+// 		ProtoV5ProviderFactories: accProviders,
+// 		CheckDestroy:             testAccCheckDatadogApplicationKeyDestroy(providers.frameworkProvider),
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccDatasourceApplicationKeyNameConfig(applicationKeyName),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckDatadogApplicationKeyExists(providers.frameworkProvider, "datadog_application_key.app_key_1"),
+// 					resource.TestCheckResourceAttr("datadog_application_key.app_key_1", "name", fmt.Sprintf("%s 1", applicationKeyName)),
+// 					resource.TestCheckResourceAttr("datadog_application_key.app_key_2", "name", fmt.Sprintf("%s 2", applicationKeyName)),
+// 					resource.TestCheckResourceAttr("data.datadog_application_key.app_key", "name", fmt.Sprintf("%s 1", applicationKeyName)),
+// 					resource.TestCheckResourceAttrSet("data.datadog_application_key.app_key", "id"),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccDatasourceAppKeyExactMatch(applicationKeyName),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckDatadogApplicationKeyExists(providers.frameworkProvider, "datadog_application_key.app_key_1"),
+// 					resource.TestCheckResourceAttr("datadog_application_key.app_key_1", "name", applicationKeyName),
+// 					resource.TestCheckResourceAttr("datadog_application_key.app_key_2", "name", fmt.Sprintf("%s 2", applicationKeyName)),
+// 					resource.TestCheckResourceAttr("data.datadog_application_key.app_key", "name", applicationKeyName),
+// 					resource.TestCheckResourceAttrSet("data.datadog_application_key.app_key", "id"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func TestAccDatadogApplicationKeyDatasource_exactMatchName(t *testing.T) {
-	if isRecording() || isReplaying() {
-		t.Skip("This test doesn't support recording or replaying")
-	}
-	t.Parallel()
-	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
-	applicationKeyName := uniqueEntityName(ctx, t)
+// func TestAccDatadogApplicationKeyDatasource_exactMatchName(t *testing.T) {
+// 	if isRecording() || isReplaying() {
+// 		t.Skip("This test doesn't support recording or replaying")
+// 	}
+// 	t.Parallel()
+// 	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
+// 	applicationKeyName := uniqueEntityName(ctx, t)
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV5ProviderFactories: accProviders,
-		CheckDestroy:             testAccCheckDatadogApplicationKeyDestroy(providers.frameworkProvider),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDatasourceAppKeyExactMatch(applicationKeyName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDatadogApplicationKeyExists(providers.frameworkProvider, "datadog_application_key.app_key_1"),
-					resource.TestCheckResourceAttr("datadog_application_key.app_key_1", "name", applicationKeyName),
-					resource.TestCheckResourceAttr("datadog_application_key.app_key_2", "name", fmt.Sprintf("%s 2", applicationKeyName)),
-					resource.TestCheckResourceAttr("data.datadog_application_key.app_key", "name", applicationKeyName),
-					resource.TestCheckResourceAttrSet("data.datadog_application_key.app_key", "id"),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:                 func() { testAccPreCheck(t) },
+// 		ProtoV5ProviderFactories: accProviders,
+// 		CheckDestroy:             testAccCheckDatadogApplicationKeyDestroy(providers.frameworkProvider),
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccDatasourceAppKeyExactMatch(applicationKeyName),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckDatadogApplicationKeyExists(providers.frameworkProvider, "datadog_application_key.app_key_1"),
+// 					resource.TestCheckResourceAttr("datadog_application_key.app_key_1", "name", applicationKeyName),
+// 					resource.TestCheckResourceAttr("datadog_application_key.app_key_2", "name", fmt.Sprintf("%s 2", applicationKeyName)),
+// 					resource.TestCheckResourceAttr("data.datadog_application_key.app_key", "name", applicationKeyName),
+// 					resource.TestCheckResourceAttrSet("data.datadog_application_key.app_key", "id"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
 func TestAccDatadogApplicationKeyDatasource_matchIdError(t *testing.T) {
 	if isRecording() || isReplaying() {

--- a/datadog/tests/resource_datadog_application_key_test.go
+++ b/datadog/tests/resource_datadog_application_key_test.go
@@ -21,7 +21,6 @@ func TestAccDatadogApplicationKey_Update(t *testing.T) {
 	applicationKeyName := uniqueEntityName(ctx, t)
 	applicationKeyNameUpdate := applicationKeyName + "-2"
 	resourceName := "datadog_application_key.foo"
-	var keyValue string
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -34,15 +33,6 @@ func TestAccDatadogApplicationKey_Update(t *testing.T) {
 					testAccCheckDatadogApplicationKeyExists(providers.frameworkProvider, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", applicationKeyName),
 					resource.TestCheckResourceAttrSet(resourceName, "key"),
-					func(s *terraform.State) error {
-						resource, ok := s.RootModule().Resources[resourceName]
-						if !ok {
-							return fmt.Errorf("Resource not found: %s", resourceName)
-						}
-						// Store the key value for later comparison after update
-						keyValue = resource.Primary.Attributes["key"]
-						return nil
-					},
 				),
 			},
 			{
@@ -52,48 +42,37 @@ func TestAccDatadogApplicationKey_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", applicationKeyNameUpdate),
 					testAccCheckDatadogApplicationKeyNameMatches(providers.frameworkProvider, resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "key"),
-					func(s *terraform.State) error {
-						resource, ok := s.RootModule().Resources[resourceName]
-						if !ok {
-							return fmt.Errorf("Resource not found: %s", resourceName)
-						}
-						stateKeyValue := resource.Primary.Attributes["key"]
-						if stateKeyValue != keyValue {
-							return fmt.Errorf("application key value %s does not match expected value %s", stateKeyValue, keyValue)
-						}
-						return nil
-					},
 				),
 			},
 		},
 	})
 }
 
-func TestDatadogApplicationKey_import(t *testing.T) {
-	if isRecording() || isReplaying() {
-		t.Skip("This test doesn't support recording or replaying")
-	}
-	t.Parallel()
-	resourceName := "datadog_application_key.foo"
-	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
-	applicationKeyName := uniqueEntityName(ctx, t)
+// func TestDatadogApplicationKey_import(t *testing.T) {
+// 	if isRecording() || isReplaying() {
+// 		t.Skip("This test doesn't support recording or replaying")
+// 	}
+// 	t.Parallel()
+// 	resourceName := "datadog_application_key.foo"
+// 	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
+// 	applicationKeyName := uniqueEntityName(ctx, t)
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV5ProviderFactories: accProviders,
-		CheckDestroy:             testAccCheckDatadogApplicationKeyDestroy(providers.frameworkProvider),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckDatadogApplicationKeyConfigRequired(applicationKeyName),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:                 func() { testAccPreCheck(t) },
+// 		ProtoV5ProviderFactories: accProviders,
+// 		CheckDestroy:             testAccCheckDatadogApplicationKeyDestroy(providers.frameworkProvider),
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccCheckDatadogApplicationKeyConfigRequired(applicationKeyName),
+// 			},
+// 			{
+// 				ResourceName:      resourceName,
+// 				ImportState:       true,
+// 				ImportStateVerify: true,
+// 			},
+// 		},
+// 	})
+// }
 
 func testAccCheckDatadogApplicationKeyConfigRequired(uniq string) string {
 	return fmt.Sprintf(`

--- a/datadog/tests/resource_datadog_domain_allowlist_test.go
+++ b/datadog/tests/resource_datadog_domain_allowlist_test.go
@@ -13,7 +13,10 @@ import (
 )
 
 func TestAccDatadogDomainAllowlist_CreateUpdate(t *testing.T) {
-
+	if !isReplaying() {
+		// Skip in non-replay mode due to backend replication delay issues.
+		t.Skip("This test only runs in replay mode")
+	}
 	_, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
 
 	// When generating the casette, it may be necessary to add sleep functions before the check


### PR DESCRIPTION
ApplicationKeyDatasource is deprecated
DatadogApplicationKey_Update no longer returns a key value, no point in comparing anymore
TestAccDatadogDomainAllowlist_CreateUpdate replay only due to 2 second backend replication delay