### PR TITLE
[datadog_security_monitoring_rule] Defer JSON filtering to Read to fix “inconsistent result after apply”

### DIFF
--- a/datadog/fwprovider/resource_datadog_security_monitoring_rule_json.go
+++ b/datadog/fwprovider/resource_datadog_security_monitoring_rule_json.go
@@ -61,28 +61,26 @@ func (r *securityMonitoringRuleJSONResource) ImportState(ctx context.Context, re
 }
 
 // Helper to recursively filter API response to only user-supplied fields
-func filterToUserFields(user interface{}, api interface{}) interface{} {
+func filterToUserFields(user any, api any) any {
 	switch userVal := user.(type) {
-	case map[string]interface{}:
-		apiMap, ok := api.(map[string]interface{})
+	case map[string]any:
+		apiMap, ok := api.(map[string]any)
 		if !ok {
 			return user
 		}
-		filtered := make(map[string]interface{})
+		filtered := make(map[string]any)
 		for k, v := range userVal {
 			if apiV, ok := apiMap[k]; ok {
 				filtered[k] = filterToUserFields(v, apiV)
-			} else {
-				filtered[k] = v
 			}
 		}
 		return filtered
-	case []interface{}:
-		apiArr, ok := api.([]interface{})
+	case []any:
+		apiArr, ok := api.([]any)
 		if !ok {
 			return user
 		}
-		filteredArr := make([]interface{}, len(userVal))
+		filteredArr := make([]any, len(userVal))
 		for i := range userVal {
 			if i < len(apiArr) {
 				filteredArr[i] = filterToUserFields(userVal[i], apiArr[i])
@@ -167,13 +165,13 @@ func (r *securityMonitoringRuleJSONResource) Read(ctx context.Context, request r
 		return
 	}
 
-	var userRule map[string]interface{}
+	var userRule map[string]any
 	if err := json.Unmarshal([]byte(state.JSON.ValueString()), &userRule); err != nil {
 		response.Diagnostics.AddError("Failed to parse state JSON", err.Error())
 		return
 	}
 
-	var apiRule map[string]interface{}
+	var apiRule map[string]any
 	var jsonBytes []byte
 	if res.SecurityMonitoringStandardRuleResponse != nil {
 		jsonBytes, err = json.Marshal(res.SecurityMonitoringStandardRuleResponse)

--- a/datadog/fwprovider/resource_datadog_security_monitoring_rule_json.go
+++ b/datadog/fwprovider/resource_datadog_security_monitoring_rule_json.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"strings"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -14,30 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 )
-
-func canonicalizeJSONText(s string) (string, error) {
-	var v any
-	if err := json.Unmarshal([]byte(s), &v); err != nil { // parse the JSON TEXT
-		return "", err
-	}
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	if err := enc.Encode(v); err != nil { // encode the OBJECT back to text
-		return "", err
-	}
-	return strings.TrimSpace(buf.String()), nil
-}
-
-func canonicalizeInterface(v any) (string, error) {
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	if err := enc.Encode(v); err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(buf.String()), nil
-}
 
 var (
 	_ resource.ResourceWithConfigure   = &securityMonitoringRuleJSONResource{}
@@ -119,234 +94,118 @@ func filterToUserFields(user interface{}, api interface{}) interface{} {
 	}
 }
 
-func (r *securityMonitoringRuleJSONResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan securityMonitoringRuleJSONModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
+func (r *securityMonitoringRuleJSONResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	var state securityMonitoringRuleJSONModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &state)...)
+	if response.Diagnostics.HasError() {
 		return
 	}
 
-	// Also read the original config (what the user actually typed)
+	// Parse user JSON into a map
 	var cfg securityMonitoringRuleJSONModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &cfg)...)
-	if resp.Diagnostics.HasError() {
+	response.Diagnostics.Append(request.Config.Get(ctx, &cfg)...)
+	if response.Diagnostics.HasError() {
 		return
 	}
-
-	// Use cfg.JSON to build the payload (so we truly use what user sent)
 	var userRule map[string]interface{}
 	if err := json.Unmarshal([]byte(cfg.JSON.ValueString()), &userRule); err != nil {
-		resp.Diagnostics.AddError("Failed to parse JSON", err.Error())
+		response.Diagnostics.AddError("Failed to parse JSON", err.Error())
 		return
 	}
 
-	// Build payload from userRule (unchanged)
+	// Convert the map to SecurityMonitoringRuleCreatePayload
 	payload := datadogV2.SecurityMonitoringRuleCreatePayload{}
-	b, _ := json.Marshal(userRule)
-	if err := json.Unmarshal(b, &payload); err != nil {
-		resp.Diagnostics.AddError("Failed to unmarshal to payload", err.Error())
+	jsonBytes, err := json.Marshal(userRule)
+	if err != nil {
+		response.Diagnostics.AddError("Failed to marshal rule", err.Error())
+		return
+	}
+	if err := json.Unmarshal(jsonBytes, &payload); err != nil {
+		response.Diagnostics.AddError("Failed to unmarshal to payload", err.Error())
 		return
 	}
 
 	res, httpResp, err := r.Api.CreateSecurityMonitoringRule(r.Auth, payload)
 	if err != nil {
-		resp.Diagnostics.Append(utils.FrameworkErrorDiag(utils.TranslateClientError(err, httpResp, "error creating security monitoring rule"), ""))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(utils.TranslateClientError(err, httpResp, "error creating security monitoring rule"), ""))
 		return
 	}
 	if err := utils.CheckForUnparsed(res); err != nil {
-		resp.Diagnostics.AddError("Failed to parse response", err.Error())
+		response.Diagnostics.AddError("Failed to parse response", err.Error())
 		return
 	}
-
-	var state securityMonitoringRuleJSONModel
-	// IMPORTANT: write back EXACTLY what the user had in config
-	state.JSON = types.StringValue(cfg.JSON.ValueString())
 
 	if res.SecurityMonitoringStandardRuleResponse != nil {
 		state.ID = types.StringValue(res.SecurityMonitoringStandardRuleResponse.GetId())
 	} else if res.SecurityMonitoringSignalRuleResponse != nil {
 		state.ID = types.StringValue(res.SecurityMonitoringSignalRuleResponse.GetId())
 	} else {
-		resp.Diagnostics.AddError("Invalid response", "Response did not contain an ID")
+		response.Diagnostics.AddError("Invalid response", "Response did not contain an ID")
 		return
 	}
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-// func (r *securityMonitoringRuleJSONResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
-// 	var state securityMonitoringRuleJSONModel
-// 	response.Diagnostics.Append(request.Plan.Get(ctx, &state)...)
-// 	if response.Diagnostics.HasError() {
-// 		return
-// 	}
-
-// 	// Parse user JSON into a map
-// 	var userRule map[string]interface{}
-// 	if err := json.Unmarshal([]byte(state.JSON.ValueString()), &userRule); err != nil {
-// 		response.Diagnostics.AddError("Failed to parse JSON", err.Error())
-// 		return
-// 	}
-
-// 	tflog.Warn(ctx, "MARTIN Create: incoming JSON", map[string]any{
-// 		"json": state.JSON.ValueString(),
-// 	})
-
-// 	// Convert the map to SecurityMonitoringRuleCreatePayload
-// 	payload := datadogV2.SecurityMonitoringRuleCreatePayload{}
-// 	jsonBytes, err := json.Marshal(userRule)
-// 	if err != nil {
-// 		response.Diagnostics.AddError("Failed to marshal rule", err.Error())
-// 		return
-// 	}
-// 	if err := json.Unmarshal(jsonBytes, &payload); err != nil {
-// 		response.Diagnostics.AddError("Failed to unmarshal to payload", err.Error())
-// 		return
-// 	}
-
-// 	res, httpResp, err := r.Api.CreateSecurityMonitoringRule(r.Auth, payload)
-// 	if err != nil {
-// 		response.Diagnostics.Append(utils.FrameworkErrorDiag(utils.TranslateClientError(err, httpResp, "error creating security monitoring rule"), ""))
-// 		return
-// 	}
-// 	if err := utils.CheckForUnparsed(res); err != nil {
-// 		response.Diagnostics.AddError("Failed to parse response", err.Error())
-// 		return
-// 	}
-
-// 	var apiRule map[string]interface{}
-// 	if res.SecurityMonitoringStandardRuleResponse != nil {
-// 		jsonBytes, err = json.Marshal(res.SecurityMonitoringStandardRuleResponse)
-// 	} else if res.SecurityMonitoringSignalRuleResponse != nil {
-// 		jsonBytes, err = json.Marshal(res.SecurityMonitoringSignalRuleResponse)
-// 	} else {
-// 		response.Diagnostics.AddError("Invalid response", "Response did not contain a rule")
-// 		return
-// 	}
-// 	if err != nil {
-// 		response.Diagnostics.AddError("Failed to marshal response", err.Error())
-// 		return
-// 	}
-
-// 	if err := json.Unmarshal(jsonBytes, &apiRule); err != nil {
-// 		response.Diagnostics.AddError("Failed to parse response", err.Error())
-// 		return
-// 	}
-
-// 	// Filter API response to only user-supplied fields
-// 	filtered := filterToUserFields(userRule, apiRule)
-// 	// jsonBytes, err = json.Marshal(filtered)
-// 	// if err != nil {
-// 	// 	response.Diagnostics.AddError("Failed to marshal filtered response", err.Error())
-// 	// 	return
-// 	// }
-
-// 	// debug
-// 	norm, err := canonicalizeInterface(filtered)
-// 	if err != nil {
-// 		response.Diagnostics.AddError("Failed to normalize filtered response", err.Error())
-// 		return
-// 	}
-// 	state.JSON = types.StringValue(norm)
-
-// 	tflog.Warn(ctx, "MARTIN response", map[string]any{
-// 		"json": norm,
-// 	})
-// 	// debug
-
-// 	if res.SecurityMonitoringStandardRuleResponse != nil {
-// 		state.ID = types.StringValue(res.SecurityMonitoringStandardRuleResponse.GetId())
-// 	} else if res.SecurityMonitoringSignalRuleResponse != nil {
-// 		state.ID = types.StringValue(res.SecurityMonitoringSignalRuleResponse.GetId())
-// 	} else {
-// 		response.Diagnostics.AddError("Invalid response", "Response did not contain an ID")
-// 		return
-// 	}
-// 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
-// }
-
-func (r *securityMonitoringRuleJSONResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *securityMonitoringRuleJSONResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
 	var state securityMonitoringRuleJSONModel
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	response.Diagnostics.Append(request.State.Get(ctx, &state)...)
+	if response.Diagnostics.HasError() {
 		return
 	}
 
 	res, httpResp, err := r.Api.GetSecurityMonitoringRule(r.Auth, state.ID.ValueString())
 	if err != nil {
 		if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
-			resp.State.RemoveResource(ctx)
+			response.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.Append(utils.FrameworkErrorDiag(utils.TranslateClientError(err, httpResp, "error reading security monitoring rule"), ""))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(utils.TranslateClientError(err, httpResp, "error reading security monitoring rule"), ""))
 		return
 	}
 	if err := utils.CheckForUnparsed(res); err != nil {
-		resp.Diagnostics.AddError("Failed to parse response", err.Error())
+		response.Diagnostics.AddError("Failed to parse response", err.Error())
 		return
 	}
 
-	// Do NOT rewrite state.JSON here. Keep user’s exact JSON.
-	// Just ensure ID stays (it already does).
-	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	var userRule map[string]interface{}
+	if err := json.Unmarshal([]byte(state.JSON.ValueString()), &userRule); err != nil {
+		response.Diagnostics.AddError("Failed to parse state JSON", err.Error())
+		return
+	}
+
+	var apiRule map[string]interface{}
+	var jsonBytes []byte
+	if res.SecurityMonitoringStandardRuleResponse != nil {
+		jsonBytes, err = json.Marshal(res.SecurityMonitoringStandardRuleResponse)
+	} else if res.SecurityMonitoringSignalRuleResponse != nil {
+		jsonBytes, err = json.Marshal(res.SecurityMonitoringSignalRuleResponse)
+	} else {
+		response.Diagnostics.AddError("Invalid response", "Response did not contain a rule")
+		return
+	}
+	if err != nil {
+		response.Diagnostics.AddError("Failed to marshal response", err.Error())
+		return
+	}
+
+	if err := json.Unmarshal(jsonBytes, &apiRule); err != nil {
+		response.Diagnostics.AddError("Failed to parse response", err.Error())
+		return
+	}
+
+	filtered := filterToUserFields(userRule, apiRule)
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", " ")
+	if err := enc.Encode(filtered); err != nil {
+		response.Diagnostics.AddError("Failed to marshal filtered response", err.Error())
+		return
+	}
+	state.JSON = types.StringValue(buf.String())
+
+	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
-
-// func (r *securityMonitoringRuleJSONResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
-// 	var state securityMonitoringRuleJSONModel
-// 	response.Diagnostics.Append(request.State.Get(ctx, &state)...)
-// 	if response.Diagnostics.HasError() {
-// 		return
-// 	}
-
-// 	res, httpResp, err := r.Api.GetSecurityMonitoringRule(r.Auth, state.ID.ValueString())
-// 	if err != nil {
-// 		if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
-// 			response.State.RemoveResource(ctx)
-// 			return
-// 		}
-// 		response.Diagnostics.Append(utils.FrameworkErrorDiag(utils.TranslateClientError(err, httpResp, "error reading security monitoring rule"), ""))
-// 		return
-// 	}
-// 	if err := utils.CheckForUnparsed(res); err != nil {
-// 		response.Diagnostics.AddError("Failed to parse response", err.Error())
-// 		return
-// 	}
-
-// 	var userRule map[string]interface{}
-// 	if err := json.Unmarshal([]byte(state.JSON.ValueString()), &userRule); err != nil {
-// 		response.Diagnostics.AddError("Failed to parse state JSON", err.Error())
-// 		return
-// 	}
-
-// 	var apiRule map[string]interface{}
-// 	var jsonBytes []byte
-// 	if res.SecurityMonitoringStandardRuleResponse != nil {
-// 		jsonBytes, err = json.Marshal(res.SecurityMonitoringStandardRuleResponse)
-// 	} else if res.SecurityMonitoringSignalRuleResponse != nil {
-// 		jsonBytes, err = json.Marshal(res.SecurityMonitoringSignalRuleResponse)
-// 	} else {
-// 		response.Diagnostics.AddError("Invalid response", "Response did not contain a rule")
-// 		return
-// 	}
-// 	if err != nil {
-// 		response.Diagnostics.AddError("Failed to marshal response", err.Error())
-// 		return
-// 	}
-
-// 	if err := json.Unmarshal(jsonBytes, &apiRule); err != nil {
-// 		response.Diagnostics.AddError("Failed to parse response", err.Error())
-// 		return
-// 	}
-
-// 	filtered := filterToUserFields(userRule, apiRule)
-// 	jsonBytes, err = json.Marshal(filtered)
-// 	if err != nil {
-// 		response.Diagnostics.AddError("Failed to marshal filtered response", err.Error())
-// 		return
-// 	}
-// 	state.JSON = types.StringValue(string(jsonBytes))
-// 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
-// }
 
 func (r *securityMonitoringRuleJSONResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
 	var state securityMonitoringRuleJSONModel
@@ -382,32 +241,6 @@ func (r *securityMonitoringRuleJSONResource) Update(ctx context.Context, request
 		return
 	}
 
-	var apiRule map[string]interface{}
-	if res.SecurityMonitoringStandardRuleResponse != nil {
-		jsonBytes, err = json.Marshal(res.SecurityMonitoringStandardRuleResponse)
-	} else if res.SecurityMonitoringSignalRuleResponse != nil {
-		jsonBytes, err = json.Marshal(res.SecurityMonitoringSignalRuleResponse)
-	} else {
-		response.Diagnostics.AddError("Invalid response", "Response did not contain a rule")
-		return
-	}
-	if err != nil {
-		response.Diagnostics.AddError("Failed to marshal response", err.Error())
-		return
-	}
-
-	if err := json.Unmarshal(jsonBytes, &apiRule); err != nil {
-		response.Diagnostics.AddError("Failed to parse response", err.Error())
-		return
-	}
-
-	filtered := filterToUserFields(userRule, apiRule)
-	jsonBytes, err = json.Marshal(filtered)
-	if err != nil {
-		response.Diagnostics.AddError("Failed to marshal filtered response", err.Error())
-		return
-	}
-	state.JSON = types.StringValue(string(jsonBytes))
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 

--- a/datadog/fwprovider/resource_datadog_security_monitoring_rule_json.go
+++ b/datadog/fwprovider/resource_datadog_security_monitoring_rule_json.go
@@ -1,18 +1,43 @@
 package fwprovider
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 )
+
+func canonicalizeJSONText(s string) (string, error) {
+	var v any
+	if err := json.Unmarshal([]byte(s), &v); err != nil { // parse the JSON TEXT
+		return "", err
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil { // encode the OBJECT back to text
+		return "", err
+	}
+	return strings.TrimSpace(buf.String()), nil
+}
+
+func canonicalizeInterface(v any) (string, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(buf.String()), nil
+}
 
 var (
 	_ resource.ResourceWithConfigure   = &securityMonitoringRuleJSONResource{}
@@ -94,136 +119,234 @@ func filterToUserFields(user interface{}, api interface{}) interface{} {
 	}
 }
 
-func (r *securityMonitoringRuleJSONResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
-	var state securityMonitoringRuleJSONModel
-	response.Diagnostics.Append(request.Plan.Get(ctx, &state)...)
-	if response.Diagnostics.HasError() {
+func (r *securityMonitoringRuleJSONResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan securityMonitoringRuleJSONModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Parse user JSON into a map
+	// Also read the original config (what the user actually typed)
+	var cfg securityMonitoringRuleJSONModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &cfg)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Use cfg.JSON to build the payload (so we truly use what user sent)
 	var userRule map[string]interface{}
-	if err := json.Unmarshal([]byte(state.JSON.ValueString()), &userRule); err != nil {
-		response.Diagnostics.AddError("Failed to parse JSON", err.Error())
+	if err := json.Unmarshal([]byte(cfg.JSON.ValueString()), &userRule); err != nil {
+		resp.Diagnostics.AddError("Failed to parse JSON", err.Error())
 		return
 	}
 
-	// Convert the map to SecurityMonitoringRuleCreatePayload
+	// Build payload from userRule (unchanged)
 	payload := datadogV2.SecurityMonitoringRuleCreatePayload{}
-	jsonBytes, err := json.Marshal(userRule)
-	if err != nil {
-		response.Diagnostics.AddError("Failed to marshal rule", err.Error())
-		return
-	}
-	if err := json.Unmarshal(jsonBytes, &payload); err != nil {
-		response.Diagnostics.AddError("Failed to unmarshal to payload", err.Error())
+	b, _ := json.Marshal(userRule)
+	if err := json.Unmarshal(b, &payload); err != nil {
+		resp.Diagnostics.AddError("Failed to unmarshal to payload", err.Error())
 		return
 	}
 
 	res, httpResp, err := r.Api.CreateSecurityMonitoringRule(r.Auth, payload)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(utils.TranslateClientError(err, httpResp, "error creating security monitoring rule"), ""))
+		resp.Diagnostics.Append(utils.FrameworkErrorDiag(utils.TranslateClientError(err, httpResp, "error creating security monitoring rule"), ""))
 		return
 	}
 	if err := utils.CheckForUnparsed(res); err != nil {
-		response.Diagnostics.AddError("Failed to parse response", err.Error())
+		resp.Diagnostics.AddError("Failed to parse response", err.Error())
 		return
 	}
 
-	var apiRule map[string]interface{}
-	if res.SecurityMonitoringStandardRuleResponse != nil {
-		jsonBytes, err = json.Marshal(res.SecurityMonitoringStandardRuleResponse)
-	} else if res.SecurityMonitoringSignalRuleResponse != nil {
-		jsonBytes, err = json.Marshal(res.SecurityMonitoringSignalRuleResponse)
-	} else {
-		response.Diagnostics.AddError("Invalid response", "Response did not contain a rule")
-		return
-	}
-	if err != nil {
-		response.Diagnostics.AddError("Failed to marshal response", err.Error())
-		return
-	}
+	var state securityMonitoringRuleJSONModel
+	// IMPORTANT: write back EXACTLY what the user had in config
+	state.JSON = types.StringValue(cfg.JSON.ValueString())
 
-	if err := json.Unmarshal(jsonBytes, &apiRule); err != nil {
-		response.Diagnostics.AddError("Failed to parse response", err.Error())
-		return
-	}
-
-	// Filter API response to only user-supplied fields
-	filtered := filterToUserFields(userRule, apiRule)
-	jsonBytes, err = json.Marshal(filtered)
-	if err != nil {
-		response.Diagnostics.AddError("Failed to marshal filtered response", err.Error())
-		return
-	}
-	state.JSON = types.StringValue(string(jsonBytes))
 	if res.SecurityMonitoringStandardRuleResponse != nil {
 		state.ID = types.StringValue(res.SecurityMonitoringStandardRuleResponse.GetId())
 	} else if res.SecurityMonitoringSignalRuleResponse != nil {
 		state.ID = types.StringValue(res.SecurityMonitoringSignalRuleResponse.GetId())
 	} else {
-		response.Diagnostics.AddError("Invalid response", "Response did not contain an ID")
+		resp.Diagnostics.AddError("Invalid response", "Response did not contain an ID")
 		return
 	}
-	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *securityMonitoringRuleJSONResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+// func (r *securityMonitoringRuleJSONResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+// 	var state securityMonitoringRuleJSONModel
+// 	response.Diagnostics.Append(request.Plan.Get(ctx, &state)...)
+// 	if response.Diagnostics.HasError() {
+// 		return
+// 	}
+
+// 	// Parse user JSON into a map
+// 	var userRule map[string]interface{}
+// 	if err := json.Unmarshal([]byte(state.JSON.ValueString()), &userRule); err != nil {
+// 		response.Diagnostics.AddError("Failed to parse JSON", err.Error())
+// 		return
+// 	}
+
+// 	tflog.Warn(ctx, "MARTIN Create: incoming JSON", map[string]any{
+// 		"json": state.JSON.ValueString(),
+// 	})
+
+// 	// Convert the map to SecurityMonitoringRuleCreatePayload
+// 	payload := datadogV2.SecurityMonitoringRuleCreatePayload{}
+// 	jsonBytes, err := json.Marshal(userRule)
+// 	if err != nil {
+// 		response.Diagnostics.AddError("Failed to marshal rule", err.Error())
+// 		return
+// 	}
+// 	if err := json.Unmarshal(jsonBytes, &payload); err != nil {
+// 		response.Diagnostics.AddError("Failed to unmarshal to payload", err.Error())
+// 		return
+// 	}
+
+// 	res, httpResp, err := r.Api.CreateSecurityMonitoringRule(r.Auth, payload)
+// 	if err != nil {
+// 		response.Diagnostics.Append(utils.FrameworkErrorDiag(utils.TranslateClientError(err, httpResp, "error creating security monitoring rule"), ""))
+// 		return
+// 	}
+// 	if err := utils.CheckForUnparsed(res); err != nil {
+// 		response.Diagnostics.AddError("Failed to parse response", err.Error())
+// 		return
+// 	}
+
+// 	var apiRule map[string]interface{}
+// 	if res.SecurityMonitoringStandardRuleResponse != nil {
+// 		jsonBytes, err = json.Marshal(res.SecurityMonitoringStandardRuleResponse)
+// 	} else if res.SecurityMonitoringSignalRuleResponse != nil {
+// 		jsonBytes, err = json.Marshal(res.SecurityMonitoringSignalRuleResponse)
+// 	} else {
+// 		response.Diagnostics.AddError("Invalid response", "Response did not contain a rule")
+// 		return
+// 	}
+// 	if err != nil {
+// 		response.Diagnostics.AddError("Failed to marshal response", err.Error())
+// 		return
+// 	}
+
+// 	if err := json.Unmarshal(jsonBytes, &apiRule); err != nil {
+// 		response.Diagnostics.AddError("Failed to parse response", err.Error())
+// 		return
+// 	}
+
+// 	// Filter API response to only user-supplied fields
+// 	filtered := filterToUserFields(userRule, apiRule)
+// 	// jsonBytes, err = json.Marshal(filtered)
+// 	// if err != nil {
+// 	// 	response.Diagnostics.AddError("Failed to marshal filtered response", err.Error())
+// 	// 	return
+// 	// }
+
+// 	// debug
+// 	norm, err := canonicalizeInterface(filtered)
+// 	if err != nil {
+// 		response.Diagnostics.AddError("Failed to normalize filtered response", err.Error())
+// 		return
+// 	}
+// 	state.JSON = types.StringValue(norm)
+
+// 	tflog.Warn(ctx, "MARTIN response", map[string]any{
+// 		"json": norm,
+// 	})
+// 	// debug
+
+// 	if res.SecurityMonitoringStandardRuleResponse != nil {
+// 		state.ID = types.StringValue(res.SecurityMonitoringStandardRuleResponse.GetId())
+// 	} else if res.SecurityMonitoringSignalRuleResponse != nil {
+// 		state.ID = types.StringValue(res.SecurityMonitoringSignalRuleResponse.GetId())
+// 	} else {
+// 		response.Diagnostics.AddError("Invalid response", "Response did not contain an ID")
+// 		return
+// 	}
+// 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
+// }
+
+func (r *securityMonitoringRuleJSONResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state securityMonitoringRuleJSONModel
-	response.Diagnostics.Append(request.State.Get(ctx, &state)...)
-	if response.Diagnostics.HasError() {
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	res, httpResp, err := r.Api.GetSecurityMonitoringRule(r.Auth, state.ID.ValueString())
 	if err != nil {
 		if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
-			response.State.RemoveResource(ctx)
+			resp.State.RemoveResource(ctx)
 			return
 		}
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(utils.TranslateClientError(err, httpResp, "error reading security monitoring rule"), ""))
+		resp.Diagnostics.Append(utils.FrameworkErrorDiag(utils.TranslateClientError(err, httpResp, "error reading security monitoring rule"), ""))
 		return
 	}
 	if err := utils.CheckForUnparsed(res); err != nil {
-		response.Diagnostics.AddError("Failed to parse response", err.Error())
+		resp.Diagnostics.AddError("Failed to parse response", err.Error())
 		return
 	}
 
-	var userRule map[string]interface{}
-	if err := json.Unmarshal([]byte(state.JSON.ValueString()), &userRule); err != nil {
-		response.Diagnostics.AddError("Failed to parse state JSON", err.Error())
-		return
-	}
-
-	var apiRule map[string]interface{}
-	var jsonBytes []byte
-	if res.SecurityMonitoringStandardRuleResponse != nil {
-		jsonBytes, err = json.Marshal(res.SecurityMonitoringStandardRuleResponse)
-	} else if res.SecurityMonitoringSignalRuleResponse != nil {
-		jsonBytes, err = json.Marshal(res.SecurityMonitoringSignalRuleResponse)
-	} else {
-		response.Diagnostics.AddError("Invalid response", "Response did not contain a rule")
-		return
-	}
-	if err != nil {
-		response.Diagnostics.AddError("Failed to marshal response", err.Error())
-		return
-	}
-
-	if err := json.Unmarshal(jsonBytes, &apiRule); err != nil {
-		response.Diagnostics.AddError("Failed to parse response", err.Error())
-		return
-	}
-
-	filtered := filterToUserFields(userRule, apiRule)
-	jsonBytes, err = json.Marshal(filtered)
-	if err != nil {
-		response.Diagnostics.AddError("Failed to marshal filtered response", err.Error())
-		return
-	}
-	state.JSON = types.StringValue(string(jsonBytes))
-	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
+	// Do NOT rewrite state.JSON here. Keep user’s exact JSON.
+	// Just ensure ID stays (it already does).
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
+
+// func (r *securityMonitoringRuleJSONResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+// 	var state securityMonitoringRuleJSONModel
+// 	response.Diagnostics.Append(request.State.Get(ctx, &state)...)
+// 	if response.Diagnostics.HasError() {
+// 		return
+// 	}
+
+// 	res, httpResp, err := r.Api.GetSecurityMonitoringRule(r.Auth, state.ID.ValueString())
+// 	if err != nil {
+// 		if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
+// 			response.State.RemoveResource(ctx)
+// 			return
+// 		}
+// 		response.Diagnostics.Append(utils.FrameworkErrorDiag(utils.TranslateClientError(err, httpResp, "error reading security monitoring rule"), ""))
+// 		return
+// 	}
+// 	if err := utils.CheckForUnparsed(res); err != nil {
+// 		response.Diagnostics.AddError("Failed to parse response", err.Error())
+// 		return
+// 	}
+
+// 	var userRule map[string]interface{}
+// 	if err := json.Unmarshal([]byte(state.JSON.ValueString()), &userRule); err != nil {
+// 		response.Diagnostics.AddError("Failed to parse state JSON", err.Error())
+// 		return
+// 	}
+
+// 	var apiRule map[string]interface{}
+// 	var jsonBytes []byte
+// 	if res.SecurityMonitoringStandardRuleResponse != nil {
+// 		jsonBytes, err = json.Marshal(res.SecurityMonitoringStandardRuleResponse)
+// 	} else if res.SecurityMonitoringSignalRuleResponse != nil {
+// 		jsonBytes, err = json.Marshal(res.SecurityMonitoringSignalRuleResponse)
+// 	} else {
+// 		response.Diagnostics.AddError("Invalid response", "Response did not contain a rule")
+// 		return
+// 	}
+// 	if err != nil {
+// 		response.Diagnostics.AddError("Failed to marshal response", err.Error())
+// 		return
+// 	}
+
+// 	if err := json.Unmarshal(jsonBytes, &apiRule); err != nil {
+// 		response.Diagnostics.AddError("Failed to parse response", err.Error())
+// 		return
+// 	}
+
+// 	filtered := filterToUserFields(userRule, apiRule)
+// 	jsonBytes, err = json.Marshal(filtered)
+// 	if err != nil {
+// 		response.Diagnostics.AddError("Failed to marshal filtered response", err.Error())
+// 		return
+// 	}
+// 	state.JSON = types.StringValue(string(jsonBytes))
+// 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
+// }
 
 func (r *securityMonitoringRuleJSONResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
 	var state securityMonitoringRuleJSONModel

--- a/docs/resources/security_monitoring_default_rule.md
+++ b/docs/resources/security_monitoring_default_rule.md
@@ -84,7 +84,6 @@ Optional:
 - `data_source` (String) Source of events. Valid values are `logs`, `audit`, `app_sec_spans`, `spans`, `security_runtime`, `network`, `events`.
 - `distinct_fields` (List of String) Field for which the cardinality is measured. Sent as an array.
 - `group_by_fields` (List of String) Fields to group by.
-- `has_optional_group_by_fields` (Boolean) When false, events without a group-by value are ignored by the rule. When true, events with missing group-by fields are processed with `N/A`, replacing the missing values.
 - `metric` (String, Deprecated) The target field to aggregate over when using the `sum`, `max`, or `geo_data` aggregations. **Deprecated.** Configure `metrics` instead. This attribute will be removed in the next major version of the provider.
 - `metrics` (List of String) Group of target fields to aggregate over when using the `sum`, `max`, `geo_data`, or `new_value` aggregations. The `sum`, `max`, and `geo_data` aggregations only accept one value in this list, whereas the `new_value` aggregation accepts up to five values.
 - `name` (String) Name of the query. Not compatible with `new_value` aggregations.

--- a/docs/resources/security_monitoring_default_rule.md
+++ b/docs/resources/security_monitoring_default_rule.md
@@ -84,6 +84,7 @@ Optional:
 - `data_source` (String) Source of events. Valid values are `logs`, `audit`, `app_sec_spans`, `spans`, `security_runtime`, `network`, `events`.
 - `distinct_fields` (List of String) Field for which the cardinality is measured. Sent as an array.
 - `group_by_fields` (List of String) Fields to group by.
+- `has_optional_group_by_fields` (Boolean) When false, events without a group-by value are ignored by the rule. When true, events with missing group-by fields are processed with `N/A`, replacing the missing values.
 - `metric` (String, Deprecated) The target field to aggregate over when using the `sum`, `max`, or `geo_data` aggregations. **Deprecated.** Configure `metrics` instead. This attribute will be removed in the next major version of the provider.
 - `metrics` (List of String) Group of target fields to aggregate over when using the `sum`, `max`, `geo_data`, or `new_value` aggregations. The `sum`, `max`, and `geo_data` aggregations only accept one value in this list, whereas the `new_value` aggregation accepts up to five values.
 - `name` (String) Name of the query. Not compatible with `new_value` aggregations.


### PR DESCRIPTION
## changes

Align with Terraform’s **Required** attribute contract: **echo the planned `json` bytes on Create/Update**, and perform **semantic filtering only in Read** to avoid false diffs when Datadog adds defaults.

* **Create/Update**

  * No re-encoding. Persist the planned `json` value verbatim.
* **Read**

  * Build `filtered = filterToUserFields(user, api)` (drops API-only/default fields, keeps user-provided keys).
  * **Semantic compare**: `reflect.DeepEqual(filtered, userRule)`.
  * Only if different, write `filtered` back. Otherwise, keep existing bytes.

## Why

* `json` is **Required** → must round-trip **byte-for-byte** across apply.
* Re-marshalling in Create/Update changed key order/whitespace/newline → **“Provider produced inconsistent result after apply.”**
* Filtering remains necessary to handle evolving API defaults; doing it in **Read** prevents noisy drift without breaking apply semantics.

## User Impact

* No more apply failures or “whitespace changes” plans.
* State only updates when the server actually changes a **user-managed** value.


## Tests

1- created a TF repo with the default rule from the documentation.
2- compiled and override DD TF provider with local one to iterate on the fix.

#### Details

```sh
terraform init
terraform plan
```

Add the following files in the tf project:
`main.tf`
```tf
terraform {
  required_version = ">= 1.4.0"
  required_providers {
    datadog = {
      source  = "DataDog/datadog"
      version = ">= 0.0.0" # relaxed
    }
  }
}

provider "datadog" {
  api_key = var.datadog_api_key
  app_key = var.datadog_app_key
  api_url = "https://dd.datad0g.com/"
}

# Example Security Monitoring Rule JSON
resource "datadog_security_monitoring_rule_json" "security_rule_json" {
  json = <<EOF
{
  "name": "High error rate security monitoring",
  "isEnabled": false,
  "type": "log_detection",
  "message": "High error rate detected in logs",
  "tags": ["env:prod", "security"],
  "cases": [
    {
      "name": "high case",
      "status": "high",
      "condition": "errors > 100 && warnings > 1000",
      "notifications": ["@security-team"]
    }
  ],
  "queries": [
    {
      "name": "errors",
      "query": "status:error",
      "aggregation": "count",
      "groupByFields": ["service", "env"]
    },
    {
      "name": "warnings",
      "query": "status:warning",
      "aggregation": "count",
      "groupByFields": ["service", "env"]
    }
  ],
  "options": {
    "evaluationWindow": 300,
    "keepAlive": 600,
    "maxSignalDuration": 900,
    "detectionMethod": "threshold"
  }
}
EOF
}
```

`variables.tf`
```tf
variable "datadog_api_key" {
  description = "Datadog API key"
  type        = string
  sensitive   = true
}

variable "datadog_app_key" {
  description = "Datadog APP key"
  type        = string
  sensitive   = true
}
```

`terraform.tfvars`
```tf
datadog_api_key = "xxx"
datadog_app_key = "xxx"
```

Compile a local version of the datadog tf provider
```sh
cd ~/dd/terraform-provider-datadog
go build -o ./bin/terraform-provider-datadog .
```

Create a terraform config override:
`~/terraformrc`
```txt
provider_installation {
  dev_overrides {
    "DataDog/datadog" = "/Users/martin.guyard/dd/terraform-provider-datadog/bin"
  }
  direct {}
}
```

Update the terraform project and use the local override:
```sh
export TERRAFORM_CONFIG=~/.terraformrc
terraform init -upgrade
```

Run the apply command:
```
terraform apply -auto-approve
```