### PR TITLE
[Doc fix] Use correct parameter name for datadog_security_monitoring_rule_json

### DIFF
--- a/docs/resources/security_monitoring_rule_json.md
+++ b/docs/resources/security_monitoring_rule_json.md
@@ -15,7 +15,7 @@ Provides a Datadog Security Monitoring Rule JSON resource. This can be used to c
 ```terraform
 # Example Security Monitoring Rule JSON
 resource "datadog_security_monitoring_rule_json" "security_rule_json" {
-  rule = <<EOF
+  json = <<EOF
 {
   "name": "High error rate security monitoring",
   "isEnabled": true,

--- a/examples/resources/datadog_security_monitoring_rule_json/resource.tf
+++ b/examples/resources/datadog_security_monitoring_rule_json/resource.tf
@@ -1,6 +1,6 @@
 # Example Security Monitoring Rule JSON
 resource "datadog_security_monitoring_rule_json" "security_rule_json" {
-  rule = <<EOF
+  json = <<EOF
 {
   "name": "High error rate security monitoring",
   "isEnabled": true,
@@ -39,4 +39,4 @@ resource "datadog_security_monitoring_rule_json" "security_rule_json" {
   }
 }
 EOF
-} 
+}


### PR DESCRIPTION
## Changes
Update the parameter name to the correct one.

The "schema" section below on the same page says the parameter name `json` correctly [here](https://github.com/DataDog/terraform-provider-datadog/blob/master/docs/resources/security_monitoring_rule_json.md#required), but the example uses the `rule` parameter name incorrectly.