### PR TITLE
[resource_datadog_application_key] Update docs for application key

### DIFF
--- a/docs/resources/application_key.md
+++ b/docs/resources/application_key.md
@@ -13,8 +13,7 @@ Provides a Datadog Application Key resource. This can be used to create and mana
 ## Example Usage
 
 ```terraform
-# Source the permissions for scoped keys
-data "datadog_permissions" "dd_perms" {}
+# See the permissions available for scoped keys at https://docs.datadoghq.com/account_management/rbac/permissions/#permissions-list
 
 # Create an unrestricted Application Key
 # This key inherits all permissions of the user that owns the key
@@ -27,8 +26,8 @@ resource "datadog_application_key" "unrestricted_key" {
 resource "datadog_application_key" "monitor_management_key" {
   name = "Monitor Management Key"
   scopes = [
-    data.datadog_permissions.dd_perms.permissions.monitors_read,
-    data.datadog_permissions.dd_perms.permissions.monitors_write
+    "monitors_read",
+    "monitors_write"
   ]
 }
 ```

--- a/examples/resources/datadog_application_key/resource.tf
+++ b/examples/resources/datadog_application_key/resource.tf
@@ -1,5 +1,4 @@
-# Source the permissions for scoped keys
-data "datadog_permissions" "dd_perms" {}
+# See the permissions available for scoped keys at https://docs.datadoghq.com/account_management/rbac/permissions/#permissions-list
 
 # Create an unrestricted Application Key
 # This key inherits all permissions of the user that owns the key
@@ -12,7 +11,7 @@ resource "datadog_application_key" "unrestricted_key" {
 resource "datadog_application_key" "monitor_management_key" {
   name = "Monitor Management Key"
   scopes = [
-    data.datadog_permissions.dd_perms.permissions.monitors_read,
-    data.datadog_permissions.dd_perms.permissions.monitors_write
+    "monitors_read",
+    "monitors_write"
   ]
 }


### PR DESCRIPTION
The docs reference the permissions data source and indicate that you should pass in UUIDs from the data source. This is actually incorrect - the user should be passing in the scope names, otherwise they'll encounter a 400 upon `apply`.