### PR TITLE
[datadog_synthetics_test] Add QoL feedback when converting multistep API test

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -1036,7 +1036,7 @@ func syntheticsTestAPIStep() *schema.Schema {
 	requestElemSchema.Schema["http_version"] = syntheticsHttpVersionOption()
 
 	return &schema.Schema{
-		Description: "Steps for multistep api tests",
+		Description: "Steps for multistep API tests",
 		Type:        schema.TypeList,
 		Optional:    true,
 		Elem: &schema.Resource{
@@ -1113,7 +1113,7 @@ func syntheticsTestAPIStep() *schema.Schema {
 					Description: "Generate variables using JavaScript.",
 				},
 				"request_definition": {
-					Description: "The request for the api step.",
+					Description: "The request for the API step.",
 					Type:        schema.TypeList,
 					MaxItems:    1,
 					Optional:    true,
@@ -1786,7 +1786,7 @@ func syntheticsConfigVariable() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"example": {
-					Description: "Example for the variable. This value is not returned by the api when `secure = true`. Avoid drift by only making updates to this value from within Terraform.",
+					Description: "Example for the variable. This value is not returned by the API when `secure = true`. Avoid drift by only making updates to this value from within Terraform.",
 					Type:        schema.TypeString,
 					Optional:    true,
 				},
@@ -1797,7 +1797,7 @@ func syntheticsConfigVariable() *schema.Schema {
 					ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[A-Z][A-Z0-9_]+[A-Z0-9]$`), "must be all uppercase with underscores"),
 				},
 				"pattern": {
-					Description: "Pattern of the variable. This value is not returned by the api when `secure = true`. Avoid drift by only making updates to this value from within Terraform.",
+					Description: "Pattern of the variable. This value is not returned by the API when `secure = true`. Avoid drift by only making updates to this value from within Terraform.",
 					Type:        schema.TypeString,
 					Optional:    true,
 				},
@@ -1883,7 +1883,7 @@ func resourceDatadogSyntheticsTestCreate(ctx context.Context, d *schema.Resource
 			getSyntheticsApiTestResponse, httpResponseGet, err = apiInstances.GetSyntheticsApiV1().GetAPITest(auth, createdSyntheticsTest.GetPublicId())
 			if err != nil {
 				if httpResponseGet != nil && httpResponseGet.StatusCode == 404 {
-					return retry.RetryableError(fmt.Errorf("synthetics api test not created yet"))
+					return retry.RetryableError(fmt.Errorf("synthetics API test not created yet"))
 				}
 
 				return retry.NonRetryableError(err)

--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -2666,7 +2666,7 @@ func buildDatadogSyntheticsAPITest(d *schema.ResourceData) (*datadogV1.Synthetic
 	hasRootProperties := false
 
 	if _, hasMultistepApiStep := d.GetOk("api_step"); hasMultistepApiStep {
-		// Only check the most common required properties for API tests, which could be left over when migrating to a multistep API test.
+		// Only check the most common required properties for API tests, which could be left over at the root when migrating to a multistep API test.
 		// Keeping those would produce backend validation errors unexpected by the user, so we fail loudly with a helpful error message.
 		requiredProperties := []string{"request_definition", "assertion"}
 		for _, requiredProperty := range requiredProperties {
@@ -2683,14 +2683,14 @@ func buildDatadogSyntheticsAPITest(d *schema.ResourceData) (*datadogV1.Synthetic
 		subtypeStr := d.Get("subtype").(string)
 		if subtypeStr != "multi" {
 			if hasRootProperties {
-				// When root properties are set, the backend does not return a validation error.
+				// When root properties are set, the backend would not return a validation error.
 				// To avoid breaking changes, we simply warn the user that the `api_step` blocks are ignored.
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Warning,
 					Summary:  fmt.Sprintf("`api_step` blocks can only be set for multistep API tests. They will be ignored because test subtype is \"%s\" (expected \"multi\")", subtypeStr),
 				})
 			} else {
-				// When no root properties are set, the backend returns a validation error, so we fail loudly with a helpful error message.
+				// When no root properties are set, the backend would return a validation error, so we fail loudly with a helpful error message.
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Error,
 					Summary:  fmt.Sprintf("`api_step` blocks can only be set for multistep API tests. Expected test subtype: \"multi\", got \"%s\"", subtypeStr),

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -750,7 +750,7 @@ resource "datadog_synthetics_test" "test_grpc_health" {
 
 ### Optional
 
-- `api_step` (Block List) Steps for multi-step api tests (see [below for nested schema](#nestedblock--api_step))
+- `api_step` (Block List) Steps for multistep api tests (see [below for nested schema](#nestedblock--api_step))
 - `assertion` (Block List) Assertions used for the test. Multiple `assertion` blocks are allowed with the structure below. (see [below for nested schema](#nestedblock--assertion))
 - `browser_step` (Block List) Steps for browser tests. (see [below for nested schema](#nestedblock--browser_step))
 - `browser_variable` (Block List) Variables used for a browser test steps. Multiple `variable` blocks are allowed with the structure below. (see [below for nested schema](#nestedblock--browser_variable))
@@ -804,7 +804,7 @@ Optional:
 - `request_proxy` (Block List, Max: 1) The proxy to perform the test. (see [below for nested schema](#nestedblock--api_step--request_proxy))
 - `request_query` (Map of String) Query arguments name and value map.
 - `retry` (Block List, Max: 1) (see [below for nested schema](#nestedblock--api_step--retry))
-- `subtype` (String) The subtype of the Synthetic multi-step API test step. Valid values are `http`, `grpc`, `ssl`, `dns`, `tcp`, `udp`, `icmp`, `websocket`, `wait`. Defaults to `"http"`.
+- `subtype` (String) The subtype of the Synthetic multistep API test step. Valid values are `http`, `grpc`, `ssl`, `dns`, `tcp`, `udp`, `icmp`, `websocket`, `wait`. Defaults to `"http"`.
 - `value` (Number) The time to wait in seconds. Minimum value: 0. Maximum value: 180.
 
 <a id="nestedblock--api_step--assertion"></a>

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -750,7 +750,7 @@ resource "datadog_synthetics_test" "test_grpc_health" {
 
 ### Optional
 
-- `api_step` (Block List) Steps for multistep api tests (see [below for nested schema](#nestedblock--api_step))
+- `api_step` (Block List) Steps for multistep API tests (see [below for nested schema](#nestedblock--api_step))
 - `assertion` (Block List) Assertions used for the test. Multiple `assertion` blocks are allowed with the structure below. (see [below for nested schema](#nestedblock--assertion))
 - `browser_step` (Block List) Steps for browser tests. (see [below for nested schema](#nestedblock--browser_step))
 - `browser_variable` (Block List) Variables used for a browser test steps. Multiple `variable` blocks are allowed with the structure below. (see [below for nested schema](#nestedblock--browser_variable))
@@ -797,7 +797,7 @@ Optional:
 - `is_critical` (Boolean) Determines whether or not to consider the entire test as failed if this step fails. Can be used only if `allow_failure` is `true`.
 - `request_basicauth` (Block List, Max: 1) The HTTP basic authentication credentials. Exactly one nested block is allowed with the structure below. (see [below for nested schema](#nestedblock--api_step--request_basicauth))
 - `request_client_certificate` (Block List, Max: 1) Client certificate to use when performing the test request. Exactly one nested block is allowed with the structure below. (see [below for nested schema](#nestedblock--api_step--request_client_certificate))
-- `request_definition` (Block List, Max: 1) The request for the api step. (see [below for nested schema](#nestedblock--api_step--request_definition))
+- `request_definition` (Block List, Max: 1) The request for the API step. (see [below for nested schema](#nestedblock--api_step--request_definition))
 - `request_file` (Block List) Files to be used as part of the request in the test. (see [below for nested schema](#nestedblock--api_step--request_file))
 - `request_headers` (Map of String) Header name and value map.
 - `request_metadata` (Map of String) Metadata to include when performing the gRPC request.
@@ -1200,9 +1200,9 @@ Required:
 
 Optional:
 
-- `example` (String) Example for the variable. This value is not returned by the api when `secure = true`. Avoid drift by only making updates to this value from within Terraform.
+- `example` (String) Example for the variable. This value is not returned by the API when `secure = true`. Avoid drift by only making updates to this value from within Terraform.
 - `id` (String) When type = `global`, ID of the global variable to use.
-- `pattern` (String) Pattern of the variable. This value is not returned by the api when `secure = true`. Avoid drift by only making updates to this value from within Terraform.
+- `pattern` (String) Pattern of the variable. This value is not returned by the API when `secure = true`. Avoid drift by only making updates to this value from within Terraform.
 - `secure` (Boolean) Whether the value of this variable will be obfuscated in test results. Defaults to `false`.
 
 


### PR DESCRIPTION
This PR adds diagnostics for common mistakes when migrating an API test that was previously terraformed to do 1 thing, into a multistep API test that does this same thing + some extra steps.

For example, here I copied the previous logic and pasted it into an `api_step`, but forgot to remove the leftover `request_definition` and `assertion` at the root:

![image](https://github.com/user-attachments/assets/d6c791f9-19aa-4a9d-9b12-37c83f65264c)

Another common mistake is forgetting to update the `subtype` to `multi`. In that case, here is the error:

![image](https://github.com/user-attachments/assets/9d6ca574-e6dc-4c47-bf57-bdf97237a355)

This PR only impacts `type = "api"` tests, in `resourceDatadogSyntheticsTestCreate` and `resourceDatadogSyntheticsTestUpdate`.