### PR TITLE
[datadog_restriction_policy] Update comment for usage with monitors

### DIFF
--- a/datadog/fwprovider/resource_datadog_restriction_policy.go
+++ b/datadog/fwprovider/resource_datadog_restriction_policy.go
@@ -62,7 +62,7 @@ func (r *RestrictionPolicyResource) Schema(_ context.Context, _ resource.SchemaR
 					"* [Resource type definition](https://docs.datadoghq.com/api/latest/restriction-policies/#supported-resources)\n" +
 					"\nRestrictions :\n" +
 					"* Dashboards : support is in private beta. Reach out to your Datadog contact or support to enable this.\n" +
-					"* Monitors : Management of restriction policy through terraform is currently not available",
+					"* Monitors : Management of restriction policy through terraform is now available in Preview. Please request access via https://docs.datadoghq.com/help",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},

--- a/docs/resources/restriction_policy.md
+++ b/docs/resources/restriction_policy.md
@@ -42,7 +42,7 @@ Resources to define `resource_type` :
 
 Restrictions :
 * Dashboards : support is in private beta. Reach out to your Datadog contact or support to enable this.
-* Monitors : Management of restriction policy through terraform is currently not available
+* Monitors : Management of restriction policy through terraform is now available in Preview. Please request access via https://docs.datadoghq.com/help
 
 ### Optional
 


### PR DESCRIPTION
Update documentation to note that restriction policy resource can be used with monitors, it should be requested.