### PR TITLE
[datadog_api_key] Support `remote_config_read_enabled` argument

### DIFF
--- a/datadog/fwprovider/data_source_datadog_api_key.go
+++ b/datadog/fwprovider/data_source_datadog_api_key.go
@@ -24,7 +24,7 @@ type apiKeyDataSourceModel struct {
 	Name         types.String `tfsdk:"name"`
 	ExactMatch   types.Bool   `tfsdk:"exact_match"`
 	Key          types.String `tfsdk:"key"`
-	RemoteConfig types.Bool   `tfsdk:"remote_config"`
+	RemoteConfig types.Bool   `tfsdk:"remote_config_read_enabled"`
 }
 
 type apiKeyDataSource struct {
@@ -63,7 +63,7 @@ func (d *apiKeyDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 				Computed:    true,
 				Sensitive:   true,
 			},
-			"remote_config": schema.BoolAttribute{
+			"remote_config_read_enabled": schema.BoolAttribute{
 				Description: "Whether the API key will be used for remote config.",
 				Computed:    true,
 			},

--- a/datadog/fwprovider/data_source_datadog_api_key.go
+++ b/datadog/fwprovider/data_source_datadog_api_key.go
@@ -20,10 +20,11 @@ func NewAPIKeyDataSource() datasource.DataSource {
 }
 
 type apiKeyDataSourceModel struct {
-	ID         types.String `tfsdk:"id"`
-	Name       types.String `tfsdk:"name"`
-	ExactMatch types.Bool   `tfsdk:"exact_match"`
-	Key        types.String `tfsdk:"key"`
+	ID           types.String `tfsdk:"id"`
+	Name         types.String `tfsdk:"name"`
+	ExactMatch   types.Bool   `tfsdk:"exact_match"`
+	Key          types.String `tfsdk:"key"`
+	RemoteConfig types.Bool   `tfsdk:"remote_config"`
 }
 
 type apiKeyDataSource struct {
@@ -61,6 +62,10 @@ func (d *apiKeyDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 				Description: "The value of the API Key.",
 				Computed:    true,
 				Sensitive:   true,
+			},
+			"remote_config": schema.BoolAttribute{
+				Description: "Whether the API key will be used for remote config.",
+				Computed:    true,
 			},
 		},
 		DeprecationMessage: "Deprecated. This will be removed in a future release with prior notice. Securely store your API keys using a secret management system or use the datadog_api_key resource to manage API keys in your Datadog account.",
@@ -157,6 +162,7 @@ func (r *apiKeyDataSource) updateState(state *apiKeyDataSourceModel, apiKeyData 
 	state.ID = types.StringValue(apiKeyData.GetId())
 	state.Name = types.StringValue(apiKeyAttributes.GetName())
 	state.Key = types.StringValue(apiKeyAttributes.GetKey())
+	state.RemoteConfig = types.BoolValue(apiKeyAttributes.GetRemoteConfigReadEnabled())
 }
 
 func (r *apiKeyDataSource) checkAPIDeprecated(apiKeyData *datadogV2.FullAPIKey, resp *datasource.ReadResponse) bool {

--- a/datadog/fwprovider/data_source_datadog_api_key.go
+++ b/datadog/fwprovider/data_source_datadog_api_key.go
@@ -64,7 +64,7 @@ func (d *apiKeyDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 				Sensitive:   true,
 			},
 			"remote_config_read_enabled": schema.BoolAttribute{
-				Description: "Whether the API key will be used for remote config.",
+				Description: "Whether the API key is used for remote config.",
 				Computed:    true,
 			},
 		},

--- a/datadog/fwprovider/data_source_datadog_teams.go
+++ b/datadog/fwprovider/data_source_datadog_teams.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 )
 

--- a/datadog/fwprovider/resource_datadog_api_key.go
+++ b/datadog/fwprovider/resource_datadog_api_key.go
@@ -62,7 +62,7 @@ func (r *apiKeyResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"remote_config_read_enabled": schema.BoolAttribute{
-				Description: "Whether the API key will be used for remote config. Warning : default value is true for backwards compatibility",
+				Description: "Whether the API key isgi used for remote config. Warning : default value is true for backwards compatibility",
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(true),

--- a/datadog/fwprovider/resource_datadog_api_key.go
+++ b/datadog/fwprovider/resource_datadog_api_key.go
@@ -62,7 +62,7 @@ func (r *apiKeyResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"remote_config_read_enabled": schema.BoolAttribute{
-				Description: "Whether the API key isgi used for remote config. Warning : default value is true for backwards compatibility",
+				Description: "Whether the API key is used for remote config. Warning : default value is true for backwards compatibility",
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(true),

--- a/datadog/fwprovider/resource_datadog_api_key.go
+++ b/datadog/fwprovider/resource_datadog_api_key.go
@@ -29,7 +29,7 @@ type apiKeyResourceModel struct {
 	ID           types.String `tfsdk:"id"`
 	Name         types.String `tfsdk:"name"`
 	Key          types.String `tfsdk:"key"`
-	RemoteConfig types.Bool   `tfsdk:"remote_config"`
+	RemoteConfig types.Bool   `tfsdk:"remote_config_read_enabled"`
 }
 
 type apiKeyResource struct {
@@ -61,7 +61,7 @@ func (r *apiKeyResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				Sensitive:     true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"remote_config": schema.BoolAttribute{
+			"remote_config_read_enabled": schema.BoolAttribute{
 				Description: "Whether the API key will be used for remote config. Warning : default value is true for backwards compatibility",
 				Optional:    true,
 				Computed:    true,

--- a/datadog/tests/resource_datadog_api_key_test.go
+++ b/datadog/tests/resource_datadog_api_key_test.go
@@ -28,11 +28,12 @@ func TestAccDatadogApiKey_Update(t *testing.T) {
 		CheckDestroy:             testAccCheckDatadogApiKeyDestroy(providers.frameworkProvider),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDatadogApiKeyConfigRequired(apiKeyName),
+				Config: testAccCheckDatadogApiKeyConfigRequired(apiKeyName, nil),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatadogApiKeyExists(providers.frameworkProvider, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", apiKeyName),
 					resource.TestCheckResourceAttrSet(resourceName, "key"),
+					resource.TestCheckResourceAttr(resourceName, "remote_config", "true"),
 					func(s *terraform.State) error {
 						resource, ok := s.RootModule().Resources[resourceName]
 						if !ok {
@@ -45,10 +46,31 @@ func TestAccDatadogApiKey_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckDatadogApiKeyConfigRequired(apiKeyNameUpdate),
+				Config: testAccCheckDatadogApiKeyConfigRequired(apiKeyNameUpdate, Ptr(true)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatadogApiKeyExists(providers.frameworkProvider, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", apiKeyNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "remote_config", "true"),
+					func(s *terraform.State) error {
+						resource, ok := s.RootModule().Resources[resourceName]
+						if !ok {
+							return fmt.Errorf("Resource not found: %s", resourceName)
+						}
+
+						stateAPIKey := resource.Primary.Attributes["key"]
+						if stateAPIKey != apiKey {
+							return fmt.Errorf("API key (%s) does not match expected value (%s)", stateAPIKey, apiKey)
+						}
+						return nil
+					},
+				),
+			},
+			{
+				Config: testAccCheckDatadogApiKeyConfigRequired(apiKeyNameUpdate, Ptr(false)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogApiKeyExists(providers.frameworkProvider, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", apiKeyNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "remote_config", "false"),
 					func(s *terraform.State) error {
 						resource, ok := s.RootModule().Resources[resourceName]
 						if !ok {
@@ -82,7 +104,7 @@ func TestDatadogApiKey_import(t *testing.T) {
 		CheckDestroy:             testAccCheckDatadogApiKeyDestroy(providers.frameworkProvider),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDatadogApiKeyConfigRequired(apiKeyName),
+				Config: testAccCheckDatadogApiKeyConfigRequired(apiKeyName, nil),
 			},
 			{
 				ResourceName:      resourceName,
@@ -93,11 +115,16 @@ func TestDatadogApiKey_import(t *testing.T) {
 	})
 }
 
-func testAccCheckDatadogApiKeyConfigRequired(uniq string) string {
+func testAccCheckDatadogApiKeyConfigRequired(uniq string, remoteConfig *bool) string {
+	remoteConfigParam := ""
+	if remoteConfig != nil {
+		remoteConfigParam = fmt.Sprintf("remote_config = %t", *remoteConfig)
+	}
 	return fmt.Sprintf(`
 resource "datadog_api_key" "foo" {
   name = "%s"
-}`, uniq)
+  %s
+}`, uniq, remoteConfigParam)
 }
 
 func testAccCheckDatadogApiKeyExists(accProvider *fwprovider.FrameworkProvider, n string) resource.TestCheckFunc {
@@ -152,4 +179,8 @@ func datadogApiKeyDestroyHelper(ctx context.Context, s *terraform.State, apiInst
 	}
 
 	return nil
+}
+
+func Ptr[T any](v T) *T {
+	return &v
 }

--- a/datadog/tests/resource_datadog_api_key_test.go
+++ b/datadog/tests/resource_datadog_api_key_test.go
@@ -33,7 +33,7 @@ func TestAccDatadogApiKey_Update(t *testing.T) {
 					testAccCheckDatadogApiKeyExists(providers.frameworkProvider, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", apiKeyName),
 					resource.TestCheckResourceAttrSet(resourceName, "key"),
-					resource.TestCheckResourceAttr(resourceName, "remote_config", "true"),
+					resource.TestCheckResourceAttr(resourceName, "remote_config_read_enabled", "true"),
 					func(s *terraform.State) error {
 						resource, ok := s.RootModule().Resources[resourceName]
 						if !ok {
@@ -50,7 +50,7 @@ func TestAccDatadogApiKey_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatadogApiKeyExists(providers.frameworkProvider, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", apiKeyNameUpdate),
-					resource.TestCheckResourceAttr(resourceName, "remote_config", "true"),
+					resource.TestCheckResourceAttr(resourceName, "remote_config_read_enabled", "true"),
 					func(s *terraform.State) error {
 						resource, ok := s.RootModule().Resources[resourceName]
 						if !ok {
@@ -70,7 +70,7 @@ func TestAccDatadogApiKey_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatadogApiKeyExists(providers.frameworkProvider, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", apiKeyNameUpdate),
-					resource.TestCheckResourceAttr(resourceName, "remote_config", "false"),
+					resource.TestCheckResourceAttr(resourceName, "remote_config_read_enabled", "false"),
 					func(s *terraform.State) error {
 						resource, ok := s.RootModule().Resources[resourceName]
 						if !ok {
@@ -118,7 +118,7 @@ func TestDatadogApiKey_import(t *testing.T) {
 func testAccCheckDatadogApiKeyConfigRequired(uniq string, remoteConfig *bool) string {
 	remoteConfigParam := ""
 	if remoteConfig != nil {
-		remoteConfigParam = fmt.Sprintf("remote_config = %t", *remoteConfig)
+		remoteConfigParam = fmt.Sprintf("remote_config_read_enabled = %t", *remoteConfig)
 	}
 	return fmt.Sprintf(`
 resource "datadog_api_key" "foo" {

--- a/docs/data-sources/api_key.md
+++ b/docs/data-sources/api_key.md
@@ -30,3 +30,4 @@ data "datadog_api_key" "foo" {
 ### Read-Only
 
 - `key` (String, Sensitive) The value of the API Key.
+- `remote_config` (Boolean) Whether the API key will be used for remote config.

--- a/docs/data-sources/api_key.md
+++ b/docs/data-sources/api_key.md
@@ -30,4 +30,4 @@ data "datadog_api_key" "foo" {
 ### Read-Only
 
 - `key` (String, Sensitive) The value of the API Key.
-- `remote_config_read_enabled` (Boolean) Whether the API key will be used for remote config.
+- `remote_config_read_enabled` (Boolean) Whether the API key is used for remote config.

--- a/docs/data-sources/api_key.md
+++ b/docs/data-sources/api_key.md
@@ -30,4 +30,4 @@ data "datadog_api_key" "foo" {
 ### Read-Only
 
 - `key` (String, Sensitive) The value of the API Key.
-- `remote_config` (Boolean) Whether the API key will be used for remote config.
+- `remote_config_read_enabled` (Boolean) Whether the API key will be used for remote config.

--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -28,7 +28,7 @@ resource "datadog_api_key" "foo" {
 
 ### Optional
 
-- `remote_config_read_enabled` (Boolean) Whether the API key will be used for remote config. Warning : default value is true for backwards compatibility Defaults to `true`.
+- `remote_config_read_enabled` (Boolean) Whether the API key is used for remote config. Warning : default value is true for backwards compatibility Defaults to `true`.
 
 ### Read-Only
 

--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -26,6 +26,10 @@ resource "datadog_api_key" "foo" {
 
 - `name` (String) Name for API Key.
 
+### Optional
+
+- `remote_config` (Boolean) Whether the API key will be used for remote config. Warning : default value is true for backwards compatibility Defaults to `true`.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.

--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -28,7 +28,7 @@ resource "datadog_api_key" "foo" {
 
 ### Optional
 
-- `remote_config` (Boolean) Whether the API key will be used for remote config. Warning : default value is true for backwards compatibility Defaults to `true`.
+- `remote_config_read_enabled` (Boolean) Whether the API key will be used for remote config. Warning : default value is true for backwards compatibility Defaults to `true`.
 
 ### Read-Only
 


### PR DESCRIPTION
Fixes: #1875 

This PR allows to manage the `remote_config_read_enabled` on datadog_api_key . It is used for [remote config](https://docs.datadoghq.com/agent/remote_config/?tab=configurationyamlfile) feature. 

Specific point : the default value at API level is true (which is a not standard logic) so we need to have a true default value at resource level

As the test is not eligible for cassettes, I run `RECORD=none TESTARGS="-run TestAccDatadogApiKey_Update" make testall" and the test was fine. 