### PR TITLE
[datadog_role] Add permissions attribute to datadog_role data source

### DIFF
--- a/datadog/tests/data_source_datadog_role_test.go
+++ b/datadog/tests/data_source_datadog_role_test.go
@@ -19,7 +19,10 @@ func TestAccDatadogRoleDatasource(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatasourceRoleConfig(),
-				Check:  resource.TestCheckResourceAttr("data.datadog_role.foo", "name", "Datadog Standard Role"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.datadog_role.foo", "name", "Datadog Standard Role"),
+					resource.TestCheckResourceAttrSet("data.datadog_role.foo", "permissions.#"),
+				),
 			},
 		},
 	})
@@ -44,7 +47,10 @@ func TestAccDatadogRoleDatasourceExactMatch(t *testing.T) {
 			},
 			{
 				Config: testAccDatasourceRoleExactMatchConfig(rolename),
-				Check:  resource.TestCheckResourceAttr("data.datadog_role.exact_match", "name", rolename+" main"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.datadog_role.exact_match", "name", rolename+" main"),
+					resource.TestCheckResourceAttrSet("data.datadog_role.exact_match", "permissions.#"),
+				),
 			},
 		},
 	})

--- a/docs/data-sources/role.md
+++ b/docs/data-sources/role.md
@@ -29,4 +29,5 @@ data "datadog_role" "test" {
 
 - `id` (String) The ID of this resource.
 - `name` (String) Name of the role.
+- `permissions` (Map of String) Map of permissions granted to this role, keyed by permission name and returning the permission ID.
 - `user_count` (Number) Number of users assigned to this role.


### PR DESCRIPTION
This PR extends the `datadog_role` data source to include a `permissions` attribute that returns all permissions associated with a role. The permissions are returned as a map (name → ID), consistent with the `datadog_permissions` data source format. This enhancement enables users to programmatically inherit permissions from existing roles when creating custom roles, rather than manually maintaining permission lists.

If preferable this can be made into a different datasource all_together (i.e. `datadog_role_permissions`)

Example:

```hcl
# Get all available permissions to look up IDs by name
data "datadog_permissions" "all" {}

# Get the existing "Datadog Read Only" role and its permissions
data "datadog_role" "readonly" {
  filter = "Datadog Read Only"
}

# Create a custom role that inherits all read permissions plus adds write access for notebooks and dashboards
resource "datadog_role" "custom_analyst" {
  name        = "Custom Analyst"
  description = "Read-only access plus dashboard and notebook write permissions"
  
  default_permissions_opt_out = true

  dynamic "permission" {
    for_each = data.datadog_role.readonly.permissions
    content {
      id = permission.value
    }
  }

  permission {
    id = data.datadog_permissions.all.permissions["dashboards_write"]
  }
  
  permission {
    id = data.datadog_permissions.all.permissions["notebooks_write"]
  }
}
```

Without this feature, users have to manually enumerate every single permission ID from the base role, which is error-prone and difficult to maintain as permissions change over time.
