### PR TITLE
[CCV-4000] [datadog_cost_budget] Fix update creating duplicate instead of updating existing

### DIFF
--- a/datadog/fwprovider/resource_datadog_cost_budget.go
+++ b/datadog/fwprovider/resource_datadog_cost_budget.go
@@ -156,6 +156,15 @@ func (r *costBudgetResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
+	// we need to retrieve the ID from the current state and copy it to the plan
+	// otherwise the API will create a new budget instead of updating
+	var state costBudgetModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.ID = state.ID
+
 	apiReq := buildBudgetWithEntriesFromModel(plan)
 	apiResp, response, err := r.Api.UpsertBudget(r.Auth, apiReq)
 	if err != nil {


### PR DESCRIPTION
## What

Fix `datadog_cost_budget` resource Update operation creating duplicate budgets instead of updating existing ones

## Why

When users run `terraform apply` to update an existing budget, the provider was creating a new budget with a different ID instead of modifying the existing one. This issue was reported by Indeed customer

## Root Cause

The `Update()` function in `resource_datadog_cost_budget.go` was only reading from `req.Plan`, which contains the user's desired changes from their `.tf` file. However, Terraform doesn't include the resource ID in the plan (since users don't specify it in their config, it's marked as `Optional: true` in the schema)

The ID is only available in `req.State` (from `terraform.tfstate` file). without the ID, the `UpsertBudget` API call creates a new resource instead of updating the existing one.

## The Fix

Added code to:
1. Read the current state to get the existing ID
2. Copy the ID from state into the plan
3. Build the API request with the ID included

## Testing

!! _**Please read the testing process below to understand how this was verified**_!!

before anything, wanted to test if problem from API or Terraform so:
Tested the API directly with curl to confirm it handles updates correctly when ID is provided:

```
curl -X PUT -H "DD-API-KEY: $DD_API_KEY" -H "DD-APPLICATION-KEY: $DD_APP_KEY" \
  -H "Content-Type: application/vnd.api+json" \
  https://api.datadoghq.com/api/v2/cost/budget \
  -d '{"data":{"id":"...","type":"budget","attributes":{...}}}'
```
Returns same ID (API works correctly)This confirmed the bug was in the Terraform provider, not the API!

### Test 1: Verify Update Fix (Create -> Update Workflow)

This test confirms the update bug is fixed

**Commands:**
`cd terraform_examples`

<details>
<summary>Step 1: Create main.tf</summary>

```
cat > main.tf << 'EOF'
terraform {
  required_providers {
    datadog = { source = "datadog/datadog" }
  }
}
provider "datadog" {}

resource "datadog_cost_budget" "test" {
  name          = "Terraform Test Budget Zeina"
  metrics_query = "sum:aws.cost.amortized{*} by {service}"
  start_month   = 202501
  end_month     = 202503
  entries {
    month  = 202501
    amount = 100
    tag_filters {
      tag_key   = "service"
      tag_value = "ec2"
    }
  }
  entries {
    month  = 202502
    amount = 100
    tag_filters {
      tag_key   = "service"
      tag_value = "ec2"
    }
  }
  entries {
    month  = 202503
    amount = 100
    tag_filters {
      tag_key   = "service"
      tag_value = "ec2"
    }
  }
}
EOF
```
</details>

<details>
<summary>Step 2: Create budget</summary>

```
terraform init
terraform apply -auto-approve
# Created with ID: ...
```
</details>

<details>
<summary>Step 3: Modify main.tf (change name and amounts to 150)</summary>
... edit file ...
</details>

<details>
<summary>Step 4: Update budget</summary>

`terraform apply -auto-approve`

ID stayed same: so fix is verified

**Result:** 

- **Before fix**: ID changed on update (new budget created)

- **After fix**: ID stays the same (existing budget updated)
</details>

### Test 2: Check for Schema Discrepancies (Import -> Plan)

This test confirms no other discrepancies exist between UI-created budgets and Terraform schema


**Commands:**
<details>
<summary>Step 1: Import a UI-created budget (has tag filters, multiple entries so we check if problem with tags)</summary>

```
cat > import_test.tf << 'EOF'
terraform {
  required_providers {
    datadog = { source = "datadog/datadog" }
  }
}
provider "datadog" {}
resource "datadog_cost_budget" "ui_created" {}
EOF
```

`terraform import datadog_cost_budget.ui_created ... (type its id)`

Import successful
</details>

<details>
<summary>Step 2: See what was imported</summary>

`terraform show > imported_budget.txt`

Shows 12 monthly entries, each with tag_filters
</details>
<details>
<summary>Step 3: Copy imported config to import_test.tf</summary>

</details>
<details>
<summary>Step 4: Check for drift</summary>

`terraform plan`
Output: "No changes. Your infrastructure matches the configuration"

Result:

- Tag filters work correctly (nested in entries as expected)
- No schema mismatches between UI and Terraform
- No drift detected
</details>

