### PR TITLE
[datadog_dashboard] Make the `is_read_only` deprecation warning wording stronger

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -136,7 +136,7 @@ func resourceDatadogDashboard() *schema.Resource {
 					Default:       false,
 					ConflictsWith: []string{"restricted_roles"},
 					Description:   "Whether this dashboard is read-only.",
-					Deprecated:    "Prefer using `restricted_roles` to define which roles are required to edit the dashboard.",
+					Deprecated:    "This field is deprecated and non-functional. Use `restricted_roles` instead to define which roles are required to edit the dashboard.",
 				},
 				"tags": {
 					Type:        schema.TypeList,

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -738,7 +738,7 @@ resource "datadog_dashboard" "free_dashboard" {
 
 - `dashboard_lists` (Set of Number) A list of dashboard lists this dashboard belongs to. This attribute should not be set if managing the corresponding dashboard lists using Terraform as it causes inconsistent behavior.
 - `description` (String) The description of the dashboard.
-- `is_read_only` (Boolean, Deprecated) Whether this dashboard is read-only. **Deprecated.** Prefer using `restricted_roles` to define which roles are required to edit the dashboard. Defaults to `false`.
+- `is_read_only` (Boolean, Deprecated) Whether this dashboard is read-only. **Deprecated.** This field is deprecated and non-functional. Use `restricted_roles` instead to define which roles are required to edit the dashboard. Defaults to `false`.
 - `notify_list` (Set of String) The list of handles for the users to notify when changes are made to this dashboard.
 - `reflow_type` (String) The reflow type of a new dashboard layout. Set this only when layout type is `ordered`. If set to `fixed`, the dashboard expects all widgets to have a layout, and if it's set to `auto`, widgets should not have layouts. Valid values are `auto`, `fixed`.
 - `restricted_roles` (Set of String) UUIDs of roles whose associated users are authorized to edit the dashboard.


### PR DESCRIPTION
SSIA, `is_read_only` functionality will be fully removed soon.