### PR TITLE
[datadog_synthetics_test] Add an example for ICMP testing

### DIFF
--- a/datadog/tests/data_source_datadog_app_builder_app_test.go
+++ b/datadog/tests/data_source_datadog_app_builder_app_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
 )
 

--- a/datadog/tests/resource_datadog_app_builder_app_test.go
+++ b/datadog/tests/resource_datadog_app_builder_app_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 )

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -208,6 +208,54 @@ resource "datadog_synthetics_test" "test_dns" {
   }
 }
 
+# Example Usage (Synthetics ICMP test)
+# Create a new Datadog Synthetics ICMP test on example.org
+resource "datadog_synthetics_test" "test_api_icmp" {
+  name      = "ICMP Test on example.com"
+  type      = "api"
+  subtype   = "icmp"
+  status    = "live"
+  locations = ["aws:eu-central-1"]
+
+  request_definition {
+    host                    = "example.com"
+    no_saving_response_body = "false"
+    number_of_packets       = "1"
+    persist_cookies         = "false"
+    should_track_hops       = "false"
+    timeout                 = "0"
+  }
+
+  assertion {
+    operator = "is"
+    target   = "0"
+    type     = "packetLossPercentage"
+  }
+
+  assertion {
+    operator = "lessThan"
+    property = "avg"
+    target   = "1000"
+    type     = "latency"
+  }
+
+  assertion {
+    operator = "moreThanOrEqual"
+    target   = "1"
+    type     = "packetsReceived"
+  }
+  options_list {
+    tick_every = 900
+    retry {
+      count    = 2
+      interval = 300
+    }
+    monitor_options {
+      renotify_interval = 120
+    }
+  }
+}
+
 
 # Example Usage (Synthetics Multistep API test)
 # Create a new Datadog Synthetics Multistep API test

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -216,6 +216,7 @@ resource "datadog_synthetics_test" "test_api_icmp" {
   subtype   = "icmp"
   status    = "live"
   locations = ["aws:eu-central-1"]
+  tags      = ["foo:bar", "foo", "env:test"]
 
   request_definition {
     host                    = "example.com"

--- a/examples/resources/datadog_synthetics_test/resource.tf
+++ b/examples/resources/datadog_synthetics_test/resource.tf
@@ -175,6 +175,7 @@ resource "datadog_synthetics_test" "test_api_icmp" {
   subtype   = "icmp"
   status    = "live"
   locations = ["aws:eu-central-1"]
+  tags      = ["foo:bar", "foo", "env:test"]
 
   request_definition {
     host                    = "example.com"

--- a/examples/resources/datadog_synthetics_test/resource.tf
+++ b/examples/resources/datadog_synthetics_test/resource.tf
@@ -167,6 +167,54 @@ resource "datadog_synthetics_test" "test_dns" {
   }
 }
 
+# Example Usage (Synthetics ICMP test)
+# Create a new Datadog Synthetics ICMP test on example.org
+resource "datadog_synthetics_test" "test_api_icmp" {
+  name      = "ICMP Test on example.com"
+  type      = "api"
+  subtype   = "icmp"
+  status    = "live"
+  locations = ["aws:eu-central-1"]
+
+  request_definition {
+    host                    = "example.com"
+    no_saving_response_body = "false"
+    number_of_packets       = "1"
+    persist_cookies         = "false"
+    should_track_hops       = "false"
+    timeout                 = "0"
+  }
+
+  assertion {
+    operator = "is"
+    target   = "0"
+    type     = "packetLossPercentage"
+  }
+
+  assertion {
+    operator = "lessThan"
+    property = "avg"
+    target   = "1000"
+    type     = "latency"
+  }
+
+  assertion {
+    operator = "moreThanOrEqual"
+    target   = "1"
+    type     = "packetsReceived"
+  }
+  options_list {
+    tick_every = 900
+    retry {
+      count    = 2
+      interval = 300
+    }
+    monitor_options {
+      renotify_interval = 120
+    }
+  }
+}
+
 
 # Example Usage (Synthetics Multistep API test)
 # Create a new Datadog Synthetics Multistep API test


### PR DESCRIPTION
**What's New:**
ICMP Test Example: Demonstrates how to configure an ICMP test using the provider.