### PR TITLE
[datadog_synthetics_tests] Fix encoding bug on plain_proto_file / compressedProtoFile

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -3543,7 +3543,8 @@ func decompressAndDecodeValue(value string, acceptBase64Only bool) (string, erro
 		return "", err
 	}
 	zl, err := zlib.NewReader(bytes.NewReader(decodedValue))
-	// Dirty hack
+	// A past UI bug corrupted some tests by not compressing `compressedProtoFile`,
+	// so we return the base64-decoded string to be stored in `plain_proto_file` directly.
 	if err != nil {
 		if acceptBase64Only {
 			return string(b), nil


### PR DESCRIPTION
A past bug in Datadog UI corrupted the value of `compressedProtoFile` for gRPC tests or multistep API tests with gRPC step(s).

This field should be zlib-compressed then base64-encoded. Unfortunately, the past UI bug made it so that when updating an synthetics test in the UI, the `compressedProtoFile` was only base64-encoded.

While the issue is now fixed at UI level, we have to handle corrupted tests by accepting without error both a b64 or a zlib+b64 field.