### PR TITLE
[datadog_application_key] Support scoped app key management

### DIFF
--- a/datadog/fwprovider/data_source_datadog_application_key.go
+++ b/datadog/fwprovider/data_source_datadog_application_key.go
@@ -56,6 +56,11 @@ func (d *applicationKeyDataSource) Schema(_ context.Context, req datasource.Sche
 				Computed:    true,
 				Sensitive:   true,
 			},
+			"scopes": schema.SetAttribute{
+				Description: "Authorization scopes for the Application Key.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
 		},
 		DeprecationMessage: "The datadog_application_key data source is deprecated and will be removed in a future release with prior notice. Securely store your application key using a secret management system or use the datadog_application_key resource to manage application keys in your Datadog account.",
 	}

--- a/datadog/fwprovider/resource_datadog_application_key.go
+++ b/datadog/fwprovider/resource_datadog_application_key.go
@@ -188,10 +188,6 @@ func (r *applicationKeyResource) updateState(ctx context.Context, state *applica
 func getScopesFromStateAttribute(scopes types.Set) []string {
 	scopesList := []string{}
 
-	if scopes.IsNull() {
-		return scopesList
-	}
-
 	for _, scope := range scopes.Elements() {
 		scopesList = append(scopesList, scope.(types.String).ValueString())
 	}

--- a/datadog/fwprovider/resource_datadog_application_key.go
+++ b/datadog/fwprovider/resource_datadog_application_key.go
@@ -4,9 +4,11 @@ import (
 	"context"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	frameworkPath "github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -58,6 +60,9 @@ func (r *applicationKeyResource) Schema(_ context.Context, _ resource.SchemaRequ
 				Description: "Authorization scopes for the Application Key. Application Keys configured with no scopes have full access.",
 				Optional:    true,
 				ElementType: types.StringType,
+				Validators: []validator.Set{
+					setvalidator.SizeAtLeast(1),
+				},
 			},
 			"id": utils.ResourceIDAttribute(),
 		},

--- a/docs/data-sources/application_key.md
+++ b/docs/data-sources/application_key.md
@@ -26,6 +26,7 @@ data "datadog_application_key" "foo" {
 - `exact_match` (Boolean) Whether to use exact match when searching by name.
 - `id` (String) Id for Application Key.
 - `name` (String) Name for Application Key.
+- `scopes` (Set of String) Authorization scopes for the Application Key.
 
 ### Read-Only
 

--- a/docs/resources/application_key.md
+++ b/docs/resources/application_key.md
@@ -26,6 +26,10 @@ resource "datadog_application_key" "foo" {
 
 - `name` (String) Name for Application Key.
 
+### Optional
+
+- `scopes` (Set of String) Authorization scopes for the Application Key. Application Keys configured with no scopes have full access.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.


### PR DESCRIPTION
This PR allows users to manage (create/update) scoped app keys in Terraform

Tested manually with:
```
resource "datadog_application_key" "app_key_1" {
  name = "willson tf scoped app key test"
  scopes = ["dashboards_read", "dashboards_write"]
}
```

Also verified that an invalid scope in the list results in a 400.