### PR TITLE
[Doc] (feat) added  description enrichment for more validators

### DIFF
--- a/datadog/fwprovider/resource_datadog_software_catalog.go
+++ b/datadog/fwprovider/resource_datadog_software_catalog.go
@@ -209,7 +209,7 @@ func (v validEntityYAMLValidator) Description(ctx context.Context) string {
 }
 
 func (v validEntityYAMLValidator) MarkdownDescription(_ context.Context) string {
-	return "entity must be a valid entity YAML/JSON structure"
+	return "Entity must be a valid entity YAML/JSON structure."
 }
 
 func (v validEntityYAMLValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {

--- a/datadog/fwprovider/resource_datadog_software_catalog.go
+++ b/datadog/fwprovider/resource_datadog_software_catalog.go
@@ -8,10 +8,10 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
-	"github.com/Masterminds/semver/v3"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/customtypes"
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	frameworkPath "github.com/hashicorp/terraform-plugin-framework/path"
@@ -161,7 +161,7 @@ func (r *catalogEntityResource) Schema(_ context.Context, _ resource.SchemaReque
 			"entity": schema.StringAttribute{
 				Description:   "The catalog entity definition.",
 				Required:      true,
-				Validators:    []validator.String{validEntityYAMLValidator{}},
+				Validators:    []validator.String{validators.ValidEntityYAMLValidator()},
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplaceIf(replacePlanModifier, modifierDesc, modifierDesc)},
 				CustomType:    customtypes.YAMLStringType{},
 			},
@@ -198,43 +198,6 @@ var replacePlanModifier = func(ctx context.Context, request planmodifier.StringR
 		oldRef := oldEntity.reference()
 		newRef := newEntity.reference()
 		response.RequiresReplace = !oldRef.equal(*newRef)
-	}
-}
-
-type validEntityYAMLValidator struct {
-}
-
-func (v validEntityYAMLValidator) Description(ctx context.Context) string {
-	return v.MarkdownDescription(ctx)
-}
-
-func (v validEntityYAMLValidator) MarkdownDescription(_ context.Context) string {
-	return "Entity must be a valid entity YAML/JSON structure."
-}
-
-func (v validEntityYAMLValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
-	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
-		return
-	}
-	inYAML := req.ConfigValue.ValueString()
-	e, err := entityFromYAML(inYAML)
-	if err != nil {
-		resp.Diagnostics.AddAttributeError(req.Path, "", "entity must be a valid entity YAML/JSON structure")
-		return
-	}
-
-	// verify apiVersion is v3 or above
-	if e.APIVersion == "" {
-		resp.Diagnostics.AddAttributeError(req.Path, "", "apiVersion must be non empty (v3 or above)")
-		return
-	}
-
-	version, err := semver.NewVersion(e.APIVersion)
-	if err != nil {
-		resp.Diagnostics.AddAttributeError(req.Path, "", "apiVersion must be a valid version (v3 or above)")
-	}
-	if version.Major() < 3 {
-		resp.Diagnostics.AddAttributeError(req.Path, "", "apiVersion must be v3 or above")
 	}
 }
 

--- a/datadog/internal/fwutils/fw_enrich_schema.go
+++ b/datadog/internal/fwutils/fw_enrich_schema.go
@@ -98,7 +98,7 @@ func buildEnrichedSchemaDescription(rv reflect.Value) {
 					// If we would use "only" Index(i) we would have { 2 <VALUE> }
 					validValuesMsg += fmt.Sprintf("%s`%v`", sep, allowedValues.Index(i).Field(1))
 				}
-				currentDesc = fmt.Sprintf("%s valid values are %s.", currentDesc, validValuesMsg)
+				currentDesc = fmt.Sprintf("%s Valid values are %s.", currentDesc, validValuesMsg)
 				break
 			}
 
@@ -107,11 +107,11 @@ func buildEnrichedSchemaDescription(rv reflect.Value) {
 				strings.HasPrefix(rv_validators.Index(i).Elem().Type().Name(), "validEntityYAMLValidator") ||
 				strings.HasPrefix(rv_validators.Index(i).Elem().Type().Name(), "cidrIpValidator") ||
 				strings.HasPrefix(rv_validators.Index(i).Elem().Type().Name(), "lengthAtLeastValidator") ||
-				// BetweenValidator is a "homemade" validator and does not come from Hashicorp, it lives in out validators package as Float64Between
+				// BetweenValidator is a custom validator and does not come from Hashicorp, it lives in out validators package as Float64Between
 				// It validates a string representation of a float64
 				strings.HasPrefix(rv_validators.Index(i).Elem().Type().Name(), "BetweenValidator") {
 				validationMessage := rv_validators.Index(i).Elem().Interface().(validator.String).Description(context.Background())
-				currentDesc = fmt.Sprintf("%s %s.", currentDesc, validationMessage)
+				currentDesc = fmt.Sprintf("%s %s", ensureTrailingPoint(currentDesc), formatDescription(validationMessage))
 				break
 			}
 
@@ -119,7 +119,7 @@ func buildEnrichedSchemaDescription(rv reflect.Value) {
 			if strings.HasPrefix(rv_validators.Index(i).Elem().Type().Name(), "betweenValidator") ||
 				strings.HasPrefix(rv_validators.Index(i).Elem().Type().Name(), "atLeastValidator") {
 				validationMessage := rv_validators.Index(i).Elem().Interface().(validator.Int64).Description(context.Background())
-				currentDesc = fmt.Sprintf("%s %s.", currentDesc, validationMessage)
+				currentDesc = fmt.Sprintf("%s %s", ensureTrailingPoint(currentDesc), formatDescription(validationMessage))
 				break
 			}
 
@@ -141,4 +141,25 @@ func buildEnrichedSchemaDescription(rv reflect.Value) {
 	}
 
 	descField.SetString(currentDesc)
+}
+
+func formatDescription(s string) string {
+	return ensureTrailingPoint(ensureCapitalize(s))
+}
+
+func ensureCapitalize(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	return strings.ToUpper(s[0:1]) + s[1:]
+}
+
+func ensureTrailingPoint(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	if s[len(s)-1:] == "." {
+		return s
+	}
+	return s + "."
 }

--- a/datadog/internal/fwutils/fw_enrich_schema.go
+++ b/datadog/internal/fwutils/fw_enrich_schema.go
@@ -98,7 +98,7 @@ func buildEnrichedSchemaDescription(rv reflect.Value) {
 					// If we would use "only" Index(i) we would have { 2 <VALUE> }
 					validValuesMsg += fmt.Sprintf("%s`%v`", sep, allowedValues.Index(i).Field(1))
 				}
-				currentDesc = fmt.Sprintf("%s. Valid values are %s.", currentDesc, validValuesMsg)
+				currentDesc = fmt.Sprintf("%s valid values are %s.", currentDesc, validValuesMsg)
 				break
 			}
 

--- a/datadog/internal/fwutils/fw_enrich_schema_test.go
+++ b/datadog/internal/fwutils/fw_enrich_schema_test.go
@@ -324,6 +324,7 @@ func TestNestedNestedBlock(t *testing.T) {
 		expectedDescription string
 	}
 	testCases := map[string]testStruct{
+		// String validators
 		"description with string enum validator in nested nested block": {
 			schema: schema.Schema{
 				Blocks: map[string]schema.Block{
@@ -353,6 +354,305 @@ func TestNestedNestedBlock(t *testing.T) {
 				},
 			},
 			expectedDescription: "Nested test attribute. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`.",
+		},
+		"description with string oneOf validator in nested nested block": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"nested_block": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.StringAttribute{
+									Required:    true,
+									Description: "Example description.",
+								},
+							},
+							Blocks: map[string]schema.Block{
+								"block": schema.SingleNestedBlock{
+									Attributes: map[string]schema.Attribute{
+										"test_attribute": schema.StringAttribute{
+											Required:    true,
+											Description: "Nested test attribute.",
+											Validators: []validator.String{
+												stringvalidator.OneOf("asc", "desc"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Nested test attribute. valid values are `asc`, `desc`.",
+		},
+		"description with string regexMatches with message validator in nested nested block": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"nested_block": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.StringAttribute{
+									Required:    true,
+									Description: "Example description.",
+								},
+							},
+							Blocks: map[string]schema.Block{
+								"block": schema.SingleNestedBlock{
+									Attributes: map[string]schema.Attribute{
+										"test_attribute": schema.StringAttribute{
+											Required:    true,
+											Description: "Nested test attribute.",
+											Validators: []validator.String{
+												stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z][A-Z0-9_]+[A-Z0-9]$`), "must be all uppercase with underscores"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Nested test attribute. must be all uppercase with underscores.",
+		},
+		"description with string regexMatches without message validator in nested nested block": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"nested_block": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.StringAttribute{
+									Required:    true,
+									Description: "Example description.",
+								},
+							},
+							Blocks: map[string]schema.Block{
+								"block": schema.SingleNestedBlock{
+									Attributes: map[string]schema.Attribute{
+										"test_attribute": schema.StringAttribute{
+											Required:    true,
+											Description: "Nested test attribute.",
+											Validators: []validator.String{
+												stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z][A-Z0-9_]+[A-Z0-9]$`), ""),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Nested test attribute. value must match regular expression '^[A-Z][A-Z0-9_]+[A-Z0-9]$'.",
+		},
+		"description with string entity YAML validator in nested nested block": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"nested_block": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.StringAttribute{
+									Required:    true,
+									Description: "Example description.",
+								},
+							},
+							Blocks: map[string]schema.Block{
+								"block": schema.SingleNestedBlock{
+									Attributes: map[string]schema.Attribute{
+										"test_attribute": schema.StringAttribute{
+											Required:    true,
+											Description: "Nested test attribute.",
+											Validators: []validator.String{
+												validators.ValidEntityYAMLValidator(),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Nested test attribute. Entity must be a valid entity YAML/JSON structure.",
+		},
+		"description with string CIDR IP validator in nested nested block": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"nested_block": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.StringAttribute{
+									Required:    true,
+									Description: "Example description.",
+								},
+							},
+							Blocks: map[string]schema.Block{
+								"block": schema.SingleNestedBlock{
+									Attributes: map[string]schema.Attribute{
+										"test_attribute": schema.StringAttribute{
+											Required:    true,
+											Description: "Nested test attribute.",
+											Validators: []validator.String{
+												validators.CidrIpValidator(),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Nested test attribute. String must be a valid CIDR block or IP address.",
+		},
+		"description with string lengthAtLeast validator in nested nested block": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"nested_block": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.StringAttribute{
+									Required:    true,
+									Description: "Example description.",
+								},
+							},
+							Blocks: map[string]schema.Block{
+								"block": schema.SingleNestedBlock{
+									Attributes: map[string]schema.Attribute{
+										"test_attribute": schema.StringAttribute{
+											Required:    true,
+											Description: "Nested test attribute.",
+											Validators: []validator.String{
+												stringvalidator.LengthAtLeast(1),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Nested test attribute. string length must be at least 1.",
+		},
+		"description with string betweenValidator|float validator in nested nested block": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"nested_block": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.StringAttribute{
+									Required:    true,
+									Description: "Example description.",
+								},
+							},
+							Blocks: map[string]schema.Block{
+								"block": schema.SingleNestedBlock{
+									Attributes: map[string]schema.Attribute{
+										"test_attribute": schema.StringAttribute{
+											Required:    true,
+											Description: "Nested test attribute.",
+											Validators: []validator.String{
+												validators.Float64Between(0, 1),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Nested test attribute. value must be between 0.00 and 1.00.",
+		},
+
+		// Int validators
+		"description with int64 betweenValidator|int validator in nested nested block": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"nested_block": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.Int64Attribute{
+									Required:    true,
+									Description: "Example description.",
+								},
+							},
+							Blocks: map[string]schema.Block{
+								"block": schema.SingleNestedBlock{
+									Attributes: map[string]schema.Attribute{
+										"test_attribute": schema.Int64Attribute{
+											Required:    true,
+											Description: "Nested test attribute.",
+											Validators: []validator.Int64{
+												int64validator.Between(4, 10),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Nested test attribute. value must be between 4 and 10.",
+		},
+		"description with int64 atLeast validator in nested nested block": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"nested_block": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.Int64Attribute{
+									Required:    true,
+									Description: "Example description.",
+								},
+							},
+							Blocks: map[string]schema.Block{
+								"block": schema.SingleNestedBlock{
+									Attributes: map[string]schema.Attribute{
+										"test_attribute": schema.Int64Attribute{
+											Required:    true,
+											Description: "Nested test attribute.",
+											Validators: []validator.Int64{
+												int64validator.AtLeast(1),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Nested test attribute. value must be at least 1.",
+		},
+		"description without validator in nested nested block": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"nested_block": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.StringAttribute{
+									Required:    true,
+									Description: "Example description.",
+								},
+							},
+							Blocks: map[string]schema.Block{
+								"block": schema.SingleNestedBlock{
+									Attributes: map[string]schema.Attribute{
+										"test_attribute": schema.StringAttribute{
+											Required:    true,
+											Description: "Nested test attribute.",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Nested test attribute.",
 		},
 	}
 	for name, testCase := range testCases {
@@ -393,7 +693,7 @@ func TestEnrichSchemaSingleNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`.",
+			expectedDescription: "Nested test attribute. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`.",
 		},
 		"description without validator": {
 			schema: schema.Schema{

--- a/datadog/internal/fwutils/fw_enrich_schema_test.go
+++ b/datadog/internal/fwutils/fw_enrich_schema_test.go
@@ -36,6 +36,108 @@ func TestEnrichSchemaAttributes(t *testing.T) {
 			},
 			expectedDescription: "Example description. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`.",
 		},
+		"description with string oneOf validator": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"test_attribute": schema.StringAttribute{
+						Required:    true,
+						Description: "Example description.",
+						Validators: []validator.String{
+							stringvalidator.OneOf("asc", "desc"),
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. valid values are `asc`, `desc`.",
+		},
+		"description with string regexMatches with message validator": {
+			schema: schema.Schema{
+
+				Attributes: map[string]schema.Attribute{
+					"test_attribute": schema.StringAttribute{
+						Required:    true,
+						Description: "Example description.",
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z][A-Z0-9_]+[A-Z0-9]$`), "must be all uppercase with underscores"),
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. must be all uppercase with underscores.",
+		},
+		"description with string regexMatches without message validator": {
+			schema: schema.Schema{
+
+				Attributes: map[string]schema.Attribute{
+					"test_attribute": schema.StringAttribute{
+						Required:    true,
+						Description: "Example description.",
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z][A-Z0-9_]+[A-Z0-9]$`), ""),
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. value must match regular expression '^[A-Z][A-Z0-9_]+[A-Z0-9]$'.",
+		},
+		"description with string entity YAML validator": {
+			schema: schema.Schema{
+
+				Attributes: map[string]schema.Attribute{
+					"test_attribute": schema.StringAttribute{
+						Required:    true,
+						Description: "Example description.",
+						Validators:  []validator.String{validators.ValidEntityYAMLValidator()},
+					},
+				},
+			},
+			expectedDescription: "Example description. Entity must be a valid entity YAML/JSON structure.",
+		},
+		"description with string CIDR IP validator": {
+			schema: schema.Schema{
+
+				Attributes: map[string]schema.Attribute{
+					"test_attribute": schema.StringAttribute{
+						Required:    true,
+						Description: "Example description.",
+						Validators:  []validator.String{validators.CidrIpValidator()},
+					},
+				},
+			},
+			expectedDescription: "Example description. String must be a valid CIDR block or IP address.",
+		},
+		"description with string lengthAtLeast validator": {
+			schema: schema.Schema{
+
+				Attributes: map[string]schema.Attribute{
+					"test_attribute": schema.StringAttribute{
+						Required:    true,
+						Description: "Example description.",
+						Validators: []validator.String{
+							stringvalidator.LengthAtLeast(1),
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. string length must be at least 1.",
+		},
+		"description with string betweenValidator|float validator": {
+			schema: schema.Schema{
+
+				Attributes: map[string]schema.Attribute{
+					"test_attribute": schema.StringAttribute{
+						Required:    true,
+						Description: "Example description.",
+						Validators: []validator.String{
+							validators.Float64Between(0, 1),
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. value must be between 0.00 and 1.00.",
+		},
+
+		// Int validators
 		"description with int64 enum validator": {
 			schema: schema.Schema{
 				Attributes: map[string]schema.Attribute{
@@ -49,6 +151,34 @@ func TestEnrichSchemaAttributes(t *testing.T) {
 				},
 			},
 			expectedDescription: "Example description. Valid values are `-1`, `0`, `1`, `2`, `3`.",
+		},
+		"description with int64 betweenValidator|int validator": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"test_attribute": schema.Int64Attribute{
+						Required:    true,
+						Description: "Example description.",
+						Validators: []validator.Int64{
+							int64validator.Between(4, 10),
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. value must be between 4 and 10.",
+		},
+		"description with int64 atLeast validator": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"test_attribute": schema.Int64Attribute{
+						Required:    true,
+						Description: "Example description.",
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. value must be at least 1.",
 		},
 		"description without validators": {
 			schema: schema.Schema{

--- a/datadog/internal/fwutils/fw_enrich_schema_test.go
+++ b/datadog/internal/fwutils/fw_enrich_schema_test.go
@@ -693,7 +693,167 @@ func TestEnrichSchemaSingleNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Nested test attribute. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`.",
+			expectedDescription: "Example description. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`.",
+		},
+		"description with string oneOf validator": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"nested_block": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"test_attribute": schema.StringAttribute{
+								Required:    true,
+								Description: "Example description.",
+								Validators: []validator.String{
+									stringvalidator.OneOf("asc", "desc"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. valid values are `asc`, `desc`.",
+		},
+		"description with string regexMatches with message validator": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"nested_block": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"test_attribute": schema.StringAttribute{
+								Required:    true,
+								Description: "Example description.",
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z][A-Z0-9_]+[A-Z0-9]$`), "must be all uppercase with underscores"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. must be all uppercase with underscores.",
+		},
+		"description with string regexMatches without message validator": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"nested_block": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"test_attribute": schema.StringAttribute{
+								Required:    true,
+								Description: "Example description.",
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z][A-Z0-9_]+[A-Z0-9]$`), ""),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. value must match regular expression '^[A-Z][A-Z0-9_]+[A-Z0-9]$'.",
+		},
+		"description with string entity YAML validator": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"nested_block": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"test_attribute": schema.StringAttribute{
+								Required:    true,
+								Description: "Example description.",
+								Validators:  []validator.String{validators.ValidEntityYAMLValidator()},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. Entity must be a valid entity YAML/JSON structure.",
+		},
+		"description with string CIDR IP validator": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"nested_block": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"test_attribute": schema.StringAttribute{
+								Required:    true,
+								Description: "Example description.",
+								Validators:  []validator.String{validators.CidrIpValidator()},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. String must be a valid CIDR block or IP address.",
+		},
+		"description with string lengthAtLeast validator": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"nested_block": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"test_attribute": schema.StringAttribute{
+								Required:    true,
+								Description: "Example description.",
+								Validators: []validator.String{
+									stringvalidator.LengthAtLeast(1),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. string length must be at least 1.",
+		},
+		"description with string betweenValidator|float validator": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"nested_block": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"test_attribute": schema.StringAttribute{
+								Required:    true,
+								Description: "Example description.",
+								Validators: []validator.String{
+									validators.Float64Between(0, 1),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. value must be between 0.00 and 1.00.",
+		},
+
+		// Int validators
+		"description with int64 betweenValidator|int validator": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"nested_block": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"test_attribute": schema.Int64Attribute{
+								Required:    true,
+								Description: "Example description.",
+								Validators: []validator.Int64{
+									int64validator.Between(4, 10),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. value must be between 4 and 10.",
+		},
+		"description with int64 atLeast validator": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"nested_block": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"test_attribute": schema.Int64Attribute{
+								Required:    true,
+								Description: "Example description.",
+								Validators: []validator.Int64{
+									int64validator.AtLeast(1),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. value must be at least 1.",
 		},
 		"description without validator": {
 			schema: schema.Schema{

--- a/datadog/internal/fwutils/fw_enrich_schema_test.go
+++ b/datadog/internal/fwutils/fw_enrich_schema_test.go
@@ -48,7 +48,7 @@ func TestEnrichSchemaAttributes(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. valid values are `asc`, `desc`.",
+			expectedDescription: "Example description. Valid values are `asc`, `desc`.",
 		},
 		"description with string regexMatches with message validator": {
 			schema: schema.Schema{
@@ -63,7 +63,7 @@ func TestEnrichSchemaAttributes(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. must be all uppercase with underscores.",
+			expectedDescription: "Example description. Must be all uppercase with underscores.",
 		},
 		"description with string regexMatches without message validator": {
 			schema: schema.Schema{
@@ -78,7 +78,7 @@ func TestEnrichSchemaAttributes(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. value must match regular expression '^[A-Z][A-Z0-9_]+[A-Z0-9]$'.",
+			expectedDescription: "Example description. Value must match regular expression '^[A-Z][A-Z0-9_]+[A-Z0-9]$'.",
 		},
 		"description with string entity YAML validator": {
 			schema: schema.Schema{
@@ -119,7 +119,7 @@ func TestEnrichSchemaAttributes(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. string length must be at least 1.",
+			expectedDescription: "Example description. String length must be at least 1.",
 		},
 		"description with string betweenValidator|float validator": {
 			schema: schema.Schema{
@@ -134,7 +134,7 @@ func TestEnrichSchemaAttributes(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. value must be between 0.00 and 1.00.",
+			expectedDescription: "Example description. Value must be between 0.00 and 1.00.",
 		},
 
 		// Int validators
@@ -164,7 +164,7 @@ func TestEnrichSchemaAttributes(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. value must be between 4 and 10.",
+			expectedDescription: "Example description. Value must be between 4 and 10.",
 		},
 		"description with int64 atLeast validator": {
 			schema: schema.Schema{
@@ -178,7 +178,7 @@ func TestEnrichSchemaAttributes(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. value must be at least 1.",
+			expectedDescription: "Example description. Value must be at least 1.",
 		},
 		"description without validators": {
 			schema: schema.Schema{
@@ -254,7 +254,7 @@ func TestEnrichSchemaListNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. valid values are `asc`, `desc`.",
+			expectedDescription: "Example description. Valid values are `asc`, `desc`.",
 		},
 		"description with string regexMatches with message validator": {
 			schema: schema.Schema{
@@ -274,7 +274,7 @@ func TestEnrichSchemaListNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. must be all uppercase with underscores.",
+			expectedDescription: "Example description. Must be all uppercase with underscores.",
 		},
 		"description with string regexMatches without message validator": {
 			schema: schema.Schema{
@@ -294,7 +294,7 @@ func TestEnrichSchemaListNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. value must match regular expression '^[A-Z][A-Z0-9_]+[A-Z0-9]$'.",
+			expectedDescription: "Example description. Value must match regular expression '^[A-Z][A-Z0-9_]+[A-Z0-9]$'.",
 		},
 		"description with string entity YAML validator": {
 			schema: schema.Schema{
@@ -350,7 +350,7 @@ func TestEnrichSchemaListNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. string length must be at least 1.",
+			expectedDescription: "Example description. String length must be at least 1.",
 		},
 		"description with string betweenValidator|float validator": {
 			schema: schema.Schema{
@@ -370,7 +370,7 @@ func TestEnrichSchemaListNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. value must be between 0.00 and 1.00.",
+			expectedDescription: "Example description. Value must be between 0.00 and 1.00.",
 		},
 
 		// Int validators
@@ -392,7 +392,7 @@ func TestEnrichSchemaListNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. value must be between 4 and 10.",
+			expectedDescription: "Example description. Value must be between 4 and 10.",
 		},
 		"description with int64 atLeast validator": {
 			schema: schema.Schema{
@@ -412,7 +412,7 @@ func TestEnrichSchemaListNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. value must be at least 1.",
+			expectedDescription: "Example description. Value must be at least 1.",
 		},
 		"description without validator": {
 			schema: schema.Schema{
@@ -513,7 +513,7 @@ func TestNestedNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Nested test attribute. valid values are `asc`, `desc`.",
+			expectedDescription: "Nested test attribute. Valid values are `asc`, `desc`.",
 		},
 		"description with string regexMatches with message validator in nested nested block": {
 			schema: schema.Schema{
@@ -543,7 +543,7 @@ func TestNestedNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Nested test attribute. must be all uppercase with underscores.",
+			expectedDescription: "Nested test attribute. Must be all uppercase with underscores.",
 		},
 		"description with string regexMatches without message validator in nested nested block": {
 			schema: schema.Schema{
@@ -573,7 +573,7 @@ func TestNestedNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Nested test attribute. value must match regular expression '^[A-Z][A-Z0-9_]+[A-Z0-9]$'.",
+			expectedDescription: "Nested test attribute. Value must match regular expression '^[A-Z][A-Z0-9_]+[A-Z0-9]$'.",
 		},
 		"description with string entity YAML validator in nested nested block": {
 			schema: schema.Schema{
@@ -663,7 +663,7 @@ func TestNestedNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Nested test attribute. string length must be at least 1.",
+			expectedDescription: "Nested test attribute. String length must be at least 1.",
 		},
 		"description with string betweenValidator|float validator in nested nested block": {
 			schema: schema.Schema{
@@ -693,7 +693,7 @@ func TestNestedNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Nested test attribute. value must be between 0.00 and 1.00.",
+			expectedDescription: "Nested test attribute. Value must be between 0.00 and 1.00.",
 		},
 
 		// Int validators
@@ -725,7 +725,7 @@ func TestNestedNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Nested test attribute. value must be between 4 and 10.",
+			expectedDescription: "Nested test attribute. Value must be between 4 and 10.",
 		},
 		"description with int64 atLeast validator in nested nested block": {
 			schema: schema.Schema{
@@ -755,7 +755,7 @@ func TestNestedNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Nested test attribute. value must be at least 1.",
+			expectedDescription: "Nested test attribute. Value must be at least 1.",
 		},
 		"description without validator in nested nested block": {
 			schema: schema.Schema{
@@ -841,7 +841,7 @@ func TestEnrichSchemaSingleNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. valid values are `asc`, `desc`.",
+			expectedDescription: "Example description. Valid values are `asc`, `desc`.",
 		},
 		"description with string regexMatches with message validator": {
 			schema: schema.Schema{
@@ -859,7 +859,7 @@ func TestEnrichSchemaSingleNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. must be all uppercase with underscores.",
+			expectedDescription: "Example description. Must be all uppercase with underscores.",
 		},
 		"description with string regexMatches without message validator": {
 			schema: schema.Schema{
@@ -877,7 +877,7 @@ func TestEnrichSchemaSingleNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. value must match regular expression '^[A-Z][A-Z0-9_]+[A-Z0-9]$'.",
+			expectedDescription: "Example description. Value must match regular expression '^[A-Z][A-Z0-9_]+[A-Z0-9]$'.",
 		},
 		"description with string entity YAML validator": {
 			schema: schema.Schema{
@@ -927,7 +927,7 @@ func TestEnrichSchemaSingleNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. string length must be at least 1.",
+			expectedDescription: "Example description. String length must be at least 1.",
 		},
 		"description with string betweenValidator|float validator": {
 			schema: schema.Schema{
@@ -945,7 +945,7 @@ func TestEnrichSchemaSingleNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. value must be between 0.00 and 1.00.",
+			expectedDescription: "Example description. Value must be between 0.00 and 1.00.",
 		},
 
 		// Int validators
@@ -965,7 +965,7 @@ func TestEnrichSchemaSingleNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. value must be between 4 and 10.",
+			expectedDescription: "Example description. Value must be between 4 and 10.",
 		},
 		"description with int64 atLeast validator": {
 			schema: schema.Schema{
@@ -983,7 +983,7 @@ func TestEnrichSchemaSingleNestedBlock(t *testing.T) {
 					},
 				},
 			},
-			expectedDescription: "Example description. value must be at least 1.",
+			expectedDescription: "Example description. Value must be at least 1.",
 		},
 		"description without validator": {
 			schema: schema.Schema{

--- a/datadog/internal/validators/cidr_ip_validator.go
+++ b/datadog/internal/validators/cidr_ip_validator.go
@@ -12,7 +12,7 @@ type cidrIpValidator struct {
 }
 
 func (v cidrIpValidator) Description(ctx context.Context) string {
-	return "String must be a valid CIDR block or IP address."
+	return "String must be a valid CIDR block or IP address"
 }
 
 func (v cidrIpValidator) MarkdownDescription(ctx context.Context) string {

--- a/datadog/internal/validators/cidr_ip_validator.go
+++ b/datadog/internal/validators/cidr_ip_validator.go
@@ -12,7 +12,7 @@ type cidrIpValidator struct {
 }
 
 func (v cidrIpValidator) Description(ctx context.Context) string {
-	return "String must be a valid CIDR block or IP address"
+	return "String must be a valid CIDR block or IP address."
 }
 
 func (v cidrIpValidator) MarkdownDescription(ctx context.Context) string {

--- a/datadog/internal/validators/entity_yaml_validator.go
+++ b/datadog/internal/validators/entity_yaml_validator.go
@@ -1,0 +1,72 @@
+package validators
+
+import (
+	"context"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"gopkg.in/yaml.v3"
+)
+
+// the entity type is a struct from the datadog_software_catalog
+// it was duplicated here to avoid looping dependencies
+type entity struct {
+	APIVersion   string         `yaml:"apiVersion" json:"apiVersion"`
+	Kind         string         `yaml:"kind" json:"kind"`
+	Metadata     map[string]any `yaml:"metadata" json:"metadata"`
+	Spec         map[string]any `yaml:"spec,omitempty" json:"spec,omitempty"`
+	Integrations map[string]any `yaml:"integrations,omitempty" json:"integrations,omitempty"`
+	Extensions   map[string]any `yaml:"extensions,omitempty" json:"extensions,omitempty"`
+	Datadog      map[string]any `yaml:"datadog,omitempty" json:"datadog,omitempty"`
+}
+
+// entityFromYAML is a function from the datadog_software_catalog
+// it was duplicated here to avoid looping dependencies
+func entityFromYAML(inYAML string) (entity, error) {
+	var e entity
+	err := yaml.Unmarshal([]byte(inYAML), &e)
+	return e, err
+}
+
+var _ validator.String = validEntityYAMLValidator{}
+
+type validEntityYAMLValidator struct {
+}
+
+func (v validEntityYAMLValidator) Description(ctx context.Context) string {
+	return v.MarkdownDescription(ctx)
+}
+
+func (v validEntityYAMLValidator) MarkdownDescription(_ context.Context) string {
+	return "Entity must be a valid entity YAML/JSON structure."
+}
+
+func (v validEntityYAMLValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	inYAML := req.ConfigValue.ValueString()
+	e, err := entityFromYAML(inYAML)
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(req.Path, "", "entity must be a valid entity YAML/JSON structure")
+		return
+	}
+
+	// verify apiVersion is v3 or above
+	if e.APIVersion == "" {
+		resp.Diagnostics.AddAttributeError(req.Path, "", "apiVersion must be non empty (v3 or above)")
+		return
+	}
+
+	version, err := semver.NewVersion(e.APIVersion)
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(req.Path, "", "apiVersion must be a valid version (v3 or above)")
+	}
+	if version.Major() < 3 {
+		resp.Diagnostics.AddAttributeError(req.Path, "", "apiVersion must be v3 or above")
+	}
+}
+
+func ValidEntityYAMLValidator() validator.String {
+	return validEntityYAMLValidator{}
+}

--- a/datadog/internal/validators/entity_yaml_validator.go
+++ b/datadog/internal/validators/entity_yaml_validator.go
@@ -38,7 +38,7 @@ func (v validEntityYAMLValidator) Description(ctx context.Context) string {
 }
 
 func (v validEntityYAMLValidator) MarkdownDescription(_ context.Context) string {
-	return "Entity must be a valid entity YAML/JSON structure."
+	return "Entity must be a valid entity YAML/JSON structure"
 }
 
 func (v validEntityYAMLValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {

--- a/datadog/internal/validators/validators.go
+++ b/datadog/internal/validators/validators.go
@@ -256,6 +256,8 @@ func ValidateBasicEmail(val any, path cty.Path) diag.Diagnostics {
 	return nil
 }
 
+var _ validator.String = BetweenValidator{}
+
 type BetweenValidator struct {
 	min float64
 	max float64
@@ -266,7 +268,7 @@ func (v BetweenValidator) Description(ctx context.Context) string {
 }
 
 func (v BetweenValidator) MarkdownDescription(_ context.Context) string {
-	return fmt.Sprintf("value must be between %f and %f", v.min, v.max)
+	return fmt.Sprintf("value must be between %.2f and %.2f", v.min, v.max)
 }
 
 func (v BetweenValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {

--- a/datadog/internal/validators/validators.go
+++ b/datadog/internal/validators/validators.go
@@ -268,7 +268,7 @@ func (v BetweenValidator) Description(ctx context.Context) string {
 }
 
 func (v BetweenValidator) MarkdownDescription(_ context.Context) string {
-	return fmt.Sprintf("value must be between %.2f and %.2f", v.min, v.max)
+	return fmt.Sprintf("Value must be between %.2f and %.2f.", v.min, v.max)
 }
 
 func (v BetweenValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {

--- a/datadog/internal/validators/validators_test.go
+++ b/datadog/internal/validators/validators_test.go
@@ -1,6 +1,7 @@
 package validators
 
 import (
+	"context"
 	"testing"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
@@ -210,7 +211,7 @@ func TestValidateFloat64Between(t *testing.T) {
 
 	for _, tc := range cases {
 		validationResult := validator.StringResponse{}
-		Float64Between(0.1, 1).ValidateString(nil, validator.StringRequest{ConfigValue: basetypes.NewStringValue(tc.InputValue)}, &validationResult)
+		Float64Between(0.1, 1).ValidateString(context.Background(), validator.StringRequest{ConfigValue: basetypes.NewStringValue(tc.InputValue)}, &validationResult)
 		if tc.ExpectedError == false && len(validationResult.Diagnostics) != 0 {
 			t.Fatalf("Expected no diagnostics for input %v, found %d instead", tc.InputValue, len(validationResult.Diagnostics))
 		}

--- a/docs/resources/action_connection.md
+++ b/docs/resources/action_connection.md
@@ -113,8 +113,8 @@ Optional:
 
 Optional:
 
-- `account_id` (String) AWS account that the connection is created for
-- `role` (String) Role to assume
+- `account_id` (String) [Length > 1] AWS account that the connection is created for
+- `role` (String) [Length > 1] Role to assume
 
 Read-Only:
 
@@ -128,7 +128,7 @@ Read-Only:
 
 Optional:
 
-- `base_url` (String) Base HTTP url for the integration
+- `base_url` (String) [Length > 1] Base HTTP url for the integration
 - `token_auth` (Block, Optional) Configuration for an HTTP connection that uses token auth (see [below for nested schema](#nestedblock--http--token_auth))
 
 <a id="nestedblock--http--token_auth"></a>
@@ -146,8 +146,8 @@ Optional:
 
 Optional:
 
-- `content` (String) Serialized body content
-- `content_type` (String) Content type of the body
+- `content` (String) [Length > 1] Serialized body content
+- `content_type` (String) [Length > 1] Content type of the body
 
 
 <a id="nestedblock--http--token_auth--header"></a>
@@ -155,8 +155,8 @@ Optional:
 
 Optional:
 
-- `name` (String) Header name
-- `value` (String)
+- `name` (String) [Length > 1] Header name
+- `value` (String) [Length > 1]
 
 
 <a id="nestedblock--http--token_auth--token"></a>
@@ -164,9 +164,9 @@ Optional:
 
 Optional:
 
-- `name` (String) Token name
-- `type` (String) Token type
-- `value` (String, Sensitive) Token value
+- `name` (String) [Length > 1] Token name
+- `type` (String) Token type. Valid values are `SECRET`.
+- `value` (String, Sensitive) [Length > 1] Token value
 
 
 <a id="nestedblock--http--token_auth--url_parameter"></a>
@@ -174,8 +174,8 @@ Optional:
 
 Optional:
 
-- `name` (String) URL parameter name
-- `value` (String) URL parameter value
+- `name` (String) [Length > 1] URL parameter name
+- `value` (String) [Length > 1] URL parameter value
 
 ## Import
 

--- a/docs/resources/action_connection.md
+++ b/docs/resources/action_connection.md
@@ -165,7 +165,7 @@ Optional:
 Optional:
 
 - `name` (String) Token name string length must be at least 1.
-- `type` (String) Token type. Valid values are `SECRET`.
+- `type` (String) Token type valid values are `SECRET`.
 - `value` (String, Sensitive) Token value string length must be at least 1.
 
 

--- a/docs/resources/action_connection.md
+++ b/docs/resources/action_connection.md
@@ -113,8 +113,8 @@ Optional:
 
 Optional:
 
-- `account_id` (String) AWS account that the connection is created for string length must be at least 1.
-- `role` (String) Role to assume string length must be at least 1.
+- `account_id` (String) AWS account that the connection is created for. String length must be at least 1.
+- `role` (String) Role to assume. String length must be at least 1.
 
 Read-Only:
 
@@ -128,7 +128,7 @@ Read-Only:
 
 Optional:
 
-- `base_url` (String) Base HTTP url for the integration string length must be at least 1.
+- `base_url` (String) Base HTTP url for the integration. String length must be at least 1.
 - `token_auth` (Block, Optional) Configuration for an HTTP connection that uses token auth (see [below for nested schema](#nestedblock--http--token_auth))
 
 <a id="nestedblock--http--token_auth"></a>
@@ -146,8 +146,8 @@ Optional:
 
 Optional:
 
-- `content` (String) Serialized body content string length must be at least 1.
-- `content_type` (String) Content type of the body string length must be at least 1.
+- `content` (String) Serialized body content. String length must be at least 1.
+- `content_type` (String) Content type of the body. String length must be at least 1.
 
 
 <a id="nestedblock--http--token_auth--header"></a>
@@ -155,8 +155,8 @@ Optional:
 
 Optional:
 
-- `name` (String) Header name string length must be at least 1.
-- `value` (String) string length must be at least 1.
+- `name` (String) Header name. String length must be at least 1.
+- `value` (String) String length must be at least 1.
 
 
 <a id="nestedblock--http--token_auth--token"></a>
@@ -164,9 +164,9 @@ Optional:
 
 Optional:
 
-- `name` (String) Token name string length must be at least 1.
-- `type` (String) Token type valid values are `SECRET`.
-- `value` (String, Sensitive) Token value string length must be at least 1.
+- `name` (String) Token name. String length must be at least 1.
+- `type` (String) Token type Valid values are `SECRET`.
+- `value` (String, Sensitive) Token value. String length must be at least 1.
 
 
 <a id="nestedblock--http--token_auth--url_parameter"></a>
@@ -174,8 +174,8 @@ Optional:
 
 Optional:
 
-- `name` (String) URL parameter name string length must be at least 1.
-- `value` (String) URL parameter value string length must be at least 1.
+- `name` (String) URL parameter name. String length must be at least 1.
+- `value` (String) URL parameter value. String length must be at least 1.
 
 ## Import
 

--- a/docs/resources/action_connection.md
+++ b/docs/resources/action_connection.md
@@ -113,8 +113,8 @@ Optional:
 
 Optional:
 
-- `account_id` (String) [Length > 1] AWS account that the connection is created for
-- `role` (String) [Length > 1] Role to assume
+- `account_id` (String) AWS account that the connection is created for string length must be at least 1.
+- `role` (String) Role to assume string length must be at least 1.
 
 Read-Only:
 
@@ -128,7 +128,7 @@ Read-Only:
 
 Optional:
 
-- `base_url` (String) [Length > 1] Base HTTP url for the integration
+- `base_url` (String) Base HTTP url for the integration string length must be at least 1.
 - `token_auth` (Block, Optional) Configuration for an HTTP connection that uses token auth (see [below for nested schema](#nestedblock--http--token_auth))
 
 <a id="nestedblock--http--token_auth"></a>
@@ -146,8 +146,8 @@ Optional:
 
 Optional:
 
-- `content` (String) [Length > 1] Serialized body content
-- `content_type` (String) [Length > 1] Content type of the body
+- `content` (String) Serialized body content string length must be at least 1.
+- `content_type` (String) Content type of the body string length must be at least 1.
 
 
 <a id="nestedblock--http--token_auth--header"></a>
@@ -155,8 +155,8 @@ Optional:
 
 Optional:
 
-- `name` (String) [Length > 1] Header name
-- `value` (String) [Length > 1]
+- `name` (String) Header name string length must be at least 1.
+- `value` (String) string length must be at least 1.
 
 
 <a id="nestedblock--http--token_auth--token"></a>
@@ -164,9 +164,9 @@ Optional:
 
 Optional:
 
-- `name` (String) [Length > 1] Token name
+- `name` (String) Token name string length must be at least 1.
 - `type` (String) Token type. Valid values are `SECRET`.
-- `value` (String, Sensitive) [Length > 1] Token value
+- `value` (String, Sensitive) Token value string length must be at least 1.
 
 
 <a id="nestedblock--http--token_auth--url_parameter"></a>
@@ -174,8 +174,8 @@ Optional:
 
 Optional:
 
-- `name` (String) [Length > 1] URL parameter name
-- `value` (String) [Length > 1] URL parameter value
+- `name` (String) URL parameter name string length must be at least 1.
+- `value` (String) URL parameter value string length must be at least 1.
 
 ## Import
 

--- a/docs/resources/apm_retention_filter.md
+++ b/docs/resources/apm_retention_filter.md
@@ -33,7 +33,7 @@ resource "datadog_apm_retention_filter" "foo" {
 - `enabled` (Boolean) the status of the retention filter.
 - `filter_type` (String) The type of the retention filter, currently only spans-processing-sampling is available. Valid values are `spans-sampling-processor`.
 - `name` (String) The name of the retention filter.
-- `rate` (String) Sample rate to apply to spans going through this retention filter as a string, a value of 1.0 keeps all spans matching the query.
+- `rate` (String) [Min 0.0, Max 1.0] Sample rate to apply to spans going through this retention filter as a string, a value of 1.0 keeps all spans matching the query.
 
 ### Optional
 

--- a/docs/resources/apm_retention_filter.md
+++ b/docs/resources/apm_retention_filter.md
@@ -33,7 +33,7 @@ resource "datadog_apm_retention_filter" "foo" {
 - `enabled` (Boolean) the status of the retention filter.
 - `filter_type` (String) The type of the retention filter, currently only spans-processing-sampling is available. Valid values are `spans-sampling-processor`.
 - `name` (String) The name of the retention filter.
-- `rate` (String) [Min 0.0, Max 1.0] Sample rate to apply to spans going through this retention filter as a string, a value of 1.0 keeps all spans matching the query.
+- `rate` (String) Sample rate to apply to spans going through this retention filter as a string, a value of 1.0 keeps all spans matching the query. value must be between 0.00 and 1.00.
 
 ### Optional
 

--- a/docs/resources/apm_retention_filter.md
+++ b/docs/resources/apm_retention_filter.md
@@ -33,7 +33,7 @@ resource "datadog_apm_retention_filter" "foo" {
 - `enabled` (Boolean) the status of the retention filter.
 - `filter_type` (String) The type of the retention filter, currently only spans-processing-sampling is available. Valid values are `spans-sampling-processor`.
 - `name` (String) The name of the retention filter.
-- `rate` (String) Sample rate to apply to spans going through this retention filter as a string, a value of 1.0 keeps all spans matching the query. value must be between 0.00 and 1.00.
+- `rate` (String) Sample rate to apply to spans going through this retention filter as a string, a value of 1.0 keeps all spans matching the query. Value must be between 0.00 and 1.00.
 
 ### Optional
 

--- a/docs/resources/app_builder_app.md
+++ b/docs/resources/app_builder_app.md
@@ -155,15 +155,15 @@ resource "datadog_app_builder_app" "example_app_escaped_interpolated" {
 
 ### Required
 
-- `app_json` (String) The JSON representation of the App.
+- `app_json` (String) The JSON representation of the App. String length must be at least 1.
 
 ### Optional
 
 - `action_query_names_to_connection_ids` (Map of String) If specified, this will override the Action Connection IDs for the specified Action Query Names in the App JSON. Otherwise, a map of the App's Action Query Names to Action Connection IDs will be returned in output.
-- `description` (String) If specified, this will override the human-readable description of the App in the App JSON.
-- `name` (String) If specified, this will override the name of the App in the App JSON.
+- `description` (String) If specified, this will override the human-readable description of the App in the App JSON. String length must be at least 1.
+- `name` (String) If specified, this will override the name of the App in the App JSON. String length must be at least 1.
 - `published` (Boolean) Set the app to published or unpublished. Published apps are available to other users. To ensure the app is accessible to the correct users, you also need to set a [Restriction Policy](https://docs.datadoghq.com/api/latest/restriction-policies/) on the app if a policy does not yet exist. Defaults to `false`.
-- `root_instance_name` (String) The name of the root component of the app. This must be a grid component that contains all other components. If specified, this will override the root instance name of the App in the App JSON.
+- `root_instance_name` (String) The name of the root component of the app. This must be a grid component that contains all other components. If specified, this will override the root instance name of the App in the App JSON. String length must be at least 1.
 
 ### Read-Only
 

--- a/docs/resources/ip_allowlist.md
+++ b/docs/resources/ip_allowlist.md
@@ -48,7 +48,7 @@ resource "datadog_ip_allowlist" "example" {
 
 Required:
 
-- `cidr_block` (String) IP address or range of addresses. String must be a valid CIDR block or IP address.
+- `cidr_block` (String) IP address or range of addresses. String must be a valid CIDR block or IP address..
 
 Optional:
 

--- a/docs/resources/ip_allowlist.md
+++ b/docs/resources/ip_allowlist.md
@@ -48,7 +48,7 @@ resource "datadog_ip_allowlist" "example" {
 
 Required:
 
-- `cidr_block` (String) IP address or range of addresses.
+- `cidr_block` (String) IP address or range of addresses. String must be a valid CIDR block or IP address.
 
 Optional:
 

--- a/docs/resources/ip_allowlist.md
+++ b/docs/resources/ip_allowlist.md
@@ -48,7 +48,7 @@ resource "datadog_ip_allowlist" "example" {
 
 Required:
 
-- `cidr_block` (String) IP address or range of addresses. String must be a valid CIDR block or IP address..
+- `cidr_block` (String) IP address or range of addresses. String must be a valid CIDR block or IP address.
 
 Optional:
 

--- a/docs/resources/software_catalog.md
+++ b/docs/resources/software_catalog.md
@@ -248,7 +248,7 @@ EOF
 
 ### Required
 
-- `entity` (String) The catalog entity definition. Entity must be a valid entity YAML/JSON structure..
+- `entity` (String) The catalog entity definition. Entity must be a valid entity YAML/JSON structure.
 
 ### Read-Only
 

--- a/docs/resources/software_catalog.md
+++ b/docs/resources/software_catalog.md
@@ -248,7 +248,7 @@ EOF
 
 ### Required
 
-- `entity` (String) The catalog entity definition. entity must be a valid entity YAML/JSON structure.
+- `entity` (String) The catalog entity definition. Entity must be a valid entity YAML/JSON structure..
 
 ### Read-Only
 

--- a/docs/resources/software_catalog.md
+++ b/docs/resources/software_catalog.md
@@ -248,7 +248,7 @@ EOF
 
 ### Required
 
-- `entity` (String) The catalog entity definition.
+- `entity` (String) The catalog entity definition. entity must be a valid entity YAML/JSON structure.
 
 ### Read-Only
 

--- a/docs/resources/synthetics_concurrency_cap.md
+++ b/docs/resources/synthetics_concurrency_cap.md
@@ -24,7 +24,7 @@ resource "datadog_synthetics_concurrency_cap" "this" {
 
 ### Required
 
-- `on_demand_concurrency_cap` (Number) [Min 1] Value of the on-demand concurrency cap, customizing the number of Synthetic tests run in parallel.
+- `on_demand_concurrency_cap` (Number) Value of the on-demand concurrency cap, customizing the number of Synthetic tests run in parallel. value must be at least 1.
 
 ### Read-Only
 

--- a/docs/resources/synthetics_concurrency_cap.md
+++ b/docs/resources/synthetics_concurrency_cap.md
@@ -24,7 +24,7 @@ resource "datadog_synthetics_concurrency_cap" "this" {
 
 ### Required
 
-- `on_demand_concurrency_cap` (Number) Value of the on-demand concurrency cap, customizing the number of Synthetic tests run in parallel.
+- `on_demand_concurrency_cap` (Number) [Min 1] Value of the on-demand concurrency cap, customizing the number of Synthetic tests run in parallel.
 
 ### Read-Only
 

--- a/docs/resources/synthetics_concurrency_cap.md
+++ b/docs/resources/synthetics_concurrency_cap.md
@@ -24,7 +24,7 @@ resource "datadog_synthetics_concurrency_cap" "this" {
 
 ### Required
 
-- `on_demand_concurrency_cap` (Number) Value of the on-demand concurrency cap, customizing the number of Synthetic tests run in parallel. value must be at least 1.
+- `on_demand_concurrency_cap` (Number) Value of the on-demand concurrency cap, customizing the number of Synthetic tests run in parallel. Value must be at least 1.
 
 ### Read-Only
 

--- a/docs/resources/synthetics_global_variable.md
+++ b/docs/resources/synthetics_global_variable.md
@@ -28,7 +28,7 @@ resource "datadog_synthetics_global_variable" "test_variable" {
 
 ### Required
 
-- `name` (String) Synthetics global variable name. must be all uppercase with underscores
+- `name` (String) Synthetics global variable name. must be all uppercase with underscores.
 
 ### Optional
 
@@ -59,8 +59,8 @@ Optional:
 
 Required:
 
-- `digits` (Number) [Min 4, Max 10] Number of digits for the OTP.
-- `refresh_interval` (Number) [Min 0, Max 999] Interval for which to refresh the token (in seconds).
+- `digits` (Number) Number of digits for the OTP. value must be between 4 and 10.
+- `refresh_interval` (Number) Interval for which to refresh the token (in seconds). value must be between 0 and 999.
 
 
 

--- a/docs/resources/synthetics_global_variable.md
+++ b/docs/resources/synthetics_global_variable.md
@@ -28,7 +28,7 @@ resource "datadog_synthetics_global_variable" "test_variable" {
 
 ### Required
 
-- `name` (String) Synthetics global variable name. must be all uppercase with underscores.
+- `name` (String) Synthetics global variable name. Must be all uppercase with underscores.
 
 ### Optional
 
@@ -59,8 +59,8 @@ Optional:
 
 Required:
 
-- `digits` (Number) Number of digits for the OTP. value must be between 4 and 10.
-- `refresh_interval` (Number) Interval for which to refresh the token (in seconds). value must be between 0 and 999.
+- `digits` (Number) Number of digits for the OTP. Value must be between 4 and 10.
+- `refresh_interval` (Number) Interval for which to refresh the token (in seconds). Value must be between 0 and 999.
 
 
 

--- a/docs/resources/synthetics_global_variable.md
+++ b/docs/resources/synthetics_global_variable.md
@@ -28,7 +28,7 @@ resource "datadog_synthetics_global_variable" "test_variable" {
 
 ### Required
 
-- `name` (String) Synthetics global variable name.
+- `name` (String) Synthetics global variable name. must be all uppercase with underscores
 
 ### Optional
 
@@ -59,8 +59,8 @@ Optional:
 
 Required:
 
-- `digits` (Number) Number of digits for the OTP.
-- `refresh_interval` (Number) Interval for which to refresh the token (in seconds).
+- `digits` (Number) [Min 4, Max 10] Number of digits for the OTP.
+- `refresh_interval` (Number) [Min 0, Max 999] Interval for which to refresh the token (in seconds).
 
 
 

--- a/docs/resources/workflow_automation.md
+++ b/docs/resources/workflow_automation.md
@@ -67,14 +67,14 @@ resource "datadog_workflow_automation" "workflow" {
 ### Required
 
 - `description` (String) Description of the workflow.
-- `name` (String) Name of the workflow.
+- `name` (String) [Length > 1] Name of the workflow.
 - `published` (Boolean) Set the workflow to published or unpublished. Workflows in an unpublished state are only executable through manual runs. Automatic triggers such as Schedule do not execute the workflow until it is published.
 - `spec_json` (String) The spec defines what the workflow does.
 - `tags` (Set of String) Tags of the workflow.
 
 ### Optional
 
-- `webhook_secret` (String, Sensitive) If a webhook trigger is defined on this workflow, a webhookSecret is required and should be provided here.
+- `webhook_secret` (String, Sensitive) [Length > 16] If a webhook trigger is defined on this workflow, a webhookSecret is required and should be provided here.
 
 ### Read-Only
 

--- a/docs/resources/workflow_automation.md
+++ b/docs/resources/workflow_automation.md
@@ -67,14 +67,14 @@ resource "datadog_workflow_automation" "workflow" {
 ### Required
 
 - `description` (String) Description of the workflow.
-- `name` (String) Name of the workflow. string length must be at least 1.
+- `name` (String) Name of the workflow. String length must be at least 1.
 - `published` (Boolean) Set the workflow to published or unpublished. Workflows in an unpublished state are only executable through manual runs. Automatic triggers such as Schedule do not execute the workflow until it is published.
 - `spec_json` (String) The spec defines what the workflow does.
 - `tags` (Set of String) Tags of the workflow.
 
 ### Optional
 
-- `webhook_secret` (String, Sensitive) If a webhook trigger is defined on this workflow, a webhookSecret is required and should be provided here. string length must be at least 16.
+- `webhook_secret` (String, Sensitive) If a webhook trigger is defined on this workflow, a webhookSecret is required and should be provided here. String length must be at least 16.
 
 ### Read-Only
 

--- a/docs/resources/workflow_automation.md
+++ b/docs/resources/workflow_automation.md
@@ -67,14 +67,14 @@ resource "datadog_workflow_automation" "workflow" {
 ### Required
 
 - `description` (String) Description of the workflow.
-- `name` (String) [Length > 1] Name of the workflow.
+- `name` (String) Name of the workflow. string length must be at least 1.
 - `published` (Boolean) Set the workflow to published or unpublished. Workflows in an unpublished state are only executable through manual runs. Automatic triggers such as Schedule do not execute the workflow until it is published.
 - `spec_json` (String) The spec defines what the workflow does.
 - `tags` (Set of String) Tags of the workflow.
 
 ### Optional
 
-- `webhook_secret` (String, Sensitive) [Length > 16] If a webhook trigger is defined on this workflow, a webhookSecret is required and should be provided here.
+- `webhook_secret` (String, Sensitive) If a webhook trigger is defined on this workflow, a webhookSecret is required and should be provided here. string length must be at least 16.
 
 ### Read-Only
 


### PR DESCRIPTION
### Motivation
Some validators did not have an description enrichment set up. This PRs aims to add description enrichment that takes into account more validators.

### Changes

Enrichment added for the following validators: 
- `oneOfValidator`
-  `regexMatchesValidator`
- `ValidEntityYAMLValidator`
- `cidrIpValidator`
- `lengthAtLeastValidator`
- `betweenValidator`
- `atLeastValidator`