### PR TITLE
[data_source_service_level_objective] Add attributes tags computed

### DIFF
--- a/datadog/tests/data_source_datadog_service_level_objective_test.go
+++ b/datadog/tests/data_source_datadog_service_level_objective_test.go
@@ -52,6 +52,9 @@ func checkServiceLevelObjectiveDatasourceAttrs(accProvider func() (*schema.Provi
 		resource.TestCheckResourceAttr("data.datadog_service_level_objective.foo", "timeframe", "7d"),
 		resource.TestCheckResourceAttr("data.datadog_service_level_objective.foo", "query.0.numerator", fmt.Sprintf("sum:%s{type:good}.as_count()", uniq)),
 		resource.TestCheckResourceAttr("data.datadog_service_level_objective.foo", "query.0.denominator", "sum:my.metric{*}.as_count()"),
+		resource.TestCheckResourceAttr("data.datadog_service_level_objective.foo", "tags.#", "2"),
+		resource.TestCheckTypeSetElemAttr("data.datadog_service_level_objective.foo", "tags.*", uniq),
+		resource.TestCheckTypeSetElemAttr("data.datadog_service_level_objective.foo", "tags.*", fmt.Sprintf("foo:%s", uniq)),
 	)
 }
 

--- a/docs/data-sources/service_level_objective.md
+++ b/docs/data-sources/service_level_objective.md
@@ -38,6 +38,7 @@ data "datadog_service_level_objective" "api_slo" {
 - `description` (String) The description of the service level objective.
 - `name` (String) Name of the Datadog service level objective
 - `query` (List of Object) The metric query of good / total events (see [below for nested schema](#nestedatt--query))
+- `tags` (Set of String) List of tags associated with the service level objective.
 - `target_threshold` (Number) The primary target threshold of the service level objective.
 - `timeframe` (String) The primary timeframe of the service level objective.
 - `type` (String) The type of the service level objective. The mapping from these types to the types found in the Datadog Web UI can be found in the Datadog API [documentation page](https://docs.datadoghq.com/api/v1/service-level-objectives/#create-a-slo-object). Available values are: `metric` and `monitor`.


### PR DESCRIPTION
**Motivation:**

Currently, the data_source_service_level_objective does not return the tags associated with an SLO. 
This limitation makes it difficult to automate SLO management via Terraform, especially when tags are used to filter or organize SLOs.

**Changes made:**

- Modified the data_source service_level_objective schema to include the tags attribute of type (Set of String).
- Updated the data_source_service_level_objective_read function to retrieve and return the tags associated with the SLO.
- Added unit tests to verify the behavior of the new tags attribute.
- Updated the documentation to reflect this change.