### PR TITLE
[datadog_integration_aws_account] Fix incorrect import docs instructions

### DIFF
--- a/docs/resources/integration_aws_account.md
+++ b/docs/resources/integration_aws_account.md
@@ -219,4 +219,4 @@ Import is supported using the following syntax:
 ```shell
 terraform import datadog_integration_aws_account.example "<datadog-aws-account-config-id>"
 ```
- AWS Account Config ID can be retrieved by using the [List all AWS integrations](https://docs.datadoghq.com/api/latest/aws-integration/#list-all-aws-integrations) endpoint and querying by AWS Account ID, or by accessing the `id` field of an existing `datadog_integration_aws` resource.
+ AWS Account Config ID can be retrieved by using the [List all AWS integrations](https://docs.datadoghq.com/api/latest/aws-integration/#list-all-aws-integrations) endpoint and querying by AWS Account ID.

--- a/examples/resources/datadog_integration_aws_account/import.sh
+++ b/examples/resources/datadog_integration_aws_account/import.sh
@@ -1,4 +1,4 @@
-# AWS Account Config ID can be retrieved by using the List all AWS integrations endpoint and querying by AWS Account ID,
+# AWS Account Config ID can be retrieved by using the List all AWS integrations endpoint and querying by AWS Account ID:
 # https://docs.datadoghq.com/api/latest/aws-integration/#list-all-aws-integrations
 
 


### PR DESCRIPTION
Fixes an incorrect statement in the import docs. The old `datadog_integration_aws` account `id` value cannot be used to import to the new `datadog_integration_aws_account` resource; it must be the Datadog UUID.

Reported by issue: https://github.com/DataDog/terraform-provider-datadog/issues/2733