### PR TITLE
Make test cassettes not owned by anyone

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,8 @@
 
 # All your base
 *                                         @DataDog/api-reliability
+# Except cassettes
+datadog/tests/cassettes/
 
 /.generator                               @DataDog/api-reliability
 


### PR DESCRIPTION
This would simplify PR review, requiring less teams to approve in simple cases where one resource is modified.