### PR TITLE
[synthetics_test] Add private location api key field

### DIFF
--- a/datadog/tests/resource_datadog_synthetics_private_location_test.go
+++ b/datadog/tests/resource_datadog_synthetics_private_location_test.go
@@ -35,7 +35,7 @@ func TestAccDatadogSyntheticsPrivateLocation_importBasic(t *testing.T) {
 				ResourceName:            "datadog_synthetics_private_location.foo",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"config"},
+				ImportStateVerifyIgnore: []string{"config", "api_key"},
 			},
 		},
 	})
@@ -96,6 +96,8 @@ func createSyntheticsPrivateLocationStep(ctx context.Context, accProvider *fwpro
 				"datadog_synthetics_private_location.foo", "tags.0", "foo:bar"),
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_private_location.foo", "tags.1", "baz"),
+			resource.TestCheckResourceAttr(
+				"datadog_synthetics_private_location.foo", "api_key", "1234567890"),
 			resource.TestCheckResourceAttrSet(
 				"datadog_synthetics_private_location.foo", "config"),
 			resource.TestCheckResourceAttrSet(
@@ -110,6 +112,7 @@ resource "datadog_synthetics_private_location" "foo" {
 	name = "%s"
 	description = "a private location"
 	tags = ["foo:bar", "baz"]
+	api_key = "1234567890"
 }`, uniqPrivateLocation)
 }
 
@@ -131,6 +134,8 @@ func updateSyntheticsPrivateLocationStep(ctx context.Context, accProvider *fwpro
 				"datadog_synthetics_private_location.foo", "tags.1", "baz"),
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_private_location.foo", "tags.2", "env:test"),
+			resource.TestCheckResourceAttr(
+				"datadog_synthetics_private_location.foo", "api_key", "0987654321"),
 			resource.TestCheckResourceAttrSet(
 				"datadog_synthetics_private_location.foo", "config"),
 			resource.TestCheckResourceAttrSet(
@@ -145,6 +150,7 @@ resource "datadog_synthetics_private_location" "foo" {
 	name = "%s"
 	description = "an updated private location"
 	tags = ["foo:bar", "baz", "env:test"]
+	api_key = "0987654321"
 }`, uniqPrivateLocation)
 }
 

--- a/docs/resources/synthetics_private_location.md
+++ b/docs/resources/synthetics_private_location.md
@@ -29,6 +29,7 @@ resource "datadog_synthetics_private_location" "private_location" {
 
 ### Optional
 
+- `api_key` (String, Sensitive) API key used to generate the private location configuration.
 - `description` (String) Description of the private location. Defaults to `""`.
 - `metadata` (Block List) The private location metadata (see [below for nested schema](#nestedblock--metadata))
 - `tags` (List of String) A list of tags to associate with your synthetics private location.


### PR DESCRIPTION
This PR adds support for the API key field in the private location resource, in response to [this issue](https://github.com/DataDog/terraform-provider-datadog/issues/1636).
This field is only used to generate the PL configuration at resource creation.