### PR TITLE
[datadog_application_key] Support scoped app key management for service accounts

### DIFF
--- a/datadog/tests/resource_datadog_application_key_test.go
+++ b/datadog/tests/resource_datadog_application_key_test.go
@@ -80,6 +80,10 @@ func TestAccDatadogApplicationKey_Error(t *testing.T) {
 				Config:      testAccCheckDatadogScopedApplicationKeyConfigRequired(applicationKeyNameUpdate, []string{}),
 				ExpectError: regexp.MustCompile(`Attribute scopes set must contain at least 1 elements`),
 			},
+			{
+				Config:      testAccCheckDatadogScopedApplicationKeyConfigRequired(applicationKeyNameUpdate, []string{"invalid"}),
+				ExpectError: regexp.MustCompile(`Invalid scopes`),
+			},
 		},
 	})
 }

--- a/datadog/tests/resource_datadog_service_account_application_key_test.go
+++ b/datadog/tests/resource_datadog_service_account_application_key_test.go
@@ -3,6 +3,8 @@ package test
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -20,6 +22,7 @@ func TestAccServiceAccountApplicationKeyBasic(t *testing.T) {
 	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
 	uniq := uniqueEntityName(ctx, t)
 	uniqUpdated := uniq + "updated"
+	scopes := []string{"dashboards_read", "dashboards_write"}
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: accProviders,
 		CheckDestroy:             testAccCheckDatadogServiceAccountApplicationKeyDestroy(providers.frameworkProvider),
@@ -54,7 +57,51 @@ func TestAccServiceAccountApplicationKeyBasic(t *testing.T) {
 						"datadog_service_account_application_key.foo", "last4"),
 					resource.TestCheckResourceAttrPair(
 						"datadog_service_account_application_key.foo", "service_account_id", "datadog_service_account.bar", "id"),
+					resource.TestCheckNoResourceAttr("datadog_service_account_application_key.foo", "scopes"),
 				),
+			},
+			{
+				Config: testAccCheckDatadogServiceAccountScopedApplicationKey(uniqUpdated, scopes),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogServiceAccountApplicationKeyExists(providers.frameworkProvider),
+					resource.TestCheckResourceAttr(
+						"datadog_service_account_application_key.foo", "name", uniqUpdated),
+					resource.TestCheckResourceAttrSet(
+						"datadog_service_account_application_key.foo", "key"),
+					resource.TestCheckResourceAttrSet(
+						"datadog_service_account_application_key.foo", "created_at"),
+					resource.TestCheckResourceAttrSet(
+						"datadog_service_account_application_key.foo", "last4"),
+					resource.TestCheckResourceAttrPair(
+						"datadog_service_account_application_key.foo", "service_account_id", "datadog_service_account.bar", "id"),
+					resource.TestCheckResourceAttrSet(
+						"datadog_service_account_application_key.foo", "scopes.#"),
+					resource.TestCheckTypeSetElemAttr(
+						"datadog_service_account_application_key.foo", "scopes.*", scopes[0]),
+					resource.TestCheckTypeSetElemAttr(
+						"datadog_service_account_application_key.foo", "scopes.*", scopes[1]),
+				),
+			},
+		},
+	})
+}
+
+func TestAccServiceAccountApplicationKey_Error(t *testing.T) {
+	if isRecording() || isReplaying() {
+		t.Skip("This test doesn't support recording or replaying")
+	}
+	t.Parallel()
+	ctx, _, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
+	applicationKeyName := uniqueEntityName(ctx, t)
+	applicationKeyNameUpdate := applicationKeyName + "-2"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: accProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckDatadogScopedApplicationKeyConfigRequired(applicationKeyNameUpdate, []string{}),
+				ExpectError: regexp.MustCompile(`Attribute scopes set must contain at least 1 elements`),
 			},
 		},
 	})
@@ -103,6 +150,27 @@ resource "datadog_service_account_application_key" "foo" {
     service_account_id = datadog_service_account.bar.id
     name = "%s"
 }`, uniq)
+}
+
+func testAccCheckDatadogServiceAccountScopedApplicationKey(uniq string, scopes []string) string {
+	formattedScopes := ""
+	if len(scopes) == 0 {
+		formattedScopes = "[]"
+	} else {
+		formattedScopes = fmt.Sprintf("[\"%s\"]", strings.Join(scopes, "\", \""))
+	}
+
+	return fmt.Sprintf(`
+resource "datadog_service_account" "bar" {
+	email = "new@example.com"
+	name  = "testTerraformServiceAccountApplicationKeys"
+}
+
+resource "datadog_service_account_application_key" "foo" {
+    service_account_id = datadog_service_account.bar.id
+    name = "%s"
+	scopes = %s
+}`, uniq, formattedScopes)
 }
 
 func testAccCheckDatadogServiceAccountApplicationKeyDestroy(accProvider *fwprovider.FrameworkProvider) func(*terraform.State) error {

--- a/datadog/tests/resource_datadog_service_account_application_key_test.go
+++ b/datadog/tests/resource_datadog_service_account_application_key_test.go
@@ -103,6 +103,10 @@ func TestAccServiceAccountApplicationKey_Error(t *testing.T) {
 				Config:      testAccCheckDatadogScopedApplicationKeyConfigRequired(applicationKeyNameUpdate, []string{}),
 				ExpectError: regexp.MustCompile(`Attribute scopes set must contain at least 1 elements`),
 			},
+			{
+				Config:      testAccCheckDatadogScopedApplicationKeyConfigRequired(applicationKeyNameUpdate, []string{"invalid"}),
+				ExpectError: regexp.MustCompile(`Invalid scopes`),
+			},
 		},
 	})
 }

--- a/datadog/tests/resource_datadog_service_account_application_key_test.go
+++ b/datadog/tests/resource_datadog_service_account_application_key_test.go
@@ -100,11 +100,11 @@ func TestAccServiceAccountApplicationKey_Error(t *testing.T) {
 		ProtoV5ProviderFactories: accProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckDatadogScopedApplicationKeyConfigRequired(applicationKeyNameUpdate, []string{}),
+				Config:      testAccCheckDatadogServiceAccountScopedApplicationKey(applicationKeyNameUpdate, []string{}),
 				ExpectError: regexp.MustCompile(`Attribute scopes set must contain at least 1 elements`),
 			},
 			{
-				Config:      testAccCheckDatadogScopedApplicationKeyConfigRequired(applicationKeyNameUpdate, []string{"invalid"}),
+				Config:      testAccCheckDatadogServiceAccountScopedApplicationKey(applicationKeyNameUpdate, []string{"invalid"}),
 				ExpectError: regexp.MustCompile(`Invalid scopes`),
 			},
 		},

--- a/docs/resources/service_account_application_key.md
+++ b/docs/resources/service_account_application_key.md
@@ -28,6 +28,10 @@ resource "datadog_service_account_application_key" "foo" {
 - `name` (String) Name of the application key.
 - `service_account_id` (String) ID of the service account that owns this key.
 
+### Optional
+
+- `scopes` (Set of String) Authorization scopes for the Application Key. Application Keys configured with no scopes have full access.
+
 ### Read-Only
 
 - `created_at` (String) Creation date of the application key.


### PR DESCRIPTION
Similar to https://github.com/DataDog/terraform-provider-datadog/pull/2760, but for service accounts.

Tested manually with:
```
resource "datadog_service_account" "foo" {
	email = "new@example.com"
	name  = "terraform test"
}

resource "datadog_service_account_application_key" "foo" {
  service_account_id = datadog_service_account.foo.id
  name               = "terraform test app key"
  scopes             = ["dashboards_write"]
}
```

Also verified that an invalid scope in the list results in a 400.