### PR TITLE
[provider] Bump Datadog Go SDK

### DIFF
--- a/docs/resources/integration_aws_tag_filter.md
+++ b/docs/resources/integration_aws_tag_filter.md
@@ -27,7 +27,7 @@ resource "datadog_integration_aws_tag_filter" "foo" {
 ### Required
 
 - `account_id` (String) Your AWS Account ID without dashes.
-- `namespace` (String) The namespace associated with the tag filter entry. Valid values are `elb`, `application_elb`, `sqs`, `rds`, `custom`, `network_elb`, `lambda`.
+- `namespace` (String) The namespace associated with the tag filter entry. Valid values are `elb`, `application_elb`, `sqs`, `rds`, `custom`, `network_elb`, `lambda`, `step_functions`.
 - `tag_filter_str` (String) The tag filter string.
 
 ### Read-Only

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-datadog
 
 require (
-	github.com/DataDog/datadog-api-client-go/v2 v2.33.1-0.20241113153831-04f32a8539e4
+	github.com/DataDog/datadog-api-client-go/v2 v2.33.1-0.20241120195630-c33c4f106e88
 	github.com/DataDog/dd-sdk-go-testing v0.0.0-20211116174033-1cd082e322ad
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/datadog-api-client-go/v2 v2.33.1-0.20241113153831-04f32a8539e4 h1:1QSRccPmp7/Jap3EMZ27e4qDWlr5jUyy89ToVBbGyeY=
-github.com/DataDog/datadog-api-client-go/v2 v2.33.1-0.20241113153831-04f32a8539e4/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
+github.com/DataDog/datadog-api-client-go/v2 v2.33.1-0.20241120195630-c33c4f106e88 h1:tyd/Jsn6fmvORRepj0CcwU6YhNHlMvRZieau+SSeYP0=
+github.com/DataDog/datadog-api-client-go/v2 v2.33.1-0.20241120195630-c33c4f106e88/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=


### PR DESCRIPTION
SSIA, bump it as far as we can without hitting the synthetics breaking change