### PR TITLE
[Generator] (fix) Removed an import from test template

### DIFF
--- a/.generator/src/generator/templates/resource_test.j2
+++ b/.generator/src/generator/templates/resource_test.j2
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 )
 


### PR DESCRIPTION
## Motivation
The resource's test generation had a superfluous import of `"github.com/terraform-providers/terraform-provider-datadog/datadog"`.

## Changes
- removed import of `"github.com/terraform-providers/terraform-provider-datadog/datadog"` in resource test template