### PR TITLE
[datadog_monitor] Make cloud cost query `aggregator` field required

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -581,7 +581,7 @@ func getMonitorFormulaQuerySchema() *schema.Schema {
 							},
 							"aggregator": {
 								Type:             schema.TypeString,
-								Optional:         true,
+								Required:         true,
 								ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewMonitorFormulaAndFunctionCostAggregatorFromValue),
 								Description:      "The aggregation methods available for cloud cost queries.",
 							},

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -166,13 +166,10 @@ Optional:
 
 Required:
 
+- `aggregator` (String) The aggregation methods available for cloud cost queries. Valid values are `avg`, `sum`, `max`, `min`, `last`, `area`, `l2norm`, `percentile`, `stddev`.
 - `data_source` (String) The data source for cloud cost queries. Valid values are `metrics`, `cloud_cost`, `datadog_usage`.
 - `name` (String) The name of the query for use in formulas.
 - `query` (String) The cloud cost query definition.
-
-Optional:
-
-- `aggregator` (String) The aggregation methods available for cloud cost queries. Valid values are `avg`, `sum`, `max`, `min`, `last`, `area`, `l2norm`, `percentile`, `stddev`.
 
 
 <a id="nestedblock--variables--event_query"></a>


### PR DESCRIPTION
This field is required by the API. This PR updates the schema so it is consistent with that.

Previous behavior:

```
╷
│ Error: error validating monitor from /api/v1/monitor/validate: 400 Bad Request: {"errors":["'aggregator' is a required property"]}
│
│   with datadog_monitor.Cloud_Cost_monitor_terraform_export,
│   on main.tf line 232, in resource "datadog_monitor" "Cloud_Cost_monitor":
│  232: resource "datadog_monitor" "Cloud_Cost_monitor_terraform_export" {
│
╵
```


New behavior:

```
╷
│ Error: Missing required argument
│
│   on main.tf line 238, in resource "datadog_monitor" "Cloud_Cost_monitor":
│  238:     cloud_cost_query {
│
│ The argument "aggregator" is required, but no definition was found.
```