### PR TITLE
[datadog_integration_aws] EXTERNAL_ID environment variable is now optional for import

### DIFF
--- a/datadog/resource_datadog_integration_aws.go
+++ b/datadog/resource_datadog_integration_aws.go
@@ -361,7 +361,8 @@ func resourceDatadogIntegrationAwsImport(ctx context.Context, d *schema.Resource
 	if d.Id() == "" {
 		return nil, fmt.Errorf("error importing aws integration resource. Resource with id `%s` does not exist", originalId)
 	}
-
-	d.Set("external_id", os.Getenv("EXTERNAL_ID"))
+	if v, ok := os.LookupEnv("EXTERNAL_ID"); ok {
+		d.Set("external_id", v)
+	}
 	return []*schema.ResourceData{d}, nil
 }

--- a/examples/resources/datadog_integration_aws/import.sh
+++ b/examples/resources/datadog_integration_aws/import.sh
@@ -1,2 +1,8 @@
-# Amazon Web Services integrations can be imported using their account ID and role name separated with a colon (:), while the external_id should be passed by setting an environment variable called EXTERNAL_ID
+# Amazon Web Services integrations can be imported using their account ID and role name separated with a colon (:),
+# The EXTERNAL_ID variable is optional and allows to set external_id
+
+# Import will be done and the external_id will be set to the value of the EXTERNAL_ID variable
 EXTERNAL_ID=${external_id} terraform import datadog_integration_aws.test ${account_id}:${role_name}
+
+# Import will be done and the external_id will not be set
+terraform import datadog_integration_aws.test ${account_id}:${role_name}


### PR DESCRIPTION
Fixes #2257 

The `external_id` field is a computed field that is : 
* never set outside of create => no risk of drift 
* never used for requesting Datadog API => no risk at the execution of actions 

With the [import block](https://developer.hashicorp.com/terraform/language/import) (tf 1.5+), needing an environment variable can be an issue => we put this environment variable as optional.  
