### PR TITLE
[data_datadog_application_key] remove scopes from schema

### DIFF
--- a/datadog/fwprovider/data_source_datadog_application_key.go
+++ b/datadog/fwprovider/data_source_datadog_application_key.go
@@ -82,7 +82,7 @@ func (d *applicationKeyDataSource) Read(ctx context.Context, req datasource.Read
 		}
 		appKeyData := ddResp.GetData()
 		if !d.checkAPIDeprecated(&appKeyData, resp) {
-			d.updateState(ctx, &state, &appKeyData)
+			d.updateState(&state, &appKeyData)
 		}
 	} else if !state.Name.IsNull() {
 		optionalParams := datadogV2.NewListCurrentUserApplicationKeysOptionalParameters()

--- a/docs/data-sources/application_key.md
+++ b/docs/data-sources/application_key.md
@@ -26,7 +26,6 @@ data "datadog_application_key" "foo" {
 - `exact_match` (Boolean) Whether to use exact match when searching by name.
 - `id` (String) Id for Application Key.
 - `name` (String) Name for Application Key.
-- `scopes` (Set of String) Authorization scopes for the Application Key.
 
 ### Read-Only
 


### PR DESCRIPTION
fixes regression caused by https://github.com/DataDog/terraform-provider-datadog/pull/2760, which added scopes to the Schema but not the model or state update