### PR TITLE
[datadog_synthetics_test] Specify the unit in the example for file upload

### DIFF
--- a/datadog/fwprovider/data_source_datadog_synthetics_locations.go
+++ b/datadog/fwprovider/data_source_datadog_synthetics_locations.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 )
 

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -429,7 +429,7 @@ resource "datadog_synthetics_test" "test_browser" {
     params {
       files = jsonencode([{
         name    = "hello.txt"   // Name of the file
-        size    = 11            // Size of the file
+        size    = 11            // Size of the file in bytes
         content = "Hello world" // Content of the file
       }])
       element = "*[@id='simple-file-upload']"

--- a/examples/resources/datadog_synthetics_test/resource.tf
+++ b/examples/resources/datadog_synthetics_test/resource.tf
@@ -388,7 +388,7 @@ resource "datadog_synthetics_test" "test_browser" {
     params {
       files = jsonencode([{
         name    = "hello.txt"   // Name of the file
-        size    = 11            // Size of the file
+        size    = 11            // Size of the file in bytes
         content = "Hello world" // Content of the file
       }])
       element = "*[@id='simple-file-upload']"


### PR DESCRIPTION
This PR updates the comments in the Datadog Synthetics Test resource example to explicitly state that the size parameter in file uploads is measured in bytes.

