### PR TITLE
Update Logs code ownership to specific teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@ datadog/*datadog_downtime*                @DataDog/api-clients @DataDog/monitor-
 datadog/*datadog_integration_aws*         @DataDog/api-clients @DataDog/cloud-integrations
 datadog/*datadog_integration_pagerduty*   @DataDog/api-clients @DataDog/saas-integrations @DataDog/saas-integrations
 datadog/*datadog_integration_opsgenie*    @DataDog/api-clients @Datadog/collaboration-integrations
-datadog/*datadog_logs*                    @DataDog/api-clients @DataDog/logs-backend @DataDog/logs-app
+datadog/*datadog_logs*                    @DataDog/api-clients @DataDog/logs-backend @DataDog/logs-core @DataDog/logs-forwarding @DataDog/logs-app
 datadog/*datadog_metric*                  @DataDog/api-clients @DataDog/metrics-intake @DataDog/metrics-query @DataDog/points-aggregation
 datadog/*datadog_monitor*                 @DataDog/api-clients @DataDog/monitor-app
 datadog/*datadog_screenboard*             @DataDog/api-clients @DataDog/dashboards-backend


### PR DESCRIPTION
What does this PR do?
---------------------

- Update code ownership to contain specific logs-backend teams. This is in preparation for the deprecation of #logs-backend slack channel, to ensure all code is owned by at least one of the four sub-teams.
- Not associated with any story.