### PR TITLE
[DOCS] Updated documentation

### DIFF
--- a/docs/resources/action_connection.md
+++ b/docs/resources/action_connection.md
@@ -181,6 +181,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_action_connection.my_connection 11111111-2222-3333-4444-555555555555
 ```

--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -39,6 +39,8 @@ resource "datadog_api_key" "foo" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_api_key.foo 11111111-2222-3333-4444-555555555555
 ```

--- a/docs/resources/apm_retention_filter.md
+++ b/docs/resources/apm_retention_filter.md
@@ -55,6 +55,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Import existing APM retention filter 
 terraform import datadog_apm_retention_filter.foo <filter_id>

--- a/docs/resources/apm_retention_filter_order.md
+++ b/docs/resources/apm_retention_filter_order.md
@@ -45,6 +45,8 @@ resource "datadog_apm_retention_filter_order" "bar" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Import existing APM retention filter order
 # Note: Value of <foo> can be anything as this id is not stored by the resource

--- a/docs/resources/app_builder_app.md
+++ b/docs/resources/app_builder_app.md
@@ -173,6 +173,8 @@ resource "datadog_app_builder_app" "example_app_escaped_interpolated" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_app_builder_app.my_app 11111111-2222-3333-4444-555555555555
 ```

--- a/docs/resources/application_key.md
+++ b/docs/resources/application_key.md
@@ -39,6 +39,8 @@ resource "datadog_application_key" "foo" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_application_key.foo 11111111-2222-3333-4444-555555555555
 ```

--- a/docs/resources/appsec_waf_custom_rule.md
+++ b/docs/resources/appsec_waf_custom_rule.md
@@ -170,6 +170,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_appsec_waf_custom_rule.new_list ""
 ```

--- a/docs/resources/appsec_waf_exclusion_filter.md
+++ b/docs/resources/appsec_waf_exclusion_filter.md
@@ -93,6 +93,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_appsec_exclusion_filter.passlist_entry "45b7032f-0ac4-4b2f-9118-363523c625f6"
 ```

--- a/docs/resources/authn_mapping.md
+++ b/docs/resources/authn_mapping.md
@@ -47,6 +47,8 @@ resource "datadog_authn_mapping" "dev_ro_role_mapping" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # AuthN mappings can be imported using their ID, e.g.
 terraform import datadog_authn_mapping.dev_ro_mapping 000000-0000-0000-0000-000000000000

--- a/docs/resources/cloud_configuration_rule.md
+++ b/docs/resources/cloud_configuration_rule.md
@@ -88,6 +88,8 @@ Required:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Security monitoring rules can be imported using ID, e.g.
 terraform import datadog_cloud_configuration_rule.my_rule m0o-hto-lkb

--- a/docs/resources/cloud_workload_security_agent_rule.md
+++ b/docs/resources/cloud_workload_security_agent_rule.md
@@ -42,6 +42,8 @@ resource "datadog_cloud_workload_security_agent_rule" "my_agent_rule" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Cloud Workload Security Agent rules can be imported using ID, e.g.
 terraform import datadog_cloud_workload_security_agent_rule.my_agent_rule m0o-hto-lkb

--- a/docs/resources/compliance_resource_evaluation_filter.md
+++ b/docs/resources/compliance_resource_evaluation_filter.md
@@ -41,6 +41,8 @@ resource "datadog_compliance_resource_evaluation_filter" "basic_filter" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_compliance_resource_evaluation_filter.test_filter aws:00000000000000
 ```

--- a/docs/resources/csm_threats_agent_rule.md
+++ b/docs/resources/csm_threats_agent_rule.md
@@ -73,6 +73,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # CSM Agent Rules can be imported using ID. For example:
 terraform import datadog_csm_threats_agent_rule.my_agent_rule m0o-hto-lkb

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -29243,6 +29243,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_dashboard.my_service_dashboard sv7-gyh-kas
 ```

--- a/docs/resources/dashboard_json.md
+++ b/docs/resources/dashboard_json.md
@@ -525,6 +525,8 @@ EOF
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_dashboard_json.my_service_dashboard sv7-gyh-kas
 ```

--- a/docs/resources/dashboard_list.md
+++ b/docs/resources/dashboard_list.md
@@ -93,6 +93,8 @@ Required:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_dashboard_list.new_list 123456
 ```

--- a/docs/resources/downtime.md
+++ b/docs/resources/downtime.md
@@ -87,6 +87,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_downtime.bytes_received_localhost 2081
 ```

--- a/docs/resources/downtime_schedule.md
+++ b/docs/resources/downtime_schedule.md
@@ -101,6 +101,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_downtime_schedule.new_list "00e000000-0000-1234-0000-000000000000"
 ```

--- a/docs/resources/integration_aws.md
+++ b/docs/resources/integration_aws.md
@@ -57,6 +57,8 @@ resource "datadog_integration_aws" "sandbox" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Amazon Web Services integrations can be imported using their account ID and role name separated with a colon (:), while the external_id should be passed by setting an environment variable called EXTERNAL_ID
 EXTERNAL_ID=${external_id} terraform import datadog_integration_aws.test ${account_id}:${role_name}

--- a/docs/resources/integration_aws_event_bridge.md
+++ b/docs/resources/integration_aws_event_bridge.md
@@ -44,6 +44,8 @@ resource "datadog_integration_aws_event_bridge" "foo" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Amazon Web Service EventBridge integrations are imported using the Event Source name as listed for an integrated AWS account in Datadog
 terraform import datadog_integration_aws_event_bridge.foo event-source-name-abc12345

--- a/docs/resources/integration_aws_external_id.md
+++ b/docs/resources/integration_aws_external_id.md
@@ -78,6 +78,8 @@ resource "datadog_integration_aws_external_id" "foo" {}
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Amazon Web Services external IDs can be imported using the ID value.
 terraform import datadog_integration_aws_external_id.foo ${id}

--- a/docs/resources/integration_aws_lambda_arn.md
+++ b/docs/resources/integration_aws_lambda_arn.md
@@ -48,6 +48,8 @@ resource "datadog_integration_aws_lambda_arn" "main_collector" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Amazon Web Services Lambda ARN integrations can be imported using their account_id and lambda_arn separated with a space (` `).
 terraform import datadog_integration_aws_lambda_arn.test "1234567890 arn:aws:lambda:us-east-1:1234567890:function:datadog-forwarder-Forwarder"

--- a/docs/resources/integration_aws_log_collection.md
+++ b/docs/resources/integration_aws_log_collection.md
@@ -39,6 +39,8 @@ resource "datadog_integration_aws_log_collection" "main" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Amazon Web Services log collection integrations can be imported using the `account ID`.
 terraform import datadog_integration_aws_log_collection.test 1234567890

--- a/docs/resources/integration_aws_tag_filter.md
+++ b/docs/resources/integration_aws_tag_filter.md
@@ -41,6 +41,8 @@ resource "datadog_integration_aws_tag_filter" "foo" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Amazon Web Services log filter resource can be imported using their account ID and namespace separated with a colon (:).
 terraform import datadog_integration_aws_tag_filter.foo ${account_id}:${namespace}

--- a/docs/resources/integration_azure.md
+++ b/docs/resources/integration_azure.md
@@ -67,6 +67,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Microsoft Azure integrations can be imported using their `tenant name` and `client` id separated with a colon (`:`).
 # The client_secret should be passed by setting the environment variable CLIENT_SECRET

--- a/docs/resources/integration_cloudflare_account.md
+++ b/docs/resources/integration_cloudflare_account.md
@@ -43,6 +43,8 @@ resource "datadog_integration_cloudflare_account" "foo" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_integration_cloudflare_account.new_list "<ID>"
 ```

--- a/docs/resources/integration_confluent_account.md
+++ b/docs/resources/integration_confluent_account.md
@@ -42,6 +42,8 @@ resource "datadog_integration_confluent_account" "foo" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Confluent account ID can be retrieved using the ListConfluentAccounts endpoint
 # https://docs.datadoghq.com/api/latest/confluent-cloud/#list-confluent-accounts

--- a/docs/resources/integration_confluent_resource.md
+++ b/docs/resources/integration_confluent_resource.md
@@ -50,6 +50,8 @@ resource "datadog_integration_confluent_resource" "foo" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_integration_confluent_resource.new_list "confluent_account_id:confluent_resource_id"
 ```

--- a/docs/resources/integration_fastly_account.md
+++ b/docs/resources/integration_fastly_account.md
@@ -37,6 +37,8 @@ resource "datadog_integration_fastly_account" "foo" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_integration_fastly_account.new_list "a8f5f167f44f4964e6c998dee827110c"
 ```

--- a/docs/resources/integration_fastly_service.md
+++ b/docs/resources/integration_fastly_service.md
@@ -46,6 +46,8 @@ resource "datadog_integration_fastly_service" "foo" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_integration_fastly_service.new_list "account-id:service-id"
 ```

--- a/docs/resources/integration_gcp.md
+++ b/docs/resources/integration_gcp.md
@@ -73,6 +73,8 @@ resource "datadog_integration_gcp" "awesome_gcp_project_integration" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Google Cloud Platform integrations can be imported using their project ID, e.g.
 terraform import datadog_integration_gcp.awesome_gcp_project_integration project_id

--- a/docs/resources/integration_gcp_sts.md
+++ b/docs/resources/integration_gcp_sts.md
@@ -75,6 +75,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_integration_gcp_sts.foo "9c303af3-b963-45e0-8c8f-469b9e1a213f"
 ```

--- a/docs/resources/integration_pagerduty_service_object.md
+++ b/docs/resources/integration_pagerduty_service_object.md
@@ -40,6 +40,8 @@ resource "datadog_integration_pagerduty_service_object" "testing_bar" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Pagerduty service object can be imported using the service_name, while the service_key should be passed by setting the environment variable SERVICE_KEY
 SERVICE_KEY=${service_key} terraform import datadog_integration_pagerduty_service_object.foo ${service_name}

--- a/docs/resources/integration_slack_channel.md
+++ b/docs/resources/integration_slack_channel.md
@@ -54,6 +54,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Slack channel integrations can be imported using their account_name and channel_name separated with a colon (`:`).
 terraform import datadog_integration_slack_channel.test_channel "foo:#test_channel"

--- a/docs/resources/logs_archive.md
+++ b/docs/resources/logs_archive.md
@@ -95,6 +95,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_logs_archive.my_s3_archive 1Aabc2_dfQPLnXy3HlfK4hi
 ```

--- a/docs/resources/logs_archive_order.md
+++ b/docs/resources/logs_archive_order.md
@@ -36,6 +36,8 @@ resource "datadog_logs_archive_order" "sample_archive_order" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # There must be at most one datadog_logs_archive_order resource. You can import the datadog_logs_archive_order or create an archive order.
 terraform import <datadog_logs_archive_order.name> archiveOrderID

--- a/docs/resources/logs_custom_destination.md
+++ b/docs/resources/logs_custom_destination.md
@@ -142,6 +142,8 @@ Required:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Custom destinations can be imported using the destination ID. Caution: auth credentials can not be imported.
 terraform import datadog_logs_custom_destination.sample_destination "destination-id"

--- a/docs/resources/logs_custom_pipeline.md
+++ b/docs/resources/logs_custom_pipeline.md
@@ -777,6 +777,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # To find the pipeline ID, click the "edit" button in the UI to open the pipeline details.
 # The pipeline ID is the last part of the URL.

--- a/docs/resources/logs_index.md
+++ b/docs/resources/logs_index.md
@@ -108,6 +108,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import <datadog_logs_index.name> <indexName>
 ```

--- a/docs/resources/logs_index_order.md
+++ b/docs/resources/logs_index_order.md
@@ -41,6 +41,8 @@ resource "datadog_logs_index_order" "sample_index_order" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # The Datadog Terraform Provider does not support the creation and deletion of index orders. There must be at most one `datadog_logs_index_order` resource
 # `<name>` can be whatever you specify in your code. Datadog does not store the name on the server.

--- a/docs/resources/logs_integration_pipeline.md
+++ b/docs/resources/logs_integration_pipeline.md
@@ -33,6 +33,8 @@ resource "datadog_logs_integration_pipeline" "python" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # To find the pipeline ID, click the "view" button in the UI to open the pipeline details.
 # The pipeline ID is the last part of the URL.

--- a/docs/resources/logs_metric.md
+++ b/docs/resources/logs_metric.md
@@ -83,6 +83,8 @@ Required:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_logs_metric.testing_logs_metric testing.logs.metric
 ```

--- a/docs/resources/logs_pipeline_order.md
+++ b/docs/resources/logs_pipeline_order.md
@@ -39,6 +39,8 @@ resource "datadog_logs_pipeline_order" "sample_pipeline_order" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # There must be at most one datadog_logs_pipeline_order resource. Pipeline order creation is not supported from logs config API. You can import the datadog_logs_pipeline_order or create a pipeline order (which is actually doing the update operation).
 terraform import <datadog_logs_pipeline_order.name> <name>

--- a/docs/resources/metric_metadata.md
+++ b/docs/resources/metric_metadata.md
@@ -47,6 +47,8 @@ resource "datadog_metric_metadata" "request_time" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_metric_metadata.request_time request.time
 ```

--- a/docs/resources/metric_tag_configuration.md
+++ b/docs/resources/metric_tag_configuration.md
@@ -69,6 +69,8 @@ Required:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_metric_tag_configuration.example_dist_metric example.terraform.dist.metric
 ```

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -238,6 +238,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_monitor.bytes_received_localhost 2081
 ```

--- a/docs/resources/monitor_json.md
+++ b/docs/resources/monitor_json.md
@@ -60,6 +60,8 @@ EOF
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_monitor_json.monitor_json 123456
 ```

--- a/docs/resources/monitor_notification_rule.md
+++ b/docs/resources/monitor_notification_rule.md
@@ -51,6 +51,8 @@ Required:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_monitor_notification_rule.new_list "00e000000-0000-1234-0000-000000000000"
 ```

--- a/docs/resources/observability_pipeline.md
+++ b/docs/resources/observability_pipeline.md
@@ -1333,6 +1333,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_observability_pipeline.example_pipeline 8beabbc4-1f4d-11f0-942b-da7ad0900001
 ```

--- a/docs/resources/on_call_escalation_policy.md
+++ b/docs/resources/on_call_escalation_policy.md
@@ -80,6 +80,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Import an existing on_call_schedule
 terraform import datadog_on_call_schedule.test "b03a07d5-49da-43e9-83b4-5d84969b588b"

--- a/docs/resources/openapi_api.md
+++ b/docs/resources/openapi_api.md
@@ -35,6 +35,8 @@ resource "datadog_openapi_api" "my-api" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_openapi_api.new_list "90646597-5fdb-4a17-a240-647003f8c028"
 ```

--- a/docs/resources/organization_settings.md
+++ b/docs/resources/organization_settings.md
@@ -92,6 +92,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_organization_settings.organization 11111111-2222-3333-4444-555555555555
 ```

--- a/docs/resources/powerpack.md
+++ b/docs/resources/powerpack.md
@@ -8184,6 +8184,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_powerpack.foo 11111111-2222-3333-4444-555555555555
 ```

--- a/docs/resources/restriction_policy.md
+++ b/docs/resources/restriction_policy.md
@@ -64,6 +64,8 @@ Required:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_restriction_policy.new_list "<policy_id>"
 ```

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -61,6 +61,8 @@ Read-Only:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Roles can be imported using their ID, e.g.
 terraform import datadog_role.example_role 000000-0000-0000-0000-000000000000

--- a/docs/resources/rum_application.md
+++ b/docs/resources/rum_application.md
@@ -39,6 +39,8 @@ resource "datadog_rum_application" "rum_application" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_rum_application.rum_application a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6
 ```

--- a/docs/resources/rum_metric.md
+++ b/docs/resources/rum_metric.md
@@ -96,6 +96,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_rum_metric.testing_rum_metric "testing.rum.metric"
 ```

--- a/docs/resources/rum_retention_filter.md
+++ b/docs/resources/rum_retention_filter.md
@@ -48,6 +48,8 @@ resource "datadog_rum_retention_filter" "testing_rum_retention_filter" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_rum_retention_filter.testing_rum_retention_filter "<application_id>:<retention_filter_id>"
 ```

--- a/docs/resources/rum_retention_filters_order.md
+++ b/docs/resources/rum_retention_filters_order.md
@@ -69,6 +69,8 @@ resource "datadog_rum_retention_filters_order" "my_rum_retention_filters_order" 
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_rum_retention_filters_order.testing_rum_retention_filters_order "<application_id>"
 ```

--- a/docs/resources/security_monitoring_default_rule.md
+++ b/docs/resources/security_monitoring_default_rule.md
@@ -69,6 +69,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Default rules need to be imported using their ID before applying.
 resource "datadog_security_monitoring_default_rule" "adefaultrule" {

--- a/docs/resources/security_monitoring_filter.md
+++ b/docs/resources/security_monitoring_filter.md
@@ -62,6 +62,8 @@ Required:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Security monitoring filters can be imported using ID, e.g.
 terraform import datadog_security_monitoring_filter.my_filter m0o-hto-lkb

--- a/docs/resources/security_monitoring_rule.md
+++ b/docs/resources/security_monitoring_rule.md
@@ -259,6 +259,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Security monitoring rules can be imported using ID, e.g.
 terraform import datadog_security_monitoring_rule.my_rule m0o-hto-lkb

--- a/docs/resources/security_monitoring_rule_json.md
+++ b/docs/resources/security_monitoring_rule_json.md
@@ -72,6 +72,8 @@ EOF
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_security_monitoring_rule_json.security_rule_json aaa-yyy-vvv
 ```

--- a/docs/resources/security_monitoring_suppression.md
+++ b/docs/resources/security_monitoring_suppression.md
@@ -50,6 +50,8 @@ resource "datadog_security_monitoring_suppression" "my_suppression" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Security monitoring suppressions can be imported using ID, for example:
 terraform import datadog_security_monitoring_suppression.my_suppression m0o-hto-lkb

--- a/docs/resources/security_notification_rule.md
+++ b/docs/resources/security_notification_rule.md
@@ -78,6 +78,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_security_notification_rule.signal_rule yq9-t9l-bso
 ```

--- a/docs/resources/sensitive_data_scanner_group.md
+++ b/docs/resources/sensitive_data_scanner_group.md
@@ -55,6 +55,8 @@ Required:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_sensitive_data_scanner_group.new_list "<group_id>"
 ```

--- a/docs/resources/sensitive_data_scanner_group_order.md
+++ b/docs/resources/sensitive_data_scanner_group_order.md
@@ -39,6 +39,8 @@ resource "datadog_sensitive_data_scanner_group_order" "mygrouporder" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_sensitive_data_scanner_group_order.mygrouporder order
 ```

--- a/docs/resources/sensitive_data_scanner_rule.md
+++ b/docs/resources/sensitive_data_scanner_rule.md
@@ -136,6 +136,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_sensitive_data_scanner_rule.new_list "<rule_id>"
 ```

--- a/docs/resources/service_account.md
+++ b/docs/resources/service_account.md
@@ -46,6 +46,8 @@ resource "datadog_service_account" "bar" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_service_account.example_sa 6f1b44c0-30b2-11eb-86bc-279f7c1ebaa4
 ```

--- a/docs/resources/service_account_application_key.md
+++ b/docs/resources/service_account_application_key.md
@@ -43,6 +43,8 @@ resource "datadog_service_account_application_key" "foo" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Importing a service account's application key cannot import the value of the key.
 terraform import datadog_service_account_application_key.this "<service_account_id>:<application_key_id>"

--- a/docs/resources/service_definition_yaml.md
+++ b/docs/resources/service_definition_yaml.md
@@ -194,6 +194,8 @@ EOF
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_service_definition_yaml.service_definition "<dd-service>"
 ```

--- a/docs/resources/service_level_objective.md
+++ b/docs/resources/service_level_objective.md
@@ -220,6 +220,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Service Level Objectives can be imported using their string ID, e.g.
 terraform import datadog_service_level_objective.baz 12345678901234567890123456789012

--- a/docs/resources/slo_correction.md
+++ b/docs/resources/slo_correction.md
@@ -75,6 +75,8 @@ resource "datadog_slo_correction" "example_slo_correction_with_recurrence" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_slo_correction.testing_slo_correction 11111111-3fee-11eb-8a13-77cd9f15119e
 ```

--- a/docs/resources/software_catalog.md
+++ b/docs/resources/software_catalog.md
@@ -258,6 +258,8 @@ EOF
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_software_catalog.this <name>
 ```

--- a/docs/resources/spans_metric.md
+++ b/docs/resources/spans_metric.md
@@ -85,6 +85,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_spans_metric.testing_spans_metric testing.span.metric
 ```

--- a/docs/resources/synthetics_concurrency_cap.md
+++ b/docs/resources/synthetics_concurrency_cap.md
@@ -34,6 +34,8 @@ resource "datadog_synthetics_concurrency_cap" "this" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # The Synthetics concurrency cap can be imported. <name> can be whatever you specify in your code. Datadog does not store the name on the server.
 terraform import datadog_synthetics_concurrency_cap.this <name>

--- a/docs/resources/synthetics_global_variable.md
+++ b/docs/resources/synthetics_global_variable.md
@@ -92,6 +92,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Synthetics global variables can be imported using their string ID, e.g.
 terraform import datadog_synthetics_global_variable.fizz abcde123-fghi-456-jkl-mnopqrstuv

--- a/docs/resources/synthetics_private_location.md
+++ b/docs/resources/synthetics_private_location.md
@@ -50,6 +50,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Synthetics private locations can be imported using their string ID, e.g.
 terraform import datadog_synthetics_private_location.bar pl:private-location-name-abcdef123456

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -42,6 +42,8 @@ resource "datadog_team" "foo" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_team.foo "bf064c56-edb0-11ed-ae91-da7ad0900002"
 ```

--- a/docs/resources/team_link.md
+++ b/docs/resources/team_link.md
@@ -49,6 +49,8 @@ resource "datadog_team_link" "foo" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_team_link.new_list "${team_id}:${resource_id}"
 ```

--- a/docs/resources/team_membership.md
+++ b/docs/resources/team_membership.md
@@ -51,6 +51,8 @@ resource "datadog_team_membership" "foo" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # This resource is imported using team_id and user_id seperated by `:`.
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -50,6 +50,8 @@ resource "datadog_user" "foo" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_user.example_user 6f1b44c0-30b2-11eb-86bc-279f7c1ebaa4
 ```

--- a/docs/resources/user_role.md
+++ b/docs/resources/user_role.md
@@ -47,6 +47,8 @@ resource "datadog_user_role" "new_user_with_monitor_writer_role" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # This resource is imported using user_id and role_id seperated by `:`.
 

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -46,6 +46,8 @@ resource "datadog_webhook" "foo" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_webhook.foo example-webhook
 ```

--- a/docs/resources/webhook_custom_variable.md
+++ b/docs/resources/webhook_custom_variable.md
@@ -39,6 +39,8 @@ resource "datadog_webhook_custom_variable" "foo" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_webhook_custom_variable.foo EXAMPLE_VARIABLE
 ```

--- a/docs/resources/workflow_automation.md
+++ b/docs/resources/workflow_automation.md
@@ -84,6 +84,8 @@ resource "datadog_workflow_automation" "workflow" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import datadog_workflow_automation.my_workflow 11111111-2222-3333-4444-555555555555
 ```


### PR DESCRIPTION
## Motivation
The autogeneration added an extra line to the documentation referencing imports.

## Changes
Adds the following line to any resource supporting imports:
```
The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
```