### PR TITLE
[datadog_synthetics_test] Add step public id in the state

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -1163,6 +1163,11 @@ func syntheticsTestBrowserStep() *schema.Schema {
 					Type:        schema.TypeString,
 					Required:    true,
 				},
+				"public_id": {
+					Description: "The identifier of the step on the backend.",
+					Type:        schema.TypeString,
+					Computed:    true,
+				},
 				"type": {
 					Description:      "Type of the step.",
 					Type:             schema.TypeString,
@@ -2115,6 +2120,7 @@ func updateSyntheticsBrowserTestLocalState(d *schema.ResourceData, syntheticsTes
 	for stepIndex, step := range steps {
 		localStep := make(map[string]interface{})
 		localStep["name"] = step.GetName()
+		localStep["public_id"] = step.GetPublicId()
 		localStep["type"] = string(step.GetType())
 		localStep["timeout"] = step.GetTimeout()
 
@@ -2139,6 +2145,11 @@ func updateSyntheticsBrowserTestLocalState(d *schema.ResourceData, syntheticsTes
 		forceElementUpdate, ok := d.GetOk(fmt.Sprintf("browser_step.%d.force_element_update", stepIndex))
 		if ok {
 			localStep["force_element_update"] = forceElementUpdate
+		}
+
+		publicId, ok := d.GetOk(fmt.Sprintf("browser_step.%d.public_id", stepIndex))
+		if ok {
+			localStep["public_id"] = publicId
 		}
 
 		params := step.GetParams()

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -1005,6 +1005,10 @@ Optional:
 - `no_screenshot` (Boolean) Prevents saving screenshots of the step.
 - `timeout` (Number) Used to override the default timeout of a step.
 
+Read-Only:
+
+- `public_id` (String) The identifier of the step on the backend.
+
 <a id="nestedblock--browser_step--params"></a>
 ### Nested Schema for `browser_step.params`
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-datadog
 
 require (
-	github.com/DataDog/datadog-api-client-go/v2 v2.34.0
+	github.com/DataDog/datadog-api-client-go/v2 v2.34.1-0.20241226155556-e60f30b0e84e
 	github.com/DataDog/dd-sdk-go-testing v0.0.0-20211116174033-1cd082e322ad
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/datadog-api-client-go/v2 v2.34.0 h1:0VVmv8uZg8vdBuEpiF2nBGUezl2QITrxdEsLgh38j8M=
-github.com/DataDog/datadog-api-client-go/v2 v2.34.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
+github.com/DataDog/datadog-api-client-go/v2 v2.34.1-0.20241226155556-e60f30b0e84e h1:yNSemkpqKE/PXqRWOX0wPQIMF4lC+3SlPI4us6/GYz8=
+github.com/DataDog/datadog-api-client-go/v2 v2.34.1-0.20241226155556-e60f30b0e84e/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=


### PR DESCRIPTION
Following https://github.com/DataDog/datadog-api-spec/pull/3074, this PR adds the `public_id` as a computed field of the browser steps.