### PR TITLE
incident-36868

### DIFF
--- a/datadog/resource_datadog_dashboard_json.go
+++ b/datadog/resource_datadog_dashboard_json.go
@@ -263,11 +263,20 @@ func prepResource(attrMap map[string]interface{}) map[string]interface{} {
 			attrMap["is_read_only"] = false
 		}
 	}
-	// handle `notify_list` order
-	if notifyList, ok := attrMap["notify_list"].([]interface{}); ok {
-		sort.SliceStable(notifyList, func(i, j int) bool {
-			return notifyList[i].(string) < notifyList[j].(string)
-		})
+
+	// Remove null template_variables and notify_list to avoid unnecessary diffs
+	if templateVars, ok := attrMap["template_variables"]; ok && templateVars == nil {
+		delete(attrMap, "template_variables")
+	}
+	if notifyList, ok := attrMap["notify_list"]; ok {
+		if notifyList == nil {
+			delete(attrMap, "notify_list")
+		} else if notifyListSlice, ok := notifyList.([]interface{}); ok {
+			// handle `notify_list` order
+			sort.SliceStable(notifyListSlice, func(i, j int) bool {
+				return notifyListSlice[i].(string) < notifyListSlice[j].(string)
+			})
+		}
 	}
 
 	return attrMap


### PR DESCRIPTION
# Fix unnecessary diffs for template_variables and notify_list in dashboard_json resource

## Description
When using the `datadog_dashboard_json` resource, Terraform would show unnecessary diffs during plan/apply when `template_variables` or `notify_list` fields were not explicitly defined in the configuration. This was happening because Terraform was treating an undefined field differently from a field set to `null`.

## Changes
Modified the `prepResource` function to:
- Remove `template_variables` from state comparison when it's null or undefined
- Remove `notify_list` from state comparison when it's null or undefined
- Only sort `notify_list` when it contains actual values

## Testing
To verify this fix:

1. Create a dashboard_json resource without explicitly defining template_variables or notify_list:
```hcl
resource "datadog_dashboard_json" "test" {
 dashboard = <<EOF
{
   "title":"Ordered Layout Dashboard",
   "description":"Created using the Datadog provider in Terraform",
   "layout_type": "ordered",
   "widgets": [],
}
EOF
```

2. Run `terraform apply` to create the dashboard

3. Run `terraform plan` - you should see no changes detected. Previously, this would show:
```
Terraform will perform the following actions:

  # datadog_dashboard_json.timeseries will be updated in-place
  ~ resource "datadog_dashboard_json" "test" {
      ~ dashboard               = jsonencode(
          ~ {
              - notify_list        = null
              - template_variables = null
                # (6 unchanged attributes hidden)
            }
        )
        id                      = "wcu-vpm-pye"
        # (2 unchanged attributes hidden)
    }
```