### PR TITLE
[datadog_spans_metric] Suppress unknown include_percentiles state

### DIFF
--- a/datadog/fwprovider/resource_datadog_spans_metric.go
+++ b/datadog/fwprovider/resource_datadog_spans_metric.go
@@ -20,8 +20,9 @@ import (
 )
 
 var (
-	_ resource.ResourceWithConfigure   = &spansMetricResource{}
-	_ resource.ResourceWithImportState = &spansMetricResource{}
+	_ resource.ResourceWithConfigure      = &spansMetricResource{}
+	_ resource.ResourceWithImportState    = &spansMetricResource{}
+	_ resource.ResourceWithValidateConfig = &spansMetricResource{}
 )
 
 type spansMetricResource struct {
@@ -170,6 +171,27 @@ func (m includePercentilesUnknownSuppressor) PlanModifyBool(ctx context.Context,
 
 	if !req.StateValue.IsNull() && resp.PlanValue.IsUnknown() {
 		resp.PlanValue = req.StateValue
+	}
+}
+
+func (r *spansMetricResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data spansMetricModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.Compute.IncludePercentiles.IsNull() || data.Compute.IncludePercentiles.IsUnknown() {
+		return
+	}
+
+	if data.Compute.AggregationType.ValueString() != "distribution" && !data.Compute.IncludePercentiles.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			frameworkPath.Root("compute").AtName("include_percentiles"),
+			"Invalid configuration",
+			"include_percentiles can only be set when aggregation_type is 'distribution'",
+		)
 	}
 }
 

--- a/datadog/tests/resource_datadog_spans_metric_test.go
+++ b/datadog/tests/resource_datadog_spans_metric_test.go
@@ -226,7 +226,7 @@ func testAccCheckDatadogSpansMetricTestingCountGroupBys(uniq string) string {
 			}
 			group_by {
 				path     = "resource_name1"
-				tag_name = "my_resource1"
+				tag_name = "MY_RESOURCE1"
 			}
 		}
 	`, uniq)


### PR DESCRIPTION
This occurs in the event of tag_name being normalized (e.g. from uppercase to lowercase). When that occurs, TF will mark include_percentiles as unknown, since it's a calculated field. We know that in this case nothing should happen though.

Should fix #2888 