### PR TITLE
[datadog_monitor_json] Fix erroneous drift on restriction_policy field

### DIFF
--- a/datadog/resource_datadog_monitor_json.go
+++ b/datadog/resource_datadog_monitor_json.go
@@ -125,8 +125,15 @@ func resourceDatadogMonitorJSONRead(_ context.Context, d *schema.ResourceData, m
 	// try to keep restricted_roles from mixing into it from API responses
 	monitor := d.Get("monitor").(string)
 	attrMap, _ := structure.ExpandJsonFromString(monitor)
-	if _, ok := attrMap["restricted_roles"]; !ok {
-		url += "?with_restricted_roles=false"
+	queryAttrs := make([]string, 0)
+	if _, ok := attrMap["restricted_roles"]; ok {
+		queryAttrs = append(queryAttrs, "with_restricted_roles=true")
+	}
+	if _, ok := attrMap["restriction_policy"]; ok {
+		queryAttrs = append(queryAttrs, "with_restriction_policy=true")
+	}
+	if len(queryAttrs) > 0 {
+		url = fmt.Sprintf("%s?%s", url, strings.Join(queryAttrs, "&"))
 	}
 
 	respByte, httpResp, err := utils.SendRequest(auth, apiInstances.HttpClient, "GET", url, nil)

--- a/datadog/resource_datadog_monitor_json.go
+++ b/datadog/resource_datadog_monitor_json.go
@@ -126,9 +126,12 @@ func resourceDatadogMonitorJSONRead(_ context.Context, d *schema.ResourceData, m
 	monitor := d.Get("monitor").(string)
 	attrMap, _ := structure.ExpandJsonFromString(monitor)
 	queryAttrs := make([]string, 0)
-	if _, ok := attrMap["restricted_roles"]; ok {
-		queryAttrs = append(queryAttrs, "with_restricted_roles=true")
+	if _, ok := attrMap["restricted_roles"]; !ok {
+		queryAttrs = append(queryAttrs, "with_restricted_roles=false")
 	}
+	// Restriction policies are not returned in the API response by default
+	// In order to prevent some erroneous drift, we return it (and take in account in the state)
+	// if the user requests some restriction policy (behavior similar to Optional Computed)
 	if _, ok := attrMap["restriction_policy"]; ok {
 		queryAttrs = append(queryAttrs, "with_restriction_policy=true")
 	}


### PR DESCRIPTION
Closes #2515 

The /api/v1/monitor/{id} doesn't returns the restriction_policies by default so if the user requests some, there is some unexpected drift. 

With this PR, we are requesting the `restriction_policy` field if it is defined in the json submitted by the user.
