### PR TITLE
[synthetics_test] Add API endpoint link to synthetics location list

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -100,7 +100,7 @@ func resourceDatadogSyntheticsTest() *schema.Resource {
 					},
 				},
 				"locations": {
-					Description: "Array of locations used to run the test. Refer to [the Datadog Synthetics location data source](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/data-sources/synthetics_locations) to retrieve the list of locations.",
+					Description: "Array of locations used to run the test. Refer to [the Datadog Synthetics location data source](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/data-sources/synthetics_locations) to retrieve the list of locations or find the possible values listed in [this API response](https://app.datadoghq.com/api/v1/synthetics/locations?only_public=true).",
 					Type:        schema.TypeSet,
 					Required:    true,
 					Elem: &schema.Schema{

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -733,7 +733,7 @@ resource "datadog_synthetics_test" "test_grpc_health" {
 
 ### Required
 
-- `locations` (Set of String) Array of locations used to run the test. Refer to [the Datadog Synthetics location data source](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/data-sources/synthetics_locations) to retrieve the list of locations.
+- `locations` (Set of String) Array of locations used to run the test. Refer to [the Datadog Synthetics location data source](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/data-sources/synthetics_locations) to retrieve the list of locations or find the possible values listed in [this API response](https://app.datadoghq.com/api/v1/synthetics/locations?only_public=true).
 - `name` (String) Name of Datadog synthetics test.
 - `status` (String) Define whether you want to start (`live`) or pause (`paused`) a Synthetic test. Valid values are `live`, `paused`.
 - `type` (String) Synthetics test type. Valid values are `api`, `browser`, `mobile`.


### PR DESCRIPTION
### Description

Adds a link to the official Datadog API documentation for the `locations` field in the Synthetics resource. This improves the clarity of the field by pointing users directly to locations id+name.

### Changes overview

- Updated `locations` field description in the schema.
- Updated corresponding `.md` documentation file.

### Related ticket

- [SYNTH-19809] Update location array examples in Synthetics terraform docs


[SYNTH-19809]: https://datadoghq.atlassian.net/browse/SYNTH-19809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ