### PR TITLE
Documentation fix for synthetics test resource

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -1581,7 +1581,7 @@ func syntheticsMobileStepParams() schema.Schema {
 					ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewSyntheticsCheckTypeFromValue),
 				},
 				"element": {
-					Description: "Element to use for the step, JSON encoded string.",
+					Description: "Element to use for the step",
 					Type:        schema.TypeList,
 					MaxItems:    1,
 					Optional:    true,

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -1354,7 +1354,7 @@ Optional:
 - `check` (String) Check type to use for an assertion step. Valid values are `equals`, `notEquals`, `contains`, `notContains`, `startsWith`, `notStartsWith`, `greater`, `lower`, `greaterEquals`, `lowerEquals`, `matchRegex`, `between`, `isEmpty`, `notIsEmpty`.
 - `delay` (Number) Delay between each key stroke for a "type test" step.
 - `direction` (String) Valid values are `up`, `down`, `left`, `right`.
-- `element` (Block List, Max: 1) Element to use for the step, JSON encoded string. (see [below for nested schema](#nestedblock--mobile_step--params--element))
+- `element` (Block List, Max: 1) Element to use for the step (see [below for nested schema](#nestedblock--mobile_step--params--element))
 - `enable` (Boolean)
 - `max_scrolls` (Number)
 - `positions` (Block List) (see [below for nested schema](#nestedblock--mobile_step--params--positions))


### PR DESCRIPTION
Small fix in the documentation for Synthetics mobile tests: the step params element are not json encoded.