### PR TITLE
chore: correct `datadogMetricTagsDataSource` interface check

### DIFF
--- a/datadog/fwprovider/data_source_datadog_metric_tags.go
+++ b/datadog/fwprovider/data_source_datadog_metric_tags.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	_ datasource.DataSource = &datadogUsersDataSource{}
+	_ datasource.DataSource = &datadogMetricTagsDataSource{}
 )
 
 type datadogMetricTagsModel struct {


### PR DESCRIPTION
Previously, `data_source_datadog_metric_tags.go` checked that `datadogUsersDataSource` implements `datasource.DataSource`; that was likely a copy pasta typo. Now, it correctly checks that `datadogMetricTagsDataSource` implements `datasource.DataSource`.