### PR TITLE
Fix generator to take in account `required` / `enum` / `read_only` / `nullable` cases

### DIFF
--- a/.generator/src/generator/setup.py
+++ b/.generator/src/generator/setup.py
@@ -18,7 +18,7 @@ def load_environment(version: str) -> Environment:
     env.filters["attribute_name"] = formatter.attribute_name
     env.filters["camel_case"] = formatter.camel_case
     env.filters["sanitize_description"] = formatter.sanitize_description
-    env.filters["simple_type"] = formatter.simple_type
+
     env.filters["snake_case"] = formatter.snake_case
     env.filters["untitle_case"] = formatter.untitle_case
     env.filters["variable_name"] = formatter.variable_name
@@ -39,6 +39,11 @@ def load_environment(version: str) -> Environment:
     env.globals["get_terraform_schema_type"] = formatter.get_terraform_schema_type
     env.globals["get_type_for_parameter"] = type.get_type_for_parameter
     env.globals["get_type"] = type.type_to_go
+    env.globals["is_required"] = utils.is_required
+    env.globals["is_computed"] = utils.is_computed
+    env.globals["is_enum"] = utils.is_enum
+    env.globals["is_nullable"] = utils.is_nullable
+    env.globals["simple_type"] = formatter.simple_type
 
     env.globals["GET_OPERATION"] = utils.GET_OPERATION
     env.globals["CREATE_OPERATION"] = utils.CREATE_OPERATION

--- a/.generator/src/generator/templates/utils/request_builder_helper.j2
+++ b/.generator/src/generator/templates/utils/request_builder_helper.j2
@@ -2,23 +2,31 @@
     {%- set primitiveAttr, primitiveArrAttr, nonPrimitiveListAttr, nonPrimitiveObjAttr = schema|tf_sort_properties_by_type %}
 
     {%- for attr, attrSchema in primitiveAttr.items() %}
-    {%- set isRequired = attr in schema.get("required", []) %}
+    {%- set isRequired = is_required(schema) %}
+    {%- if not is_computed(attrSchema) %}
     {{- baseRequestBuilder(attr, attrSchema, baseSetter, baseAccessor, required=isRequired) }}
+    {%- endif %}
     {%- endfor %}
 
     {%- for attr, attrSchema in primitiveArrAttr.items() %}
-    {%- set isRequired = attr in schema.get("required", []) %}
+    {%- set isRequired = is_required(schema) %}
+    {%- if not is_computed(attrSchema) %}
     {{ baseRequestBuilder(attr, attrSchema, baseSetter, baseAccessor, required=isRequired) }}
+    {%- endif %}
     {%- endfor %}
 
     {%- for attr, attrSchema in nonPrimitiveListAttr.items() %}
-    {%- set isRequired = attr in attrSchema.get("required", []) %}
+    {%- set isRequired = is_required(attrSchema) %}
+    {%- if not is_computed(attrSchema) %}
     {{ baseRequestBuilder(attr, attrSchema, baseSetter, baseAccessor, required=isRequired) }}
+    {%- endif %}
     {%- endfor %}
 
     {%- for attr, attrSchema in nonPrimitiveObjAttr.items() %}
-    {%- set isRequired = attr in schema.get("required", []) %}
+    {%- set isRequired = is_required(schema) %}
+    {%- if not is_computed(attrSchema) %}
     {{ baseRequestBuilder(attr, attrSchema, baseSetter, baseAccessor, required=isRequired) }}
+    {%- endif %}
     {%- endfor %}
 
 {%- endmacro %}
@@ -38,7 +46,11 @@
     {%- if not required %}
     if !{{ baseAccessor }}.{{ name|camel_case }}.IsNull() {
     {%- endif %}
+    {%- if is_enum(schema) %}
+    {{ baseSetter }}.Set{{ name|camel_case }}(datadog{{ version }}.{{ get_type(schema) }}({{ baseAccessor }}.{{ name|camel_case }}.Value{{ get_terraform_schema_type(schema) }}()))
+    {%- else %}
     {{ baseSetter }}.Set{{ name|camel_case }}({{ baseAccessor }}.{{ name|camel_case }}.Value{{ get_terraform_schema_type(schema) }}())
+    {%- endif %}
     {%- if not required %}
     }
     {%- endif %}
@@ -51,8 +63,11 @@
     var {{ name|variable_name }} datadog{{ version }}.{{ get_type(schema) }}
 
     {{ requestBuilder(schema, name|variable_name, baseAccessor~"."~name|camel_case) }}
-
+    {%- if is_nullable(schema) %}
+    {{ baseSetter }}.{{ name|camel_case }} = *datadog{{ version }}.NewNullable{{ get_type(schema) }}(&{{ name|variable_name }})
+    {%- else %}
     {{ baseSetter }}.{{ name|camel_case }} = {%- if not required %}&{% endif %}{{ name|variable_name }}
+    {%- endif %}
     {%- if not required %}
     }
     {%- endif %}
@@ -81,7 +96,7 @@
 {%- macro requestBaseFunc(name, funcName, parameterBodySchema) %}
 func (r *{{ name|camel_case|untitle_case }}Resource) {{ funcName }}(ctx context.Context, state *{{ name|camel_case|untitle_case }}Model) (*datadog{{ version }}.{{ get_type(parameterBodySchema) }}, diag.Diagnostics) {
     diags := diag.Diagnostics{}
-
+    req := &datadog{{ version }}.{{ get_type(parameterBodySchema) }}{}
 	{%- if parameterBodySchema|is_json_api %}
 	{%- set jsonAttributeSchema = json_api_attributes_schema(parameterBodySchema) %}
     {%- set parameterBodyDataSchema = parameterBodySchema.properties.data %}

--- a/.generator/src/generator/templates/utils/resource_test_helper.j2
+++ b/.generator/src/generator/templates/utils/resource_test_helper.j2
@@ -6,7 +6,7 @@ resource "datadog_{{ name }}" "foo" {
         {%- if parameterSchema|is_json_api %}
             {%- set jsonAttributeSchema = json_api_attributes_schema(parameterSchema) %}
             {%- for attr, schema in jsonAttributeSchema.properties.items() %}
-                {%- set isRequired = attr in jsonAttributeSchema.get("required", []) %}
+                {%- set isRequired = is_required(jsonAttributeSchema) %}
                 {{- baseSchema(attr, schema, required=isRequired) }}
             {%- endfor %}
         {%- else %}
@@ -34,7 +34,7 @@ resource "datadog_{{ name }}" "foo" {
 {%- macro typeObjectSchema(name, schema, required=False) %}
     {{ name }} {
         {%- for attr, childSchema in schema.get("properties", {}).items() %}
-            {%- set isRequired = attr in childSchema.get("required", []) %}
+            {%- set isRequired = is_required(childSchema) %}
             {{- baseSchema(attr, childSchema, required=isRequired) }}
         {%- endfor%}
     }

--- a/.generator/src/generator/templates/utils/schema_helper.j2
+++ b/.generator/src/generator/templates/utils/schema_helper.j2
@@ -1,16 +1,20 @@
 {%- macro typePrimitiveSchema(name, schema, required=False) %}
 "{{ name }}": schema.{{ get_terraform_schema_type(schema) }}Attribute{
-    {% if required %}Required:    true,{% else %}Optional:    true,{% endif %}
+    {{- RequiredOptionalComputed(schema, required) }}
     Description: "{{ schema.description|sanitize_description if schema.description else "UPDATE ME" }}",
 },
 {%- endmacro %}
 
 {%- macro typePrimitiveArraySchema(name, schema, required=False) %}
 "{{ name }}": schema.{{ get_terraform_schema_type(schema) }}Attribute{
-    {% if required %}Required:    true,{% else %}Optional:    true,{% endif %}
+    {{- RequiredOptionalComputed(schema, required) }}
     Description: "{{ schema.description|sanitize_description if schema.description else "UPDATE ME" }}",
     ElementType: types.{{ get_terraform_schema_type(schema.get("items")) }}Type,
 },
+{%- endmacro %}
+
+{%- macro RequiredOptionalComputed(schema, required=False) %}
+{% if is_computed(schema) %} Computed: true,{% elif required %}Required:    true,{% else %}Optional:    true,{% endif %}
 {%- endmacro %}
 
 {%- macro baseBlockListAttrSchemaBuilder(name, schema, required=False) %}

--- a/.generator/src/generator/templates/utils/state_helper.j2
+++ b/.generator/src/generator/templates/utils/state_helper.j2
@@ -2,22 +2,22 @@
     {%- set primitiveAttr, primitiveArrAttr, nonPrimitiveListAttr, nonPrimitiveObjAttr = schema|tf_sort_properties_by_type %}
 
     {%- for attr, schema in primitiveAttr.items() %}
-    {%- set isRequired = attr in schema.get("required", []) or schema.get("required") %}
+    {%- set isRequired = is_required(schema,attr) %}
     {{ baseStateSetter(attr, schema, baseSetter, baseAccessor, required=isRequired) }}
     {%- endfor %}
 
     {%- for attr, schema in primitiveArrAttr.items() %}
-    {%- set isRequired = attr in schema.get("required", []) or schema.get("required") %}
+    {%- set isRequired = is_required(schema,attr) %}
     {{ baseStateSetter(attr, schema, baseSetter, baseAccessor, required=isRequired) }}
     {%- endfor %}
 
     {%- for attr, schema in nonPrimitiveListAttr.items() %}
-    {%- set isRequired = attr in schema.get("required", []) or schema.get("required") %}
+    {%- set isRequired = is_required(schema,attr) %}
     {{ baseStateSetter(attr, schema, baseSetter, baseAccessor, required=isRequired) }}
     {%- endfor %}
 
     {%- for attr, schema in nonPrimitiveObjAttr.items() %}
-    {%- set isRequired = attr in schema.get("required", []) or schema.get("required") %}
+    {%- set isRequired = is_required(schema,attr) %}
     {{ baseStateSetter(attr, schema, baseSetter, baseAccessor, required=isRequired) }}
     {%- endfor %}
 {%- endmacro %}
@@ -36,7 +36,11 @@
     {%- if not required %}
     if {{ name|variable_name }}, ok := {{ baseAccessor }}.Get{{ name|camel_case }}Ok(); ok {
     {%- endif %}
+    {%- if is_enum(schema) %}
+    {{ baseSetter }}.{{ name|camel_case }} = types.{{ get_terraform_schema_type(schema) }}Value({{ simple_type(schema) }}({% if required %}{{ baseAccessor }}.Get{{ name|camel_case }}(){% else %}*{{ name|variable_name }}{% endif %}))
+    {%- else %}
     {{ baseSetter }}.{{ name|camel_case }} = types.{{ get_terraform_schema_type(schema) }}Value({% if required %}{{ baseAccessor }}.Get{{ name|camel_case }}(){% else %}*{{ name|variable_name }}{% endif %})
+    {%- endif %}
     {%- if not required %}
     }
     {%- endif %}

--- a/.generator/src/generator/utils.py
+++ b/.generator/src/generator/utils.py
@@ -47,3 +47,23 @@ def is_primitive(schema):
     if schema and schema.get("type") in PRIMITIVE_TYPES:
         return True
     return False
+
+def is_required(schema, attr=None):
+    req_args =schema.get("required")
+    if req_args is None:
+        return False
+    if isinstance(req_args, bool):
+        return req_args
+    if isinstance(req_args, list):
+        return attr in req_args
+    raise ValueError(f"Invalid required value: {schema} ({attr})")
+
+def is_computed(schema):
+    v = schema.get("readOnly", None) is True
+    return v
+
+def is_enum(schema):
+    return "enum" in schema
+
+def is_nullable(schema):
+    return schema.get("nullable", False)


### PR DESCRIPTION
In order to produce `datadog_shared_dashboard` resource, here is some fixes to the generator : https://github.com/DataDog/terraform-provider-datadog/pull/2838

Use scaffolding generator to create shared dashboard resource and apply the following changes : 
* fix `required` logic : the required field can be either : 
  * an array (at the parent object) : https://json-schema.org/understanding-json-schema/reference/object#required
  * a boolean field (at the field level) : https://swagger.io/docs/specification/v3_0/describing-parameters/#required-and-optional-parameters 
* improve `enum` logic : For enum,  it is needed from/to cast to the base type
* add `read_only` logic : For field being a `read-only` field, it should be Computed only field 
* add `nullable` logic : For field being a `nullable`, the name of the generated functions in datadog-api-client-go is different (begins with Nullable) 