### PR TITLE
[datadog_monitors] Fix `datadog_monitors` datasource not failing if no monitors found

### DIFF
--- a/datadog/data_source_datadog_monitors.go
+++ b/datadog/data_source_datadog_monitors.go
@@ -87,9 +87,6 @@ func dataSourceDatadogMonitorsRead(ctx context.Context, d *schema.ResourceData, 
 	if err != nil {
 		return utils.TranslateClientErrorDiag(err, httpresp, "error querying monitors")
 	}
-	if len(monitors) == 0 {
-		return diag.Errorf("your query returned no result, please try a less specific search criteria")
-	}
 
 	d.SetId(computeMonitorsDatasourceID(d))
 


### PR DESCRIPTION
Fixes #2782 

It is quite idiomatic with terraform datasources to have 2 datasources : 
* a singular one (`datadog_monitor` in our case) that will fails if the search criteria matches 0 or more than 1 results 
* a plural one (`datadog_monitors` in our case) that will not fails based on the number of items matching the search criteria as it returns an array. 

this PR implement this policy if there is no monitors matched.