### PR TITLE
[datadog_observability_pipeline] Amazon S3 Destination

### DIFF
--- a/datadog/fwprovider/observability_pipeline/amazon_s3_destination.go
+++ b/datadog/fwprovider/observability_pipeline/amazon_s3_destination.go
@@ -1,0 +1,148 @@
+package observability_pipeline
+
+import (
+	"context"
+
+	datadogV2 "github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// AmazonS3DestinationModel represents the Terraform model for the AmazonS3Destination
+type AmazonS3DestinationModel struct {
+	Id           types.String  `tfsdk:"id"`
+	Inputs       types.List    `tfsdk:"inputs"`
+	Bucket       types.String  `tfsdk:"bucket"`
+	Region       types.String  `tfsdk:"region"`
+	KeyPrefix    types.String  `tfsdk:"key_prefix"`
+	StorageClass types.String  `tfsdk:"storage_class"`
+	Auth         *AwsAuthModel `tfsdk:"auth"`
+}
+
+// AwsAuthModel represents AWS authentication credentials
+type AwsAuthModel struct {
+	AssumeRole  types.String `tfsdk:"assume_role"`
+	ExternalId  types.String `tfsdk:"external_id"`
+	SessionName types.String `tfsdk:"session_name"`
+}
+
+// AmazonS3DestinationSchema returns the schema for the AmazonS3Destination
+func AmazonS3DestinationSchema() schema.ListNestedBlock {
+	return schema.ListNestedBlock{
+		Description: "The `amazon_s3` destination sends your logs in Datadog-rehydratable format to an Amazon S3 bucket for archiving.",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"id": schema.StringAttribute{
+					Required:    true,
+					Description: "Unique identifier for the destination component.",
+				},
+				"inputs": schema.ListAttribute{
+					Required:    true,
+					ElementType: types.StringType,
+					Description: "A list of component IDs whose output is used as the `input` for this component.",
+				},
+				"bucket": schema.StringAttribute{
+					Required:    true,
+					Description: "S3 bucket name.",
+				},
+				"region": schema.StringAttribute{
+					Required:    true,
+					Description: "AWS region of the S3 bucket.",
+				},
+				"key_prefix": schema.StringAttribute{
+					Required:    true,
+					Description: "Prefix for object keys.",
+				},
+				"storage_class": schema.StringAttribute{
+					Required:    true,
+					Description: "S3 storage class.",
+					Validators: []validator.String{
+						stringvalidator.OneOf("STANDARD", "REDUCED_REDUNDANCY", "INTELLIGENT_TIERING", "STANDARD_IA", "EXPRESS_ONEZONE", "ONEZONE_IA", "GLACIER", "GLACIER_IR", "DEEP_ARCHIVE"),
+					},
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"auth": schema.SingleNestedBlock{
+					Description: "AWS authentication credentials used for accessing AWS services such as S3. If omitted, the system's default credentials are used (for example, the IAM role and environment variables).",
+					Attributes: map[string]schema.Attribute{
+						"assume_role": schema.StringAttribute{
+							Optional:    true,
+							Description: "The Amazon Resource Name (ARN) of the role to assume.",
+						},
+						"external_id": schema.StringAttribute{
+							Optional:    true,
+							Description: "A unique identifier for cross-account role assumption.",
+						},
+						"session_name": schema.StringAttribute{
+							Optional:    true,
+							Description: "A session identifier used for logging and tracing the assumed role session.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// ExpandAmazonS3Destination converts the Terraform model to the API model
+func ExpandAmazonS3Destination(ctx context.Context, src *AmazonS3DestinationModel) datadogV2.ObservabilityPipelineConfigDestinationItem {
+	dest := datadogV2.NewObservabilityPipelineAmazonS3DestinationWithDefaults()
+	dest.SetId(src.Id.ValueString())
+
+	var inputs []string
+	src.Inputs.ElementsAs(ctx, &inputs, false)
+	dest.SetInputs(inputs)
+
+	dest.SetBucket(src.Bucket.ValueString())
+	dest.SetRegion(src.Region.ValueString())
+	dest.SetKeyPrefix(src.KeyPrefix.ValueString())
+	dest.SetStorageClass(datadogV2.ObservabilityPipelineAmazonS3DestinationStorageClass(src.StorageClass.ValueString()))
+
+	if src.Auth != nil {
+		auth := datadogV2.ObservabilityPipelineAwsAuth{}
+		if !src.Auth.AssumeRole.IsNull() {
+			auth.AssumeRole = src.Auth.AssumeRole.ValueStringPointer()
+		}
+		if !src.Auth.ExternalId.IsNull() {
+			auth.ExternalId = src.Auth.ExternalId.ValueStringPointer()
+		}
+		if !src.Auth.SessionName.IsNull() {
+			auth.SessionName = src.Auth.SessionName.ValueStringPointer()
+		}
+		dest.SetAuth(auth)
+	}
+
+	return datadogV2.ObservabilityPipelineConfigDestinationItem{
+		ObservabilityPipelineAmazonS3Destination: dest,
+	}
+}
+
+// FlattenAmazonS3Destination converts the API model to the Terraform model
+func FlattenAmazonS3Destination(ctx context.Context, src *datadogV2.ObservabilityPipelineAmazonS3Destination) *AmazonS3DestinationModel {
+	if src == nil {
+		return nil
+	}
+
+	inputs, _ := types.ListValueFrom(ctx, types.StringType, src.GetInputs())
+
+	model := &AmazonS3DestinationModel{
+		Id:           types.StringValue(src.GetId()),
+		Inputs:       inputs,
+		Bucket:       types.StringValue(src.GetBucket()),
+		Region:       types.StringValue(src.GetRegion()),
+		KeyPrefix:    types.StringValue(src.GetKeyPrefix()),
+		StorageClass: types.StringValue(string(src.GetStorageClass())),
+	}
+
+	if auth, ok := src.GetAuthOk(); ok {
+		model.Auth = &AwsAuthModel{
+			AssumeRole:  types.StringPointerValue(auth.AssumeRole),
+			ExternalId:  types.StringPointerValue(auth.ExternalId),
+			SessionName: types.StringPointerValue(auth.SessionName),
+		}
+	}
+
+	return model
+}

--- a/datadog/fwprovider/observability_pipeline/aws_auth.go
+++ b/datadog/fwprovider/observability_pipeline/aws_auth.go
@@ -1,0 +1,65 @@
+package observability_pipeline
+
+import (
+	datadogV2 "github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// AwsAuthModel represents AWS authentication credentials
+type AwsAuthModel struct {
+	AssumeRole  types.String `tfsdk:"assume_role"`
+	ExternalId  types.String `tfsdk:"external_id"`
+	SessionName types.String `tfsdk:"session_name"`
+}
+
+// ExpandAwsAuth converts the Terraform AWS auth model to the Datadog API model
+func ExpandAwsAuth(authTF *AwsAuthModel) *datadogV2.ObservabilityPipelineAwsAuth {
+	if authTF == nil {
+		return nil
+	}
+	auth := datadogV2.ObservabilityPipelineAwsAuth{}
+	if !authTF.AssumeRole.IsNull() {
+		auth.AssumeRole = authTF.AssumeRole.ValueStringPointer()
+	}
+	if !authTF.ExternalId.IsNull() {
+		auth.ExternalId = authTF.ExternalId.ValueStringPointer()
+	}
+	if !authTF.SessionName.IsNull() {
+		auth.SessionName = authTF.SessionName.ValueStringPointer()
+	}
+	return &auth
+}
+
+// FlattenAwsAuth converts the Datadog API AWS auth model to the Terraform model
+func FlattenAwsAuth(src *datadogV2.ObservabilityPipelineAwsAuth) *AwsAuthModel {
+	if src == nil {
+		return nil
+	}
+	return &AwsAuthModel{
+		AssumeRole:  types.StringPointerValue(src.AssumeRole),
+		ExternalId:  types.StringPointerValue(src.ExternalId),
+		SessionName: types.StringPointerValue(src.SessionName),
+	}
+}
+
+// AwsAuthSchema returns the schema for AWS authentication configuration
+func AwsAuthSchema() schema.SingleNestedBlock {
+	return schema.SingleNestedBlock{
+		Description: "AWS authentication credentials used for accessing AWS services. If omitted, the system's default credentials are used (for example, the IAM role and environment variables).",
+		Attributes: map[string]schema.Attribute{
+			"assume_role": schema.StringAttribute{
+				Optional:    true,
+				Description: "The Amazon Resource Name (ARN) of the role to assume.",
+			},
+			"external_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "A unique identifier for cross-account role assumption.",
+			},
+			"session_name": schema.StringAttribute{
+				Optional:    true,
+				Description: "A session identifier used for logging and tracing the assumed role session.",
+			},
+		},
+	}
+}

--- a/datadog/fwprovider/resource_datadog_observability_pipeline.go
+++ b/datadog/fwprovider/resource_datadog_observability_pipeline.go
@@ -88,10 +88,10 @@ type kafkaSourceSaslModel struct {
 }
 
 type amazonS3SourceModel struct {
-	Id     types.String  `tfsdk:"id"`     // Unique identifier for the component
-	Region types.String  `tfsdk:"region"` // AWS region where the S3 bucket resides
-	Auth   *awsAuthModel `tfsdk:"auth"`   // AWS authentication credentials
-	Tls    *tlsModel     `tfsdk:"tls"`    // TLS encryption configuration
+	Id     types.String                         `tfsdk:"id"`     // Unique identifier for the component
+	Region types.String                         `tfsdk:"region"` // AWS region where the S3 bucket resides
+	Auth   *observability_pipeline.AwsAuthModel `tfsdk:"auth"`   // AWS authentication credentials
+	Tls    *tlsModel                            `tfsdk:"tls"`    // TLS encryption configuration
 }
 
 type tlsModel struct {
@@ -585,15 +585,9 @@ type sumoLogicSourceModel struct {
 }
 
 type amazonDataFirehoseSourceModel struct {
-	Id   types.String  `tfsdk:"id"`
-	Auth *awsAuthModel `tfsdk:"auth"`
-	Tls  *tlsModel     `tfsdk:"tls"`
-}
-
-type awsAuthModel struct {
-	AssumeRole  types.String `tfsdk:"assume_role"`
-	ExternalId  types.String `tfsdk:"external_id"`
-	SessionName types.String `tfsdk:"session_name"`
+	Id   types.String                         `tfsdk:"id"`
+	Auth *observability_pipeline.AwsAuthModel `tfsdk:"auth"`
+	Tls  *tlsModel                            `tfsdk:"tls"`
 }
 
 type httpClientSourceModel struct {
@@ -3667,17 +3661,10 @@ func expandAmazonS3Source(src *amazonS3SourceModel) datadogV2.ObservabilityPipel
 	s.SetRegion(src.Region.ValueString())
 
 	if src.Auth != nil {
-		auth := datadogV2.ObservabilityPipelineAwsAuth{}
-		if !src.Auth.AssumeRole.IsNull() {
-			auth.SetAssumeRole(src.Auth.AssumeRole.ValueString())
+		auth := observability_pipeline.ExpandAwsAuth(src.Auth)
+		if auth != nil {
+			s.SetAuth(*auth)
 		}
-		if !src.Auth.ExternalId.IsNull() {
-			auth.SetExternalId(src.Auth.ExternalId.ValueString())
-		}
-		if !src.Auth.SessionName.IsNull() {
-			auth.SetSessionName(src.Auth.SessionName.ValueString())
-		}
-		s.SetAuth(auth)
 	}
 
 	if src.Tls != nil {
@@ -3699,12 +3686,8 @@ func flattenAmazonS3Source(src *datadogV2.ObservabilityPipelineAmazonS3Source) *
 		Region: types.StringValue(src.GetRegion()),
 	}
 
-	if src.Auth != nil {
-		out.Auth = &awsAuthModel{
-			AssumeRole:  types.StringPointerValue(src.Auth.AssumeRole),
-			ExternalId:  types.StringPointerValue(src.Auth.ExternalId),
-			SessionName: types.StringPointerValue(src.Auth.SessionName),
-		}
+	if auth, ok := src.GetAuthOk(); ok {
+		out.Auth = observability_pipeline.FlattenAwsAuth(auth)
 	}
 
 	if src.Tls != nil {
@@ -4289,17 +4272,10 @@ func expandAmazonDataFirehoseSource(src *amazonDataFirehoseSourceModel) datadogV
 	firehose.SetId(src.Id.ValueString())
 
 	if src.Auth != nil {
-		auth := datadogV2.ObservabilityPipelineAwsAuth{}
-		if !src.Auth.AssumeRole.IsNull() {
-			auth.SetAssumeRole(src.Auth.AssumeRole.ValueString())
+		auth := observability_pipeline.ExpandAwsAuth(src.Auth)
+		if auth != nil {
+			firehose.SetAuth(*auth)
 		}
-		if !src.Auth.ExternalId.IsNull() {
-			auth.SetExternalId(src.Auth.ExternalId.ValueString())
-		}
-		if !src.Auth.SessionName.IsNull() {
-			auth.SetSessionName(src.Auth.SessionName.ValueString())
-		}
-		firehose.SetAuth(auth)
 	}
 
 	if src.Tls != nil {
@@ -4320,12 +4296,8 @@ func flattenAmazonDataFirehoseSource(src *datadogV2.ObservabilityPipelineAmazonD
 		Id: types.StringValue(src.GetId()),
 	}
 
-	if src.Auth != nil {
-		out.Auth = &awsAuthModel{
-			AssumeRole:  types.StringPointerValue(src.Auth.AssumeRole),
-			ExternalId:  types.StringPointerValue(src.Auth.ExternalId),
-			SessionName: types.StringPointerValue(src.Auth.SessionName),
-		}
+	if auth, ok := src.GetAuthOk(); ok {
+		out.Auth = observability_pipeline.FlattenAwsAuth(auth)
 	}
 
 	if src.Tls != nil {

--- a/datadog/fwprovider/resource_datadog_observability_pipeline.go
+++ b/datadog/fwprovider/resource_datadog_observability_pipeline.go
@@ -287,22 +287,22 @@ type fieldValue struct {
 // Destination models
 
 type destinationsModel struct {
-	DatadogLogsDestination        []*datadogLogsDestinationModel                   `tfsdk:"datadog_logs"`
-	GoogleCloudStorageDestination []*gcsDestinationModel                           `tfsdk:"google_cloud_storage"`
-	SplunkHecDestination          []*splunkHecDestinationModel                     `tfsdk:"splunk_hec"`
-	SumoLogicDestination          []*sumoLogicDestinationModel                     `tfsdk:"sumo_logic"`
-	RsyslogDestination            []*rsyslogDestinationModel                       `tfsdk:"rsyslog"`
-	SyslogNgDestination           []*syslogNgDestinationModel                      `tfsdk:"syslog_ng"`
-	ElasticsearchDestination      []*elasticsearchDestinationModel                 `tfsdk:"elasticsearch"`
-	AzureStorageDestination       []*azureStorageDestinationModel                  `tfsdk:"azure_storage"`
-	MicrosoftSentinelDestination  []*microsoftSentinelDestinationModel             `tfsdk:"microsoft_sentinel"`
-	GoogleChronicleDestination    []*googleChronicleDestinationModel               `tfsdk:"google_chronicle"`
-	NewRelicDestination           []*newRelicDestinationModel                      `tfsdk:"new_relic"`
-	SentinelOneDestination        []*sentinelOneDestinationModel                   `tfsdk:"sentinel_one"`
-	OpenSearchDestination         []*opensearchDestinationModel                    `tfsdk:"opensearch"`
-	AmazonOpenSearchDestination   []*amazonOpenSearchDestinationModel              `tfsdk:"amazon_opensearch"`
-	SocketDestination             []*observability_pipeline.SocketDestinationModel `tfsdk:"socket"`
-	AmazonS3Destination           []*amazonS3DestinationModel                      `tfsdk:"amazon_s3"`
+	DatadogLogsDestination        []*datadogLogsDestinationModel                     `tfsdk:"datadog_logs"`
+	GoogleCloudStorageDestination []*gcsDestinationModel                             `tfsdk:"google_cloud_storage"`
+	SplunkHecDestination          []*splunkHecDestinationModel                       `tfsdk:"splunk_hec"`
+	SumoLogicDestination          []*sumoLogicDestinationModel                       `tfsdk:"sumo_logic"`
+	RsyslogDestination            []*rsyslogDestinationModel                         `tfsdk:"rsyslog"`
+	SyslogNgDestination           []*syslogNgDestinationModel                        `tfsdk:"syslog_ng"`
+	ElasticsearchDestination      []*elasticsearchDestinationModel                   `tfsdk:"elasticsearch"`
+	AzureStorageDestination       []*azureStorageDestinationModel                    `tfsdk:"azure_storage"`
+	MicrosoftSentinelDestination  []*microsoftSentinelDestinationModel               `tfsdk:"microsoft_sentinel"`
+	GoogleChronicleDestination    []*googleChronicleDestinationModel                 `tfsdk:"google_chronicle"`
+	NewRelicDestination           []*newRelicDestinationModel                        `tfsdk:"new_relic"`
+	SentinelOneDestination        []*sentinelOneDestinationModel                     `tfsdk:"sentinel_one"`
+	OpenSearchDestination         []*opensearchDestinationModel                      `tfsdk:"opensearch"`
+	AmazonOpenSearchDestination   []*amazonOpenSearchDestinationModel                `tfsdk:"amazon_opensearch"`
+	SocketDestination             []*observability_pipeline.SocketDestinationModel   `tfsdk:"socket"`
+	AmazonS3Destination           []*observability_pipeline.AmazonS3DestinationModel `tfsdk:"amazon_s3"`
 }
 
 type amazonOpenSearchDestinationModel struct {
@@ -310,16 +310,6 @@ type amazonOpenSearchDestinationModel struct {
 	Inputs    types.List                 `tfsdk:"inputs"`
 	BulkIndex types.String               `tfsdk:"bulk_index"`
 	Auth      *amazonOpenSearchAuthModel `tfsdk:"auth"`
-}
-
-type amazonS3DestinationModel struct {
-	Id           types.String  `tfsdk:"id"`
-	Inputs       types.List    `tfsdk:"inputs"`
-	Bucket       types.String  `tfsdk:"bucket"`
-	Region       types.String  `tfsdk:"region"`
-	KeyPrefix    types.String  `tfsdk:"key_prefix"`
-	StorageClass types.String  `tfsdk:"storage_class"`
-	Auth         *awsAuthModel `tfsdk:"auth"`
 }
 
 type amazonOpenSearchAuthModel struct {
@@ -2267,61 +2257,8 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 									},
 								},
 							},
-							"socket": observability_pipeline.SocketDestinationSchema(),
-							"amazon_s3": schema.ListNestedBlock{
-								Description: "The `amazon_s3` destination sends your logs in Datadog-rehydratable format to an Amazon S3 bucket for archiving.",
-								NestedObject: schema.NestedBlockObject{
-									Attributes: map[string]schema.Attribute{
-										"id": schema.StringAttribute{
-											Required:    true,
-											Description: "Unique identifier for the destination component.",
-										},
-										"inputs": schema.ListAttribute{
-											Required:    true,
-											ElementType: types.StringType,
-											Description: "A list of component IDs whose output is used as the `input` for this component.",
-										},
-										"bucket": schema.StringAttribute{
-											Required:    true,
-											Description: "S3 bucket name.",
-										},
-										"region": schema.StringAttribute{
-											Required:    true,
-											Description: "AWS region of the S3 bucket.",
-										},
-										"key_prefix": schema.StringAttribute{
-											Required:    true,
-											Description: "Prefix for object keys.",
-										},
-										"storage_class": schema.StringAttribute{
-											Required:    true,
-											Description: "S3 storage class.",
-											Validators: []validator.String{
-												stringvalidator.OneOf("STANDARD", "REDUCED_REDUNDANCY", "INTELLIGENT_TIERING", "STANDARD_IA", "EXPRESS_ONEZONE", "ONEZONE_IA", "GLACIER", "GLACIER_IR", "DEEP_ARCHIVE"),
-											},
-										},
-									},
-									Blocks: map[string]schema.Block{
-										"auth": schema.SingleNestedBlock{
-											Description: "AWS authentication credentials used for accessing AWS services such as S3. If omitted, the system's default credentials are used (for example, the IAM role and environment variables).",
-											Attributes: map[string]schema.Attribute{
-												"assume_role": schema.StringAttribute{
-													Optional:    true,
-													Description: "The Amazon Resource Name (ARN) of the role to assume.",
-												},
-												"external_id": schema.StringAttribute{
-													Optional:    true,
-													Description: "A unique identifier for cross-account role assumption.",
-												},
-												"session_name": schema.StringAttribute{
-													Optional:    true,
-													Description: "A session identifier used for logging and tracing the assumed role session.",
-												},
-											},
-										},
-									},
-								},
-							},
+							"socket":    observability_pipeline.SocketDestinationSchema(),
+							"amazon_s3": observability_pipeline.AmazonS3DestinationSchema(),
 						},
 					},
 				},
@@ -2624,7 +2561,7 @@ func expandPipeline(ctx context.Context, state *observabilityPipelineModel) (*da
 		config.Destinations = append(config.Destinations, observability_pipeline.ExpandSocketDestination(ctx, d))
 	}
 	for _, d := range state.Config.Destinations.AmazonS3Destination {
-		config.Destinations = append(config.Destinations, expandAmazonS3Destination(ctx, d))
+		config.Destinations = append(config.Destinations, observability_pipeline.ExpandAmazonS3Destination(ctx, d))
 	}
 
 	attrs.SetConfig(*config)
@@ -2811,7 +2748,7 @@ func flattenPipeline(ctx context.Context, state *observabilityPipelineModel, res
 		if d := observability_pipeline.FlattenSocketDestination(ctx, d.ObservabilityPipelineSocketDestination); d != nil {
 			outCfg.Destinations.SocketDestination = append(outCfg.Destinations.SocketDestination, d)
 		}
-		if d := flattenAmazonS3Destination(ctx, d.ObservabilityPipelineAmazonS3Destination); d != nil {
+		if d := observability_pipeline.FlattenAmazonS3Destination(ctx, d.ObservabilityPipelineAmazonS3Destination); d != nil {
 			outCfg.Destinations.AmazonS3Destination = append(outCfg.Destinations.AmazonS3Destination, d)
 		}
 
@@ -5075,70 +5012,4 @@ func expandDatadogTagsProcessor(ctx context.Context, src *observability_pipeline
 
 func flattenDatadogTagsProcessor(ctx context.Context, src *datadogV2.ObservabilityPipelineDatadogTagsProcessor) *observability_pipeline.DatadogTagsProcessorModel {
 	return observability_pipeline.FlattenDatadogTagsProcessor(ctx, src)
-}
-
-func expandAmazonS3Destination(ctx context.Context, src *amazonS3DestinationModel) datadogV2.ObservabilityPipelineConfigDestinationItem {
-	dest := datadogV2.NewObservabilityPipelineAmazonS3DestinationWithDefaults()
-	dest.SetId(src.Id.ValueString())
-
-	var inputs []string
-	src.Inputs.ElementsAs(ctx, &inputs, false)
-	dest.SetInputs(inputs)
-
-	dest.SetBucket(src.Bucket.ValueString())
-	dest.SetRegion(src.Region.ValueString())
-
-	if !src.KeyPrefix.IsNull() {
-		dest.SetKeyPrefix(src.KeyPrefix.ValueString())
-	}
-
-	dest.SetStorageClass(datadogV2.ObservabilityPipelineAmazonS3DestinationStorageClass(src.StorageClass.ValueString()))
-
-	if src.Auth != nil {
-		auth := datadogV2.ObservabilityPipelineAwsAuth{}
-		if !src.Auth.AssumeRole.IsNull() {
-			auth.AssumeRole = src.Auth.AssumeRole.ValueStringPointer()
-		}
-		if !src.Auth.ExternalId.IsNull() {
-			auth.ExternalId = src.Auth.ExternalId.ValueStringPointer()
-		}
-		if !src.Auth.SessionName.IsNull() {
-			auth.SessionName = src.Auth.SessionName.ValueStringPointer()
-		}
-		dest.SetAuth(auth)
-	}
-
-	return datadogV2.ObservabilityPipelineConfigDestinationItem{
-		ObservabilityPipelineAmazonS3Destination: dest,
-	}
-}
-
-func flattenAmazonS3Destination(ctx context.Context, src *datadogV2.ObservabilityPipelineAmazonS3Destination) *amazonS3DestinationModel {
-	if src == nil {
-		return nil
-	}
-
-	inputs, _ := types.ListValueFrom(ctx, types.StringType, src.GetInputs())
-
-	model := &amazonS3DestinationModel{
-		Id:           types.StringValue(src.GetId()),
-		Inputs:       inputs,
-		Bucket:       types.StringValue(src.GetBucket()),
-		Region:       types.StringValue(src.GetRegion()),
-		StorageClass: types.StringValue(string(src.GetStorageClass())),
-	}
-
-	if v, ok := src.GetKeyPrefixOk(); ok {
-		model.KeyPrefix = types.StringValue(*v)
-	}
-
-	if auth, ok := src.GetAuthOk(); ok {
-		model.Auth = &awsAuthModel{
-			AssumeRole:  types.StringPointerValue(auth.AssumeRole),
-			ExternalId:  types.StringPointerValue(auth.ExternalId),
-			SessionName: types.StringPointerValue(auth.SessionName),
-		}
-	}
-
-	return model
 }

--- a/datadog/tests/resource_datadog_observability_pipeline_test.go
+++ b/datadog/tests/resource_datadog_observability_pipeline_test.go
@@ -3266,7 +3266,7 @@ resource "datadog_observability_pipeline" "amazon_s3" {
         key_prefix   = "logs/"
         storage_class = "STANDARD"
 
-        		auth {
+        auth {
           assume_role  = "arn:aws:iam::123456789012:role/example-role"
           external_id  = "external-id-123"
           session_name = "s3-session"


### PR DESCRIPTION
Fix - Including the Amazon S3 destination which was already within the API Spec

API Implementation was in this commit https://github.com/DataDog/datadog-api-spec/pull/3807/commits/161e7ffc1dcbe79f385afa7763ade4c261f03555

