### PR TITLE
[datadog_synthetics_global_variable] Remove drift on `option` argument

### DIFF
--- a/datadog/resource_datadog_synthetics_global_variable.go
+++ b/datadog/resource_datadog_synthetics_global_variable.go
@@ -391,7 +391,6 @@ func updateSyntheticsGlobalVariableLocalState(d *schema.ResourceData, synthetics
 		}
 		if len(localVariableOptions) != 0 {
 			d.Set("options", []map[string]interface{}{localVariableOptions})
-			panic(fmt.Sprintf("options: %v", localVariableOptions))
 		}
 	}
 

--- a/datadog/resource_datadog_synthetics_global_variable.go
+++ b/datadog/resource_datadog_synthetics_global_variable.go
@@ -385,9 +385,14 @@ func updateSyntheticsGlobalVariableLocalState(d *schema.ResourceData, synthetics
 			if syntheticsGlobalVariableTOTPParameters.HasRefreshInterval() {
 				localTotpParameters["refresh_interval"] = syntheticsGlobalVariableTOTPParameters.GetRefreshInterval()
 			}
-			localVariableOptions["totp_parameters"] = []map[string]interface{}{localTotpParameters}
+			if len(localTotpParameters) > 0 {
+				localVariableOptions["totp_parameters"] = []map[string]interface{}{localTotpParameters}
+			}
 		}
-		d.Set("options", []map[string]interface{}{localVariableOptions})
+		if len(localVariableOptions) != 0 {
+			d.Set("options", []map[string]interface{}{localVariableOptions})
+			panic(fmt.Sprintf("options: %v", localVariableOptions))
+		}
 	}
 
 	if syntheticsGlobalVariable.HasAttributes() {


### PR DESCRIPTION
When creating the resource 
```hcl
resource "datadog_synthetics_global_variable" "test_variable" {
  name        = "EXAMPLE_VARIABLE"
  description = "Description of the variable"
  tags        = ["foo:bar", "env:test"]
  value       = "variable-value"
}
```
the following drift was always present 
```
Terraform will perform the following actions:

  # datadog_synthetics_global_variable.test_variable will be updated in-place
  ~ resource "datadog_synthetics_global_variable" "test_variable" {
        id               = "xxx"
        name             = "EXAMPLE_VARIABLE"
        tags             = [
            "foo:bar",
            "env:test",
        ]
        # (4 unchanged attributes hidden)

      - options {
          - totp_parameters {}
        }
    }
```
This PR removes this unwanted drift 