### PR TITLE
ci(4.x): run checks for 4.x branch

### DIFF
--- a/.github/workflows/sdkv2_deprecation.yaml
+++ b/.github/workflows/sdkv2_deprecation.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - 4.x
 
 jobs:
   check-sdkv2:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,13 @@ on:
   pull_request:
     branches:
       - master
+      - 4.x
   schedule:
     - cron: "0 1 * * *"
   push:
     branches:
       - mq-working-branch-master-**
+      - mq-working-branch-4.x-**
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}-test


### PR DESCRIPTION
APIR-2320

# Changes
Adds Github checks for 4.x tf provider release branch

# Motivation
This to ensure the code standard is fulfilled while we're working on 4.x release