### PR TITLE
[APIR-1709][resource_datadog_integration_aws_account] Update docs for logs_config.lambda_forwarder.sources field

### DIFF
--- a/datadog/fwprovider/resource_datadog_integration_aws_account.go
+++ b/datadog/fwprovider/resource_datadog_integration_aws_account.go
@@ -298,6 +298,7 @@ func (r *integrationAwsAccountResource) Schema(_ context.Context, _ resource.Sch
 								Computed: true,
 								Description: "List of service IDs set to enable automatic log collection. Use " +
 									"[`datadog_integration_aws_available_logs_services` data source](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/data-sources/integration_aws_available_logs_services) " +
+									"or [the AWS Logs Integration API](https://docs.datadoghq.com/api/latest/aws-logs-integration/?#get-list-of-aws-log-ready-services) " +
 									"to get allowed values. Defaults to `[]`.",
 								ElementType: types.StringType,
 								Default:     listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{})),

--- a/docs/resources/integration_aws_account.md
+++ b/docs/resources/integration_aws_account.md
@@ -164,7 +164,7 @@ Required:
 Optional:
 
 - `lambdas` (List of String) List of Datadog Lambda Log Forwarder ARNs in your AWS account. Defaults to `[]`.
-- `sources` (List of String) List of service IDs set to enable automatic log collection. Use [`datadog_integration_aws_available_logs_services` data source](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/data-sources/integration_aws_available_logs_services) to get allowed values. Defaults to `[]`.
+- `sources` (List of String) List of service IDs set to enable automatic log collection. Use [`datadog_integration_aws_available_logs_services` data source](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/data-sources/integration_aws_available_logs_services) or [the AWS Logs Integration API](https://docs.datadoghq.com/api/latest/aws-logs-integration/?#get-list-of-aws-log-ready-services) to get allowed values. Defaults to `[]`.
 
 
 <a id="nestedblock--metrics_config"></a>


### PR DESCRIPTION
Addresses docs issue raised in https://github.com/DataDog/terraform-provider-datadog/issues/3032