### PR TITLE
Thibault.viennot/add config file

### DIFF
--- a/.generator/README.md
+++ b/.generator/README.md
@@ -1,6 +1,6 @@
 # Terraform Generation
 
-The goal of this sub-project is to generate the scaffolding to create a terraform resource.
+The goal of this sub-project is to generate the scaffolding to create a Terraform resource.
 
 > [!CAUTION]
 > This code is HIGHLY experimental and should stabilize over the next weeks/months. As such this code is NOT intended for production uses.
@@ -17,31 +17,60 @@ The goal of this sub-project is to generate the scaffolding to create a terrafor
 
 Install the necessary dependencies by running `poetry install`
 
-### Mark resources to be generated
+### Marking the resources to be generated
 
-For the generator to create a resource one must tag the resource's CRUD actions with `x-terraform-resource: <resource_name>` in the openApi specification.
+The generator reads a configuration file in order to generate the appropriate resources.
+The configuration file should look like the following:
 
 ```yaml
-paths:
-  /users:
-    post:
-      #  [...]
-      x-terraform-resource: user
-  /users/{user_id}:
-    get:
-      #  [...]
-      x-terraform-resource: user
-    patch:
-      #  [...]
-      x-terraform-resource: user
+resources:
+  { resource_name }:
+    read:
+      method: { read_method }
+      path: { read_path }
+    create:
+      method: { create_method }
+      path: { create_path }
+    update:
+      method: { update_method }
+      path: { update_path }
     delete:
-      #  [...]
-      x-terraform-resource: user
+      method: { delete_method }
+      path: { delete_path }
+  ...
 ```
 
-The routes tagged in this example will generate a `user` resource.
+- `resource_name` is the name of the resource to be generated.
+- `xxx_method` should be the HTTP method used by the relevant route
+- `xxx_path` should be the HTTP route of the resource's CRUD operation
 
-### Run the generator
+> [!NOTE]
+> An example using the `team` resource would look like this:
+>
+> ```yaml
+> resources:
+>   team:
+>     get:
+>       method: get
+>       path: /api/v2/team/{team_id}
+>     create:
+>       method: post
+>       path: /api/v2/team
+>     update:
+>       method: patch
+>       path: /api/v2/team/{team_id}
+>     delete:
+>       method: delete
+>       path: /api/v2/team/{team_id}
+> ```
 
-When all resources to be generated are tagged run `poetry run python -m generator <openapi_spec_path>`.
-the generated resources will be placed in `/datadog/fwprovider/`.
+### Running the generator
+
+Once the configuration file is written, you can run the following command to generate the Terraform resources:
+
+```sh
+  $ poetry run python -m generator <openapi_spec_path> <configuration_path>
+```
+
+> [!NOTE]
+> The generated resources will be placed in `datadog/fwprovider/`

--- a/.generator/src/generator/cli.py
+++ b/.generator/src/generator/cli.py
@@ -14,13 +14,19 @@ from . import openapi
         exists=True, file_okay=True, dir_okay=False, path_type=pathlib.Path
     ),
 )
+@click.argument(
+    "config_path",
+    type=click.Path(
+        exists=True, file_okay=True, dir_okay=False, path_type=pathlib.Path
+    ),
+)
 @click.option(
     "-o",
     "--output",
     default="../datadog/",
     type=click.Path(path_type=pathlib.Path),
 )
-def cli(spec_path, output):
+def cli(spec_path, config_path, output):
     """
     Generate a terraform code snippet from OpenAPI specification.
     """
@@ -29,6 +35,7 @@ def cli(spec_path, output):
     templates = setup.load_templates(env=env)
 
     spec = setup.load(spec_path)
+    config = setup.load(config_path)
 
     operations = openapi.operations_to_generate(spec)
 

--- a/.generator/src/generator/cli.py
+++ b/.generator/src/generator/cli.py
@@ -28,7 +28,7 @@ def cli(spec_path, output):
 
     templates = setup.load_templates(env=env)
 
-    spec = openapi.load(spec_path)
+    spec = setup.load(spec_path)
 
     operations = openapi.operations_to_generate(spec)
 

--- a/.generator/src/generator/cli.py
+++ b/.generator/src/generator/cli.py
@@ -37,19 +37,19 @@ def cli(spec_path, config_path, output):
     spec = setup.load(spec_path)
     config = setup.load(config_path)
 
-    operations = openapi.operations_to_generate(spec)
+    resources_to_generate = openapi.get_resources(spec, config)
 
-    for name, operations in operations.items():
+    for name, resource in resources_to_generate.items():
         generate_resource(
             name=name,
-            operations=operations,
+            resource=resource,
             output=output,
             templates=templates,
         )
 
 
 def generate_resource(
-    name: str, operations: dict, output: pathlib.Path, templates: dict[str, Template]
+    name: str, resource: dict, output: pathlib.Path, templates: dict[str, Template]
 ) -> None:
     """
     Generates files related to a resource.
@@ -62,19 +62,19 @@ def generate_resource(
     # TF resource file
     filename = output / f"fwprovider/resource_datadog_{name}.go"
     with filename.open("w") as fp:
-        fp.write(templates["base"].render(name=name, operations=operations))
+        fp.write(templates["base"].render(name=name, operations=resource))
 
     # TF test file
     filename = output / "tests" / f"resource_datadog_{name}_test.go"
     with filename.open("w") as fp:
-        fp.write(templates["test"].render(name=name, operations=operations))
+        fp.write(templates["test"].render(name=name, operations=resource))
 
     # TF resource example
     filename = output.parent / f"examples/resources/datadog_{name}/resource.tf"
     with filename.open("w") as fp:
-        fp.write(templates["example"].render(name=name, operations=operations))
+        fp.write(templates["example"].render(name=name, operations=resource))
 
     # TF import example
     filename = output.parent / f"examples/resources/datadog_{name}/import.sh"
     with filename.open("w") as fp:
-        fp.write(templates["import"].render(name=name, operations=operations))
+        fp.write(templates["import"].render(name=name, operations=resource))

--- a/.generator/src/generator/openapi.py
+++ b/.generator/src/generator/openapi.py
@@ -1,20 +1,9 @@
-import pathlib
-import yaml
-
-from jsonref import JsonRef
-
 from .utils import (
     GET_OPERATION,
     CREATE_OPERATION,
     UPDATE_OPERATION,
     DELETE_OPERATION,
 )
-
-
-def load(filename):
-    path = pathlib.Path(filename)
-    with path.open() as fp:
-        return JsonRef.replace_refs(yaml.safe_load(fp))
 
 
 def get_name(schema):

--- a/.generator/src/generator/setup.py
+++ b/.generator/src/generator/setup.py
@@ -1,5 +1,8 @@
 from jinja2 import Environment, FileSystemLoader, Template
 import pathlib
+import yaml
+
+from jsonref import JsonRef
 
 from . import openapi
 from . import formatter
@@ -55,3 +58,9 @@ def load_templates(env: Environment) -> dict[str, Template]:
         "import": env.get_template("resource_import_example.j2"),
     }
     return templates
+
+
+def load(filename):
+    path = pathlib.Path(filename)
+    with path.open() as fp:
+        return JsonRef.replace_refs(yaml.safe_load(fp))


### PR DESCRIPTION
## Motivation

Currently the generator finds resources to generate by iterating over the entire openAPI spec and looks for a x-terraform-resource tag. This is both expensive at runtime and tedious for the user to tag.

To remediate this, we will change the CLI to ingest a configuration file and read the resources to generate from there. 

## Changes
- The CLI now reads a configuration file to decide what resources to generate
- The README has been updated to indicate the new way to use the CLI
- The load function has been moved from `openapi.py` to `setup.py`
- The `operations_to_generate` has been renamed to `get_resources`