### PR TITLE
[workflow_automation] Clean up state if workflow not found

### DIFF
--- a/datadog/fwprovider/data_source_datadog_workflow_automation.go
+++ b/datadog/fwprovider/data_source_datadog_workflow_automation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"sort"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
@@ -90,8 +91,14 @@ func (d *workflowAutomationDatasource) Read(ctx context.Context, request datasou
 		return
 	}
 
-	readResp, err := readWorkflow(d.Auth, d.Api, state.ID.ValueString())
+	readResp, err, httpStatusCode := readWorkflow(d.Auth, d.Api, state.ID.ValueString())
 	if err != nil {
+		if httpStatusCode == http.StatusNotFound {
+			// If the workflow is not found, we log a warning and remove the resource from state. This may be due to changes in the UI.
+			response.Diagnostics.AddWarning("The workflow with ID '"+state.ID.ValueString()+"' is not found. It may have been deleted outside of Terraform.", err.Error())
+			response.State.RemoveResource(ctx)
+			return
+		}
 		response.Diagnostics.AddError("Could not read workflow", err.Error())
 		return
 	}

--- a/datadog/fwprovider/resource_datadog_workflow_automation.go
+++ b/datadog/fwprovider/resource_datadog_workflow_automation.go
@@ -146,8 +146,15 @@ func (r *workflowAutomationResource) Read(ctx context.Context, request resource.
 		return
 	}
 
-	readResp, err := readWorkflow(r.Auth, r.Api, state.ID.ValueString())
+	readResp, err, httpStatusCode := readWorkflow(r.Auth, r.Api, state.ID.ValueString())
 	if err != nil {
+		if httpStatusCode == http.StatusNotFound {
+			// If the workflow is not found, we log a warning and remove the resource from state. This may be due to changes in the UI.
+			response.Diagnostics.AddWarning("The workflow with ID '"+state.ID.ValueString()+"' is not found. It may have been deleted outside of Terraform.", err.Error())
+			response.State.RemoveResource(ctx)
+			return
+		}
+
 		response.Diagnostics.AddError("Could not read workflow", err.Error())
 		return
 	}
@@ -317,22 +324,22 @@ func apiResponseToWorkflowAutomationResourceModel(workflow *datadogV2.GetWorkflo
 }
 
 // Read logic is shared between data source and resource
-func readWorkflow(authCtx context.Context, api *datadogV2.WorkflowAutomationApi, id string) (*datadogV2.GetWorkflowResponse, error) {
+func readWorkflow(authCtx context.Context, api *datadogV2.WorkflowAutomationApi, id string) (*datadogV2.GetWorkflowResponse, error, int) {
 	workflow, httpResponse, err := api.GetWorkflow(authCtx, id)
 	if err != nil {
 		if httpResponse != nil {
 			body, err := io.ReadAll(httpResponse.Body)
 			if err != nil {
-				return nil, fmt.Errorf("could not read error response")
+				return nil, fmt.Errorf("could not read error response"), httpResponse.StatusCode
 			}
-			return nil, fmt.Errorf("%s", body)
+			return nil, fmt.Errorf("%s", body), httpResponse.StatusCode
 		}
-		return nil, err
+		return nil, err, httpResponse.StatusCode
 	}
 
 	if _, ok := workflow.GetDataOk(); !ok {
-		return nil, fmt.Errorf("workflow not found")
+		return nil, fmt.Errorf("workflow not found"), httpResponse.StatusCode
 	}
 
-	return &workflow, nil
+	return &workflow, nil, httpResponse.StatusCode
 }


### PR DESCRIPTION
This is a common practice for terraform resources / data sources. It was a miss on my part when I made this resource. We need to be cleaning up from our state when we receive not found so we don't lock the user out of using Terraform. 