### PR TITLE
[datadog_security_notification_rule] Add Host and IaC security notification rule types

### DIFF
--- a/docs/resources/security_monitoring_rule.md
+++ b/docs/resources/security_monitoring_rule.md
@@ -98,7 +98,7 @@ Optional:
 
 Required:
 
-- `type` (String) Type of action to perform when the case triggers. Valid values are `block_ip`, `block_user`, `user_behavior`.
+- `type` (String) Type of action to perform when the case triggers. Valid values are `block_ip`, `block_user`, `user_behavior`, `flag_ip`.
 
 Optional:
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-datadog
 
 require (
-	github.com/DataDog/datadog-api-client-go/v2 v2.43.1-0.20250718145654-5da39b37a83e
+	github.com/DataDog/datadog-api-client-go/v2 v2.43.1-0.20250806202348-95edcab5de53
 	github.com/DataDog/dd-sdk-go-testing v0.0.0-20211116174033-1cd082e322ad
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/datadog-api-client-go/v2 v2.43.1-0.20250718145654-5da39b37a83e h1:g6635RjZdFUX+UHYjSCbcLESdt9nNpBxNgZ55ShY15I=
-github.com/DataDog/datadog-api-client-go/v2 v2.43.1-0.20250718145654-5da39b37a83e/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
+github.com/DataDog/datadog-api-client-go/v2 v2.43.1-0.20250806202348-95edcab5de53 h1:hJOaZlmg+OCgIVUc8TvnQMUCkha7P6sHZhPlRk5T1aQ=
+github.com/DataDog/datadog-api-client-go/v2 v2.43.1-0.20250806202348-95edcab5de53/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=


### PR DESCRIPTION
[SEC-23660] Add host and IaC security notification rule types.

The new rule types are `iac_misconfiguration` and `host_vulnerability`.

Example of a rule using those two rule types:
```resource "datadog_security_notification_rule" "vulnerability_rule" {
  name = "My vulnerability notification rule"
  selectors {
    trigger_source = "security_findings"
    rule_types     = ["iac_misconfiguration", "host_vulnerability"]
    severities     = ["critical", "high"]
  }
  time_aggregation = 36000
  targets          = ["@john@email.com"]
}
```

[SEC-23660]: https://datadoghq.atlassian.net/browse/SEC-23660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ