### PR TITLE
[datadog_app_builder_app] Mention export button in description

### DIFF
--- a/datadog/fwprovider/resource_datadog_app_builder_app.go
+++ b/datadog/fwprovider/resource_datadog_app_builder_app.go
@@ -64,7 +64,7 @@ func (r *appBuilderAppResource) Metadata(_ context.Context, request resource.Met
 
 func (r *appBuilderAppResource) Schema(_ context.Context, _ resource.SchemaRequest, response *resource.SchemaResponse) {
 	response.Schema = schema.Schema{
-		Description: "Provides a Datadog App resource for creating and managing Datadog Apps from App Builder using the JSON definition.",
+		Description: "Provides a Datadog App resource for creating and managing Datadog Apps from App Builder using the JSON definition. To easily export an App for use with Terraform, use the export button in the Datadog App Builder UI.",
 		Attributes: map[string]schema.Attribute{
 			"id": utils.ResourceIDAttribute(),
 			"app_json": schema.StringAttribute{

--- a/docs/resources/app_builder_app.md
+++ b/docs/resources/app_builder_app.md
@@ -3,12 +3,12 @@
 page_title: "datadog_app_builder_app Resource - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  Provides a Datadog App resource for creating and managing Datadog Apps from App Builder using the JSON definition.
+  Provides a Datadog App resource for creating and managing Datadog Apps from App Builder using the JSON definition. To easily export an App for use with Terraform, use the export button in the Datadog App Builder UI.
 ---
 
 # datadog_app_builder_app (Resource)
 
-Provides a Datadog App resource for creating and managing Datadog Apps from App Builder using the JSON definition.
+Provides a Datadog App resource for creating and managing Datadog Apps from App Builder using the JSON definition. To easily export an App for use with Terraform, use the export button in the Datadog App Builder UI.
 
 ## Example Usage
 


### PR DESCRIPTION
## Motivation

- Updates resource description to mention export button for visibility. This aligns with Workflow's description: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/workflow_automation
- Original PR: https://github.com/DataDog/terraform-provider-datadog/pull/2723
- Ticket: https://datadoghq.atlassian.net/browse/APPS-2302