### PR TITLE
[datadog_on_call_team_routing_rules] Fix incorrect comment in import section of the documentation

### DIFF
--- a/docs/resources/on_call_team_routing_rules.md
+++ b/docs/resources/on_call_team_routing_rules.md
@@ -120,6 +120,6 @@ Import is supported using the following syntax:
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-# Import an existing on_call_schedule
+# Import existing on_call_team_routing_rules
 terraform import datadog_on_call_team_routing_rules.test "b03a07d5-49da-43e9-83b4-5d84969b588b"
 ```

--- a/examples/resources/datadog_on_call_team_routing_rules/import.sh
+++ b/examples/resources/datadog_on_call_team_routing_rules/import.sh
@@ -1,2 +1,2 @@
-# Import an existing on_call_schedule
+# Import an existing on_call_team_routing_rules
 terraform import datadog_on_call_team_routing_rules.test "b03a07d5-49da-43e9-83b4-5d84969b588b"


### PR DESCRIPTION
There's a typo in the Terraform provider documentation for [datadog_on_call_team_routing_rules](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/on_call_team_routing_rules). 

In the Import section, the comment currently says: `# Import an existing on_call_schedule`

This comment appears to be a copy-paste from the `on_call_schedule` resource and should refer to `on_call_team_routing_rules` instead.
