### PR TITLE
[datadog_synthetics_test] Prevent updating `files` with the backend response to keep the plan stable

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -2150,6 +2150,11 @@ func updateSyntheticsBrowserTestLocalState(d *schema.ResourceData, syntheticsTes
 				// keep the element from the local state instead
 				element := d.Get(fmt.Sprintf("browser_step.%d.params.0.element", stepIndex))
 				localParams["element"] = element
+			} else if key == "files" {
+				// prevent overriding `files` in the local state with the one received from the backend, and
+				// keep the files from the local state instead
+				files := d.Get(fmt.Sprintf("browser_step.%d.params.0.files", stepIndex))
+				localParams["files"] = files
 			} else {
 				localParams[convertStepParamsKey(key)] = convertStepParamsValueForState(convertStepParamsKey(key), value)
 			}
@@ -4651,6 +4656,7 @@ func decompressAndDecodeValue(value string) string {
 	return string(compressedProtoFile)
 }
 
+// TODO
 func convertStepParamsValueForConfig(stepType interface{}, key string, value interface{}) interface{} {
 	switch key {
 	case "element", "email", "file", "files", "request":

--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -4656,7 +4656,6 @@ func decompressAndDecodeValue(value string) string {
 	return string(compressedProtoFile)
 }
 
-// TODO
 func convertStepParamsValueForConfig(stepType interface{}, key string, value interface{}) interface{} {
 	switch key {
 	case "element", "email", "file", "files", "request":


### PR DESCRIPTION
This PR prevents updating the `files` param from the upload file step in browser tests, to keep next plans stable.

Without this, the next plans keep trying to align the state returned by the backend and the local config:
```
~ files      = jsonencode(
    ~ [
        ~ {
            - bucketKey = "browser-upload-file-step/72e-vim-wme/2024-12-17T13:05:48.286579_f235f491-4dfd-4fbd-96ae-ed1b233b3e41.json"
            + content   = "this is the new new test content"
              name      = "test file"
              # (1 unchanged attribute hidden)
          },
      ]
  )
```