### PR TITLE
[datadog_synthetics_test] Fix retry maximum value

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -605,7 +605,7 @@ func syntheticsTestOptionsRetry() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"count": {
-					Description: "Number of retries needed to consider a location as failed before sending a notification alert. Maximum value: `5`.",
+					Description: "Number of retries needed to consider a location as failed before sending a notification alert. Maximum value: `3` for `api` tests, `2` for `browser` and `mobile` tests.",
 					Type:        schema.TypeInt,
 					Default:     0,
 					Optional:    true,

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -935,7 +935,7 @@ Optional:
 
 Optional:
 
-- `count` (Number) Number of retries needed to consider a location as failed before sending a notification alert. Maximum value: `5`. Defaults to `0`.
+- `count` (Number) Number of retries needed to consider a location as failed before sending a notification alert. Maximum value: `3` for `api` tests, `2` for `browser` and `mobile` tests. Defaults to `0`.
 - `interval` (Number) Interval between a failed test and the next retry in milliseconds. Maximum value: `5000`. Defaults to `300`.
 
 
@@ -1184,7 +1184,7 @@ Optional:
 
 Optional:
 
-- `count` (Number) Number of retries needed to consider a location as failed before sending a notification alert. Maximum value: `5`. Defaults to `0`.
+- `count` (Number) Number of retries needed to consider a location as failed before sending a notification alert. Maximum value: `3` for `api` tests, `2` for `browser` and `mobile` tests. Defaults to `0`.
 - `interval` (Number) Interval between a failed test and the next retry in milliseconds. Maximum value: `5000`. Defaults to `300`.
 
 
@@ -1362,7 +1362,7 @@ Optional:
 
 Optional:
 
-- `count` (Number) Number of retries needed to consider a location as failed before sending a notification alert. Maximum value: `5`. Defaults to `0`.
+- `count` (Number) Number of retries needed to consider a location as failed before sending a notification alert. Maximum value: `3` for `api` tests, `2` for `browser` and `mobile` tests. Defaults to `0`.
 - `interval` (Number) Interval between a failed test and the next retry in milliseconds. Maximum value: `5000`. Defaults to `300`.
 
 


### PR DESCRIPTION
The maximum value showed in the documentation for `retry` is incorrect, leading to confusion because users can get validation errors because of it.
This PR fixes that.