### PR TITLE
feat: add write-only argument helpers

### DIFF
--- a/datadog/internal/fwutils/writeonly_helpers.go
+++ b/datadog/internal/fwutils/writeonly_helpers.go
@@ -1,0 +1,209 @@
+package fwutils
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	frameworkPath "github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// MergeAttributes combines multiple attribute maps into a single map.
+// Later maps take precedence over earlier ones for duplicate keys.
+func MergeAttributes(attributeMaps ...map[string]schema.Attribute) map[string]schema.Attribute {
+	result := make(map[string]schema.Attribute)
+	for _, attrs := range attributeMaps {
+		for key, attr := range attrs {
+			result[key] = attr
+		}
+	}
+	return result
+}
+
+// WriteOnlySecretConfig configures a secret attribute that supports both modes:
+// - Plaintext mode: for Terraform <1.11 or users preferring state storage
+// - Write-only mode: for Terraform 1.11+ with secrets not stored in state
+type WriteOnlySecretConfig struct {
+	OriginalAttr         string // Plaintext attribute (e.g., "secret_key")
+	WriteOnlyAttr        string // Write-only attribute (e.g., "secret_key_wo")
+	TriggerAttr          string // Version trigger (e.g., "secret_key_wo_version")
+	OriginalDescription  string
+	WriteOnlyDescription string
+	TriggerDescription   string
+}
+
+// CreateWriteOnlySecretAttributes generates three attributes for dual-mode secret support:
+// 1. Original attr (plaintext) - for TF <1.11 or backwards compatibility
+// 2. Write-only attr - for TF 1.11+ (not stored in state)
+// 3. Version trigger - when changed, applies the write-only secret
+// Users choose one mode via ExactlyOneOf validator.
+func CreateWriteOnlySecretAttributes(config WriteOnlySecretConfig) map[string]schema.Attribute {
+	attrs := map[string]schema.Attribute{
+		config.OriginalAttr: schema.StringAttribute{
+			Optional:    true,
+			Description: config.OriginalDescription,
+			Sensitive:   true,
+			Validators: []validator.String{
+				stringvalidator.ExactlyOneOf(
+					frameworkPath.MatchRoot(config.OriginalAttr),
+					frameworkPath.MatchRoot(config.WriteOnlyAttr),
+				),
+				stringvalidator.PreferWriteOnlyAttribute(
+					frameworkPath.MatchRoot(config.WriteOnlyAttr),
+				),
+			},
+		},
+		config.WriteOnlyAttr: schema.StringAttribute{
+			Optional:    true,
+			Description: config.WriteOnlyDescription,
+			Sensitive:   true,
+			WriteOnly:   true,
+			Validators: []validator.String{
+				stringvalidator.ExactlyOneOf(
+					frameworkPath.MatchRoot(config.OriginalAttr),
+					frameworkPath.MatchRoot(config.WriteOnlyAttr),
+				),
+				stringvalidator.AlsoRequires(
+					frameworkPath.MatchRoot(config.TriggerAttr),
+				),
+			},
+		},
+		config.TriggerAttr: schema.StringAttribute{
+			Optional:    true,
+			Description: config.TriggerDescription,
+			Validators: []validator.String{
+				stringvalidator.LengthAtLeast(1),
+				stringvalidator.AlsoRequires(frameworkPath.Expressions{
+					frameworkPath.MatchRoot(config.WriteOnlyAttr),
+				}...),
+			},
+		},
+	}
+
+	return attrs
+}
+
+// SecretResult contains the result of secret retrieval from either write-only or plaintext attributes.
+type SecretResult struct {
+	// Value contains the secret value (from write-only OR plaintext attribute).
+	// Only valid when ShouldSetValue is true.
+	Value string
+
+	// ShouldSetValue indicates whether the caller should set the secret field.
+	// True when a value was found (handles empty string as valid value).
+	// False when no value found or when omitting for partial update.
+	ShouldSetValue bool
+
+	Diagnostics diag.Diagnostics
+}
+
+// WriteOnlySecretHandler manages secret retrieval for both plaintext and write-only modes
+type WriteOnlySecretHandler struct {
+	Config                 WriteOnlySecretConfig
+	SecretRequiredOnUpdate bool // If true, API requires secret in every update; if false (default), secret is optional
+}
+
+// GetSecretForCreate retrieves secret for resource creation.
+// Checks write-only attribute first, then falls back to plaintext attribute.
+// Returns ShouldSetValue=true if either attribute has a value.
+func (h *WriteOnlySecretHandler) GetSecretForCreate(ctx context.Context, config *tfsdk.Config) SecretResult {
+	result := SecretResult{}
+
+	// Check write-only attribute first (only exists in config, never in plan/state)
+	var writeOnlySecret types.String
+	result.Diagnostics.Append(config.GetAttribute(ctx, frameworkPath.Root(h.Config.WriteOnlyAttr), &writeOnlySecret)...)
+	if result.Diagnostics.HasError() {
+		return result
+	}
+
+	if !writeOnlySecret.IsNull() && !writeOnlySecret.IsUnknown() {
+		result.Value = writeOnlySecret.ValueString()
+		result.ShouldSetValue = true
+		return result
+	}
+
+	// Fall back to plaintext attribute
+	var plaintextSecret types.String
+	result.Diagnostics.Append(config.GetAttribute(ctx, frameworkPath.Root(h.Config.OriginalAttr), &plaintextSecret)...)
+	if result.Diagnostics.HasError() {
+		return result
+	}
+
+	if !plaintextSecret.IsNull() && !plaintextSecret.IsUnknown() {
+		result.Value = plaintextSecret.ValueString()
+		result.ShouldSetValue = true
+	}
+
+	return result
+}
+
+// GetSecretForUpdate retrieves secret for resource updates, with behavior based on SecretRequiredOnUpdate.
+//
+// When SecretRequiredOnUpdate is false (default):
+//   - Pattern 1: API supports partial updates (secret is optional)
+//   - For write-only: returns ShouldSetValue=true ONLY if version trigger changed
+//   - If version unchanged: returns ShouldSetValue=false (omit for partial update)
+//   - For plaintext: returns ShouldSetValue=true if plaintext attr is set
+//
+// When SecretRequiredOnUpdate is true:
+//   - Pattern 2: API requires secret in every update request
+//   - Returns ShouldSetValue=true if write-only or plaintext attr exists in config
+//   - Version trigger only matters for forcing Terraform to detect a change
+func (h *WriteOnlySecretHandler) GetSecretForUpdate(ctx context.Context, config *tfsdk.Config, req *resource.UpdateRequest) SecretResult {
+	result := SecretResult{}
+
+	// Check if write-only secret is present in config
+	var writeOnlySecret types.String
+	result.Diagnostics.Append(config.GetAttribute(ctx, frameworkPath.Root(h.Config.WriteOnlyAttr), &writeOnlySecret)...)
+	if result.Diagnostics.HasError() {
+		return result
+	}
+
+	// If write-only is set, handle based on SecretRequiredOnUpdate and version trigger
+	if !writeOnlySecret.IsNull() && !writeOnlySecret.IsUnknown() {
+		if h.SecretRequiredOnUpdate {
+			// Pattern 2: API requires secret on every update
+			result.Value = writeOnlySecret.ValueString()
+			result.ShouldSetValue = true
+			return result
+		}
+
+		// Pattern 1: API supports partial updates
+		// Only return secret if version trigger changed
+		var planVersion, priorVersion types.String
+		result.Diagnostics.Append(req.Plan.GetAttribute(ctx, frameworkPath.Root(h.Config.TriggerAttr), &planVersion)...)
+		result.Diagnostics.Append(req.State.GetAttribute(ctx, frameworkPath.Root(h.Config.TriggerAttr), &priorVersion)...)
+		if result.Diagnostics.HasError() {
+			return result
+		}
+
+		// Version unchanged = omit secret for partial update
+		if planVersion.Equal(priorVersion) {
+			return result // ShouldSetValue=false
+		}
+
+		// Version changed - return secret for rotation
+		result.Value = writeOnlySecret.ValueString()
+		result.ShouldSetValue = true
+		return result
+	}
+
+	// Fall back to plaintext attribute
+	var plaintextSecret types.String
+	result.Diagnostics.Append(config.GetAttribute(ctx, frameworkPath.Root(h.Config.OriginalAttr), &plaintextSecret)...)
+	if result.Diagnostics.HasError() {
+		return result
+	}
+
+	if !plaintextSecret.IsNull() && !plaintextSecret.IsUnknown() {
+		result.Value = plaintextSecret.ValueString()
+		result.ShouldSetValue = true
+	}
+
+	return result
+}

--- a/datadog/internal/fwutils/writeonly_helpers_test.go
+++ b/datadog/internal/fwutils/writeonly_helpers_test.go
@@ -1,0 +1,302 @@
+package fwutils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func testWriteOnlySchema() schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"api_key": schema.StringAttribute{
+				Optional:  true,
+				Sensitive: true,
+			},
+			"api_key_wo": schema.StringAttribute{
+				Optional:  true,
+				Sensitive: true,
+				WriteOnly: true,
+			},
+			"api_key_wo_version": schema.StringAttribute{
+				Optional: true,
+			},
+		},
+	}
+}
+
+func ptr(s string) *string { return &s }
+
+func makeConfigValue(apiKey, apiKeyWo *string) tftypes.Value {
+	apiKeyVal := tftypes.NewValue(tftypes.String, nil)
+	if apiKey != nil {
+		apiKeyVal = tftypes.NewValue(tftypes.String, *apiKey)
+	}
+	apiKeyWoVal := tftypes.NewValue(tftypes.String, nil)
+	if apiKeyWo != nil {
+		apiKeyWoVal = tftypes.NewValue(tftypes.String, *apiKeyWo)
+	}
+	return tftypes.NewValue(tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"api_key":            tftypes.String,
+			"api_key_wo":         tftypes.String,
+			"api_key_wo_version": tftypes.String,
+		},
+	}, map[string]tftypes.Value{
+		"api_key":            apiKeyVal,
+		"api_key_wo":         apiKeyWoVal,
+		"api_key_wo_version": tftypes.NewValue(tftypes.String, nil),
+	})
+}
+
+func makeVersionValue(version *string) tftypes.Value {
+	versionVal := tftypes.NewValue(tftypes.String, nil)
+	if version != nil {
+		versionVal = tftypes.NewValue(tftypes.String, *version)
+	}
+	return tftypes.NewValue(tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"api_key_wo_version": tftypes.String,
+		},
+	}, map[string]tftypes.Value{
+		"api_key_wo_version": versionVal,
+	})
+}
+
+func TestCreateWriteOnlySecretAttributes(t *testing.T) {
+	config := WriteOnlySecretConfig{
+		OriginalAttr:         "api_key",
+		WriteOnlyAttr:        "api_key_wo",
+		TriggerAttr:          "api_key_wo_version",
+		OriginalDescription:  "The API key for the account.",
+		WriteOnlyDescription: "Write-only API key for the account.",
+		TriggerDescription:   "Version for api_key_wo rotation.",
+	}
+
+	attrs := CreateWriteOnlySecretAttributes(config)
+
+	if len(attrs) != 3 {
+		t.Errorf("expected 3 attributes, got %d", len(attrs))
+	}
+
+	// Verify api_key properties
+	apiKey := attrs["api_key"].(schema.StringAttribute)
+	if !apiKey.Optional || !apiKey.Sensitive || apiKey.WriteOnly {
+		t.Error("api_key: expected Optional=true, Sensitive=true, WriteOnly=false")
+	}
+	if len(apiKey.Validators) != 2 {
+		t.Errorf("api_key should have 2 validators, got %d", len(apiKey.Validators))
+	}
+
+	// Verify api_key_wo properties
+	apiKeyWo := attrs["api_key_wo"].(schema.StringAttribute)
+	if !apiKeyWo.Optional || !apiKeyWo.Sensitive || !apiKeyWo.WriteOnly {
+		t.Error("api_key_wo: expected Optional=true, Sensitive=true, WriteOnly=true")
+	}
+	if len(apiKeyWo.Validators) != 2 {
+		t.Errorf("api_key_wo should have 2 validators, got %d", len(apiKeyWo.Validators))
+	}
+
+	// Verify api_key_wo_version properties
+	version := attrs["api_key_wo_version"].(schema.StringAttribute)
+	if !version.Optional || version.Sensitive {
+		t.Error("api_key_wo_version: expected Optional=true, Sensitive=false")
+	}
+	if len(version.Validators) != 2 {
+		t.Errorf("api_key_wo_version should have 2 validators, got %d", len(version.Validators))
+	}
+}
+
+func TestGetSecretForCreate(t *testing.T) {
+	tests := []struct {
+		name          string
+		apiKey        *string
+		apiKeyWo      *string
+		wantShouldSet bool
+		wantValue     string
+	}{
+		{
+			name:          "write-only mode",
+			apiKeyWo:      ptr("secret123"),
+			wantShouldSet: true,
+			wantValue:     "secret123",
+		},
+		{
+			name:          "plaintext mode",
+			apiKey:        ptr("plaintext_secret"),
+			wantShouldSet: true,
+			wantValue:     "plaintext_secret",
+		},
+		{
+			name:          "no secret",
+			wantShouldSet: false,
+		},
+		{
+			name:          "empty string is valid",
+			apiKey:        ptr(""),
+			wantShouldSet: true,
+			wantValue:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			handler := WriteOnlySecretHandler{
+				Config: WriteOnlySecretConfig{
+					OriginalAttr:  "api_key",
+					WriteOnlyAttr: "api_key_wo",
+					TriggerAttr:   "api_key_wo_version",
+				},
+			}
+
+			tfConfig := tfsdk.Config{
+				Raw:    makeConfigValue(tt.apiKey, tt.apiKeyWo),
+				Schema: testWriteOnlySchema(),
+			}
+
+			result := handler.GetSecretForCreate(ctx, &tfConfig)
+
+			if result.Diagnostics.HasError() {
+				t.Errorf("unexpected error: %v", result.Diagnostics)
+			}
+			if result.ShouldSetValue != tt.wantShouldSet {
+				t.Errorf("ShouldSetValue = %v, want %v", result.ShouldSetValue, tt.wantShouldSet)
+			}
+			if tt.wantShouldSet && result.Value != tt.wantValue {
+				t.Errorf("Value = %q, want %q", result.Value, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestGetSecretForUpdate(t *testing.T) {
+	tests := []struct {
+		name                   string
+		stateVersion           *string
+		planVersion            *string
+		apiKey                 *string
+		apiKeyWo               *string
+		apiKeyWoUnknown        bool
+		secretRequiredOnUpdate bool
+		wantShouldSet          bool
+		wantValue              string
+	}{
+		{
+			name:          "version changed triggers update",
+			stateVersion:  ptr("1"),
+			planVersion:   ptr("2"),
+			apiKeyWo:      ptr("newsecret"),
+			wantShouldSet: true,
+			wantValue:     "newsecret",
+		},
+		{
+			name:          "version unchanged skips update (partial update)",
+			stateVersion:  ptr("1"),
+			planVersion:   ptr("1"),
+			apiKeyWo:      ptr("secret123"),
+			wantShouldSet: false,
+		},
+		{
+			name:          "null to value transition triggers update",
+			stateVersion:  nil,
+			planVersion:   ptr("1"),
+			apiKeyWo:      ptr("newsecret"),
+			wantShouldSet: true,
+			wantValue:     "newsecret",
+		},
+		{
+			name:          "plaintext fallback",
+			stateVersion:  nil,
+			planVersion:   nil,
+			apiKey:        ptr("plaintext_value"),
+			wantShouldSet: true,
+			wantValue:     "plaintext_value",
+		},
+		{
+			name:            "unknown write-only with no plaintext",
+			stateVersion:    ptr("1"),
+			planVersion:     ptr("2"),
+			apiKeyWoUnknown: true,
+			wantShouldSet:   false,
+		},
+		{
+			name:                   "secret required on update ignores version",
+			stateVersion:           ptr("1"),
+			planVersion:            ptr("1"),
+			apiKeyWo:               ptr("secret123"),
+			secretRequiredOnUpdate: true,
+			wantShouldSet:          true,
+			wantValue:              "secret123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			testSchema := testWriteOnlySchema()
+			handler := WriteOnlySecretHandler{
+				Config: WriteOnlySecretConfig{
+					OriginalAttr:  "api_key",
+					WriteOnlyAttr: "api_key_wo",
+					TriggerAttr:   "api_key_wo_version",
+				},
+				SecretRequiredOnUpdate: tt.secretRequiredOnUpdate,
+			}
+
+			priorState := tfsdk.State{
+				Raw:    makeVersionValue(tt.stateVersion),
+				Schema: testSchema,
+			}
+			plan := tfsdk.Plan{
+				Raw:    makeVersionValue(tt.planVersion),
+				Schema: testSchema,
+			}
+
+			// Build config value, handling unknown case
+			var configRaw tftypes.Value
+			if tt.apiKeyWoUnknown {
+				apiKeyVal := tftypes.NewValue(tftypes.String, nil)
+				configRaw = tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"api_key":            tftypes.String,
+						"api_key_wo":         tftypes.String,
+						"api_key_wo_version": tftypes.String,
+					},
+				}, map[string]tftypes.Value{
+					"api_key":            apiKeyVal,
+					"api_key_wo":         tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+					"api_key_wo_version": tftypes.NewValue(tftypes.String, nil),
+				})
+			} else {
+				configRaw = makeConfigValue(tt.apiKey, tt.apiKeyWo)
+			}
+
+			tfConfig := tfsdk.Config{
+				Raw:    configRaw,
+				Schema: testSchema,
+			}
+
+			req := resource.UpdateRequest{
+				State: priorState,
+				Plan:  plan,
+			}
+
+			result := handler.GetSecretForUpdate(ctx, &tfConfig, &req)
+
+			if result.Diagnostics.HasError() {
+				t.Errorf("unexpected error: %v", result.Diagnostics)
+			}
+			if result.ShouldSetValue != tt.wantShouldSet {
+				t.Errorf("ShouldSetValue = %v, want %v", result.ShouldSetValue, tt.wantShouldSet)
+			}
+			if tt.wantShouldSet && result.Value != tt.wantValue {
+				t.Errorf("Value = %q, want %q", result.Value, tt.wantValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[APIR-2172](https://datadoghq.atlassian.net/browse/APIR-2172)

[APIR-2172]: https://datadoghq.atlassian.net/browse/APIR-2172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary
Add reusable helpers for implementing write-only secret attributes in Terraform Provider Framework resources.

## Changes
- `WriteOnlySecretConfig` - Configuration struct for dual-mode secret support (plaintext + write-only)
- `CreateWriteOnlySecretAttributes()` - Generates schema attributes with `ExactlyOneOf` validators and write-only mode
- `WriteOnlySecretHandler` - Manages secret retrieval with two update patterns:
- **Partial updates** (`SecretRequiredOnUpdate=false`): Only sends secret when version trigger changes
- **Full updates** (`SecretRequiredOnUpdate=true`): Always includes secret in API calls
- `SecretResult` - Return type with `Value`, `ShouldSetValue`, and `Diagnostics`

## Test Plan
  - [x] Table-driven tests for `GetSecretForCreate` and `GetSecretForUpdate`
  - [x] Tests cover both `SecretRequiredOnUpdate` modes
  - [x] Tests verify version trigger change detection