### PR TITLE
[datadog_api_key] Use plan modifier for API keys.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,8 +27,9 @@ datadog/*cloud_configuration*             @DataDog/api-clients @DataDog/k9-cloud
 datadog/*service_account*                 @DataDog/api-clients @DataDog/team-aaa
 
 # Framework resources/data-sources
-datadog/**/*datadog_api_key*                     @DataDog/api-clients @DataDog/team-aaa
+datadog/**/*datadog_api_key*                     @DataDog/api-clients @DataDog/credentials-management
 datadog/**/*datadog_apm_retention_filter*        @DataDog/api-clients @DataDog/apm-trace-intake
+datadog/**/*datadog_application_key*             @DataDog/api-clients @DataDog/credentials-management
 datadog/**/*datadog_hosts*                       @DataDog/api-clients @DataDog/redapl-storage
 datadog/**/*datadog_ip_ranges*                   @DataDog/api-clients @DataDog/team-aaa
 datadog/**/*datadog_integration_aws*             @DataDog/api-clients @DataDog/cloud-integrations

--- a/datadog/fwprovider/resource_datadog_api_key.go
+++ b/datadog/fwprovider/resource_datadog_api_key.go
@@ -7,6 +7,8 @@ import (
 	frameworkPath "github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -51,9 +53,10 @@ func (r *apiKeyResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				Required:    true,
 			},
 			"key": schema.StringAttribute{
-				Description: "The value of the API Key.",
-				Computed:    true,
-				Sensitive:   true,
+				Description:   "The value of the API Key.",
+				Computed:      true,
+				Sensitive:     true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			// Resource ID
 			"id": utils.ResourceIDAttribute(),


### PR DESCRIPTION
API keys are not returned by the API after creation, so we should save the previous state values to avoid the `Provider returned invalid result object after apply` and overwrite of state value with null.

Tested by creating an application key and updating its name.