### PR TITLE
[datadog_security_monitoring_suppression] Fix issue when dealing with empty array of tags in Rules

### DIFF
--- a/datadog/resource_datadog_security_monitoring_rule.go
+++ b/datadog/resource_datadog_security_monitoring_rule.go
@@ -1923,6 +1923,9 @@ func buildUpdatePayload(d *schema.ResourceData) (*datadogV2.SecurityMonitoringRu
 			tags[i] = value.(string)
 		}
 		payload.SetTags(tags)
+	} else {
+		// Hack because the Go client does not serialize empty arrays to the JSON payload
+		payload.AdditionalProperties = map[string]any{"tags": []string{}}
 	}
 
 	tfFilters := d.Get("filter")


### PR DESCRIPTION
Similar to this PR/change: https://github.com/DataDog/terraform-provider-datadog/pull/3181/files#diff-98e31eb3de7abdef4c78a8f3632d7ccdf52807b0a58945da3a8c610959f394aeR1784, when users update the list for an empty list, the Go client ignores this list.

This PR fixes this issue.