### PR TITLE
guard against nil elements

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -6066,10 +6066,10 @@ func buildDatadogListStreamRequests(terraformRequests *[]interface{}) (*[]datado
 
 		if len(terraformColumns) == 1 {
 			if terraformColumns[0] == nil {
-				return nil, fmt.Errorf("list_stream_definition requires at least one column in request.columns")
+				return nil, fmt.Errorf("list_stream_definition requires request.columns to not be nil")
 			}
 			if m, ok := terraformColumns[0].(map[string]interface{}); !ok || m == nil || len(m) == 0 {
-				return nil, fmt.Errorf("list_stream_definition requires at least one column in request.columns")
+				return nil, fmt.Errorf("list_stream_definition requires request.columns to be a non-empty map")
 			}
 		}
 


### PR DESCRIPTION
# Test
with ~/.terraformrc set as instructed in DEVELOPMENT.md and this in examples/main.tf:
```
# terraform_examples/main.tf
terraform {
  required_providers {
    datadog = {
      source = "datadog/datadog"
    }
  }
}
provider "datadog" {
  api_key = "xxx"
  app_key = "yyy"
}
# ... any resource config
resource "datadog_dashboard" "ordered_dashboard" {
  title       = "Ordered Layout Dashboard"
  description = "Created using the Datadog provider in Terraform"
  layout_type = "ordered"
  widget {
    list_stream_definition {
      title       = "ECS Events"
      title_align = "left"
      title_size  = "16"
      request {
        response_format = "event_list"
        columns {}
        query {
          data_source  = "event_stream"
          event_size   = "s"
          indexes      = []
          query_string = "source:amazon_ecs"
        }
      }
    }
    widget_layout {
      is_column_break = false
      height          = 7
      width           = 6
      x               = 6
      y               = 0
    }
  }
}
```
run: `make build && cd examples && terraform init && terraform plan && terraform apply`

You should see informative error
<img width="768" height="169" alt="image" src="https://github.com/user-attachments/assets/693d3672-3132-4c53-9ffe-ea369cf9d3ff" />
