### PR TITLE
Allow merge queue machinery to work

### DIFF
--- a/repository.datadog.yaml
+++ b/repository.datadog.yaml
@@ -1,0 +1,4 @@
+---
+schema-version: v1
+kind: mergequeue
+skip_labels: true


### PR DESCRIPTION
Labels from merge queues are generating changelog checks which in turn prevent the merge queue from going through.
Disabling merge queue labeling the github PR should fix this case.