### PR TITLE
[datadog_cloud_configuration_rule] Changed tags field type to Set

### DIFF
--- a/datadog/internal/utils/utils.go
+++ b/datadog/internal/utils/utils.go
@@ -349,6 +349,16 @@ func GetStringSlice(d Resource, key string) []string {
 	return []string{}
 }
 
+// GetStringSliceFromSet returns a string slice for a given schema.Set
+func GetStringSliceFromSet(set *schema.Set) []string {
+	values := set.List()
+	stringValues := make([]string, len(values))
+	for i, value := range values {
+		stringValues[i] = value.(string)
+	}
+	return stringValues
+}
+
 // GetMultiEnvVar returns first matching env var
 func GetMultiEnvVar(envVars ...string) (string, error) {
 	for _, value := range envVars {

--- a/datadog/resource_datadog_cloud_configuration_rule.go
+++ b/datadog/resource_datadog_cloud_configuration_rule.go
@@ -98,7 +98,7 @@ func cloudConfigurationRuleSchema() map[string]*schema.Schema {
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
 		tagsField: {
-			Type:        schema.TypeList,
+			Type:        schema.TypeSet,
 			Optional:    true,
 			Description: "Tags of the rule, propagated to findings and signals. Defaults to empty list.",
 			Elem:        &schema.Schema{Type: schema.TypeString},
@@ -158,7 +158,7 @@ func buildRuleCreatePayload(d *schema.ResourceData) *datadogV2.SecurityMonitorin
 	payload.SetOptions(buildRuleCreationOptions(d))
 	payload.SetComplianceSignalOptions(*buildComplianceSignalOptions(d))
 	payload.SetCases(*buildRuleCreationCases(d))
-	payload.SetTags(utils.GetStringSlice(d, tagsField))
+	payload.SetTags(utils.GetStringSliceFromSet(d.Get(tagsField).(*schema.Set)))
 	payload.SetType(datadogV2.CLOUDCONFIGURATIONRULETYPE_CLOUD_CONFIGURATION)
 	payload.SetFilters(buildFiltersFromResourceData(d))
 
@@ -219,7 +219,7 @@ func buildRuleUpdatePayload(d *schema.ResourceData) *datadogV2.SecurityMonitorin
 	payload.SetOptions(buildRuleUpdateOptions(d))
 	payload.SetComplianceSignalOptions(*buildComplianceSignalOptions(d))
 	payload.SetCases(*buildRuleUpdateCases(d))
-	payload.SetTags(utils.GetStringSlice(d, tagsField))
+	payload.SetTags(utils.GetStringSliceFromSet(d.Get(tagsField).(*schema.Set)))
 	payload.SetFilters(buildFiltersFromResourceData(d))
 	return &payload
 }

--- a/docs/resources/cloud_configuration_rule.md
+++ b/docs/resources/cloud_configuration_rule.md
@@ -70,7 +70,7 @@ resource "datadog_cloud_configuration_rule" "myrule" {
 - `group_by` (List of String) Defaults to empty list. This function will be deprecated soon. Use the notification rules function instead. Fields to group by when generating signals, e.g. @resource.
 - `notifications` (List of String) This function will be deprecated soon. Use the notification rules function instead. Notification targets for signals. Defaults to empty list.
 - `related_resource_types` (List of String) Related resource types to be checked by the rule. Defaults to empty list.
-- `tags` (List of String) Tags of the rule, propagated to findings and signals. Defaults to empty list.
+- `tags` (Set of String) Tags of the rule, propagated to findings and signals. Defaults to empty list.
 
 ### Read-Only
 


### PR DESCRIPTION
## Motivation
In Terraform lists are a sequence of values in which order matters . Sets are unordered collection of unique values.
We are currently trying to add default_tags to the `datadog_cloud_configuration_rule` resource and the orderness of the list type is currently blocking us. 

This change will unblock #2969 

## Changes
- Changed the type of the `tags` field to `schema.TypeList`
- added a `GetStringSliceFromSet` function to have an alternative to `GetStringSlice` which only applies to slices