### PR TITLE
fix(github-workflows): use official GitHub action for token generation

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -21,10 +21,10 @@ jobs:
           exit 1;
       - name: Get GitHub App token
         id: get_token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-          private_key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
       - name: Check PR title
         if: github.event.pull_request.draft == false && false == contains(join(github.event.pull_request.labels.*.name, ','), 'changelog/note') && false == contains(join(github.event.pull_request.labels.*.name, ','), 'changelog/no-changelog')
         uses: actions/github-script@v6

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: Get GitHub App token
         id: get_token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-          private_key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v3
       - name: Create PR
         uses: actions/github-script@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - name: Get GitHub App token
         id: get_token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-          private_key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Create tag
         id: create_tag


### PR DESCRIPTION
# Changes

- Replaces usage of `tibdex/github-app-token` with official GitHub action