### PR TITLE
[synthetics_test] update api client to ensure the `message` field is set for mobile tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-datadog
 
 require (
-	github.com/DataDog/datadog-api-client-go/v2 v2.41.1-0.20250625122828-7d842183d973
+	github.com/DataDog/datadog-api-client-go/v2 v2.41.1-0.20250630111742-7f5716e93469
 	github.com/DataDog/dd-sdk-go-testing v0.0.0-20211116174033-1cd082e322ad
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/datadog-api-client-go/v2 v2.41.1-0.20250625122828-7d842183d973 h1:Eb53EFWbLRG2Dtz7UtF6T3eVQU8+SukbcejMSW/0ujA=
-github.com/DataDog/datadog-api-client-go/v2 v2.41.1-0.20250625122828-7d842183d973/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
+github.com/DataDog/datadog-api-client-go/v2 v2.41.1-0.20250630111742-7f5716e93469 h1:RicWoJVF+Dgrx2480HtfDegC2ymsdRdt9Z2ba+O6Hgk=
+github.com/DataDog/datadog-api-client-go/v2 v2.41.1-0.20250630111742-7f5716e93469/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=


### PR DESCRIPTION
Currently, when the `message` field is not set for a synthetics mobile test, the `""` default value is not sent to our API, resulting in a `400` error (`schema.ResourceData.GetOk` returns `"", false` for an empty string
https://github.com/DataDog/terraform-provider-datadog/blob/e591a45d6f1c4b01f02da9d592e88da8c1d85da7/datadog/resource_datadog_synthetics_test_.go#L3135
).

This update of the client ensures the request will be sent with the `message` field set to an empty string instead in this case.

Related client change: https://github.com/DataDog/datadog-api-client-go/pull/3182