### PR TITLE
[datadog_integration_aws_account] Fix missing double quotes breaking docs rendering

### DIFF
--- a/docs/resources/integration_aws_account.md
+++ b/docs/resources/integration_aws_account.md
@@ -55,7 +55,7 @@ resource "datadog_integration_aws_account" "foo" {
     collect_custom_metrics    = true
     enabled                   = true
     namespace_filters {
-      exclude_only = ["AWS/SQS", "AWS/ElasticMapReduce", "AWS/Usage]
+      exclude_only = ["AWS/SQS", "AWS/ElasticMapReduce", "AWS/Usage"]
     }
     tag_filters {
       namespace = "AWS/EC2"


### PR DESCRIPTION
Currently rendered docs are broken due to this missing `"`.
This example is not auto-generated by `make docs` since it's in the [exclusion list](https://github.com/DataDog/terraform-provider-datadog/blob/9a686fc93093533def3f4a955e77e121c3074144/scripts/generate-docs.sh#L6).
 
<img width="639" height="406" alt="image" src="https://github.com/user-attachments/assets/d76223f7-cf9f-421a-98cc-5abc2ac490c0" />
