### PR TITLE
Add support for default tags in log pipelines

### DIFF
--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -468,11 +468,11 @@ func tagDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) erro
 	tagSet := resourceTags.(*schema.Set)
 	for _, tag := range tagSet.List() {
 		key, value, _ := strings.Cut(tag.(string), ":")
-		old_val, ok := tags[key]
+		oldVal, ok := tags[key]
 		if !ok {
-			old_val = []string{}
+			oldVal = []string{}
 		}
-		tags[key] = append(old_val.([]string), value)
+		tags[key] = append(oldVal.([]string), value)
 	}
 	for k, v := range providerConf.DefaultTags {
 		if _, alreadyDefined := tags[k]; !alreadyDefined {

--- a/datadog/resource_datadog_logs_custom_pipeline.go
+++ b/datadog/resource_datadog_logs_custom_pipeline.go
@@ -377,6 +377,7 @@ func resourceDatadogLogsCustomPipeline() *schema.Resource {
 		UpdateContext: resourceDatadogLogsPipelineUpdate,
 		ReadContext:   resourceDatadogLogsPipelineRead,
 		DeleteContext: resourceDatadogLogsPipelineDelete,
+		CustomizeDiff: tagDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -1220,7 +1221,7 @@ func getPipelineSchema(isNested bool) map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name":        {Type: schema.TypeString, Required: true},
 		"is_enabled":  {Type: schema.TypeBool, Optional: true},
-		"tags":        {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+		"tags":        {Type: schema.TypeSet, Optional: true, Computed: true, Elem: &schema.Schema{Type: schema.TypeString}},
 		"description": {Type: schema.TypeString, Optional: true},
 		"filter": {
 			Type:     schema.TypeList,


### PR DESCRIPTION
[Since pipeline tags are already supported](https://github.com/DataDog/terraform-provider-datadog/pull/2773), this change adds default tags support to log pipelines for consistency. Thanks for the review!