### PR TITLE
[Generator] (fix) Fixed schema generation

### DIFF
--- a/.generator/src/generator/templates/utils/state_helper.j2
+++ b/.generator/src/generator/templates/utils/state_helper.j2
@@ -2,22 +2,22 @@
     {%- set primitiveAttr, primitiveArrAttr, nonPrimitiveListAttr, nonPrimitiveObjAttr = schema|tf_sort_properties_by_type %}
 
     {%- for attr, schema in primitiveAttr.items() %}
-    {%- set isRequired = attr in schema.get("required", []) or schema.get("_tf_required") %}
+    {%- set isRequired = attr in schema.get("required", []) or schema.get("required") %}
     {{ baseStateSetter(attr, schema, baseSetter, baseAccessor, required=isRequired) }}
     {%- endfor %}
 
     {%- for attr, schema in primitiveArrAttr.items() %}
-    {%- set isRequired = attr in schema.get("required", []) or schema.get("_tf_required") %}
+    {%- set isRequired = attr in schema.get("required", []) or schema.get("required") %}
     {{ baseStateSetter(attr, schema, baseSetter, baseAccessor, required=isRequired) }}
     {%- endfor %}
 
     {%- for attr, schema in nonPrimitiveListAttr.items() %}
-    {%- set isRequired = attr in schema.get("required", []) or schema.get("_tf_required") %}
+    {%- set isRequired = attr in schema.get("required", []) or schema.get("required") %}
     {{ baseStateSetter(attr, schema, baseSetter, baseAccessor, required=isRequired) }}
     {%- endfor %}
 
     {%- for attr, schema in nonPrimitiveObjAttr.items() %}
-    {%- set isRequired = attr in schema.get("required", []) or schema.get("_tf_required") %}
+    {%- set isRequired = attr in schema.get("required", []) or schema.get("required") %}
     {{ baseStateSetter(attr, schema, baseSetter, baseAccessor, required=isRequired) }}
     {%- endfor %}
 {%- endmacro %}

--- a/.generator/src/generator/type.py
+++ b/.generator/src/generator/type.py
@@ -121,7 +121,7 @@ def tf_sort_params_by_type(parameters):
 
         for attr, s in schema["properties"].items():
             required = attr in schema.get("required", [])
-            s["_tf_required"] = required
+            s["required"] = required
 
             # categorize the parameter based on its type
             if is_primitive(s):
@@ -170,7 +170,7 @@ def tf_sort_properties_by_type(schema):
             json_attr_schema = openapi.json_api_attributes_schema(cSchema)
             for attr, s in json_attr_schema["properties"].items():
                 required = attr in json_attr_schema.get("required", [])
-                s["_tf_required"] = required
+                s["required"] = required
                 categorize_property(attr, s)
         else:
             # Process non-JSON API properties


### PR DESCRIPTION
## Motivation
Some fields in the schema generation that should be required are not tagged as such in the generated resources.
The 'required' field was ignored and all attributes in a schema were marked as optional.

## Changes
Changed the name of the checked field.