### PR TITLE
Ec/refacto formula dashboard

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -3050,20 +3050,7 @@ func buildDatadogHeatmapRequests(terraformRequests *[]interface{}) *[]datadogV1.
 			securityQuery := v[0].(map[string]interface{})
 			datadogHeatmapRequest.SecurityQuery = buildDatadogApmOrLogQuery(securityQuery)
 		} else if v, ok := terraformRequest["query"].([]interface{}); ok && len(v) > 0 {
-			queries := make([]datadogV1.FormulaAndFunctionQueryDefinition, len(v))
-			for i, q := range v {
-				query := q.(map[string]interface{})
-				if w, ok := query["event_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogEventQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["metric_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogMetricQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["process_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionProcessQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["slo_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionSLOQuery(w[0].(map[string]interface{}))
-				}
-			}
-			datadogHeatmapRequest.SetQueries(queries)
+			datadogHeatmapRequest.SetQueries(buildFormulaQuery(v))
 			datadogHeatmapRequest.SetResponseFormat(datadogV1.FormulaAndFunctionResponseFormat("timeseries"))
 		}
 		if v, ok := terraformRequest["formula"].([]interface{}); ok && len(v) > 0 {
@@ -6114,20 +6101,7 @@ func buildDatadogGeomapRequests(terraformRequests *[]interface{}) *[]datadogV1.G
 			rumQuery := v[0].(map[string]interface{})
 			datadogGeomapRequest.RumQuery = buildDatadogApmOrLogQuery(rumQuery)
 		} else if v, ok := terraformRequest["query"].([]interface{}); ok && len(v) > 0 {
-			queries := make([]datadogV1.FormulaAndFunctionQueryDefinition, len(v))
-			for i, q := range v {
-				query := q.(map[string]interface{})
-				if w, ok := query["event_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogEventQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["metric_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogMetricQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["process_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionProcessQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["slo_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionSLOQuery(w[0].(map[string]interface{}))
-				}
-			}
-			datadogGeomapRequest.SetQueries(queries)
+			datadogGeomapRequest.SetQueries(buildFormulaQuery(v))
 			// Geomap requests for formulas and functions always has a response format of "scalar"
 			datadogGeomapRequest.SetResponseFormat(datadogV1.FormulaAndFunctionResponseFormat("scalar"))
 		}

--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -2154,22 +2154,7 @@ func buildDatadogChangeRequests(terraformRequests *[]interface{}) *[]datadogV1.C
 			processQuery := v[0].(map[string]interface{})
 			datadogChangeRequest.ProcessQuery = buildDatadogProcessQuery(processQuery)
 		} else if v, ok := terraformRequest["query"].([]interface{}); ok && len(v) > 0 {
-			queries := make([]datadogV1.FormulaAndFunctionQueryDefinition, len(v))
-			for i, q := range v {
-				query := q.(map[string]interface{})
-				if w, ok := query["event_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogEventQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["metric_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogMetricQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["process_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionProcessQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["slo_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionSLOQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["cloud_cost_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionCloudCostQuery(w[0].(map[string]interface{}))
-				}
-			}
-			datadogChangeRequest.SetQueries(queries)
+			datadogChangeRequest.SetQueries(buildFormulaQuery(v))
 			// Change request for formulas and functions always have a response format of "scalar"
 			datadogChangeRequest.SetResponseFormat(datadogV1.FormulaAndFunctionResponseFormat("scalar"))
 		}
@@ -4289,22 +4274,7 @@ func buildDatadogQueryValueRequests(terraformRequests *[]interface{}) *[]datadog
 			auditQuery := v[0].(map[string]interface{})
 			datadogQueryValueRequest.AuditQuery = buildDatadogApmOrLogQuery(auditQuery)
 		} else if v, ok := terraformRequest["query"].([]interface{}); ok && len(v) > 0 {
-			queries := make([]datadogV1.FormulaAndFunctionQueryDefinition, len(v))
-			for i, q := range v {
-				query := q.(map[string]interface{})
-				if w, ok := query["event_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogEventQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["metric_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogMetricQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["process_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionProcessQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["slo_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionSLOQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["cloud_cost_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionCloudCostQuery(w[0].(map[string]interface{}))
-				}
-			}
-			datadogQueryValueRequest.SetQueries(queries)
+			datadogQueryValueRequest.SetQueries(buildFormulaQuery(v))
 			// Query Value requests for formulas and functions always has a response format of "scalar"
 			datadogQueryValueRequest.SetResponseFormat(datadogV1.FormulaAndFunctionResponseFormat("scalar"))
 		}
@@ -4611,26 +4581,7 @@ func buildDatadogQueryTableRequests(terraformRequests *[]interface{}) *[]datadog
 			apmStatsQuery := v[0].(map[string]interface{})
 			datadogQueryTableRequest.ApmStatsQuery = buildDatadogApmStatsQuery(apmStatsQuery)
 		} else if v, ok := terraformRequest["query"].([]interface{}); ok && len(v) > 0 {
-			queries := make([]datadogV1.FormulaAndFunctionQueryDefinition, len(v))
-			for i, q := range v {
-				query := q.(map[string]interface{})
-				if w, ok := query["event_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogEventQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["metric_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogMetricQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["process_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionProcessQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["apm_dependency_stats_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionAPMDependencyStatsQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["apm_resource_stats_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionAPMResourceStatsQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["slo_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionSLOQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["cloud_cost_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionCloudCostQuery(w[0].(map[string]interface{}))
-				}
-			}
-			datadogQueryTableRequest.SetQueries(queries)
+			datadogQueryTableRequest.SetQueries(buildFormulaQuery(v))
 			// Query Table request for formulas and functions always have a response format of "scalar"
 			datadogQueryTableRequest.SetResponseFormat(datadogV1.FormulaAndFunctionResponseFormat("scalar"))
 		}
@@ -5108,22 +5059,7 @@ func buildDatadogScatterplotTableRequest(terraformRequest map[string]interface{}
 	datadogScatterplotTableRequest := datadogV1.NewScatterplotTableRequest()
 
 	if v, ok := terraformRequest["query"].([]interface{}); ok && len(v) > 0 {
-		queries := make([]datadogV1.FormulaAndFunctionQueryDefinition, len(v))
-		for i, q := range v {
-			query := q.(map[string]interface{})
-			if w, ok := query["event_query"].([]interface{}); ok && len(w) > 0 {
-				queries[i] = *buildDatadogEventQuery(w[0].(map[string]interface{}))
-			} else if w, ok := query["metric_query"].([]interface{}); ok && len(w) > 0 {
-				queries[i] = *buildDatadogMetricQuery(w[0].(map[string]interface{}))
-			} else if w, ok := query["process_query"].([]interface{}); ok && len(w) > 0 {
-				queries[i] = *buildDatadogFormulaAndFunctionProcessQuery(w[0].(map[string]interface{}))
-			} else if w, ok := query["slo_query"].([]interface{}); ok && len(w) > 0 {
-				queries[i] = *buildDatadogFormulaAndFunctionSLOQuery(w[0].(map[string]interface{}))
-			} else if w, ok := query["cloud_cost_query"].([]interface{}); ok && len(w) > 0 {
-				queries[i] = *buildDatadogFormulaAndFunctionCloudCostQuery(w[0].(map[string]interface{}))
-			}
-		}
-		datadogScatterplotTableRequest.SetQueries(queries)
+		datadogScatterplotTableRequest.SetQueries(buildFormulaQuery(v))
 		datadogScatterplotTableRequest.SetResponseFormat(datadogV1.FormulaAndFunctionResponseFormat("scalar"))
 	}
 
@@ -6681,22 +6617,7 @@ func buildDatadogSunburstRequests(terraformRequests *[]interface{}) *[]datadogV1
 			auditQuery := v[0].(map[string]interface{})
 			datadogSunburstRequest.AuditQuery = buildDatadogApmOrLogQuery(auditQuery)
 		} else if v, ok := terraformRequest["query"].([]interface{}); ok && len(v) > 0 {
-			queries := make([]datadogV1.FormulaAndFunctionQueryDefinition, len(v))
-			for i, q := range v {
-				query := q.(map[string]interface{})
-				if w, ok := query["event_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogEventQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["metric_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogMetricQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["process_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionProcessQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["slo_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionSLOQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["cloud_cost_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionCloudCostQuery(w[0].(map[string]interface{}))
-				}
-			}
-			datadogSunburstRequest.SetQueries(queries)
+			datadogSunburstRequest.SetQueries(buildFormulaQuery(v))
 			datadogSunburstRequest.SetResponseFormat(datadogV1.FormulaAndFunctionResponseFormat("scalar"))
 		}
 		if v, ok := terraformRequest["formula"].([]interface{}); ok && len(v) > 0 {
@@ -6939,6 +6860,29 @@ func getFormulaSchema() *schema.Schema {
 			},
 		},
 	}
+}
+
+func buildFormulaQuery(qs []interface{}) []datadogV1.FormulaAndFunctionQueryDefinition {
+	queries := make([]datadogV1.FormulaAndFunctionQueryDefinition, len(qs))
+	for i, q := range qs {
+		query := q.(map[string]interface{})
+		if w, ok := query["event_query"].([]interface{}); ok && len(w) > 0 {
+			queries[i] = *buildDatadogEventQuery(w[0].(map[string]interface{}))
+		} else if w, ok := query["metric_query"].([]interface{}); ok && len(w) > 0 {
+			queries[i] = *buildDatadogMetricQuery(w[0].(map[string]interface{}))
+		} else if w, ok := query["process_query"].([]interface{}); ok && len(w) > 0 {
+			queries[i] = *buildDatadogFormulaAndFunctionProcessQuery(w[0].(map[string]interface{}))
+		} else if w, ok := query["apm_dependency_stats_query"].([]interface{}); ok && len(w) > 0 {
+			queries[i] = *buildDatadogFormulaAndFunctionAPMDependencyStatsQuery(w[0].(map[string]interface{}))
+		} else if w, ok := query["apm_resource_stats_query"].([]interface{}); ok && len(w) > 0 {
+			queries[i] = *buildDatadogFormulaAndFunctionAPMResourceStatsQuery(w[0].(map[string]interface{}))
+		} else if w, ok := query["slo_query"].([]interface{}); ok && len(w) > 0 {
+			queries[i] = *buildDatadogFormulaAndFunctionSLOQuery(w[0].(map[string]interface{}))
+		} else if w, ok := query["cloud_cost_query"].([]interface{}); ok && len(w) > 0 {
+			queries[i] = *buildDatadogFormulaAndFunctionCloudCostQuery(w[0].(map[string]interface{}))
+		}
+	}
+	return queries
 }
 
 func getFormulaQuerySchema() *schema.Schema {
@@ -7850,22 +7794,7 @@ func buildDatadogTimeseriesRequests(terraformRequests *[]interface{}) *[]datadog
 			auditQuery := v[0].(map[string]interface{})
 			datadogTimeseriesRequest.AuditQuery = buildDatadogApmOrLogQuery(auditQuery)
 		} else if v, ok := terraformRequest["query"].([]interface{}); ok && len(v) > 0 {
-			queries := make([]datadogV1.FormulaAndFunctionQueryDefinition, len(v))
-			for i, q := range v {
-				query := q.(map[string]interface{})
-				if w, ok := query["event_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogEventQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["metric_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogMetricQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["process_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionProcessQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["slo_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionSLOQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["cloud_cost_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionCloudCostQuery(w[0].(map[string]interface{}))
-				}
-			}
-			datadogTimeseriesRequest.SetQueries(queries)
+			datadogTimeseriesRequest.SetQueries(buildFormulaQuery(v))
 			datadogTimeseriesRequest.SetResponseFormat(datadogV1.FormulaAndFunctionResponseFormat("timeseries"))
 		}
 		if v, ok := terraformRequest["formula"].([]interface{}); ok && len(v) > 0 {
@@ -8177,22 +8106,7 @@ func buildDatadogToplistRequests(terraformRequests *[]interface{}) *[]datadogV1.
 			auditQuery := v[0].(map[string]interface{})
 			datadogToplistRequest.AuditQuery = buildDatadogApmOrLogQuery(auditQuery)
 		} else if v, ok := terraformRequest["query"].([]interface{}); ok && len(v) > 0 {
-			queries := make([]datadogV1.FormulaAndFunctionQueryDefinition, len(v))
-			for i, q := range v {
-				query := q.(map[string]interface{})
-				if w, ok := query["event_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogEventQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["metric_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogMetricQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["process_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionProcessQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["slo_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionSLOQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["cloud_cost_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionCloudCostQuery(w[0].(map[string]interface{}))
-				}
-			}
-			datadogToplistRequest.SetQueries(queries)
+			datadogToplistRequest.SetQueries(buildFormulaQuery(v))
 			// Toplist requests for formulas and functions always has a response format of "scalar"
 			datadogToplistRequest.SetResponseFormat(datadogV1.FormulaAndFunctionResponseFormat("scalar"))
 		}
@@ -9088,22 +9002,7 @@ func buildDatadogTreemapRequests(terraformRequests *[]interface{}) *[]datadogV1.
 		// Build Treemap request
 		datadogTreemapRequest := datadogV1.NewTreeMapWidgetRequest()
 		if v, ok := terraformRequest["query"].([]interface{}); ok && len(v) > 0 {
-			queries := make([]datadogV1.FormulaAndFunctionQueryDefinition, len(v))
-			for i, q := range v {
-				query := q.(map[string]interface{})
-				if w, ok := query["event_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogEventQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["metric_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogMetricQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["process_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionProcessQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["slo_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionSLOQuery(w[0].(map[string]interface{}))
-				} else if w, ok := query["cloud_cost_query"].([]interface{}); ok && len(w) > 0 {
-					queries[i] = *buildDatadogFormulaAndFunctionCloudCostQuery(w[0].(map[string]interface{}))
-				}
-			}
-			datadogTreemapRequest.SetQueries(queries)
+			datadogTreemapRequest.SetQueries(buildFormulaQuery(v))
 			datadogTreemapRequest.SetResponseFormat(datadogV1.FormulaAndFunctionResponseFormat("scalar"))
 		}
 		if v, ok := terraformRequest["formula"].([]interface{}); ok && len(v) > 0 {


### PR DESCRIPTION
Similarly to [schema](https://github.com/DataDog/terraform-provider-datadog/blob/master/datadog/resource_datadog_dashboard.go#L6944) and [HTTP=>State function](https://github.com/DataDog/terraform-provider-datadog/blob/master/datadog/resource_datadog_dashboard.go#L9859) that are already centralized , the State Function => HTTP object was not factorised and code was duplicated and not always the same . 

I am doing that for coherence but I don't know if it was on purpose as some pairs (Widget / Query Type) could be impossible. In this case, we should modify the schema or note that some pairs are incompatibles. 