### PR TITLE
[datadog_webhook] fix import 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,9 +120,9 @@ jobs:
         with:
           go-version: "1.23"
           cache: true
-      - uses: opentofu/setup-opentofu@v1
+      - uses: opentofu/setup-opentofu@592200bd4b9bbf4772ace78f887668b1aee8f716 # v1.0.5
         with:
-          tofu_version: 1.6.1
+          tofu_version: 1.6.3
           tofu_wrapper: false        
       - name: Set Terraform env vars
         run: |

--- a/datadog/fwprovider/resource_datadog_webhook.go
+++ b/datadog/fwprovider/resource_datadog_webhook.go
@@ -97,6 +97,11 @@ func (r *webhookResource) Read(ctx context.Context, request resource.ReadRequest
 	}
 
 	id := state.Name.ValueString()
+	// handle import case
+	if state.Name.IsNull() {
+		id = state.ID.ValueString()
+	}
+
 	resp, httpResp, err := r.Api.GetWebhooksIntegration(r.Auth, id)
 
 	if err != nil {


### PR DESCRIPTION
`terraform import` of existing webhooks was failing because id was read from `state.Name`, which is null when importing a resource 