### PR TITLE
[datadog_integration_aws_account] Fix panic when resources_config is omitted

### DIFF
--- a/datadog/fwprovider/resource_datadog_integration_aws_account.go
+++ b/datadog/fwprovider/resource_datadog_integration_aws_account.go
@@ -37,6 +37,7 @@ var (
 	authConfigRolePath     = authConfigPath.AtName("aws_auth_config_role")
 	xrayServicesConfigPath = path.MatchRoot("traces_config").AtName("xray_services")
 	lambdaForwarderPath    = path.MatchRoot("logs_config").AtName("lambda_forwarder")
+	resourcesConfigPath    = path.MatchRoot("resources_config")
 )
 
 type integrationAwsAccountResource struct {
@@ -175,6 +176,9 @@ func (r *integrationAwsAccountResource) ConfigValidators(ctx context.Context) []
 		resourcevalidator.Conflicting(
 			xrayServicesConfigPath.AtName("include_all"),
 			xrayServicesConfigPath.AtName("include_only"),
+		),
+		resourcevalidator.ExactlyOneOf(
+			resourcesConfigPath,
 		),
 	}
 }
@@ -859,11 +863,13 @@ func buildRequestMetricsConfig(ctx context.Context, state *integrationAwsAccount
 func buildRequestResourcesConfig(state *integrationAwsAccountModel) datadogV2.AWSResourcesConfig {
 	var resourcesConfig datadogV2.AWSResourcesConfig
 
-	if !state.ResourcesConfig.CloudSecurityPostureManagementCollection.IsNull() {
-		resourcesConfig.SetCloudSecurityPostureManagementCollection(state.ResourcesConfig.CloudSecurityPostureManagementCollection.ValueBool())
-	}
-	if !state.ResourcesConfig.ExtendedCollection.IsNull() {
-		resourcesConfig.SetExtendedCollection(state.ResourcesConfig.ExtendedCollection.ValueBool())
+	if state.ResourcesConfig != nil {
+		if !state.ResourcesConfig.CloudSecurityPostureManagementCollection.IsNull() {
+			resourcesConfig.SetCloudSecurityPostureManagementCollection(state.ResourcesConfig.CloudSecurityPostureManagementCollection.ValueBool())
+		}
+		if !state.ResourcesConfig.ExtendedCollection.IsNull() {
+			resourcesConfig.SetExtendedCollection(state.ResourcesConfig.ExtendedCollection.ValueBool())
+		}
 	}
 
 	return resourcesConfig


### PR DESCRIPTION
Raised here: https://github.com/DataDog/terraform-provider-datadog/issues/2747

`resources_config` is a required block, but we weren't
- validating that exactly one block was defined
- handling the case where the block is nil

This fix adds validation to ensure the block is present to match the expectation defined in the docs.