### PR TITLE
[datadog_synthetics_test] Fix example for GRPC testing

### DIFF
--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -261,9 +261,10 @@ resource "datadog_synthetics_test" "test_multi_step" {
     subtype = "grpc"
 
     assertion {
-      type     = "statusCode"
+      type     = "grpcMetadata"
       operator = "is"
-      target   = "200"
+      property = "X-Header"
+      target   = "test"
     }
 
     request_definition {
@@ -279,9 +280,9 @@ resource "datadog_synthetics_test" "test_multi_step" {
     subtype = "grpc"
 
     assertion {
-      type     = "statusCode"
+      type     = "grpcHealthcheckStatus"
       operator = "is"
-      target   = "200"
+      target   = "1"
     }
 
     request_definition {

--- a/examples/resources/datadog_synthetics_test/resource.tf
+++ b/examples/resources/datadog_synthetics_test/resource.tf
@@ -220,9 +220,10 @@ resource "datadog_synthetics_test" "test_multi_step" {
     subtype = "grpc"
 
     assertion {
-      type     = "statusCode"
+      type     = "grpcMetadata"
       operator = "is"
-      target   = "200"
+      property = "X-Header"
+      target   = "test"
     }
 
     request_definition {
@@ -238,9 +239,9 @@ resource "datadog_synthetics_test" "test_multi_step" {
     subtype = "grpc"
 
     assertion {
-      type     = "statusCode"
+      type     = "grpcHealthcheckStatus"
       operator = "is"
-      target   = "200"
+      target   = "1"
     }
 
     request_definition {


### PR DESCRIPTION
**What's New:**
Updated Assertions Examples: Replaced non-functional gRPC step assertions with correct and allowed versions.