### PR TITLE
Remove need for github-token when validating PR title

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -24,17 +24,10 @@ jobs:
         run: |-
           echo "::error::Add 'changelog/*' label";
           exit 1;
-      - name: Get GitHub App token
-        id: get_token
-        uses: actions/create-github-app-token@c1a285145b9d317df6ced56c09f525b5c2b6f755
-        with:
-          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
       - name: Check PR title
         if: github.event.pull_request.draft == false && false == contains(join(github.event.pull_request.labels.*.name, ','), 'changelog/note') && false == contains(join(github.event.pull_request.labels.*.name, ','), 'changelog/no-changelog')
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
         with:
-          github-token: ${{ steps.get_token.outputs.token }}
           script: |
             const re = new RegExp('\\[\\w+\\] \\w+');
             const title = context.payload.pull_request.title;


### PR DESCRIPTION
Remove retrieval of github token, since it's not needed and causes PRs coming from forks to fail the check.

One such example is https://github.com/DataDog/terraform-provider-datadog/pull/2822

Tested with a `changelog/feature` label and observed it failing the check correctly at https://github.com/DataDog/terraform-provider-datadog/actions/runs/14110718575/job/39528403961