### PR TITLE
[Generator] (fix) Support date-time format enrichment

### DIFF
--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -139,3 +139,9 @@ def get_terraform_schema_type(schema):
         "object": "Block",
         None: "String",
     }[schema.get("type")]
+
+
+def date_time_formatter(name: str, schema: dict):
+    if schema.get("format") == "date-time":
+        return f"{variable_name(name)}.String()"
+    return f"*{variable_name(name)}"

--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -74,6 +74,7 @@ def sanitize_description(description):
 def escape_reserved_keyword(word):
     """
     Escape reserved language keywords like openapi generator does it
+
     :param word: Word to escape
     :return: The escaped word if it was a reserved keyword, the word unchanged otherwise
     """
@@ -141,7 +142,18 @@ def get_terraform_schema_type(schema):
     }[schema.get("type")]
 
 
-def date_time_formatter(name: str, schema: dict):
+def date_time_formatter(name: str, schema: dict) -> str:
+    """
+    This function is intended to be used in the Jinja2 templates.
+    It was made to support the "date-time" format of the OpenAPI schema.
+    Go's time.Time type is used to represent date-time values and should be instead transformed into a string.
+    Args:
+        name (str): The name of the variable to format.
+        schema (dict): OpenApi spec as a dictionary. May contain a "format" key.
+    Returns:
+        str: The string representation of the variable in Go.
+    """
+
     if schema.get("format") == "date-time":
         return f"{variable_name(name)}.String()"
     return f"*{variable_name(name)}"

--- a/.generator/src/generator/setup.py
+++ b/.generator/src/generator/setup.py
@@ -21,12 +21,13 @@ def load_environment(version: str) -> Environment:
     env.filters["snake_case"] = formatter.snake_case
     env.filters["untitle_case"] = formatter.untitle_case
     env.filters["variable_name"] = formatter.variable_name
-    env.filters["date_time_formatter"] = formatter.date_time_formatter
+    env.filters["date_time_formatter"] = formatter.go_to_terraform_type_formatter
     env.filters["parameter_schema"] = openapi.parameter_schema
     env.filters["parameters"] = openapi.parameters
     env.filters["is_json_api"] = openapi.is_json_api
     env.filters["capitalize"] = utils.capitalize
     env.filters["is_primitive"] = utils.is_primitive
+    env.filters["print"] = utils.print_filter
     env.filters["response_type"] = type.get_type_for_response
     env.filters["return_type"] = type.return_type
     env.filters["tf_sort_params_by_type"] = type.tf_sort_params_by_type

--- a/.generator/src/generator/setup.py
+++ b/.generator/src/generator/setup.py
@@ -27,7 +27,7 @@ def load_environment(version: str) -> Environment:
     env.filters["is_json_api"] = openapi.is_json_api
     env.filters["capitalize"] = utils.capitalize
     env.filters["is_primitive"] = utils.is_primitive
-    env.filters["print"] = utils.print_filter
+    env.filters["debug"] = utils.debug_filter
     env.filters["response_type"] = type.get_type_for_response
     env.filters["return_type"] = type.return_type
     env.filters["tf_sort_params_by_type"] = type.tf_sort_params_by_type

--- a/.generator/src/generator/setup.py
+++ b/.generator/src/generator/setup.py
@@ -18,10 +18,10 @@ def load_environment(version: str) -> Environment:
     env.filters["attribute_name"] = formatter.attribute_name
     env.filters["camel_case"] = formatter.camel_case
     env.filters["sanitize_description"] = formatter.sanitize_description
-
     env.filters["snake_case"] = formatter.snake_case
     env.filters["untitle_case"] = formatter.untitle_case
     env.filters["variable_name"] = formatter.variable_name
+    env.filters["date_time_formatter"] = formatter.date_time_formatter
     env.filters["parameter_schema"] = openapi.parameter_schema
     env.filters["parameters"] = openapi.parameters
     env.filters["is_json_api"] = openapi.is_json_api

--- a/.generator/src/generator/templates/utils/state_helper.j2
+++ b/.generator/src/generator/templates/utils/state_helper.j2
@@ -36,11 +36,11 @@
     {%- if not required %}
     if {{ name|variable_name }}, ok := {{ baseAccessor }}.Get{{ name|camel_case }}Ok(); ok {
     {%- endif %}
-    {%- if is_enum(schema) %}
-    {{ baseSetter }}.{{ name|camel_case }} = types.{{ get_terraform_schema_type(schema) }}Value({{ simple_type(schema) }}({% if required %}{{ baseAccessor }}.Get{{ name|camel_case }}(){% else %}*{{ name|variable_name }}{% endif %}))
-    {%- else %}
-    {{ baseSetter }}.{{ name|camel_case }} = types.{{ get_terraform_schema_type(schema) }}Value({% if required %}{{ baseAccessor }}.Get{{ name|camel_case }}(){% else %}*{{ name|variable_name }}{% endif %})
-    {%- endif %}
+        {%- if is_enum(schema) %}
+            {{ baseSetter }}.{{ name|camel_case }} = types.{{ get_terraform_schema_type(schema) }}Value({{ simple_type(schema) }}({% if required %}{{ baseAccessor }}.Get{{ name|camel_case }}(){% else %}{{name|date_time_formatter(schema)}}{% endif %}))
+        {%- else %}
+            {{ baseSetter }}.{{ name|camel_case }} = types.{{ get_terraform_schema_type(schema) }}Value({% if required %}{{ baseAccessor }}.Get{{ name|camel_case }}(){% else %}{{name|date_time_formatter(schema)}}{% endif %})
+        {%- endif %}
     {%- if not required %}
     }
     {%- endif %}

--- a/.generator/src/generator/utils.py
+++ b/.generator/src/generator/utils.py
@@ -48,8 +48,9 @@ def is_primitive(schema):
         return True
     return False
 
+
 def is_required(schema, attr=None):
-    req_args =schema.get("required")
+    req_args = schema.get("required")
     if req_args is None:
         return False
     if isinstance(req_args, bool):
@@ -58,12 +59,15 @@ def is_required(schema, attr=None):
         return attr in req_args
     raise ValueError(f"Invalid required value: {schema} ({attr})")
 
+
 def is_computed(schema):
     v = schema.get("readOnly", None) is True
     return v
 
+
 def is_enum(schema):
     return "enum" in schema
+
 
 def is_nullable(schema):
     return schema.get("nullable", False)

--- a/.generator/src/generator/utils.py
+++ b/.generator/src/generator/utils.py
@@ -71,3 +71,8 @@ def is_enum(schema):
 
 def is_nullable(schema):
     return schema.get("nullable", False)
+
+
+def print_filter(value):
+    print(value)
+    return value

--- a/.generator/src/generator/utils.py
+++ b/.generator/src/generator/utils.py
@@ -73,6 +73,6 @@ def is_nullable(schema):
     return schema.get("nullable", False)
 
 
-def print_filter(value):
+def debug_filter(value):
     print(value)
     return value


### PR DESCRIPTION
## Motivation
Strings with the 'format' fields set to 'date-time' were being read as strings.
Meanwhile the Go client automatically converts them to `*time.Time` and breaks the updateState function.
Such fields are now properly converted back to strings when updating the state.

## Changes
- Added a new formatting function and filter to support date-time enrichment
- Changed the generation to use this filter
- Tidied `.generator/src/generator/utils.py`