### PR TITLE
Update resource_datadog_logs_metric.go

### DIFF
--- a/datadog/resource_datadog_logs_metric.go
+++ b/datadog/resource_datadog_logs_metric.go
@@ -75,7 +75,7 @@ func resourceDatadogLogsMetric() *schema.Resource {
 				},
 
 				"group_by": {
-					Type:        schema.TypeSet,
+					Type:        schema.TypeList,
 					Optional:    true,
 					Description: "The rules for the group by.",
 					Elem: &schema.Resource{


### PR DESCRIPTION
Using `TypeList` instead of TypeMap to avoid no-op changes in terraform when the order is different.

Because `group_by` is a TypeMap, the order depends on the hashcode of its attributes and should not matter. However, when running `terraform plan`, the order of `group_by` can sometimes be different. This causes Terraform to try and apply changes, when there are no changes. It leads to noise in the plan output.