### PR TITLE
[Generator] (feat) Generated resources are now formatted

### DIFF
--- a/.generator/README.md
+++ b/.generator/README.md
@@ -50,7 +50,7 @@ resources:
 > ```yaml
 > resources:
 >   team:
->     get:
+>     read:
 >       method: get
 >       path: /api/v2/team/{team_id}
 >     create:

--- a/.generator/README.md
+++ b/.generator/README.md
@@ -12,10 +12,13 @@ The goal of this sub-project is to generate the scaffolding to create a Terrafor
 - This project
 - Poetry
 - An OpenApi 3.0.x specification (Datadog's OpenApi spec can be found [here](https://github.com/DataDog/datadog-api-client-go/tree/master/.generator/schemas))
+- Go
 
 ### Install dependencies
 
 Install the necessary dependencies by running `poetry install`
+
+Install go as we use the `go fmt` command on the generated files to format them.
 
 ### Marking the resources to be generated
 

--- a/.generator/src/generator/cli.py
+++ b/.generator/src/generator/cli.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import click
 
@@ -63,11 +64,13 @@ def generate_resource(
     filename = output / f"fwprovider/resource_datadog_{name}.go"
     with filename.open("w") as fp:
         fp.write(templates["base"].render(name=name, operations=resource))
+    os.system(f"go fmt {filename}")
 
     # TF test file
     filename = output / "tests" / f"resource_datadog_{name}_test.go"
     with filename.open("w") as fp:
         fp.write(templates["test"].render(name=name, operations=resource))
+    os.system(f"go fmt {filename}")
 
     # TF resource example
     filename = output.parent / f"examples/resources/datadog_{name}/resource.tf"

--- a/.generator/src/generator/templates/base_resource.j2
+++ b/.generator/src/generator/templates/base_resource.j2
@@ -13,7 +13,6 @@ package fwprovider
 import (
 	"context"
 
-	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog{{ version }}"
     "github.com/hashicorp/terraform-plugin-framework/diag"
 	frameworkPath "github.com/hashicorp/terraform-plugin-framework/path"


### PR DESCRIPTION
## Motivation
The generated files were not properly formatted once generated.

## Changes
- Added a call to `go fmt {FILENAME}` for the generated go files.
- Updated dependencies in the README
- Fixed typo in the README