### PR TITLE
[provider] Use latest stable terraform/opentofu in CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -22,7 +22,7 @@ body:
     attributes:
       label: Terraform Version
       description: Run `terraform -v` to show the version of the terraform cli.
-      placeholder: ex. v1.5.3
+      placeholder: ex. v1.13.1
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
           - "0.14.11"
           - "0.15.5"
           - "1.1.2"
-          - "1.5.3"
+          - "1.13.1"
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}
@@ -109,7 +109,7 @@ jobs:
           cache: true
       - uses: opentofu/setup-opentofu@592200bd4b9bbf4772ace78f887668b1aee8f716 # v1.0.5
         with:
-          tofu_version: 1.6.3
+          tofu_version: 1.10.5
           tofu_wrapper: false        
       - name: Set Terraform env vars
         run: |

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TERRAFORM_VERSION: "1.5.3"
+  TERRAFORM_VERSION: "1.13.1"
 
 jobs:
   integration_tests:


### PR DESCRIPTION
Bumps the version of terraform and opentofu executables used in CI for tests and integration tests to latest currently available.

The github required checks should also be updated once this is ok.