### PR TITLE
obs-pipelines: remove rate config field in sample processors

### DIFF
--- a/datadog/fwprovider/resource_datadog_observability_pipeline.go
+++ b/datadog/fwprovider/resource_datadog_observability_pipeline.go
@@ -348,7 +348,6 @@ type grokRuleModel struct {
 }
 
 type sampleProcessorModel struct {
-	Rate       types.Int64   `tfsdk:"rate"`
 	Percentage types.Float64 `tfsdk:"percentage"`
 }
 
@@ -1376,12 +1375,8 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 													},
 													NestedObject: schema.NestedBlockObject{
 														Attributes: map[string]schema.Attribute{
-															"rate": schema.Int64Attribute{
-																Optional:    true,
-																Description: "Number of events to sample (1 in N).",
-															},
 															"percentage": schema.Float64Attribute{
-																Optional:    true,
+																Required:    true,
 																Description: "The percentage of logs to sample.",
 															},
 														},
@@ -3095,9 +3090,6 @@ func flattenSampleProcessor(ctx context.Context, src *datadogV2.ObservabilityPip
 	}
 	model := createProcessorModel(src)
 	sample := &sampleProcessorModel{}
-	if rate, ok := src.GetRateOk(); ok {
-		sample.Rate = types.Int64PointerValue(rate)
-	}
 	if percentage, ok := src.GetPercentageOk(); ok {
 		sample.Percentage = types.Float64PointerValue(percentage)
 	}
@@ -3550,9 +3542,6 @@ func expandSampleProcessorItem(ctx context.Context, common observability_pipelin
 	proc := datadogV2.NewObservabilityPipelineSampleProcessorWithDefaults()
 	common.ApplyTo(proc)
 
-	if !src.Rate.IsNull() {
-		proc.SetRate(src.Rate.ValueInt64())
-	}
 	if !src.Percentage.IsNull() {
 		proc.SetPercentage(src.Percentage.ValueFloat64())
 	}

--- a/datadog/tests/resource_datadog_observability_pipeline_test.go
+++ b/datadog/tests/resource_datadog_observability_pipeline_test.go
@@ -902,7 +902,7 @@ resource "datadog_observability_pipeline" "sample" {
         include = "*"
         
         sample {
-          rate = 10
+          percentage = 10
         }
       }
     }
@@ -941,7 +941,7 @@ resource "datadog_observability_pipeline" "sample" {
 					resource.TestCheckResourceAttr(resourceName, "config.0.processor_group.0.processor.0.id", "sample-1"),
 					resource.TestCheckResourceAttr(resourceName, "config.0.processor_group.0.processor.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "config.0.processor_group.0.processor.0.include", "*"),
-					resource.TestCheckResourceAttr(resourceName, "config.0.processor_group.0.processor.0.sample.0.rate", "10"),
+					resource.TestCheckResourceAttr(resourceName, "config.0.processor_group.0.processor.0.sample.0.percentage", "10"),
 					resource.TestCheckResourceAttr(resourceName, "config.0.processor_group.1.id", "sample-group-2"),
 					resource.TestCheckResourceAttr(resourceName, "config.0.processor_group.1.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "config.0.processor_group.1.processor.0.id", "sample-2"),

--- a/docs/resources/observability_pipeline.md
+++ b/docs/resources/observability_pipeline.md
@@ -924,10 +924,9 @@ Required:
 <a id="nestedblock--config--processor_group--processor--sample"></a>
 ### Nested Schema for `config.processor_group.processor.sample`
 
-Optional:
+Required:
 
 - `percentage` (Number) The percentage of logs to sample.
-- `rate` (Number) Number of events to sample (1 in N).
 
 
 <a id="nestedblock--config--processor_group--processor--sensitive_data_scanner"></a>


### PR DESCRIPTION
companion PR to https://github.com/DataDog/datadog-api-client-go/pull/3546

note: the go-client update commit is not included in this PR to avoid merges. Since the initial datadog-api-spec PR has been merged in the op-ga branch, syncing the op-ga datadog branch to the corresponding go client auto-generated PR should work, even if individual commits fail in the meantime