### PR TITLE
[chore] rename the package

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,7 +5,7 @@ PKG_NAME=datadog
 DIR=~/.terraform.d/plugins
 ZORKIAN_VERSION?=master
 API_CLIENT_VERSION?=master
-LOCAL_PACKAGE="github.com/terraform-providers/terraform-provider-datadog"
+LOCAL_PACKAGE="github.com/DataDog/terraform-provider-datadog"
 
 default: build
 

--- a/datadog/data_source_datadog_cloud_workload_security_agent_rules.go
+++ b/datadog/data_source_datadog_cloud_workload_security_agent_rules.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/datadog/data_source_datadog_dashboard.go
+++ b/datadog/data_source_datadog_dashboard.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/data_source_datadog_integration_aws_logs_services.go
+++ b/datadog/data_source_datadog_integration_aws_logs_services.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func dataSourceDatadogIntegrationAWSLogsServices() *schema.Resource {

--- a/datadog/data_source_datadog_logs_archives_order.go
+++ b/datadog/data_source_datadog_logs_archives_order.go
@@ -3,7 +3,7 @@ package datadog
 import (
 	"context"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/datadog/data_source_datadog_logs_indexes.go
+++ b/datadog/data_source_datadog_logs_indexes.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/datadog/data_source_datadog_logs_indexes_order.go
+++ b/datadog/data_source_datadog_logs_indexes_order.go
@@ -3,7 +3,7 @@ package datadog
 import (
 	"context"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/datadog/data_source_datadog_logs_pipelines.go
+++ b/datadog/data_source_datadog_logs_pipelines.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/data_source_datadog_monitor.go
+++ b/datadog/data_source_datadog_monitor.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/data_source_datadog_monitor_config_policies.go
+++ b/datadog/data_source_datadog_monitor_config_policies.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func dataSourceDatadogMonitorConfigPolicies() *schema.Resource {

--- a/datadog/data_source_datadog_monitors.go
+++ b/datadog/data_source_datadog_monitors.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/data_source_datadog_permissions.go
+++ b/datadog/data_source_datadog_permissions.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/datadog/data_source_datadog_role.go
+++ b/datadog/data_source_datadog_role.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func dataSourceDatadogRole() *schema.Resource {

--- a/datadog/data_source_datadog_roles.go
+++ b/datadog/data_source_datadog_roles.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func dataSourceDatadogRoles() *schema.Resource {

--- a/datadog/data_source_datadog_security_monitoring_filters.go
+++ b/datadog/data_source_datadog_security_monitoring_filters.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/datadog/data_source_datadog_security_monitoring_rules.go
+++ b/datadog/data_source_datadog_security_monitoring_rules.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"

--- a/datadog/data_source_datadog_sensitive_data_scanner_standard_pattern.go
+++ b/datadog/data_source_datadog_sensitive_data_scanner_standard_pattern.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func dataSourceDatadogSensitiveDataScannerStandardPattern() *schema.Resource {

--- a/datadog/data_source_datadog_service_level_objective.go
+++ b/datadog/data_source_datadog_service_level_objective.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func dataSourceDatadogServiceLevelObjective() *schema.Resource {

--- a/datadog/data_source_datadog_service_level_objectives.go
+++ b/datadog/data_source_datadog_service_level_objectives.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func dataSourceDatadogServiceLevelObjectives() *schema.Resource {

--- a/datadog/data_source_datadog_user.go
+++ b/datadog/data_source_datadog_user.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func dataSourceDatadogUser() *schema.Resource {

--- a/datadog/fwprovider/data_source_datadog_api_key.go
+++ b/datadog/fwprovider/data_source_datadog_api_key.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/data_source_datadog_apm_retention_filters_order.go
+++ b/datadog/fwprovider/data_source_datadog_apm_retention_filters_order.go
@@ -3,7 +3,7 @@ package fwprovider
 import (
 	"context"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"

--- a/datadog/fwprovider/data_source_datadog_application_key.go
+++ b/datadog/fwprovider/data_source_datadog_application_key.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var _ datasource.DataSource = &applicationKeyDataSource{}

--- a/datadog/fwprovider/data_source_datadog_csm_threats_agent_rule.go
+++ b/datadog/fwprovider/data_source_datadog_csm_threats_agent_rule.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/data_source_datadog_dashboard_list.go
+++ b/datadog/fwprovider/data_source_datadog_dashboard_list.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/data_source_datadog_hosts.go
+++ b/datadog/fwprovider/data_source_datadog_hosts.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var _ datasource.DataSourceWithConfigure = &hostsDataSource{}

--- a/datadog/fwprovider/data_source_datadog_integration_aws_available_logs_services.go
+++ b/datadog/fwprovider/data_source_datadog_integration_aws_available_logs_services.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/data_source_datadog_integration_aws_available_namespaces.go
+++ b/datadog/fwprovider/data_source_datadog_integration_aws_available_namespaces.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/data_source_datadog_integration_aws_namespace_rules.go
+++ b/datadog/fwprovider/data_source_datadog_integration_aws_namespace_rules.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var _ datasource.DataSourceWithConfigure = &datadogIntegrationAWSNamespaceRulesDatasource{}

--- a/datadog/fwprovider/data_source_datadog_ip_ranges.go
+++ b/datadog/fwprovider/data_source_datadog_ip_ranges.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var _ datasource.DataSourceWithConfigure = &ipRangesDataSource{}

--- a/datadog/fwprovider/data_source_datadog_logs_pipelines_order.go
+++ b/datadog/fwprovider/data_source_datadog_logs_pipelines_order.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/data_source_datadog_powerpack.go
+++ b/datadog/fwprovider/data_source_datadog_powerpack.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/data_source_datadog_role_users.go
+++ b/datadog/fwprovider/data_source_datadog_role_users.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/data_source_datadog_rum_application.go
+++ b/datadog/fwprovider/data_source_datadog_rum_application.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/data_source_datadog_sensitive_data_scanner_group_order.go
+++ b/datadog/fwprovider/data_source_datadog_sensitive_data_scanner_group_order.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var _ datasource.DataSourceWithConfigure = &sensitiveDataScannerGroupOrderDatasource{}

--- a/datadog/fwprovider/data_source_datadog_service_account.go
+++ b/datadog/fwprovider/data_source_datadog_service_account.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/data_source_datadog_synthetics_global_variable.go
+++ b/datadog/fwprovider/data_source_datadog_synthetics_global_variable.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/data_source_datadog_team.go
+++ b/datadog/fwprovider/data_source_datadog_team.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/data_source_datadog_team_memberships.go
+++ b/datadog/fwprovider/data_source_datadog_team_memberships.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/data_source_datadog_teams.go
+++ b/datadog/fwprovider/data_source_datadog_teams.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/data_source_datadog_users.go
+++ b/datadog/fwprovider/data_source_datadog_users.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/data_source_security_monitoring_suppression.go
+++ b/datadog/fwprovider/data_source_security_monitoring_suppression.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/framework_provider.go
+++ b/datadog/fwprovider/framework_provider.go
@@ -24,8 +24,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	datadogCommunity "github.com/zorkian/go-datadog-api"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/fwutils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/fwutils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var _ provider.Provider = &FrameworkProvider{}

--- a/datadog/fwprovider/resource_datadog_action_connection.go
+++ b/datadog/fwprovider/resource_datadog_action_connection.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_api_key.go
+++ b/datadog/fwprovider/resource_datadog_api_key.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_apm_retention_filter.go
+++ b/datadog/fwprovider/resource_datadog_apm_retention_filter.go
@@ -17,8 +17,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_apm_retention_filter_order.go
+++ b/datadog/fwprovider/resource_datadog_apm_retention_filter_order.go
@@ -3,7 +3,7 @@ package fwprovider
 import (
 	"context"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/diag"

--- a/datadog/fwprovider/resource_datadog_application_key.go
+++ b/datadog/fwprovider/resource_datadog_application_key.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_appsec_waf_custom_rule.go
+++ b/datadog/fwprovider/resource_datadog_appsec_waf_custom_rule.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_appsec_waf_exclusion_filter.go
+++ b/datadog/fwprovider/resource_datadog_appsec_waf_exclusion_filter.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 const (

--- a/datadog/fwprovider/resource_datadog_azure_integration.go
+++ b/datadog/fwprovider/resource_datadog_azure_integration.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_csm_threats_agent_rule.go
+++ b/datadog/fwprovider/resource_datadog_csm_threats_agent_rule.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_dashboard_list.go
+++ b/datadog/fwprovider/resource_datadog_dashboard_list.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_domain_allowlist.go
+++ b/datadog/fwprovider/resource_datadog_domain_allowlist.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_downtime_schedule.go
+++ b/datadog/fwprovider/resource_datadog_downtime_schedule.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/planmodifiers"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/planmodifiers"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"

--- a/datadog/fwprovider/resource_datadog_integration_aws_account.go
+++ b/datadog/fwprovider/resource_datadog_integration_aws_account.go
@@ -20,8 +20,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/fwutils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/fwutils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_integration_aws_event_bridge.go
+++ b/datadog/fwprovider/resource_datadog_integration_aws_event_bridge.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_integration_aws_external_id.go
+++ b/datadog/fwprovider/resource_datadog_integration_aws_external_id.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 const EXPIRY_WARNING_MESSAGE = "A new external ID must be used to create an AWS account integration in Datadog within 48 hours of creation or it will expire."

--- a/datadog/fwprovider/resource_datadog_integration_cloudflare_account.go
+++ b/datadog/fwprovider/resource_datadog_integration_cloudflare_account.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_integration_confluent_account.go
+++ b/datadog/fwprovider/resource_datadog_integration_confluent_account.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_integration_confluent_resource.go
+++ b/datadog/fwprovider/resource_datadog_integration_confluent_resource.go
@@ -15,8 +15,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_integration_fastly_account.go
+++ b/datadog/fwprovider/resource_datadog_integration_fastly_account.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_integration_fastly_service.go
+++ b/datadog/fwprovider/resource_datadog_integration_fastly_service.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_integration_gcp.go
+++ b/datadog/fwprovider/resource_datadog_integration_gcp.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 const (

--- a/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
+++ b/datadog/fwprovider/resource_datadog_integration_gcp_sts.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_integration_microsoft_teams_handle.go
+++ b/datadog/fwprovider/resource_datadog_integration_microsoft_teams_handle.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_integration_microsoft_teams_workflows_webhook_handle.go
+++ b/datadog/fwprovider/resource_datadog_integration_microsoft_teams_workflows_webhook_handle.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_ip_allowlist.go
+++ b/datadog/fwprovider/resource_datadog_ip_allowlist.go
@@ -11,9 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/planmodifiers"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/planmodifiers"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_logs_custom_destination.go
+++ b/datadog/fwprovider/resource_datadog_logs_custom_destination.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_openapi_api.go
+++ b/datadog/fwprovider/resource_datadog_openapi_api.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_restriction_policy.go
+++ b/datadog/fwprovider/resource_datadog_restriction_policy.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_rum_application.go
+++ b/datadog/fwprovider/resource_datadog_rum_application.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_rum_metric.go
+++ b/datadog/fwprovider/resource_datadog_rum_metric.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_security_monitoring_suppression.go
+++ b/datadog/fwprovider/resource_datadog_security_monitoring_suppression.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_security_notification_rule.go
+++ b/datadog/fwprovider/resource_datadog_security_notification_rule.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_sensitive_data_scanner_group_order.go
+++ b/datadog/fwprovider/resource_datadog_sensitive_data_scanner_group_order.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_service_account.go
+++ b/datadog/fwprovider/resource_datadog_service_account.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_service_account_application_key.go
+++ b/datadog/fwprovider/resource_datadog_service_account_application_key.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_software_catalog.go
+++ b/datadog/fwprovider/resource_datadog_software_catalog.go
@@ -10,8 +10,8 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/Masterminds/semver/v3"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/customtypes"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/customtypes"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	frameworkPath "github.com/hashicorp/terraform-plugin-framework/path"

--- a/datadog/fwprovider/resource_datadog_spans_metric.go
+++ b/datadog/fwprovider/resource_datadog_spans_metric.go
@@ -15,8 +15,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/planmodifiers"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/planmodifiers"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_synthetics_concurrency_cap.go
+++ b/datadog/fwprovider/resource_datadog_synthetics_concurrency_cap.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_synthetics_global_variable.go
+++ b/datadog/fwprovider/resource_datadog_synthetics_global_variable.go
@@ -19,8 +19,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_synthetics_private_location.go
+++ b/datadog/fwprovider/resource_datadog_synthetics_private_location.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_team.go
+++ b/datadog/fwprovider/resource_datadog_team.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_team_link.go
+++ b/datadog/fwprovider/resource_datadog_team_link.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_team_membership.go
+++ b/datadog/fwprovider/resource_datadog_team_membership.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_team_permission_setting.go
+++ b/datadog/fwprovider/resource_datadog_team_permission_setting.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_user_role.go
+++ b/datadog/fwprovider/resource_datadog_user_role.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_webhook.go
+++ b/datadog/fwprovider/resource_datadog_webhook.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_webhook_custom_variable.go
+++ b/datadog/fwprovider/resource_datadog_webhook_custom_variable.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/fwprovider/resource_datadog_workflow_automation.go
+++ b/datadog/fwprovider/resource_datadog_workflow_automation.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/internal/fwutils/fw_enrich_schema_test.go
+++ b/datadog/internal/fwutils/fw_enrich_schema_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 )
 
 func TestEnrichSchemaAttributes(t *testing.T) {

--- a/datadog/internal/planmodifiers/types_string_ip_normalizer.go
+++ b/datadog/internal/planmodifiers/types_string_ip_normalizer.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func NormalizeIP() planmodifier.String {

--- a/datadog/internal/planmodifiers/types_string_tag_normalizer.go
+++ b/datadog/internal/planmodifiers/types_string_tag_normalizer.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func NormalizeTag() planmodifier.String {

--- a/datadog/internal/utils/utils.go
+++ b/datadog/internal/utils/utils.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/meta"
 
-	"github.com/terraform-providers/terraform-provider-datadog/version"
+	"github.com/DataDog/terraform-provider-datadog/version"
 )
 
 // DDAPPKeyEnvName name of env var for APP key

--- a/datadog/internal/validators/tags_set_is_nomalized.go
+++ b/datadog/internal/validators/tags_set_is_nomalized.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TagsSetIsNormalized() tagsSetIsNormalized {

--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -20,8 +20,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	datadogCommunity "github.com/zorkian/go-datadog-api"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 )
 
 func init() {

--- a/datadog/resource_datadog_authn_mapping.go
+++ b/datadog/resource_datadog_authn_mapping.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 )

--- a/datadog/resource_datadog_child_organization.go
+++ b/datadog/resource_datadog_child_organization.go
@@ -3,7 +3,7 @@ package datadog
 import (
 	"context"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_cloud_configuration_rule.go
+++ b/datadog/resource_datadog_cloud_configuration_rule.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 )
 
 const nameField = "name"

--- a/datadog/resource_datadog_cloud_workload_security_agent_rule.go
+++ b/datadog/resource_datadog_cloud_workload_security_agent_rule.go
@@ -3,7 +3,7 @@ package datadog
 import (
 	"context"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"

--- a/datadog/resource_datadog_dashboard_json.go
+++ b/datadog/resource_datadog_dashboard_json.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var computedFields = []string{"id", "author_handle", "author_name", "created_at", "modified_at", "url"}

--- a/datadog/resource_datadog_downtime.go
+++ b/datadog/resource_datadog_downtime.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 
 	// embed time zone data
 	_ "time/tzdata"

--- a/datadog/resource_datadog_integration_aws.go
+++ b/datadog/resource_datadog_integration_aws.go
@@ -7,8 +7,8 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_integration_aws_lambda_arn.go
+++ b/datadog/resource_datadog_integration_aws_lambda_arn.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_integration_aws_log_collection.go
+++ b/datadog/resource_datadog_integration_aws_log_collection.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_integration_aws_tag_filter.go
+++ b/datadog/resource_datadog_integration_aws_tag_filter.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_integration_opsgenie_service_object.go
+++ b/datadog/resource_datadog_integration_opsgenie_service_object.go
@@ -3,8 +3,8 @@ package datadog
 import (
 	"context"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_integration_pagerduty.go
+++ b/datadog/resource_datadog_integration_pagerduty.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/zorkian/go-datadog-api"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 // creating/modifying/deleting PD integration and its service objects in parallel on one account

--- a/datadog/resource_datadog_integration_pagerduty_service_object.go
+++ b/datadog/resource_datadog_integration_pagerduty_service_object.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_integration_slack_channel.go
+++ b/datadog/resource_datadog_integration_slack_channel.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_logs_archive.go
+++ b/datadog/resource_datadog_logs_archive.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"

--- a/datadog/resource_datadog_logs_archive_order.go
+++ b/datadog/resource_datadog_logs_archive_order.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_logs_custom_pipeline.go
+++ b/datadog/resource_datadog_logs_custom_pipeline.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_logs_index.go
+++ b/datadog/resource_datadog_logs_index.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"sync"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_logs_index_order.go
+++ b/datadog/resource_datadog_logs_index_order.go
@@ -3,7 +3,7 @@ package datadog
 import (
 	"context"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_logs_integration_pipeline.go
+++ b/datadog/resource_datadog_logs_integration_pipeline.go
@@ -3,7 +3,7 @@ package datadog
 import (
 	"context"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_logs_metric.go
+++ b/datadog/resource_datadog_logs_metric.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_logs_pipeline_order.go
+++ b/datadog/resource_datadog_logs_pipeline_order.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_metric_metadata.go
+++ b/datadog/resource_datadog_metric_metadata.go
@@ -3,7 +3,7 @@ package datadog
 import (
 	"context"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"

--- a/datadog/resource_datadog_metric_tag_configuration.go
+++ b/datadog/resource_datadog_metric_tag_configuration.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_monitor_config_policy.go
+++ b/datadog/resource_datadog_monitor_config_policy.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 )
 
 func resourceDatadogMonitorConfigPolicy() *schema.Resource {

--- a/datadog/resource_datadog_monitor_json.go
+++ b/datadog/resource_datadog_monitor_json.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"

--- a/datadog/resource_datadog_organization_settings.go
+++ b/datadog/resource_datadog_organization_settings.go
@@ -15,8 +15,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 )
 
 func resourceDatadogOrganizationSettings() *schema.Resource {

--- a/datadog/resource_datadog_powerpack.go
+++ b/datadog/resource_datadog_powerpack.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func resourceDatadogPowerpack() *schema.Resource {

--- a/datadog/resource_datadog_role.go
+++ b/datadog/resource_datadog_role.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"reflect"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_security_monitoring_default_rule.go
+++ b/datadog/resource_datadog_security_monitoring_default_rule.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_security_monitoring_filters.go
+++ b/datadog/resource_datadog_security_monitoring_filters.go
@@ -5,8 +5,8 @@ import (
 
 	_ "gopkg.in/warnings.v0"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_security_monitoring_rule.go
+++ b/datadog/resource_datadog_security_monitoring_rule.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_sensitive_data_scanner_group.go
+++ b/datadog/resource_datadog_sensitive_data_scanner_group.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 )
 
 var sensitiveDataScannerMutex = sync.Mutex{}

--- a/datadog/resource_datadog_sensitive_data_scanner_rule.go
+++ b/datadog/resource_datadog_sensitive_data_scanner_rule.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 )
 
 func resourceDatadogSensitiveDataScannerRule() *schema.Resource {

--- a/datadog/resource_datadog_service_definition_yaml.go
+++ b/datadog/resource_datadog_service_definition_yaml.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"

--- a/datadog/resource_datadog_service_level_objective.go
+++ b/datadog/resource_datadog_service_level_objective.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_slo_correction.go
+++ b/datadog/resource_datadog_slo_correction.go
@@ -3,8 +3,8 @@ package datadog
 import (
 	"context"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -16,8 +16,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/go-cty/cty"

--- a/datadog/resource_datadog_user.go
+++ b/datadog/resource_datadog_user.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/datadog/tests/data_source_datadog_action_connection_test.go
+++ b/datadog/tests/data_source_datadog_action_connection_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
 )
 
 var (

--- a/datadog/tests/data_source_datadog_cloud_workload_security_agent_rules_test.go
+++ b/datadog/tests/data_source_datadog_cloud_workload_security_agent_rules_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
 )
 
 const tfAgentRulesSource = "data.datadog_cloud_workload_security_agent_rules.acceptance_test"

--- a/datadog/tests/data_source_datadog_csm_threats_agent_rules_test.go
+++ b/datadog/tests/data_source_datadog_csm_threats_agent_rules_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
 )
 
 func TestAccCSMThreatsAgentRuleDataSource(t *testing.T) {

--- a/datadog/tests/data_source_datadog_integration_aws_available_logs_services_test.go
+++ b/datadog/tests/data_source_datadog_integration_aws_available_logs_services_test.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"

--- a/datadog/tests/data_source_datadog_integration_aws_available_namespaces_test.go
+++ b/datadog/tests/data_source_datadog_integration_aws_available_namespaces_test.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"

--- a/datadog/tests/data_source_datadog_integration_aws_logs_services_test.go
+++ b/datadog/tests/data_source_datadog_integration_aws_logs_services_test.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/datadog/tests/data_source_datadog_logs_archives_order_test.go
+++ b/datadog/tests/data_source_datadog_logs_archives_order_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
 )
 
 func logsArchiveOrderCheckCount(accProvider func() (*schema.Provider, error)) func(state *terraform.State) error {

--- a/datadog/tests/data_source_datadog_logs_indexes_test.go
+++ b/datadog/tests/data_source_datadog_logs_indexes_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )

--- a/datadog/tests/data_source_datadog_logs_pipelines_test.go
+++ b/datadog/tests/data_source_datadog_logs_pipelines_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )

--- a/datadog/tests/data_source_datadog_security_monitoring_filters_test.go
+++ b/datadog/tests/data_source_datadog_security_monitoring_filters_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
 )
 
 const tfSecurityFiltersSource = "data.datadog_security_monitoring_filters.acceptance_test"

--- a/datadog/tests/data_source_datadog_security_monitoring_rules_test.go
+++ b/datadog/tests/data_source_datadog_security_monitoring_rules_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
 )
 
 const tfSecurityRulesSource = "data.datadog_security_monitoring_rules.acceptance_test"

--- a/datadog/tests/data_source_datadog_security_monitoring_suppressions_test.go
+++ b/datadog/tests/data_source_datadog_security_monitoring_suppressions_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
 )
 
 func TestAccSecurityMonitoringSuppressionDataSource(t *testing.T) {

--- a/datadog/tests/data_source_datadog_workflow_automation_test.go
+++ b/datadog/tests/data_source_datadog_workflow_automation_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
 )
 
 func TestAccDatadogWorkflowAutomationDatasource(t *testing.T) {

--- a/datadog/tests/framework_provider_test.go
+++ b/datadog/tests/framework_provider_test.go
@@ -19,9 +19,9 @@ import (
 	datadogCommunity "github.com/zorkian/go-datadog-api"
 	ddhttp "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 type compositeProviderStruct struct {

--- a/datadog/tests/provider_test.go
+++ b/datadog/tests/provider_test.go
@@ -18,8 +18,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	common "github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	ddtesting "github.com/DataDog/dd-sdk-go-testing"

--- a/datadog/tests/resource_datadog_action_connection_test.go
+++ b/datadog/tests/resource_datadog_action_connection_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 var (

--- a/datadog/tests/resource_datadog_api_key_test.go
+++ b/datadog/tests/resource_datadog_api_key_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccDatadogApiKey_Update(t *testing.T) {

--- a/datadog/tests/resource_datadog_apm_retention_filter_order_test.go
+++ b/datadog/tests/resource_datadog_apm_retention_filter_order_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
 )
 
 // Get the current order and inverse it

--- a/datadog/tests/resource_datadog_apm_retention_filter_test.go
+++ b/datadog/tests/resource_datadog_apm_retention_filter_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccApmRetentionFilter(t *testing.T) {

--- a/datadog/tests/resource_datadog_application_key_test.go
+++ b/datadog/tests/resource_datadog_application_key_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccDatadogApplicationKey_Update(t *testing.T) {

--- a/datadog/tests/resource_datadog_appsec_waf_custom_rule_test.go
+++ b/datadog/tests/resource_datadog_appsec_waf_custom_rule_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccAppsecWafCustomRuleBasic(t *testing.T) {

--- a/datadog/tests/resource_datadog_appsec_waf_exclusion_filter_test.go
+++ b/datadog/tests/resource_datadog_appsec_waf_exclusion_filter_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccAppsecWafExclusionFilterBasic(t *testing.T) {

--- a/datadog/tests/resource_datadog_authn_mapping_test.go
+++ b/datadog/tests/resource_datadog_authn_mapping_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccDatadogAuthNMapping_CreateUpdate(t *testing.T) {

--- a/datadog/tests/resource_datadog_cloud_configuration_rule_test.go
+++ b/datadog/tests/resource_datadog_cloud_configuration_rule_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
 )
 
 const tfCloudConfRuleName = "datadog_cloud_configuration_rule.acceptance_test"

--- a/datadog/tests/resource_datadog_cloud_workload_security_agent_rule_test.go
+++ b/datadog/tests/resource_datadog_cloud_workload_security_agent_rule_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
 )
 
 const tfAgentRuleName = "datadog_cloud_workload_security_agent_rule.acceptance_test"

--- a/datadog/tests/resource_datadog_csm_threats_agent_rule_test.go
+++ b/datadog/tests/resource_datadog_csm_threats_agent_rule_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
 )
 
 // Create an agent rule and update its description

--- a/datadog/tests/resource_datadog_dashboard_list_test.go
+++ b/datadog/tests/resource_datadog_dashboard_list_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func testAccCheckDatadogDashListConfig(uniq string) string {

--- a/datadog/tests/resource_datadog_dashboard_test.go
+++ b/datadog/tests/resource_datadog_dashboard_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/datadog/tests/resource_datadog_domain_allowlist_test.go
+++ b/datadog/tests/resource_datadog_domain_allowlist_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccDatadogDomainAllowlist_CreateUpdate(t *testing.T) {

--- a/datadog/tests/resource_datadog_downtime_schedule_test.go
+++ b/datadog/tests/resource_datadog_downtime_schedule_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccDowntimeScheduleBasicRecurring_Import(t *testing.T) {

--- a/datadog/tests/resource_datadog_downtime_test.go
+++ b/datadog/tests/resource_datadog_downtime_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/datadog/tests/resource_datadog_integration_aws_account_test.go
+++ b/datadog/tests/resource_datadog_integration_aws_account_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccIntegrationAwsAccount_RoleBased(t *testing.T) {

--- a/datadog/tests/resource_datadog_integration_aws_event_bridge_test.go
+++ b/datadog/tests/resource_datadog_integration_aws_event_bridge_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccIntegrationAwsEventBridgeBasic(t *testing.T) {

--- a/datadog/tests/resource_datadog_integration_aws_external_id_test.go
+++ b/datadog/tests/resource_datadog_integration_aws_external_id_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccIntegrationAwsExternalIDBasic(t *testing.T) {

--- a/datadog/tests/resource_datadog_integration_aws_lambda_arn_test.go
+++ b/datadog/tests/resource_datadog_integration_aws_lambda_arn_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/datadog/tests/resource_datadog_integration_aws_log_collection_test.go
+++ b/datadog/tests/resource_datadog_integration_aws_log_collection_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/datadog/tests/resource_datadog_integration_aws_tag_filter_test.go
+++ b/datadog/tests/resource_datadog_integration_aws_tag_filter_test.go
@@ -6,8 +6,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	dd "github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"

--- a/datadog/tests/resource_datadog_integration_aws_test.go
+++ b/datadog/tests/resource_datadog_integration_aws_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"

--- a/datadog/tests/resource_datadog_integration_azure_test.go
+++ b/datadog/tests/resource_datadog_integration_azure_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	dd "github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/datadog/tests/resource_datadog_integration_cloudflare_account_test.go
+++ b/datadog/tests/resource_datadog_integration_cloudflare_account_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccIntegrationCloudflareAccountBasic(t *testing.T) {

--- a/datadog/tests/resource_datadog_integration_confluent_account_test.go
+++ b/datadog/tests/resource_datadog_integration_confluent_account_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccIntegrationConfluentAccountBasic(t *testing.T) {

--- a/datadog/tests/resource_datadog_integration_confluent_resource_test.go
+++ b/datadog/tests/resource_datadog_integration_confluent_resource_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccIntegrationConfluentResourceBasic(t *testing.T) {

--- a/datadog/tests/resource_datadog_integration_fastly_account_test.go
+++ b/datadog/tests/resource_datadog_integration_fastly_account_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccIntegrationFastlyAccountBasic(t *testing.T) {

--- a/datadog/tests/resource_datadog_integration_gcp_sts_test.go
+++ b/datadog/tests/resource_datadog_integration_gcp_sts_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccIntegrationGcpStsBasic(t *testing.T) {

--- a/datadog/tests/resource_datadog_integration_gcp_test.go
+++ b/datadog/tests/resource_datadog_integration_gcp_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
 )
 
 func testAccCheckDatadogIntegrationGCPConfig(uniq string) string {

--- a/datadog/tests/resource_datadog_integration_microsoft_teams_handle_test.go
+++ b/datadog/tests/resource_datadog_integration_microsoft_teams_handle_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccMSTeamsTenantBasedHandlesBasic(t *testing.T) {

--- a/datadog/tests/resource_datadog_integration_ms_teams_workflows_handle_test.go
+++ b/datadog/tests/resource_datadog_integration_ms_teams_workflows_handle_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccMSTeamsWorkflowsWebhookHandlesBasic(t *testing.T) {

--- a/datadog/tests/resource_datadog_integration_opsgenie_service_object_test.go
+++ b/datadog/tests/resource_datadog_integration_opsgenie_service_object_test.go
@@ -6,8 +6,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/datadog/tests/resource_datadog_integration_pagerduty_test.go
+++ b/datadog/tests/resource_datadog_integration_pagerduty_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/datadog/tests/resource_datadog_integration_slack_channel_test.go
+++ b/datadog/tests/resource_datadog_integration_slack_channel_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	communityClient "github.com/zorkian/go-datadog-api"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccDatadogIntegrationSlackChannel_Basic(t *testing.T) {

--- a/datadog/tests/resource_datadog_ip_allowlist_test.go
+++ b/datadog/tests/resource_datadog_ip_allowlist_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccDatadogIPAllowlist_CreateUpdate(t *testing.T) {

--- a/datadog/tests/resource_datadog_logs_archive_order_test.go
+++ b/datadog/tests/resource_datadog_logs_archive_order_test.go
@@ -7,13 +7,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
 )
 
 func ArchiveOrderConfig() string {

--- a/datadog/tests/resource_datadog_logs_archive_test.go
+++ b/datadog/tests/resource_datadog_logs_archive_test.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"

--- a/datadog/tests/resource_datadog_logs_custom_pipeline_test.go
+++ b/datadog/tests/resource_datadog_logs_custom_pipeline_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/datadog/tests/resource_datadog_logs_metric_test.go
+++ b/datadog/tests/resource_datadog_logs_metric_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/datadog/tests/resource_datadog_metric_metadata_test.go
+++ b/datadog/tests/resource_datadog_metric_metadata_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/datadog/tests/resource_datadog_metric_tag_configuration_test.go
+++ b/datadog/tests/resource_datadog_metric_tag_configuration_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
 )
 
 func TestAccDatadogMetricTagConfiguration_Error(t *testing.T) {

--- a/datadog/tests/resource_datadog_monitor_config_policy_test.go
+++ b/datadog/tests/resource_datadog_monitor_config_policy_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/datadog/tests/resource_datadog_monitor_test.go
+++ b/datadog/tests/resource_datadog_monitor_test.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/datadog/tests/resource_datadog_openapi_api_test.go
+++ b/datadog/tests/resource_datadog_openapi_api_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccOpenapiApiBasic(t *testing.T) {

--- a/datadog/tests/resource_datadog_powerpack_test.go
+++ b/datadog/tests/resource_datadog_powerpack_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/datadog/tests/resource_datadog_restriction_policy_test.go
+++ b/datadog/tests/resource_datadog_restriction_policy_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccRestrictionPolicyBasic(t *testing.T) {

--- a/datadog/tests/resource_datadog_role_test.go
+++ b/datadog/tests/resource_datadog_role_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/datadog/tests/resource_datadog_rum_application_test.go
+++ b/datadog/tests/resource_datadog_rum_application_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"

--- a/datadog/tests/resource_datadog_rum_metric_test.go
+++ b/datadog/tests/resource_datadog_rum_metric_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccRumMetricImport(t *testing.T) {

--- a/datadog/tests/resource_datadog_security_monitoring_filter_test.go
+++ b/datadog/tests/resource_datadog_security_monitoring_filter_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
 )
 
 const tfSecurityFilterName = "datadog_security_monitoring_filter.acceptance_test"

--- a/datadog/tests/resource_datadog_security_monitoring_rule_test.go
+++ b/datadog/tests/resource_datadog_security_monitoring_rule_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
 )
 
 const tfSecurityRuleName = "datadog_security_monitoring_rule.acceptance_test"

--- a/datadog/tests/resource_datadog_security_monitoring_suppression_test.go
+++ b/datadog/tests/resource_datadog_security_monitoring_suppression_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
 )
 
 // Create a suppression and update its rule query and description without adding a start date and an expiration date

--- a/datadog/tests/resource_datadog_security_notification_rule_test.go
+++ b/datadog/tests/resource_datadog_security_notification_rule_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
 )
 
 var (

--- a/datadog/tests/resource_datadog_sensitive_data_scanner_group_test.go
+++ b/datadog/tests/resource_datadog_sensitive_data_scanner_group_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/datadog/tests/resource_datadog_sensitive_data_scanner_rule_test.go
+++ b/datadog/tests/resource_datadog_sensitive_data_scanner_rule_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/datadog/tests/resource_datadog_service_account_application_key_test.go
+++ b/datadog/tests/resource_datadog_service_account_application_key_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccServiceAccountApplicationKeyBasic(t *testing.T) {

--- a/datadog/tests/resource_datadog_service_account_test.go
+++ b/datadog/tests/resource_datadog_service_account_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
 )
 
 func TestServiceAccountCreate(t *testing.T) {

--- a/datadog/tests/resource_datadog_service_definition_yaml_test.go
+++ b/datadog/tests/resource_datadog_service_definition_yaml_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/datadog/tests/resource_datadog_service_level_objective_test.go
+++ b/datadog/tests/resource_datadog_service_level_objective_test.go
@@ -6,8 +6,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/datadog/tests/resource_datadog_slo_correction_test.go
+++ b/datadog/tests/resource_datadog_slo_correction_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/datadog/tests/resource_datadog_software_catalog_test.go
+++ b/datadog/tests/resource_datadog_software_catalog_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"

--- a/datadog/tests/resource_datadog_spans_metric_test.go
+++ b/datadog/tests/resource_datadog_spans_metric_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccSpansMetric_import(t *testing.T) {

--- a/datadog/tests/resource_datadog_synthetics_global_variable_test.go
+++ b/datadog/tests/resource_datadog_synthetics_global_variable_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
 )
 
 func getUniqueVariableName(ctx context.Context, t *testing.T) string {

--- a/datadog/tests/resource_datadog_synthetics_private_location_test.go
+++ b/datadog/tests/resource_datadog_synthetics_private_location_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccDatadogSyntheticsPrivateLocation_importBasic(t *testing.T) {

--- a/datadog/tests/resource_datadog_synthetics_test_test.go
+++ b/datadog/tests/resource_datadog_synthetics_test_test.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/datadog/tests/resource_datadog_team_link_test.go
+++ b/datadog/tests/resource_datadog_team_link_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccTeamLinkBasic(t *testing.T) {

--- a/datadog/tests/resource_datadog_team_membership_test.go
+++ b/datadog/tests/resource_datadog_team_membership_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccTeamMembershipBasic(t *testing.T) {

--- a/datadog/tests/resource_datadog_team_test.go
+++ b/datadog/tests/resource_datadog_team_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccTeamBasic(t *testing.T) {

--- a/datadog/tests/resource_datadog_user_role_test.go
+++ b/datadog/tests/resource_datadog_user_role_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 func TestAccUserRoleBasic(t *testing.T) {

--- a/datadog/tests/resource_datadog_user_test.go
+++ b/datadog/tests/resource_datadog_user_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	dd "github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"

--- a/datadog/tests/resource_datadog_webhook_custom_variable_test.go
+++ b/datadog/tests/resource_datadog_webhook_custom_variable_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"

--- a/datadog/tests/resource_datadog_webhook_test.go
+++ b/datadog/tests/resource_datadog_webhook_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"

--- a/datadog/tests/resource_datadog_workflow_automation_test.go
+++ b/datadog/tests/resource_datadog_workflow_automation_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog/internal/utils"
 )
 
 // Vars shared for data source and resource tests

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-datadog
+module github.com/DataDog/terraform-provider-datadog
 
 require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.35.1-0.20250306173106-9775f03091da

--- a/main.go
+++ b/main.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"
 	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
 
-	"github.com/terraform-providers/terraform-provider-datadog/datadog"
-	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
+	"github.com/DataDog/terraform-provider-datadog/datadog"
+	"github.com/DataDog/terraform-provider-datadog/datadog/fwprovider"
 )
 
 func main() {

--- a/scripts/changelog-links.sh
+++ b/scripts/changelog-links.sh
@@ -24,7 +24,7 @@ else
   SED="sed -i.bak -r -e"
 fi
 
-PROVIDER_URL="https:\/\/github.com\/terraform-providers\/terraform-provider-datadog\/issues"
+PROVIDER_URL="https:\/\/github.com\/DataDog\/terraform-provider-datadog\/issues"
 
 $SED "s/GH-([0-9]+)/\[#\1\]\($PROVIDER_URL\/\1\)/g" -e 's/\[\[#(.+)([0-9])\)]$/(\[#\1\2))/g' CHANGELOG.md
 


### PR DESCRIPTION
This PR renames the package to the current official URL `github.com/DataDog/terraform-provider-datadog`
instead of relying on the old URL `github.com/terraform-providers/terraform-provider-datadog`. 

This change is required to be able to import the provider as a module.