### PR TITLE
[datadog_synthetics_test] Exclude TLS version types from being converted to number

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -5405,7 +5405,9 @@ func isTargetOfTypeFloat(assertionType datadogV1.SyntheticsAssertionType, assert
 		datadogV1.SYNTHETICSASSERTIONOPERATOR_MORE_THAN,
 		datadogV1.SYNTHETICSASSERTIONOPERATOR_MORE_THAN_OR_EQUAL,
 	} {
-		if assertionOperator == operator {
+		if assertionOperator == operator &&
+			assertionType != datadogV1.SYNTHETICSASSERTIONTYPE_TLS_VERSION &&
+			assertionType != datadogV1.SYNTHETICSASSERTIONTYPE_MIN_TLS_VERSION {
 			return true
 		}
 	}


### PR DESCRIPTION
We fixed a bug recently where assertion targets were not being set as numbers correctly, but fixing that caused another bug with TLS versions specifically which can't be numbers