### PR TITLE
fix(synthetics): duplication of default info

### DIFF
--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -743,7 +743,7 @@ Required:
 
 Optional:
 
-- `elementsoperator` (String) The element from the list of results to assert on. Select from `firstElementMatches` (the first element in the list), `everyElementMatches` (every element in the list), `atLeastOneElementMatches` (at least one element in the list), or `serializationMatches` (the serialized value of the list). Defaults to `firstElementMatches`. Defaults to `"firstElementMatches"`.
+- `elementsoperator` (String) The element from the list of results to assert on. Select from `firstElementMatches` (the first element in the list), `everyElementMatches` (every element in the list), `atLeastOneElementMatches` (at least one element in the list), or `serializationMatches` (the serialized value of the list). Defaults to `firstElementMatches`.
 - `targetvalue` (String) Expected matching value.
 
 


### PR DESCRIPTION
This will remove duplicated default information for `[elementsoperator]`