### PR TITLE
[datadog_dashboard] Improve columns error handling to prevent panic

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -6064,6 +6064,7 @@ func buildDatadogListStreamRequests(terraformRequests *[]interface{}) (*[]datado
 			return nil, fmt.Errorf("list_stream_definition requires at least one column in request.columns")
 		}
 
+		// In the case where columns is passed in as {}, the length of columns is still 1, with a nil item at index 0. This extensive check prevents a panic during the for loop iteration below.
 		if len(terraformColumns) == 1 {
 			if terraformColumns[0] == nil {
 				return nil, fmt.Errorf("list_stream_definition requires request.columns to not be nil")


### PR DESCRIPTION
# Context
https://datadoghq.atlassian.net/browse/WEBPS-6724?focusedCommentId=2719102&sourceType=mention
Provider panics at the `terraform apply` stage when user passes in `columns {}`

This PR sets columns requirement to min:1, as well as checks for null items in the object.

# Test
with ~/.terraformrc set as instructed in DEVELOPMENT.md and this in examples/main.tf:
```
# terraform_examples/main.tf
terraform {
  required_providers {
    datadog = {
      source = "datadog/datadog"
    }
  }
}
provider "datadog" {
  api_key = "xxx"
  app_key = "yyy"
}
# ... any resource config
resource "datadog_dashboard" "ordered_dashboard" {
  title       = "Ordered Layout Dashboard"
  description = "Created using the Datadog provider in Terraform"
  layout_type = "ordered"
  widget {
    list_stream_definition {
      title       = "ECS Events"
      title_align = "left"
      title_size  = "16"
      request {
        response_format = "event_list"
        columns {}
        query {
          data_source  = "event_stream"
          event_size   = "s"
          indexes      = []
          query_string = "source:amazon_ecs"
        }
      }
    }
    widget_layout {
      is_column_break = false
      height          = 7
      width           = 6
      x               = 6
      y               = 0
    }
  }
}
```
run: `make build && cd examples && terraform init && terraform plan && terraform apply`

You should see informative error at the `terraform apply` stage
<img width="768" height="169" alt="image" src="https://github.com/user-attachments/assets/693d3672-3132-4c53-9ffe-ea369cf9d3ff" />