### PR TITLE
[datadog_powerpack] Added support for default tags to datadog_powerpack

### DIFF
--- a/datadog/fwprovider/framework_provider.go
+++ b/datadog/fwprovider/framework_provider.go
@@ -220,13 +220,13 @@ func (p *FrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
-				Description: "[Experimental - Monitors and Logs Pipelines only] Configuration block containing settings to apply default resource tags across all resources.",
+				Description: "[Experimental - Monitors, Powerpack and Logs Pipelines only] Configuration block containing settings to apply default resource tags across all resources.",
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"tags": schema.MapAttribute{
 							ElementType: types.StringType,
 							Optional:    true,
-							Description: "[Experimental - Monitors and Logs Pipelines only] Resource tags to be applied by default across all resources.",
+							Description: "[Experimental - Monitors, Powerpack and Logs Pipelines only] Resource tags to be applied by default across all resources.",
 						},
 					},
 				},

--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -159,14 +159,14 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeList,
 				Optional:    true,
 				MaxItems:    1,
-				Description: "[Experimental - Monitors and Logs Pipelines only] Configuration block containing settings to apply default resource tags across all resources.",
+				Description: "[Experimental - Monitors, Powerpack and Logs Pipelines only] Configuration block containing settings to apply default resource tags across all resources.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"tags": {
 							Type:        schema.TypeMap,
 							Optional:    true,
 							Elem:        &schema.Schema{Type: schema.TypeString},
-							Description: "[Experimental - Monitors and Logs Pipelines only] Resource tags to be applied by default across all resources.",
+							Description: "[Experimental - Monitors, Powerpack and Logs Pipelines only] Resource tags to be applied by default across all resources.",
 						},
 					},
 				},

--- a/datadog/resource_datadog_powerpack.go
+++ b/datadog/resource_datadog_powerpack.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
@@ -23,6 +24,7 @@ func resourceDatadogPowerpack() *schema.Resource {
 		UpdateContext: resourceDatadogPowerpackUpdate,
 		ReadContext:   resourceDatadogPowerpackRead,
 		DeleteContext: resourceDatadogPowerpackDelete,
+		CustomizeDiff: customdiff.All(tagDiff),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -47,7 +49,8 @@ func resourceDatadogPowerpack() *schema.Resource {
 				"tags": {
 					Type:        schema.TypeSet,
 					Optional:    true,
-					Description: "List of tags to identify this powerpack.",
+					Computed:    true,
+					Description: "List of tags to identify this powerpack. Note: if default tags are present at provider level, they will be added to this resource.",
 					Elem: &schema.Schema{
 						Type: schema.TypeString,
 					},

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ provider "datadog" {
 - `api_key` (String, Sensitive) (Required unless validate is false) Datadog API key. This can also be set via the DD_API_KEY environment variable.
 - `api_url` (String) The API URL. This can also be set via the DD_HOST environment variable, and defaults to `https://api.datadoghq.com`. Note that this URL must not end with the `/api/` path. For example, `https://api.datadoghq.com/` is a correct value, while `https://api.datadoghq.com/api/` is not. And if you're working with "EU" version of Datadog, use `https://api.datadoghq.eu/`. Other Datadog region examples: `https://api.us5.datadoghq.com/`, `https://api.us3.datadoghq.com/` and `https://api.ddog-gov.com/`. See https://docs.datadoghq.com/getting_started/site/ for all available regions.
 - `app_key` (String, Sensitive) (Required unless validate is false) Datadog APP key. This can also be set via the DD_APP_KEY environment variable.
-- `default_tags` (Block List, Max: 1) [Experimental - Monitors and Logs Pipelines only] Configuration block containing settings to apply default resource tags across all resources. (see [below for nested schema](#nestedblock--default_tags))
+- `default_tags` (Block List, Max: 1) [Experimental - Monitors, Powerpack and Logs Pipelines only] Configuration block containing settings to apply default resource tags across all resources. (see [below for nested schema](#nestedblock--default_tags))
 - `http_client_retry_backoff_base` (Number) The HTTP request retry back off base. Defaults to 2.
 - `http_client_retry_backoff_multiplier` (Number) The HTTP request retry back off multiplier. Defaults to 2.
 - `http_client_retry_enabled` (String) Enables request retries on HTTP status codes 429 and 5xx. Valid values are [`true`, `false`]. Defaults to `true`.
@@ -65,4 +65,4 @@ provider "datadog" {
 
 Optional:
 
-- `tags` (Map of String) [Experimental - Monitors and Logs Pipelines only] Resource tags to be applied by default across all resources.
+- `tags` (Map of String) [Experimental - Monitors, Powerpack and Logs Pipelines only] Resource tags to be applied by default across all resources.

--- a/docs/resources/powerpack.md
+++ b/docs/resources/powerpack.md
@@ -52,7 +52,7 @@ resource "datadog_powerpack" "foo" {
 - `live_span` (String) The timeframe to use when displaying the widget. Valid values are `1m`, `5m`, `10m`, `15m`, `30m`, `1h`, `4h`, `1d`, `2d`, `1w`, `1mo`, `3mo`, `6mo`, `week_to_date`, `month_to_date`, `1y`, `alert`.
 - `name` (String) The name for the powerpack.
 - `show_title` (Boolean) Whether or not title should be displayed in the powerpack.
-- `tags` (Set of String) List of tags to identify this powerpack.
+- `tags` (Set of String) List of tags to identify this powerpack. Note: if default tags are present at provider level, they will be added to this resource.
 - `template_variables` (Block List) The list of template variables for this powerpack. (see [below for nested schema](#nestedblock--template_variables))
 - `widget` (Block List) The list of widgets to display in the powerpack. (see [below for nested schema](#nestedblock--widget))
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.17.0
 	github.com/hashicorp/terraform-plugin-go v0.26.0
+	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-mux v0.18.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
 	github.com/hashicorp/terraform-plugin-testing v1.12.0
@@ -56,7 +57,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.22.0 // indirect
 	github.com/hashicorp/terraform-json v0.24.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.4 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect


### PR DESCRIPTION
Related issue: #1478 

## Motivation
This PR is the first of a string of PR to expand the resources supporting provider level tags.

## Changes
- added a `customdiff` to the `datadog_powerpack` ressource to add the tags from the provider.
- changed the `datadog_powerpack` tags to be `computed` and `optional`.
- changed the tags description to clarify the behaviour regarding the default tags from the provider. 