### PR TITLE
[datadog_synthetics_test] Only set renotify_occurrences if renotify_interval is set 

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -3833,9 +3833,9 @@ func buildDatadogTestOptions(d *schema.ResourceData) *datadogV1.SyntheticsTestOp
 
 			if renotifyInterval, ok := monitorOptions.(map[string]interface{})["renotify_interval"]; ok {
 				optionsMonitorOptions.SetRenotifyInterval(int64(renotifyInterval.(int)))
-			}
-			if renotifyOccurrences, ok := monitorOptions.(map[string]interface{})["renotify_occurrences"]; ok {
-				optionsMonitorOptions.SetRenotifyOccurrences(int64(renotifyOccurrences.(int)))
+				if renotifyOccurrences, ok := monitorOptions.(map[string]interface{})["renotify_occurrences"]; ok && renotifyInterval != 0 {
+					optionsMonitorOptions.SetRenotifyOccurrences(int64(renotifyOccurrences.(int)))
+				}
 			}
 			options.SetMonitorOptions(optionsMonitorOptions)
 		}


### PR DESCRIPTION
Since the merge of https://github.com/DataDog/terraform-provider-datadog/pull/2820, the Terraform provider for the API has been consistently expecting the `renotify_interval` option. This pull request modifies the behavior to ignore the `renotify_occurrences` option if the `renotify_interval` is not set.