### PR TITLE
Log error for sdkv2 deprecation check

### DIFF
--- a/.github/workflows/sdkv2_deprecation.yaml
+++ b/.github/workflows/sdkv2_deprecation.yaml
@@ -22,7 +22,7 @@ jobs:
       - run: echo "::error::All new resources must use the `terraform-plugin-framework`"
         if: steps.new-resources.outputs.added_files_count != '0'
       - uses: exercism/pr-commenter-action@085ef62d2a541a112c3ade1d24deea83665ea186
-        if: steps.new-resources.outputs.added_files_count != '0'
+        if: ${{ ! github.event.pull_request.head.repo.fork && steps.new-resources.outputs.added_files_count != '0' }}
         with:
           github-token: "${{ github.token }}"
           config-file: ".github/sdkv2-warning.yml"

--- a/.github/workflows/sdkv2_deprecation.yaml
+++ b/.github/workflows/sdkv2_deprecation.yaml
@@ -19,6 +19,8 @@ jobs:
         uses: tj-actions/changed-files@d6e91a2266cdb9d62096cebf1e8546899c6aa18f
         with:
           files: "datadog/*.go"
+      - run: echo "::error::All new resources must use the `terraform-plugin-framework`"
+        if: steps.new-resources.outputs.added_files_count != '0'
       - uses: exercism/pr-commenter-action@085ef62d2a541a112c3ade1d24deea83665ea186
         if: steps.new-resources.outputs.added_files_count != '0'
         with:


### PR DESCRIPTION
Forks workflows can't post comments to the PR due to token restrictions, so currently the job just fails due to lacking permissions to post a comment on the PR and doesn't explain why. This should at least make it more obvious.