### PR TITLE
feat: add framework for ephemeral resources

### DIFF
--- a/datadog/fwprovider/framework_ephemeral_resource_wrapper.go
+++ b/datadog/fwprovider/framework_ephemeral_resource_wrapper.go
@@ -1,0 +1,104 @@
+package fwprovider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+
+	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/fwutils"
+)
+
+// Interface assertions for FrameworkEphemeralResourceWrapper
+var (
+	_ ephemeral.EphemeralResource                     = &FrameworkEphemeralResourceWrapper{}
+	_ ephemeral.EphemeralResourceWithConfigure        = &FrameworkEphemeralResourceWrapper{}
+	_ ephemeral.EphemeralResourceWithValidateConfig   = &FrameworkEphemeralResourceWrapper{}
+	_ ephemeral.EphemeralResourceWithConfigValidators = &FrameworkEphemeralResourceWrapper{}
+	_ ephemeral.EphemeralResourceWithRenew            = &FrameworkEphemeralResourceWrapper{}
+	_ ephemeral.EphemeralResourceWithClose            = &FrameworkEphemeralResourceWrapper{}
+)
+
+// NewFrameworkEphemeralResourceWrapper creates a new ephemeral resource wrapper following
+// the same pattern as the existing FrameworkResourceWrapper
+func NewFrameworkEphemeralResourceWrapper(i *ephemeral.EphemeralResource) ephemeral.EphemeralResource {
+	return &FrameworkEphemeralResourceWrapper{
+		innerResource: i,
+	}
+}
+
+// FrameworkEphemeralResourceWrapper wraps ephemeral resources to provide consistent behavior
+// across all ephemeral resources, following the existing FrameworkResourceWrapper pattern
+type FrameworkEphemeralResourceWrapper struct {
+	innerResource *ephemeral.EphemeralResource
+}
+
+// Metadata implements the core ephemeral.EphemeralResource interface
+// Adds provider type name prefix to the resource type name, following existing pattern
+func (r *FrameworkEphemeralResourceWrapper) Metadata(ctx context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
+	(*r.innerResource).Metadata(ctx, req, resp)
+	resp.TypeName = req.ProviderTypeName + resp.TypeName
+}
+
+// Schema implements the core ephemeral.EphemeralResource interface
+// Enriches schema with common framework patterns
+func (r *FrameworkEphemeralResourceWrapper) Schema(ctx context.Context, req ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
+	(*r.innerResource).Schema(ctx, req, resp)
+	fwutils.EnrichFrameworkEphemeralResourceSchema(&resp.Schema)
+}
+
+// Open implements the core ephemeral.EphemeralResource interface
+// This is where ephemeral resources create/acquire their temporary resources
+func (r *FrameworkEphemeralResourceWrapper) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
+	(*r.innerResource).Open(ctx, req, resp)
+}
+
+// Configure implements the optional ephemeral.EphemeralResourceWithConfigure interface
+// Uses interface detection to only call if the inner resource supports configuration
+func (r *FrameworkEphemeralResourceWrapper) Configure(ctx context.Context, req ephemeral.ConfigureRequest, resp *ephemeral.ConfigureResponse) {
+	rCasted, ok := (*r.innerResource).(ephemeral.EphemeralResourceWithConfigure)
+	if ok {
+		if req.ProviderData == nil {
+			return
+		}
+		_, ok := req.ProviderData.(*FrameworkProvider)
+		if !ok {
+			resp.Diagnostics.AddError("Unexpected Ephemeral Resource Configure Type", "")
+			return
+		}
+
+		rCasted.Configure(ctx, req, resp)
+	}
+}
+
+// ValidateConfig implements the optional ephemeral.EphemeralResourceWithValidateConfig interface
+// Uses interface detection to only call if the inner resource supports validation
+func (r *FrameworkEphemeralResourceWrapper) ValidateConfig(ctx context.Context, req ephemeral.ValidateConfigRequest, resp *ephemeral.ValidateConfigResponse) {
+	if rCasted, ok := (*r.innerResource).(ephemeral.EphemeralResourceWithValidateConfig); ok {
+		rCasted.ValidateConfig(ctx, req, resp)
+	}
+}
+
+// ConfigValidators implements the optional ephemeral.EphemeralResourceWithConfigValidators interface
+// Uses interface detection to only call if the inner resource supports declarative validators
+func (r *FrameworkEphemeralResourceWrapper) ConfigValidators(ctx context.Context) []ephemeral.ConfigValidator {
+	if rCasted, ok := (*r.innerResource).(ephemeral.EphemeralResourceWithConfigValidators); ok {
+		return rCasted.ConfigValidators(ctx)
+	}
+	return nil
+}
+
+// Renew implements the optional ephemeral.EphemeralResourceWithRenew interface
+// Uses interface detection to only call if the inner resource supports renewal
+func (r *FrameworkEphemeralResourceWrapper) Renew(ctx context.Context, req ephemeral.RenewRequest, resp *ephemeral.RenewResponse) {
+	if rCasted, ok := (*r.innerResource).(ephemeral.EphemeralResourceWithRenew); ok {
+		rCasted.Renew(ctx, req, resp)
+	}
+}
+
+// Close implements the optional ephemeral.EphemeralResourceWithClose interface
+// Uses interface detection to only call if the inner resource supports cleanup
+func (r *FrameworkEphemeralResourceWrapper) Close(ctx context.Context, req ephemeral.CloseRequest, resp *ephemeral.CloseResponse) {
+	if rCasted, ok := (*r.innerResource).(ephemeral.EphemeralResourceWithClose); ok {
+		rCasted.Close(ctx, req, resp)
+	}
+}

--- a/datadog/tests/framework_ephemeral_resource_wrapper_test.go
+++ b/datadog/tests/framework_ephemeral_resource_wrapper_test.go
@@ -1,0 +1,121 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
+)
+
+// Simple mock for testing wrapper functionality
+type mockEphemeralResource struct{}
+
+func (m *mockEphemeralResource) Metadata(ctx context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
+	resp.TypeName = "_test_resource"
+}
+
+func (m *mockEphemeralResource) Schema(ctx context.Context, req ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{Required: true},
+		},
+	}
+}
+
+func (m *mockEphemeralResource) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
+	// Basic implementation for testing
+}
+
+func TestFrameworkEphemeralResourceWrapper_CoreMethods(t *testing.T) {
+	t.Parallel()
+
+	var mock ephemeral.EphemeralResource = &mockEphemeralResource{}
+	wrapped := fwprovider.NewFrameworkEphemeralResourceWrapper(&mock)
+
+	// Test Metadata adds provider prefix
+	t.Run("Metadata", func(t *testing.T) {
+		req := ephemeral.MetadataRequest{ProviderTypeName: "datadog"}
+		resp := &ephemeral.MetadataResponse{}
+
+		wrapped.Metadata(context.Background(), req, resp)
+
+		assert.Equal(t, "datadog_test_resource", resp.TypeName)
+	})
+
+	// Test Schema calls enrichment
+	t.Run("Schema", func(t *testing.T) {
+		req := ephemeral.SchemaRequest{}
+		resp := &ephemeral.SchemaResponse{}
+
+		wrapped.Schema(context.Background(), req, resp)
+
+		assert.NotNil(t, resp.Schema)
+		assert.Contains(t, resp.Schema.Attributes, "id")
+	})
+
+	// Test Open delegates properly
+	t.Run("Open", func(t *testing.T) {
+		req := ephemeral.OpenRequest{}
+		resp := &ephemeral.OpenResponse{}
+
+		assert.NotPanics(t, func() {
+			wrapped.Open(context.Background(), req, resp)
+		})
+	})
+}
+
+func TestFrameworkEphemeralResourceWrapper_InterfaceDetection(t *testing.T) {
+	t.Parallel()
+
+	var mock ephemeral.EphemeralResource = &mockEphemeralResource{}
+	wrappedInterface := fwprovider.NewFrameworkEphemeralResourceWrapper(&mock)
+
+	// Cast to wrapper type to access optional interface methods
+	wrapped := wrappedInterface.(*fwprovider.FrameworkEphemeralResourceWrapper)
+
+	// Test that optional methods don't panic when inner resource doesn't implement them
+	t.Run("Configure_NotImplemented", func(t *testing.T) {
+		req := ephemeral.ConfigureRequest{}
+		resp := &ephemeral.ConfigureResponse{}
+
+		assert.NotPanics(t, func() {
+			wrapped.Configure(context.Background(), req, resp)
+		})
+	})
+
+	t.Run("ValidateConfig_NotImplemented", func(t *testing.T) {
+		req := ephemeral.ValidateConfigRequest{}
+		resp := &ephemeral.ValidateConfigResponse{}
+
+		assert.NotPanics(t, func() {
+			wrapped.ValidateConfig(context.Background(), req, resp)
+		})
+	})
+
+	t.Run("ConfigValidators_NotImplemented", func(t *testing.T) {
+		validators := wrapped.ConfigValidators(context.Background())
+		assert.Nil(t, validators)
+	})
+
+	t.Run("Renew_NotImplemented", func(t *testing.T) {
+		req := ephemeral.RenewRequest{}
+		resp := &ephemeral.RenewResponse{}
+
+		assert.NotPanics(t, func() {
+			wrapped.Renew(context.Background(), req, resp)
+		})
+	})
+
+	t.Run("Close_NotImplemented", func(t *testing.T) {
+		req := ephemeral.CloseRequest{}
+		resp := &ephemeral.CloseResponse{}
+
+		assert.NotPanics(t, func() {
+			wrapped.Close(context.Background(), req, resp)
+		})
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/hashicorp/terraform-plugin-testing v1.12.0
 	github.com/jonboulle/clockwork v0.2.2
+	github.com/stretchr/testify v1.8.3
 	github.com/zorkian/go-datadog-api v2.30.0+incompatible
 	gopkg.in/DataDog/dd-trace-go.v1 v1.34.0
 	gopkg.in/dnaeon/go-vcr.v3 v3.1.2
@@ -40,6 +41,7 @@ require (
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
@@ -75,6 +77,7 @@ require (
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/philhofer/fwd v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,9 @@ github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQ
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
 github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=


### PR DESCRIPTION
This is the initial PR to start implementation of ephemeral resources requested by [Github Issue](https://github.com/DataDog/terraform-provider-datadog/issues/2916).

**Add core infrastructure for ephemeral resources in Terraform Plugin Framework**
- Framework wrapper with schema enrichment
- Private data utilities for state management between Open/Renew/Close
- Test coverage for wrapper functionality

This enables secure, stateless access to sensitive resources without
storing secrets in Terraform state files.

[APIR-2185]: https://datadoghq.atlassian.net/browse/APIR-2185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ