### PR TITLE
[Generator] Remove "-" from generated golang api reference

### DIFF
--- a/.generator/src/generator/templates/base_resource.j2
+++ b/.generator/src/generator/templates/base_resource.j2
@@ -1,4 +1,4 @@
-{%- set apiName = operations[GET_OPERATION]["schema"]["tags"][0].replace(" ", "") + "Api" %}
+{%- set apiName = operations[GET_OPERATION]["schema"]["tags"][0].replace(" ", "").replace("-", "") + "Api" %}
 {%- set getOperationId = operations[GET_OPERATION]["schema"]["operationId"] %}
 {%- set updateOperationId = operations[UPDATE_OPERATION]["schema"]["operationId"] %}
 {%- set createOperationId = operations[CREATE_OPERATION]["schema"]["operationId"] %}

--- a/.generator/src/generator/templates/data_source/base.j2
+++ b/.generator/src/generator/templates/data_source/base.j2
@@ -1,4 +1,4 @@
-{%- set apiName = operations["singular"]["schema"]["tags"][0].replace(" ", "") + "Api" %}
+{%- set apiName = operations["singular"]["schema"]["tags"][0].replace(" ", "").replace("-", "") + "Api" %}
 {%- set singularParams = operations["singular"]["schema"]|parameters %}
 {%- set singularParamAttr = singularParams|sort_schemas_by_type%}
 

--- a/.generator/src/generator/templates/resource_test.j2
+++ b/.generator/src/generator/templates/resource_test.j2
@@ -1,6 +1,6 @@
 {%- import "utils/resource_test_helper.j2" as helperMacros %}
 
-{%- set apiName = operations[GET_OPERATION]["schema"]["tags"][0].replace(" ", "") + "Api" %}
+{%- set apiName = operations[GET_OPERATION]["schema"]["tags"][0].replace(" ", "").replace("-", "") + "Api" %}
 {%- set getOperationId = operations[GET_OPERATION]["schema"]["operationId"] %}
 {%- set deleteOperationId = operations[DELETE_OPERATION]["schema"]["operationId"] %}
 {%- set readOperationParams = operations[GET_OPERATION]["schema"]|parameters %}


### PR DESCRIPTION
Following what was done in [this PR](https://github.com/DataDog/datadog-api-client-go/pull/3013); for example [here](https://github.com/DataDog/datadog-api-client-go/pull/3013/files#diff-f417b890deaaf37ed96b02f52142614d7e89ecfab0c7e0f1e17c1eb70c2edd4eR16) to remove dash from generated DD go client; strip the "-" when using go client sdk for generated terraform provider..