### PR TITLE
[datadog_synthetics_test] Fix basic auth

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -3596,8 +3596,12 @@ func buildTerraformBasicAuth(basicAuth *datadogV1.SyntheticsBasicAuth) map[strin
 	if basicAuth.SyntheticsBasicAuthWeb != nil {
 		basicAuthWeb := basicAuth.SyntheticsBasicAuthWeb
 
-		localAuth["username"] = basicAuthWeb.Username
-		localAuth["password"] = basicAuthWeb.Password
+		if v, ok := basicAuthWeb.GetUsernameOk(); ok {
+			localAuth["username"] = *v
+		}
+		if v, ok := basicAuthWeb.GetPasswordOk(); ok {
+			localAuth["password"] = *v
+		}
 		localAuth["type"] = "web"
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-datadog
 
 require (
-	github.com/DataDog/datadog-api-client-go/v2 v2.39.0
+	github.com/DataDog/datadog-api-client-go/v2 v2.39.1-0.20250623090822-b91249caa3d0
 	github.com/DataDog/dd-sdk-go-testing v0.0.0-20211116174033-1cd082e322ad
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/datadog-api-client-go/v2 v2.38.0 h1:0f2SuTVOFyDDtYvkOs+xawZLO08h10CBeiEfXsx5kVc=
-github.com/DataDog/datadog-api-client-go/v2 v2.38.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
-github.com/DataDog/datadog-api-client-go/v2 v2.39.0 h1:x1m0oPjp7h/RuuoC10gl/ROLP819CelNa3LeHTXFqgo=
-github.com/DataDog/datadog-api-client-go/v2 v2.39.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
+github.com/DataDog/datadog-api-client-go/v2 v2.39.1-0.20250623090822-b91249caa3d0 h1:yJTd9BFlTY0CBpfhGPvAfi25pSeIZBFQTEKYDmccxkk=
+github.com/DataDog/datadog-api-client-go/v2 v2.39.1-0.20250623090822-b91249caa3d0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=


### PR DESCRIPTION
This PR fixes an [issue](https://github.com/DataDog/terraform-provider-datadog/issues/2952) where importing a test with a missing password in basic auth would result in a go client error.
We modified the client to make `username` and `password` as optional, in [this PR](https://github.com/DataDog/datadog-api-client-go/pull/3163).