### PR TITLE
[datadog_dashboards] [datadog_powerpacks] add custom_links support to treemap widgets

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -9144,6 +9144,14 @@ func getTreemapDefinitionSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Optional:    true,
 		},
+		"custom_links": {
+			Description: "A nested block describing a custom link. Multiple `custom_link` blocks are allowed using the structure below.",
+			Type:        schema.TypeList,
+			Optional:    true,
+			Elem: &schema.Resource{
+				Schema: getWidgetCustomLinkSchema(),
+			},
+		},
 	}
 }
 
@@ -9163,6 +9171,10 @@ func buildDatadogTreemapDefinition(terraformDefinition map[string]interface{}) *
 
 	if v, ok := terraformDefinition["title"].(string); ok && len(v) != 0 {
 		datadogDefinition.SetTitle(v)
+	}
+
+	if v, ok := terraformDefinition["custom_links"].([]interface{}); ok && len(v) > 0 {
+		datadogDefinition.SetCustomLinks(*buildDatadogWidgetCustomLinks(&v))
 	}
 
 	return datadogDefinition
@@ -9234,6 +9246,10 @@ func buildTerraformTreemapDefinition(datadogDefinition *datadogV1.TreeMapWidgetD
 
 	if v, ok := datadogDefinition.GetTitleOk(); ok {
 		terraformDefinition["title"] = *v
+	}
+
+	if v, ok := datadogDefinition.GetCustomLinksOk(); ok {
+		terraformDefinition["custom_links"] = buildTerraformWidgetCustomLinks(v)
 	}
 
 	return terraformDefinition

--- a/docs/dashboard_widget_field_rules.md
+++ b/docs/dashboard_widget_field_rules.md
@@ -29,7 +29,7 @@
 2. Follow existing patterns for validation and types
 3. Document any special handling or requirements 
 
-## Example Configuration
+## Example configuration
 1. Provide a working example of the Terraform configuration using the new field
 2. Include comments explaining each part of the configuration
 3. Show both required and optional fields

--- a/docs/dashboard_widget_field_rules.md
+++ b/docs/dashboard_widget_field_rules.md
@@ -1,0 +1,81 @@
+# Rules for Adding Fields to Dashboard Widgets
+
+## Before Making Changes
+1. Check if the field is already implemented in the widget's schema and build functions
+2. Review the dashboard.yml API spec to understand the field's structure and requirements
+3. Look at similar implementations in other widgets for consistent patterns
+
+## Implementation Steps
+1. Start Small: Make changes one at a time and review each change independently
+2. Follow Existing Patterns: Use the same field implementation pattern as seen in other widgets
+3. Required Components:
+   - Add field to widget's schema definition function (e.g., `getTreemapDefinitionSchema`)
+   - Add field handling in Terraform-to-Datadog build function (e.g., `buildDatadogTreemapDefinition`)
+   - Add field handling in Datadog-to-Terraform build function (e.g., `buildTerraformTreemapDefinition`)
+ 
+## Common Gotchas
+1. Don't modify existing working code (e.g., title fields that are already implemented)
+2. Ensure field names in schema match the API spec
+3. Use existing helper functions when available (e.g., `getWidgetCustomLinkSchema` for custom links)
+4. Maintain consistent naming between schema and build functions
+
+## Testing
+1. Test both directions of conversion (Terraform to Datadog and vice versa)
+2. Verify optional vs required field behavior
+3. Test with and without the field present
+
+## Documentation
+1. Include field descriptions in schema
+2. Follow existing patterns for validation and types
+3. Document any special handling or requirements 
+
+## Example Configuration
+1. Provide a working example of the Terraform configuration using the new field
+2. Include comments explaining each part of the configuration
+3. Show both required and optional fields
+4. If applicable, show different variations of how the field can be used 
+
+```hcl
+resource "datadog_dashboard" "example_dashboard" {
+  title       = "Treemap Custom Links Test"
+  layout_type = "ordered"
+
+  widget {
+    treemap_definition {
+      request {
+        query {
+          metric_query {
+            query = "avg:system.cpu.user{*} by {host}"
+            name  = "cpu_usage"
+          }
+        }
+        formula {
+          formula = "cpu_usage"
+        }
+      }
+      title = "Host CPU Usage"
+      custom_links {
+        label = "View Host Details"
+        link  = "https://app.datadoghq.com/infrastructure/host/{{host}}"  # Correct template variable syntax
+      }
+      custom_links {
+        label = "View Documentation"
+        link  = "https://docs.example.com/monitoring"  # Static URL example
+      }
+    }
+  }
+}
+```
+
+## Pull Request Description
+1. Clear title describing the change (e.g., "Add custom_links support to treemap widget")
+2. Summary of changes made
+3. Link to relevant documentation or specs
+4. Impact assessment
+   - Breaking changes (if any)
+   - Backward compatibility considerations
+5. Testing instructions
+   - Example configuration
+   - Steps to verify functionality
+   - Expected behavior
+6. Screenshots or examples (if applicable) 

--- a/docs/dashboard_widget_field_rules.md
+++ b/docs/dashboard_widget_field_rules.md
@@ -9,7 +9,7 @@
 1. Start Small: Make changes one at a time and review each change independently
 2. Follow Existing Patterns: Use the same field implementation pattern as seen in other widgets
 3. Required Components:
-   - Add field to widget's schema definition function (e.g., `getTreemapDefinitionSchema`)
+   - Add field to widget's schema definition function (such as `getTreemapDefinitionSchema`)
    - Add field handling in Terraform-to-Datadog build function (e.g., `buildDatadogTreemapDefinition`)
    - Add field handling in Datadog-to-Terraform build function (e.g., `buildTerraformTreemapDefinition`)
  

--- a/docs/dashboard_widget_field_rules.md
+++ b/docs/dashboard_widget_field_rules.md
@@ -5,7 +5,7 @@
 2. Review the dashboard.yml API spec to understand the field's structure and requirements
 3. Look at similar implementations in other widgets for consistent patterns
 
-## Implementation Steps
+## Implementation steps
 1. Start small: Make changes one at a time and review each change independently
 2. Follow Existing Patterns: Use the same field implementation pattern as seen in other widgets
 3. Required Components:

--- a/docs/dashboard_widget_field_rules.md
+++ b/docs/dashboard_widget_field_rules.md
@@ -8,7 +8,7 @@
 ## Implementation steps
 1. Start small: Make changes one at a time and review each change independently
 2. Follow existing patterns: Use the same field implementation pattern as seen in other widgets
-3. Required Components:
+3. Required components:
    - Add field to widget's schema definition function (such as `getTreemapDefinitionSchema`)
    - Add field handling in Terraform-to-Datadog build function (e.g., `buildDatadogTreemapDefinition`)
    - Add field handling in Datadog-to-Terraform build function (e.g., `buildTerraformTreemapDefinition`)

--- a/docs/dashboard_widget_field_rules.md
+++ b/docs/dashboard_widget_field_rules.md
@@ -13,7 +13,7 @@
    - Add field handling in Terraform-to-Datadog build function (e.g., `buildDatadogTreemapDefinition`)
    - Add field handling in Datadog-to-Terraform build function (e.g., `buildTerraformTreemapDefinition`)
  
-## Common Gotchas
+## Common gotchas
 1. Don't modify existing working code (e.g., title fields that are already implemented)
 2. Ensure field names in schema match the API spec
 3. Use existing helper functions when available (e.g., `getWidgetCustomLinkSchema` for custom links)

--- a/docs/dashboard_widget_field_rules.md
+++ b/docs/dashboard_widget_field_rules.md
@@ -1,6 +1,6 @@
 # Rules for Adding Fields to Dashboard Widgets
 
-## Before Making Changes
+## Before making changes
 1. Check if the field is already implemented in the widget's schema and build functions.
 2. Review the dashboard.yml API spec to understand the field's structure and requirements
 3. Look at similar implementations in other widgets for consistent patterns

--- a/docs/dashboard_widget_field_rules.md
+++ b/docs/dashboard_widget_field_rules.md
@@ -1,7 +1,7 @@
 # Rules for Adding Fields to Dashboard Widgets
 
 ## Before Making Changes
-1. Check if the field is already implemented in the widget's schema and build functions
+1. Check if the field is already implemented in the widget's schema and build functions.
 2. Review the dashboard.yml API spec to understand the field's structure and requirements
 3. Look at similar implementations in other widgets for consistent patterns
 

--- a/docs/dashboard_widget_field_rules.md
+++ b/docs/dashboard_widget_field_rules.md
@@ -6,7 +6,7 @@
 3. Look at similar implementations in other widgets for consistent patterns
 
 ## Implementation Steps
-1. Start Small: Make changes one at a time and review each change independently
+1. Start small: Make changes one at a time and review each change independently
 2. Follow Existing Patterns: Use the same field implementation pattern as seen in other widgets
 3. Required Components:
    - Add field to widget's schema definition function (such as `getTreemapDefinitionSchema`)

--- a/docs/dashboard_widget_field_rules.md
+++ b/docs/dashboard_widget_field_rules.md
@@ -7,7 +7,7 @@
 
 ## Implementation steps
 1. Start small: Make changes one at a time and review each change independently
-2. Follow Existing Patterns: Use the same field implementation pattern as seen in other widgets
+2. Follow existing patterns: Use the same field implementation pattern as seen in other widgets
 3. Required Components:
    - Add field to widget's schema definition function (such as `getTreemapDefinitionSchema`)
    - Add field handling in Terraform-to-Datadog build function (e.g., `buildDatadogTreemapDefinition`)

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -13534,8 +13534,20 @@ Required:
 
 Optional:
 
+- `custom_links` (Block List) A nested block describing a custom link. Multiple `custom_link` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--group_definition--widget--split_graph_definition--source_widget_definition--treemap_definition--custom_links))
 - `request` (Block List) Nested block describing the request to use when displaying the widget. (see [below for nested schema](#nestedblock--widget--group_definition--widget--split_graph_definition--source_widget_definition--treemap_definition--request))
 - `title` (String) The title of the widget.
+
+<a id="nestedblock--widget--group_definition--widget--split_graph_definition--source_widget_definition--treemap_definition--custom_links"></a>
+### Nested Schema for `widget.group_definition.widget.split_graph_definition.source_widget_definition.treemap_definition.custom_links`
+
+Optional:
+
+- `is_hidden` (Boolean) The flag for toggling context menu link visibility.
+- `label` (String) The label for the custom link URL.
+- `link` (String) The URL of the custom link.
+- `override_label` (String) The label ID that refers to a context menu link item. When `override_label` is provided, the client request omits the label field.
+
 
 <a id="nestedblock--widget--group_definition--widget--split_graph_definition--source_widget_definition--treemap_definition--request"></a>
 ### Nested Schema for `widget.group_definition.widget.split_graph_definition.source_widget_definition.treemap_definition.request`
@@ -16268,8 +16280,20 @@ Optional:
 
 Optional:
 
+- `custom_links` (Block List) A nested block describing a custom link. Multiple `custom_link` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--group_definition--widget--treemap_definition--custom_links))
 - `request` (Block List) Nested block describing the request to use when displaying the widget. (see [below for nested schema](#nestedblock--widget--group_definition--widget--treemap_definition--request))
 - `title` (String) The title of the widget.
+
+<a id="nestedblock--widget--group_definition--widget--treemap_definition--custom_links"></a>
+### Nested Schema for `widget.group_definition.widget.treemap_definition.custom_links`
+
+Optional:
+
+- `is_hidden` (Boolean) The flag for toggling context menu link visibility.
+- `label` (String) The label for the custom link URL.
+- `link` (String) The URL of the custom link.
+- `override_label` (String) The label ID that refers to a context menu link item. When `override_label` is provided, the client request omits the label field.
+
 
 <a id="nestedblock--widget--group_definition--widget--treemap_definition--request"></a>
 ### Nested Schema for `widget.group_definition.widget.treemap_definition.request`
@@ -26138,8 +26162,20 @@ Required:
 
 Optional:
 
+- `custom_links` (Block List) A nested block describing a custom link. Multiple `custom_link` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--split_graph_definition--source_widget_definition--treemap_definition--custom_links))
 - `request` (Block List) Nested block describing the request to use when displaying the widget. (see [below for nested schema](#nestedblock--widget--split_graph_definition--source_widget_definition--treemap_definition--request))
 - `title` (String) The title of the widget.
+
+<a id="nestedblock--widget--split_graph_definition--source_widget_definition--treemap_definition--custom_links"></a>
+### Nested Schema for `widget.split_graph_definition.source_widget_definition.treemap_definition.custom_links`
+
+Optional:
+
+- `is_hidden` (Boolean) The flag for toggling context menu link visibility.
+- `label` (String) The label for the custom link URL.
+- `link` (String) The URL of the custom link.
+- `override_label` (String) The label ID that refers to a context menu link item. When `override_label` is provided, the client request omits the label field.
+
 
 <a id="nestedblock--widget--split_graph_definition--source_widget_definition--treemap_definition--request"></a>
 ### Nested Schema for `widget.split_graph_definition.source_widget_definition.treemap_definition.request`
@@ -28872,8 +28908,20 @@ Optional:
 
 Optional:
 
+- `custom_links` (Block List) A nested block describing a custom link. Multiple `custom_link` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--treemap_definition--custom_links))
 - `request` (Block List) Nested block describing the request to use when displaying the widget. (see [below for nested schema](#nestedblock--widget--treemap_definition--request))
 - `title` (String) The title of the widget.
+
+<a id="nestedblock--widget--treemap_definition--custom_links"></a>
+### Nested Schema for `widget.treemap_definition.custom_links`
+
+Optional:
+
+- `is_hidden` (Boolean) The flag for toggling context menu link visibility.
+- `label` (String) The label for the custom link URL.
+- `link` (String) The URL of the custom link.
+- `override_label` (String) The label ID that refers to a context menu link item. When `override_label` is provided, the client request omits the label field.
+
 
 <a id="nestedblock--widget--treemap_definition--request"></a>
 ### Nested Schema for `widget.treemap_definition.request`

--- a/docs/resources/powerpack.md
+++ b/docs/resources/powerpack.md
@@ -7849,8 +7849,20 @@ Optional:
 
 Optional:
 
+- `custom_links` (Block List) A nested block describing a custom link. Multiple `custom_link` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--treemap_definition--custom_links))
 - `request` (Block List) Nested block describing the request to use when displaying the widget. (see [below for nested schema](#nestedblock--widget--treemap_definition--request))
 - `title` (String) The title of the widget.
+
+<a id="nestedblock--widget--treemap_definition--custom_links"></a>
+### Nested Schema for `widget.treemap_definition.custom_links`
+
+Optional:
+
+- `is_hidden` (Boolean) The flag for toggling context menu link visibility.
+- `label` (String) The label for the custom link URL.
+- `link` (String) The URL of the custom link.
+- `override_label` (String) The label ID that refers to a context menu link item. When `override_label` is provided, the client request omits the label field.
+
 
 <a id="nestedblock--widget--treemap_definition--request"></a>
 ### Nested Schema for `widget.treemap_definition.request`


### PR DESCRIPTION
# Add custom_links support to treemap widget

## Description
This PR adds support for custom links in treemap widgets, allowing users to add clickable links to their treemap visualizations.

## Changes
- Added `custom_links` field to treemap widget schema
- Implemented custom links support in both directions (Terraform ↔ Datadog)

## Impact
No breaking changes. This is a backward-compatible enhancement that adds optional functionality to treemap widgets.

## Testing Instructions

1. Create a dashboard with a treemap widget using this configuration:
```hcl
resource "datadog_dashboard" "example_dashboard" {
  title        = "Example Dashboard with Treemap"
  description  = "Dashboard demonstrating treemap widget with custom links"
  layout_type  = "ordered"

  widget {
    treemap_definition {
      # Required: Request configuration
      request {
        # Example query showing host CPU usage
        query {
          metric_query {
            query = "avg:system.cpu.user{*} by {host}"
            name  = "cpu_usage"
          }
        }
        formula {
          formula_expression = "cpu_usage"
        }
      }

      # Optional: Widget title
      title = "Host CPU Usage Treemap"

      # Optional: Custom links configuration
      custom_links {
        label = "View Host Details"  # Text shown on the link
        link  = "https://app.datadoghq.com/infrastructure/host/{{host}}"  # URL with template variable
      }
      custom_links {
        label = "View Documentation"
        link  = "https://docs.example.com/monitoring"
      }
    }
  }
}
```

2. Verify that:
   - The dashboard is created successfully
   - The treemap widget shows the custom link in its menu
   - Clicking the link works as expected with template variables properly replaced
   - Importing the dashboard preserves custom links configuration
   - Updating custom links reflects changes in the UI
 
<img width="881" alt="Screenshot 2025-04-29 at 1 38 35 PM" src="https://github.com/user-attachments/assets/dcad8796-c9c4-46c0-8b98-31128c620dd9" />

