### PR TITLE
[resource_datadog_role] Update terraform docs to include default_permissions_opt_out attribute

### DIFF
--- a/datadog/resource_datadog_role.go
+++ b/datadog/resource_datadog_role.go
@@ -145,7 +145,7 @@ func resourceDatadogRoleCustomizeDiff(ctx context.Context, diff *schema.Resource
 
 		if permAttributes.IsDefaultPermission && !defaultPermissionsOptOut.(bool) {
 			return fmt.Errorf(
-				"permission with ID %s is a restricted (default) permission and cannot be managed by terraform, remove it from your configuration",
+				"permission with ID %s is a restricted (default) permission. To include it, set `default_permissions_opt_out` to `true`. Otherwise, please remove it from your configuration.",
 				permID,
 			)
 		}

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -37,8 +37,7 @@ resource "datadog_role" "foo" {
 
 ### Optional
 
-<!-- keep `default_permissions_opt_out` hidden until feature is released -->
-<!-- - `default_permissions_opt_out` (Boolean) If set to `true`, the role does not have default (restricted) permissions unless they are explicitly set. The `include_restricted` attribute for the `datadog_permissions` data source must be set to `true` to manage default permissions in Terraform. -->
+- `default_permissions_opt_out` (Boolean) If set to `true`, the role does not have default (restricted) permissions unless they are explicitly set. The `include_restricted` attribute for the `datadog_permissions` data source must be set to `true` to manage default permissions in Terraform.
 - `permission` (Block Set) Set of objects containing the permission ID and the name of the permissions granted to this role. (see [below for nested schema](#nestedblock--permission))
 - `validate` (Boolean) If set to `false`, skip the validation call done during plan.
 

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -4,7 +4,6 @@
 # Add here the files to be excluded from the doc generation
 exclude_files=(
   "docs/resources/integration_aws_account.md"
-  "docs/resources/role.md"
 )
 
 # Check if manual changes were made to any excluded files and exit


### PR DESCRIPTION
We have rolled out the ability for customers to remove restricted permissions from their roles. This change updates the Terraform Provider docs so that customers can make these changes in Terraform.