### PR TITLE
[Generator] Fixed generator crash

### DIFF
--- a/.generator/src/generator/type.py
+++ b/.generator/src/generator/type.py
@@ -165,7 +165,7 @@ def tf_sort_params_by_type(parameters):
             # If the schema is a JSON API schema, get the attributes schema
             schema = openapi.json_api_attributes_schema(schema)
 
-        for attr, s in schema["properties"].items():
+        for attr, s in schema.get(["properties"], {}).items():
             required = attr in schema.get("required", [])
             s["required"] = required
 


### PR DESCRIPTION
## Motivation
The generator crashed when a schema does not have any properties. This can happen if a resource creation allows for query parameters instead.

## Changes
- Changed the way we access the "properties" field.