### PR TITLE
[datadog_csm_threats] Update description to use Workload Protection

### DIFF
--- a/datadog/fwprovider/resource_datadog_csm_threats_agent_rule.go
+++ b/datadog/fwprovider/resource_datadog_csm_threats_agent_rule.go
@@ -77,7 +77,7 @@ func (r *csmThreatsAgentRuleResource) Configure(ctx context.Context, request res
 
 func (r *csmThreatsAgentRuleResource) Schema(_ context.Context, _ resource.SchemaRequest, response *resource.SchemaResponse) {
 	response.Schema = schema.Schema{
-		Description: "Provides a Datadog CSM Threats Agent Rule API resource.",
+		Description: "Provides a Datadog Workload Protection (CSM Threats) Agent Rule API resource.",
 		Attributes: map[string]schema.Attribute{
 			"id": utils.ResourceIDAttribute(),
 			"policy_id": schema.StringAttribute{

--- a/datadog/fwprovider/resource_datadog_csm_threats_policy.go
+++ b/datadog/fwprovider/resource_datadog_csm_threats_policy.go
@@ -44,7 +44,7 @@ func (r *csmThreatsPolicyResource) Configure(_ context.Context, request resource
 
 func (r *csmThreatsPolicyResource) Schema(_ context.Context, _ resource.SchemaRequest, response *resource.SchemaResponse) {
 	response.Schema = schema.Schema{
-		Description: "Provides a Datadog CSM Threats policy API resource.",
+		Description: "Provides a Datadog Workload Protection (CSM Threats) policy API resource.",
 		Attributes: map[string]schema.Attribute{
 			"id": utils.ResourceIDAttribute(),
 			"name": schema.StringAttribute{

--- a/docs/resources/csm_threats_agent_rule.md
+++ b/docs/resources/csm_threats_agent_rule.md
@@ -3,12 +3,12 @@
 page_title: "datadog_csm_threats_agent_rule Resource - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  Provides a Datadog CSM Threats Agent Rule API resource.
+  Provides a Datadog Workload Protection (CSM Threats) Agent Rule API resource.
 ---
 
 # datadog_csm_threats_agent_rule (Resource)
 
-Provides a Datadog CSM Threats Agent Rule API resource.
+Provides a Datadog Workload Protection (CSM Threats) Agent Rule API resource.
 
 ## Example Usage
 

--- a/docs/resources/csm_threats_policy.md
+++ b/docs/resources/csm_threats_policy.md
@@ -3,12 +3,12 @@
 page_title: "datadog_csm_threats_policy Resource - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  Provides a Datadog CSM Threats policy API resource.
+  Provides a Datadog Workload Protection (CSM Threats) policy API resource.
 ---
 
 # datadog_csm_threats_policy (Resource)
 
-Provides a Datadog CSM Threats policy API resource.
+Provides a Datadog Workload Protection (CSM Threats) policy API resource.
 
 ## Example Usage
 


### PR DESCRIPTION
Update TF provider description to use `Workload Protection` product name instead of the old name `CSM Threats`