### PR TITLE
[datadog_sensitive_data_standard_pattern] add description and deprecate pattern

### DIFF
--- a/datadog/data_source_datadog_sensitive_data_scanner_standard_pattern.go
+++ b/datadog/data_source_datadog_sensitive_data_scanner_standard_pattern.go
@@ -35,10 +35,16 @@ func dataSourceDatadogSensitiveDataScannerStandardPattern() *schema.Resource {
 					Type:        schema.TypeString,
 					Computed:    true,
 				},
-				"pattern": {
-					Description: "Regex that the standard pattern applies.",
+				"description": {
+					Description: "Description of the standard pattern.",
 					Type:        schema.TypeString,
 					Computed:    true,
+				},
+				"pattern": {
+					Description: "Regex to match, optionally documented for older standard rules. ",
+					Type:        schema.TypeString,
+					Computed:    true,
+					Deprecated:  "Refer to the description field to understand what the rule does.",
 				},
 				"tags": {
 					Description: "List of tags.",
@@ -88,6 +94,9 @@ func dataSourceSensitiveDataScannerStandardPatternUpdate(d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	if err := d.Set("name", standardPattern.Attributes.GetName()); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("description", standardPattern.Attributes.GetDescription()); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("pattern", standardPattern.Attributes.GetPattern()); err != nil {

--- a/docs/data-sources/sensitive_data_scanner_standard_pattern.md
+++ b/docs/data-sources/sensitive_data_scanner_standard_pattern.md
@@ -21,8 +21,9 @@ Use this data source to retrieve information about an existing sensitive data sc
 
 ### Read-Only
 
+- `description` (String) Description of the standard pattern.
 - `id` (String) The ID of this resource.
 - `included_keywords` (List of String) List of recommended keywords to improve rule accuracy.
 - `name` (String) Name of the standard pattern.
-- `pattern` (String) Regex that the standard pattern applies.
+- `pattern` (String, Deprecated) Regex to match, optionally documented for older standard rules.  **Deprecated.** Refer to the description field to understand what the rule does.
 - `tags` (List of String) List of tags.

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -1164,8 +1164,8 @@ Optional:
 
 Optional:
 
-- `count` (Number) Number of retries needed to consider a location as failed before sending a notification alert. Defaults to `0`.
-- `interval` (Number) Interval between a failed test and the next retry in milliseconds. Defaults to `300`.
+- `count` (Number) Number of retries needed to consider a location as failed before sending a notification alert. Maximum value: `5`. Defaults to `0`.
+- `interval` (Number) Interval between a failed test and the next retry in milliseconds. Maximum value: `5000`. Defaults to `300`.
 
 
 <a id="nestedblock--mobile_options_list--scheduling"></a>


### PR DESCRIPTION
Align the `datadog_sensitive_data_standard_pattern` resource with the [Public API to list standard patterns](https://docs.datadoghq.com/api/latest/sensitive-data-scanner/#list-standard-patterns)
- Add `description` attribute.
- Deprecate the `pattern` attribute.
- [Jira ticket](https://datadoghq.atlassian.net/browse/SDS-405?atlOrigin=eyJpIjoiNzM5MzQ3MDQ1MmFlNDRlY2FhMTZmOGYyZGZhYTdhYjciLCJwIjoiaiJ9)