### PR TITLE
[datadog_synthetics_private_location] Fix restriction_policy_resource_id format

### DIFF
--- a/datadog/fwprovider/resource_datadog_synthetics_private_location.go
+++ b/datadog/fwprovider/resource_datadog_synthetics_private_location.go
@@ -268,7 +268,11 @@ func (r *syntheticsPrivateLocationResource) updateState(ctx context.Context, sta
 	state.Description = types.StringValue(resp.GetDescription())
 	state.Name = types.StringValue(resp.GetName())
 	state.Tags, _ = types.ListValueFrom(ctx, types.StringType, resp.Tags)
-	state.RestrictionPolicyResourceId = types.StringValue(fmt.Sprintf("synthetics-private-location%s", resp.GetId()[2:]))
+	// Convert the private location ID to the format expected by restriction policies
+	// The format should be: synthetics-private-location:pl:xxx (keep the pl: prefix)
+	privateLocationId := resp.GetId()
+	restrictionPolicyId := fmt.Sprintf("synthetics-private-location:%s", privateLocationId)
+	state.RestrictionPolicyResourceId = types.StringValue(restrictionPolicyId)
 
 	if metadata, ok := resp.GetMetadataOk(); ok {
 		if restrictedRoles, ok := metadata.GetRestrictedRolesOk(); ok {

--- a/datadog/tests/resource_datadog_synthetics_private_location_test.go
+++ b/datadog/tests/resource_datadog_synthetics_private_location_test.go
@@ -102,7 +102,7 @@ func createSyntheticsPrivateLocationStep(ctx context.Context, accProvider *fwpro
 				"datadog_synthetics_private_location.foo", "config"),
 			resource.TestCheckResourceAttrSet(
 				"datadog_synthetics_private_location.foo", "id"),
-			checkRessourceAttributeRegex("datadog_synthetics_private_location.foo", "restriction_policy_resource_id", "synthetics-private-location:.*"),
+			checkRessourceAttributeRegex("datadog_synthetics_private_location.foo", "restriction_policy_resource_id", "synthetics-private-location:pl:.*"),
 		),
 	}
 }
@@ -141,7 +141,7 @@ func updateSyntheticsPrivateLocationStep(ctx context.Context, accProvider *fwpro
 				"datadog_synthetics_private_location.foo", "config"),
 			resource.TestCheckResourceAttrSet(
 				"datadog_synthetics_private_location.foo", "id"),
-			checkRessourceAttributeRegex("datadog_synthetics_private_location.foo", "restriction_policy_resource_id", "synthetics-private-location:.*"),
+			checkRessourceAttributeRegex("datadog_synthetics_private_location.foo", "restriction_policy_resource_id", "synthetics-private-location:pl:.*"),
 		),
 	}
 }


### PR DESCRIPTION
## What does this PR do?
Fixes the `restriction_policy_resource_id` computed field to generate the correct format (`synthetics-private-location:pl:xxx` instead of `synthetics-private-location:xxx`).

## Motivation
* Customer report [SYN-4464](https://datadoghq.atlassian.net/browse/SYN-4464): Restriction policies showed as "Unrestricted" in UI despite successful Terraform creation.
* captured in dev ticket in: https://datadoghq.atlassian.net/browse/SYNTH-22157

## Testing
- All unit and integration tests pass
- Verified in staging that I can apply restriction policies against PL

**Why weren't cassettes re-recorded?**
`restriction_policy_resource_id` field is computed client-side by the provider using unchanged logic, so it doesn't appear in the API responses that the cassettes capture.

## Who will it impact
Customers using `restriction_policy_resource_id` with `datadog_restriction_policy`. Breaking change requiring policy recreation, but existing policies weren't working anyway.

**Breaking Changes?**
No. The field is read-only output that customers copy into their restriction policy configs, so changing it can't break the private location resource itself, only the policies (which were already broken).

[SYN-4464]: https://datadoghq.atlassian.net/browse/SYN-4464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ