### PR TITLE
[OMG-623][datadog_team_membership] Correct handling of 404 when reading team memberships

### DIFF
--- a/datadog/fwprovider/resource_datadog_team_membership.go
+++ b/datadog/fwprovider/resource_datadog_team_membership.go
@@ -105,10 +105,14 @@ func (r *teamMembershipResource) Read(ctx context.Context, request resource.Read
 
 	var userTeams []datadogV2.UserTeam
 	for {
-		resp, _, err := r.Api.GetTeamMemberships(r.Auth, teamId, *datadogV2.NewGetTeamMembershipsOptionalParameters().
+		resp, httpResp, err := r.Api.GetTeamMemberships(r.Auth, teamId, *datadogV2.NewGetTeamMembershipsOptionalParameters().
 			WithPageSize(pageSize).
 			WithPageNumber(pageNumber))
 		if err != nil {
+			if httpResp != nil && httpResp.StatusCode == 404 {
+				response.State.RemoveResource(ctx)
+				return
+			}
 			response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving TeamMembership"))
 			return
 		}


### PR DESCRIPTION
Fixes an issue flagged by a customer:

> [customer] noticed deleting a team from TF (and also in the interface) causes a permanent error requiring state surgery. They deleted the file that created the team (and on-call schedule and escalation policy), and then deleted it in the interface in Datadog. Then when they tried to `plan`, they got the below error. It should resolve as a no-op, because the team is GONE.
>
> `
{"@level":"error","@message":"Error: error retrieving TeamMembership","@module":"terraform.ui","@timestamp":"2025-07-22T15:38:16.830044Z","diagnostic":{"severity":"error","summary":"error retrieving TeamMembership","detail":"404 Not Found: {\"errors\":[{\"status\":\"404\",\"title\":\"Not Found\",\"detail\":\"rpc error: code = NotFound desc = Failed to find team memberships: no team found (teamId=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX)\"}]}"},"type":"diagnostic"}
...
`
> 
> The issue was resolved by manually removing the teams from the TF state.
Here is their provider and TF version used:
Provider ~> 3.66.0
TF ~> 1.10.5