### PR TITLE
[datadog_synthetics_private_location] Add restriction_policy_resource_id to synthetics private locations to use with restriction policy

### DIFF
--- a/datadog/fwprovider/resource_datadog_synthetics_private_location.go
+++ b/datadog/fwprovider/resource_datadog_synthetics_private_location.go
@@ -33,13 +33,14 @@ type syntheticsPrivateLocationResource struct {
 }
 
 type syntheticsPrivateLocationModel struct {
-	Id          types.String                             `tfsdk:"id"`
-	Config      types.String                             `tfsdk:"config"`
-	Description types.String                             `tfsdk:"description"`
-	Metadata    []syntheticsPrivateLocationMetadataModel `tfsdk:"metadata"`
-	Name        types.String                             `tfsdk:"name"`
-	Tags        types.List                               `tfsdk:"tags"`
-	ApiKey      types.String                             `tfsdk:"api_key"`
+	Id                          types.String                             `tfsdk:"id"`
+	RestrictionPolicyResourceId types.String                             `tfsdk:"restriction_policy_resource_id"`
+	Config                      types.String                             `tfsdk:"config"`
+	Description                 types.String                             `tfsdk:"description"`
+	Metadata                    []syntheticsPrivateLocationMetadataModel `tfsdk:"metadata"`
+	Name                        types.String                             `tfsdk:"name"`
+	Tags                        types.List                               `tfsdk:"tags"`
+	ApiKey                      types.String                             `tfsdk:"api_key"`
 }
 
 type syntheticsPrivateLocationMetadataModel struct {
@@ -95,6 +96,10 @@ func (r *syntheticsPrivateLocationResource) Schema(_ context.Context, _ resource
 				Sensitive:   true,
 			},
 			"id": utils.ResourceIDAttribute(),
+			"restriction_policy_resource_id": schema.StringAttribute{
+				Description: "Resource ID to use when setting restrictions with a `datadog_restriction_policy` resource.",
+				Computed:    true,
+			},
 		},
 		Blocks: map[string]schema.Block{
 			"metadata": schema.ListNestedBlock{
@@ -263,6 +268,7 @@ func (r *syntheticsPrivateLocationResource) updateState(ctx context.Context, sta
 	state.Description = types.StringValue(resp.GetDescription())
 	state.Name = types.StringValue(resp.GetName())
 	state.Tags, _ = types.ListValueFrom(ctx, types.StringType, resp.Tags)
+	state.RestrictionPolicyResourceId = types.StringValue(fmt.Sprintf("synthetics-private-location%s", resp.GetId()[2:]))
 
 	if metadata, ok := resp.GetMetadataOk(); ok {
 		if restrictedRoles, ok := metadata.GetRestrictedRolesOk(); ok {

--- a/datadog/tests/resource_datadog_synthetics_private_location_test.go
+++ b/datadog/tests/resource_datadog_synthetics_private_location_test.go
@@ -102,6 +102,7 @@ func createSyntheticsPrivateLocationStep(ctx context.Context, accProvider *fwpro
 				"datadog_synthetics_private_location.foo", "config"),
 			resource.TestCheckResourceAttrSet(
 				"datadog_synthetics_private_location.foo", "id"),
+			checkRessourceAttributeRegex("datadog_synthetics_private_location.foo", "restriction_policy_resource_id", "synthetics-private-location:.*"),
 		),
 	}
 }
@@ -140,6 +141,7 @@ func updateSyntheticsPrivateLocationStep(ctx context.Context, accProvider *fwpro
 				"datadog_synthetics_private_location.foo", "config"),
 			resource.TestCheckResourceAttrSet(
 				"datadog_synthetics_private_location.foo", "id"),
+			checkRessourceAttributeRegex("datadog_synthetics_private_location.foo", "restriction_policy_resource_id", "synthetics-private-location:.*"),
 		),
 	}
 }

--- a/docs/resources/synthetics_private_location.md
+++ b/docs/resources/synthetics_private_location.md
@@ -38,6 +38,7 @@ resource "datadog_synthetics_private_location" "private_location" {
 
 - `config` (String, Sensitive) Configuration skeleton for the private location. See installation instructions of the private location on how to use this configuration.
 - `id` (String) The ID of this resource.
+- `restriction_policy_resource_id` (String) Resource ID to use when setting restrictions with a `datadog_restriction_policy` resource.
 
 <a id="nestedblock--metadata"></a>
 ### Nested Schema for `metadata`


### PR DESCRIPTION
The `id` of a synthetics private location has a format `pl:<id>` however our [restriction policy resource](https://docs.datadoghq.com/api/latest/restriction-policies/#supported-resources) needs a `synthetics-private-location:<id>` format, which forces user to process the id to use them in their configuration.

This PR adds a `restriction_policy_resource_id` computed attribute to synthetics private locations that can be used directly by users with the restriction policy resource.