### PR TITLE
Enrich documentation is now working with multi level nested Blocks 

### DIFF
--- a/datadog/fwprovider/resource_datadog_synthetics_global_variable.go
+++ b/datadog/fwprovider/resource_datadog_synthetics_global_variable.go
@@ -168,7 +168,7 @@ func (r *syntheticsGlobalVariableResource) Schema(_ context.Context, _ resource.
 								Attributes: map[string]schema.Attribute{
 									"type": schema.StringAttribute{
 										Required:    true,
-										Description: "Type of parser to extract the value. Valid values are `raw`, `json_path`, `regex`, `x_path`.",
+										Description: "Type of parser to extract the value.",
 										Validators:  []validator.String{validators.NewEnumValidator[validator.String](datadogV1.NewSyntheticsGlobalVariableParserTypeFromValue)},
 									},
 									"value": schema.StringAttribute{

--- a/datadog/internal/fwutils/fw_enrich_schema.go
+++ b/datadog/internal/fwutils/fw_enrich_schema.go
@@ -14,21 +14,27 @@ func EnrichFrameworkResourceSchema(s *frameworkSchema.Schema) {
 	for i, attr := range s.Attributes {
 		s.Attributes[i] = enrichDescription(attr)
 	}
+	enrichMapBlocks(s.Blocks)
+}
 
-	for _, block := range s.Blocks {
+func enrichMapBlocks(blocks map[string]frameworkSchema.Block) {
+	for _, block := range blocks {
 		switch v := block.(type) {
 		case frameworkSchema.ListNestedBlock:
 			for i, attr := range v.NestedObject.Attributes {
 				v.NestedObject.Attributes[i] = enrichDescription(attr)
 			}
+			enrichMapBlocks(v.NestedObject.Blocks)
 		case frameworkSchema.SingleNestedBlock:
 			for i, attr := range v.Attributes {
 				v.Attributes[i] = enrichDescription(attr)
 			}
+			enrichMapBlocks(v.Blocks)
 		case frameworkSchema.SetNestedBlock:
 			for i, attr := range v.NestedObject.Attributes {
 				v.NestedObject.Attributes[i] = enrichDescription(attr)
 			}
+			enrichMapBlocks(v.NestedObject.Blocks)
 		}
 	}
 }


### PR DESCRIPTION
Previously : the enrichment of documentation (ex : Default or Valid values) were only managed for Attributes and attributes at the first level Blocks 

With this PR, it works for all attributes whatever the block level. 