### PR TITLE
[on_call] update validation and documentation

### DIFF
--- a/datadog/fwprovider/resource_datadog_on_call_escalation_policy.go
+++ b/datadog/fwprovider/resource_datadog_on_call_escalation_policy.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -101,6 +102,10 @@ func (r *onCallEscalationPolicyResource) Schema(_ context.Context, _ resource.Sc
 		Blocks: map[string]schema.Block{
 			"step": schema.ListNestedBlock{
 				Description: "List of steps for the escalation policy.",
+				Validators: []validator.List{
+					listvalidator.IsRequired(),
+					listvalidator.SizeBetween(1, 10),
+				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
@@ -124,6 +129,10 @@ func (r *onCallEscalationPolicyResource) Schema(_ context.Context, _ resource.Sc
 					Blocks: map[string]schema.Block{
 						"target": schema.ListNestedBlock{
 							Description: "List of targets for the step.",
+							Validators: []validator.List{
+								listvalidator.IsRequired(),
+								listvalidator.SizeBetween(1, 10),
+							},
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
 									"user": schema.StringAttribute{

--- a/docs/resources/on_call_schedule.md
+++ b/docs/resources/on_call_schedule.md
@@ -42,12 +42,12 @@ resource "datadog_on_call_schedule" "test" {
 
 ### Required
 
+- `layer` (Block List) List of layers for the schedule. (see [below for nested schema](#nestedblock--layer))
 - `name` (String) A human-readable name for the new schedule.
 - `time_zone` (String) The time zone in which the schedule is defined.
 
 ### Optional
 
-- `layer` (Block List) List of layers for the schedule. (see [below for nested schema](#nestedblock--layer))
 - `teams` (List of String) A list of team ids associated with the schedule.
 
 ### Read-Only
@@ -60,15 +60,15 @@ resource "datadog_on_call_schedule" "test" {
 Required:
 
 - `effective_date` (String) The date/time when this layer should become active (in ISO 8601).
+- `interval` (Block List) Rotation interval for this layer. (see [below for nested schema](#nestedblock--layer--interval))
 - `name` (String) The name of this layer. Should be unique within the schedule.
+- `rotation_start` (String) The date/time when the rotation for this layer starts (in ISO 8601).
 - `users` (List of String) List of user IDs for the layer. Can either be a valid user id or null
 
 Optional:
 
 - `end_date` (String) The date/time after which this layer no longer applies (in ISO 8601).
-- `interval` (Block, Optional) (see [below for nested schema](#nestedblock--layer--interval))
 - `restriction` (Block List) List of restrictions for the layer. (see [below for nested schema](#nestedblock--layer--restriction))
-- `rotation_start` (String) The date/time when the rotation for this layer starts (in ISO 8601).
 
 Read-Only:
 
@@ -86,7 +86,7 @@ Optional:
 <a id="nestedblock--layer--restriction"></a>
 ### Nested Schema for `layer.restriction`
 
-Optional:
+Required:
 
 - `end_day` (String) The weekday when the restriction period ends. Valid values are `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`, `sunday`.
 - `end_time` (String) The time of day when the restriction ends (hh:mm:ss).

--- a/docs/resources/on_call_team_routing_rules.md
+++ b/docs/resources/on_call_team_routing_rules.md
@@ -60,7 +60,7 @@ Optional:
 - `action` (Block List) Specifies the list of actions to perform when the routing rule is matched. (see [below for nested schema](#nestedblock--rule--action))
 - `escalation_policy` (String) ID of the policy to be applied when this routing rule matches.
 - `query` (String) Defines the query or condition that triggers this routing rule. Defaults to `""`.
-- `time_restrictions` (Block, Optional) Holds time zone information and a list of time restrictions for a routing rule. (see [below for nested schema](#nestedblock--rule--time_restrictions))
+- `time_restrictions` (Block List) Holds time zone information and a list of time restrictions for a routing rule. (see [below for nested schema](#nestedblock--rule--time_restrictions))
 - `urgency` (String) Defines the urgency for pages created via this rule. Only valid if `escalation_policy` is set. Valid values are `high`, `low`, `dynamic`.
 
 Read-Only:
@@ -72,13 +72,13 @@ Read-Only:
 
 Optional:
 
-- `send_slack_message` (Block, Optional) (see [below for nested schema](#nestedblock--rule--action--send_slack_message))
-- `send_teams_message` (Block, Optional) (see [below for nested schema](#nestedblock--rule--action--send_teams_message))
+- `send_slack_message` (Block List) (see [below for nested schema](#nestedblock--rule--action--send_slack_message))
+- `send_teams_message` (Block List) (see [below for nested schema](#nestedblock--rule--action--send_teams_message))
 
 <a id="nestedblock--rule--action--send_slack_message"></a>
 ### Nested Schema for `rule.action.send_slack_message`
 
-Optional:
+Required:
 
 - `channel` (String) Slack channel ID.
 - `workspace` (String) Slack workspace ID.
@@ -87,7 +87,7 @@ Optional:
 <a id="nestedblock--rule--action--send_teams_message"></a>
 ### Nested Schema for `rule.action.send_teams_message`
 
-Optional:
+Required:
 
 - `channel` (String) Teams channel ID.
 - `team` (String) Teams team ID.
@@ -98,15 +98,15 @@ Optional:
 <a id="nestedblock--rule--time_restrictions"></a>
 ### Nested Schema for `rule.time_restrictions`
 
-Optional:
+Required:
 
-- `restriction` (Block List) List of restrictions for the rule. (see [below for nested schema](#nestedblock--rule--time_restrictions--restriction))
 - `time_zone` (String) Specifies the time zone applicable to the restrictions, e.g. `America/New_York`.
+- `restriction` (Block List) List of restrictions for the rule. (see [below for nested schema](#nestedblock--rule--time_restrictions--restriction))
 
 <a id="nestedblock--rule--time_restrictions--restriction"></a>
 ### Nested Schema for `rule.time_restrictions.restriction`
 
-Optional:
+Required:
 
 - `end_day` (String) The weekday when the restriction period ends. Valid values are `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`, `sunday`.
 - `end_time` (String) The time of day when the restriction ends (hh:mm:ss).

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -5,6 +5,8 @@
 exclude_files=(
   "docs/resources/integration_aws_account.md"
   "docs/resources/compliance_custom_framework.md"
+  "docs/resources/on_call_schedule.md"
+  "docs/resources/on_call_team_routing_rules.md"
 )
 
 # Check if manual changes were made to any excluded files and exit


### PR DESCRIPTION
Fixes https://github.com/DataDog/terraform-provider-datadog/issues/3055.

Due to https://github.com/hashicorp/terraform-plugin-framework/issues/740, we have to use `ListNestedBlock` with validators to enforce the size, since using nested attributes would be a breaking change.

And due to https://github.com/hashicorp/terraform-plugin-docs/issues/363, we have to manually update the generated docs to flag required blocks correctly.