### PR TITLE
[authentication] Better handle cases where API/App keys are set alongside cloud auth

### DIFF
--- a/datadog/fwprovider/framework_provider.go
+++ b/datadog/fwprovider/framework_provider.go
@@ -523,20 +523,8 @@ func defaultConfigureFunc(p *FrameworkProvider, request *provider.ConfigureReque
 
 	// Initialize the official Datadog V1 API client
 	auth := context.Background()
-	if config.ApiKey.ValueString() != "" || config.AppKey.ValueString() != "" {
-		auth = context.WithValue(
-			auth,
-			datadog.ContextAPIKeys,
-			map[string]datadog.APIKey{
-				"apiKeyAuth": {
-					Key: config.ApiKey.ValueString(),
-				},
-				"appKeyAuth": {
-					Key: config.AppKey.ValueString(),
-				},
-			},
-		)
-	} else if cloudProviderType != "" {
+	// Check cloud_provider_type first - explicit config takes precedence over API keys
+	if cloudProviderType != "" {
 		// Allows for delegated token authentication
 		auth = context.WithValue(
 			auth,
@@ -558,6 +546,19 @@ func defaultConfigureFunc(p *FrameworkProvider, request *provider.ConfigureReque
 			diags.AddError("cloud_provider_type must be set to a valid value unless validate = false", "")
 			return diags
 		}
+	} else if config.ApiKey.ValueString() != "" || config.AppKey.ValueString() != "" {
+		auth = context.WithValue(
+			auth,
+			datadog.ContextAPIKeys,
+			map[string]datadog.APIKey{
+				"apiKeyAuth": {
+					Key: config.ApiKey.ValueString(),
+				},
+				"appKeyAuth": {
+					Key: config.AppKey.ValueString(),
+				},
+			},
+		)
 	}
 	ddClientConfig := datadog.NewConfiguration()
 	ddClientConfig.UserAgent = utils.GetUserAgentFramework(ddClientConfig.UserAgent, request.TerraformVersion)
@@ -671,8 +672,8 @@ func defaultConfigureFunc(p *FrameworkProvider, request *provider.ConfigureReque
 	}
 
 	ddClientConfig.HTTPClient = utils.NewHTTPClient()
-	// Only set DelegatedTokenConfig if we're using cloud provider auth (not API keys)
-	if config.ApiKey.ValueString() == "" && config.AppKey.ValueString() == "" && cloudProviderType != "" {
+	// If cloud_provider_type is set, use cloud auth (takes precedence over API keys)
+	if cloudProviderType != "" {
 		switch cloudProviderType {
 		case "aws":
 			ddClientConfig.DelegatedTokenConfig = &datadog.DelegatedTokenConfig{


### PR DESCRIPTION
We realized their were situations where if the terraform provider is configured to use cloud auth (i.e. `cloud_provider_type` is specified in the config) and the API keys or App Keys are set in the terraform config or environment variables then it could result in the user getting an error of `DelegatedTokenCredentials not found in context`. 

This PR should address that issue by only using API and App keys if the cloud auth config is not specified. If the terraform provider is configured to use cloud auth it will prefer cloud auth over API and App Key auth even if API and App keys are present within the environment (or explicitly in the config).