### PR TITLE
[datadog_service_account] Fix : `roles` attribute is now always updated

### DIFF
--- a/datadog/fwprovider/resource_datadog_service_account.go
+++ b/datadog/fwprovider/resource_datadog_service_account.go
@@ -283,7 +283,7 @@ func updateServiceAccountStateV2(ctx context.Context, state *serviceAccountResou
 	state.Name = types.StringValue(userAttributes.GetName())
 	state.Disabled = types.BoolValue(userAttributes.GetDisabled())
 	diags := diag.Diagnostics{}
-	state.Roles, diags = types.SetValueFrom(ctx, types.StringType, extractRoles(userData))
+	state.Roles, diags = types.SetValueFrom(ctx, types.StringType, extractRolesFromUser(userData))
 	return diags
 }
 

--- a/datadog/fwprovider/resource_datadog_service_account.go
+++ b/datadog/fwprovider/resource_datadog_service_account.go
@@ -273,6 +273,7 @@ func extractRolesFromUser(userData datadogV2.User) []string {
 	for i, userRole := range userRoles {
 		roles[i] = userRole.GetId()
 	}
+	return roles
 }
 
 func updateServiceAccountStateV2(ctx context.Context, state *serviceAccountResourceModel, user *datadogV2.UserResponse) diag.Diagnostics {


### PR DESCRIPTION
Closes #2736 

**Current behaviour**

If you ask for a service_account without roles 
```
resource "datadog_service_account" "bar" {
  email = "etienne.carriere@datadoghq.com"
  name  = "Terraform test"
}
```
the drift will never be detected : 
* At the creation, as there is no role defined, `state.Roles` is null
* If there is a manual change on `service-account` object by adding a role, at the next refresh of state, the state.Roles is still null and will not be refreshed 

If you ask a service_account with at least one role, the issue doesn't happens as the State will not be null 

Similarly if you import a service_account, Roles will never be loaded 

**Proposed behavior** 

Update in all cases  the state.Roles from the result so we : 
* better detect drift 
* there is no false "update in place" as described in #2736 

**Risks of drift creation** 

When is called updateServiceAccountStateV2 ? 
* 2 times in Create after creation
* 1 time in Read 
* 1 time in Update after update
=> the change should not have drift impact 

As the roles parameter is `optional` and `computed`, if the user is requesting no specific roles and there is some automatic assignements it should not be seen as diff. 

