### PR TITLE
[datadog_slo_correction] Clarify 'timezone' field description in SLO correction

### DIFF
--- a/datadog/resource_datadog_slo_correction.go
+++ b/datadog/resource_datadog_slo_correction.go
@@ -53,7 +53,7 @@ func resourceDatadogSloCorrection() *schema.Resource {
 				"timezone": {
 					Type:        schema.TypeString,
 					Optional:    true,
-					Description: "The timezone to display in the UI for the correction times (defaults to \"UTC\")",
+					Description: "The timezone to display in the UI for the correction times. Prefers IANA timezone name format (for example, 'America/Los_Angeles', 'Europe/Paris'), but some common standard abbreviations are supported. Defaults to 'UTC'.",
 				},
 				"duration": {
 					Type:        schema.TypeInt,

--- a/docs/resources/slo_correction.md
+++ b/docs/resources/slo_correction.md
@@ -65,7 +65,7 @@ resource "datadog_slo_correction" "example_slo_correction_with_recurrence" {
 - `duration` (Number) Length of time in seconds for a specified `rrule` recurring SLO correction (required if specifying `rrule`)
 - `end` (Number) Ending time of the correction in epoch seconds. Required for one time corrections, but optional if `rrule` is specified
 - `rrule` (String) Recurrence rules as defined in the iCalendar RFC 5545. Supported rules for SLO corrections are `FREQ`, `INTERVAL`, `COUNT` and `UNTIL`.
-- `timezone` (String) The timezone to display in the UI for the correction times. Prefers IANA timezone name format (for example, "America/Los_Angeles", "Europe/Paris"), but some common standard abbreviations are supported. Defaults to "UTC".
+- `timezone` (String) The timezone to display in the UI for the correction times. Prefers IANA timezone name format (for example, 'America/Los_Angeles', 'Europe/Paris'), but some common standard abbreviations are supported. Defaults to 'UTC'.
 
 ### Read-Only
 


### PR DESCRIPTION
Updated the description of the 'timezone' field for clarity