### PR TITLE
[datadog_api_key] Fix bug introduced in 3.55.0 for organisation that doesn't have Remove config enabled

### DIFF
--- a/datadog/fwprovider/resource_datadog_api_key.go
+++ b/datadog/fwprovider/resource_datadog_api_key.go
@@ -62,7 +62,7 @@ func (r *apiKeyResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"remote_config_read_enabled": schema.BoolAttribute{
-				Description: "Whether the API key is used for remote config. Should be put to true only if remote config is enabled in /organization-settings/remote-config",
+				Description: "Whether the API key is used for remote config. Set to true only if remote config is enabled in `/organization-settings/remote-config`.",
 				Optional:    true,
 				Computed:    true,
 			},

--- a/datadog/tests/resource_datadog_api_key_test.go
+++ b/datadog/tests/resource_datadog_api_key_test.go
@@ -45,7 +45,7 @@ func TestAccDatadogApiKey_Update(t *testing.T) {
 					},
 				),
 			},
-			// Test will succeed only if Remove config is configured for this organisation (see /organization-settings/remote-config)
+			// Test will succeed only if Remote config is configured for this organisation (see /organization-settings/remote-config)
 			{
 				Config: testAccCheckDatadogApiKeyConfigRequired(apiKeyNameUpdate, Ptr(true)),
 				Check: resource.ComposeTestCheckFunc(

--- a/datadog/tests/resource_datadog_api_key_test.go
+++ b/datadog/tests/resource_datadog_api_key_test.go
@@ -45,6 +45,7 @@ func TestAccDatadogApiKey_Update(t *testing.T) {
 					},
 				),
 			},
+			// Test will succeed only if Remove config is configured for this organisation (see /organization-settings/remote-config)
 			{
 				Config: testAccCheckDatadogApiKeyConfigRequired(apiKeyNameUpdate, Ptr(true)),
 				Check: resource.ComposeTestCheckFunc(

--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -28,7 +28,7 @@ resource "datadog_api_key" "foo" {
 
 ### Optional
 
-- `remote_config_read_enabled` (Boolean) Whether the API key is used for remote config. Should be put to true only if remote config is enabled in /organization-settings/remote-config
+- `remote_config_read_enabled` (Boolean) Whether the API key is used for remote config. Set to true only if remote config is enabled in `/organization-settings/remote-config`.
 
 ### Read-Only
 

--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -28,7 +28,7 @@ resource "datadog_api_key" "foo" {
 
 ### Optional
 
-- `remote_config_read_enabled` (Boolean) Whether the API key is used for remote config. Warning : default value is true for backwards compatibility Defaults to `true`.
+- `remote_config_read_enabled` (Boolean) Whether the API key is used for remote config. Should be put to true only if remote config is enabled in /organization-settings/remote-config
 
 ### Read-Only
 


### PR DESCRIPTION
Fixes #2847 

Remove config is configured globally at org level (see /organization-settings/remote-config). 
* When it is not enabled, the `remote_config_read_enabled` argument of api_key is always set to `false` 
* When it is enabled, the `remote_config_read_enabled` argument is set by default to `true` but can be set explicitly to `false`

Proposed fix : 
* When the user don't set `remote_config_read_enabled` , it will be the default value (true if RC is enabled, false if not) . Similar behavior as in <3.55.0
* When the user set `remote_config_read_enabled` to `false` , it will always works 
* When the user set `remote_config_read_enabled` to `true`, 
  * it will succeeds if RC is enabled at org level 
  * it will fails if RC is not enabled at org level

You will get this error if you set the argument while RC is not enabled at org level : 
```
╷
│ Error: remote_config_read_enabled is true but Remote config is not enabled at org level
│ 
│   with datadog_api_key.rctrue,
│   on api.tf line 5, in resource "datadog_api_key" "rctrue":
│    5: resource "datadog_api_key" "rctrue" {
│ 
│ Please either remove remote_config_read_enabled from the resource configuration or enable Remote config at org level
╵
```