### PR TITLE
check comparison instead of equality

### DIFF
--- a/datadog/resource_datadog_service_definition_yaml.go
+++ b/datadog/resource_datadog_service_definition_yaml.go
@@ -128,7 +128,7 @@ func compareNullableStringArg(left map[string]interface{}, right map[string]inte
 		lv, lok := valueLVal.(string)
 		rv, rok := valueRVal.(string)
 		if lok && rok {
-			v := lv == rv
+			v := lv < rv
 			return &v
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-datadog
 
 require (
-	github.com/DataDog/datadog-api-client-go/v2 v2.34.1-0.20250203202210-56683de946fa
+	github.com/DataDog/datadog-api-client-go/v2 v2.35.1-0.20250205194829-dea7b7dca453
 	github.com/DataDog/dd-sdk-go-testing v0.0.0-20211116174033-1cd082e322ad
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/datadog-api-client-go/v2 v2.34.1-0.20250203202210-56683de946fa h1:UtJykL0b3IaZqJy6u2USt4MvFJcPdKodD7D1QaUMAUA=
-github.com/DataDog/datadog-api-client-go/v2 v2.34.1-0.20250203202210-56683de946fa/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
+github.com/DataDog/datadog-api-client-go/v2 v2.35.1-0.20250205194829-dea7b7dca453 h1:p8HaTaz+M9K61JiwgI8uF98HSUWRxY1DePBfbid+KhQ=
+github.com/DataDog/datadog-api-client-go/v2 v2.35.1-0.20250205194829-dea7b7dca453/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=


### PR DESCRIPTION
https://github.com/DataDog/terraform-provider-datadog/pull/2802 changed the sorting of contact attributes in `datadog_service_definition_yaml`. Since the backend can reorder attributes, we need to compare them directly instead of just testing for equality 

This was missed in the original PR review because the `TestAccDatadogServiceDefinition_Order` test was not run 