### PR TITLE
[chore] Remove accidental replace for datadog-api-client-go in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -103,5 +103,3 @@ require (
 )
 
 go 1.23.0
-
-replace github.com/DataDog/datadog-api-client-go/v2 v2.46.0 => ../datadog-api-client-go


### PR DESCRIPTION
Accidentally added [here](https://github.com/DataDog/terraform-provider-datadog/pull/3252/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R107) - ran `make update-go-client` to pull latest package version and had this locally without realizing it