### PR TITLE
obs-pipelines: support for optional descriptions in SDS rule patterns

### DIFF
--- a/datadog/fwprovider/resource_datadog_observability_pipeline.go
+++ b/datadog/fwprovider/resource_datadog_observability_pipeline.go
@@ -486,12 +486,14 @@ type sensitiveDataScannerProcessorPattern struct {
 }
 
 type sensitiveDataScannerCustomPattern struct {
-	Rule types.String `tfsdk:"rule"`
+	Rule        types.String `tfsdk:"rule"`
+	Description types.String `tfsdk:"description"`
 }
 
 type sensitiveDataScannerLibraryPattern struct {
 	Id                     types.String `tfsdk:"id"`
 	UseRecommendedKeywords types.Bool   `tfsdk:"use_recommended_keywords"`
+	Description            types.String `tfsdk:"description"`
 }
 
 type sensitiveDataScannerProcessorScope struct {
@@ -1120,6 +1122,10 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 																									Optional:    true,
 																									Description: "A regular expression used to detect sensitive values. Must be a valid regex.",
 																								},
+																								"description": schema.StringAttribute{
+																									Optional:    true,
+																									Description: "Human-readable description providing context about a sensitive data scanner rule",
+																								},
 																							},
 																						},
 																						Validators: []validator.List{
@@ -1137,6 +1143,10 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 																								"use_recommended_keywords": schema.BoolAttribute{
 																									Optional:    true,
 																									Description: "Whether to augment the pattern with recommended keywords (optional).",
+																								},
+																								"description": schema.StringAttribute{
+																									Optional:    true,
+																									Description: "Human-readable description providing context about a sensitive data scanner rule",
 																								},
 																							},
 																						},
@@ -2935,6 +2945,9 @@ func flattenSensitiveDataScannerProcessor(ctx context.Context, src *datadogV2.Ob
 						Rule: types.StringValue(options.GetRule()),
 					},
 				}
+				if desc, ok := options.GetDescriptionOk(); ok {
+					outPattern.Custom[0].Description = types.StringPointerValue(desc)
+				}
 			}
 			if pattern.ObservabilityPipelineSensitiveDataScannerProcessorLibraryPattern != nil {
 				options := pattern.ObservabilityPipelineSensitiveDataScannerProcessorLibraryPattern.GetOptions()
@@ -2942,6 +2955,9 @@ func flattenSensitiveDataScannerProcessor(ctx context.Context, src *datadogV2.Ob
 					{
 						Id: types.StringValue(options.GetId()),
 					},
+				}
+				if desc, ok := options.GetDescriptionOk(); ok {
+					outPattern.Library[0].Description = types.StringPointerValue(desc)
 				}
 				if useKw, ok := options.GetUseRecommendedKeywordsOk(); ok {
 					outPattern.Library[0].UseRecommendedKeywords = types.BoolPointerValue(useKw)
@@ -3628,6 +3644,9 @@ func expandSensitiveDataScannerProcessorItem(ctx context.Context, common observa
 			if len(tfPattern.Custom) > 0 {
 				options := datadogV2.NewObservabilityPipelineSensitiveDataScannerProcessorCustomPatternOptionsWithDefaults()
 				options.SetRule(tfPattern.Custom[0].Rule.ValueString())
+				if !tfPattern.Custom[0].Description.IsNull() {
+					options.SetDescription(tfPattern.Custom[0].Description.ValueString())
+				}
 				customPattern := datadogV2.NewObservabilityPipelineSensitiveDataScannerProcessorCustomPattern(
 					*options,
 					datadogV2.OBSERVABILITYPIPELINESENSITIVEDATASCANNERPROCESSORCUSTOMPATTERNTYPE_CUSTOM,
@@ -3637,6 +3656,9 @@ func expandSensitiveDataScannerProcessorItem(ctx context.Context, common observa
 			} else if len(tfPattern.Library) > 0 {
 				options := datadogV2.NewObservabilityPipelineSensitiveDataScannerProcessorLibraryPatternOptionsWithDefaults()
 				options.SetId(tfPattern.Library[0].Id.ValueString())
+				if !tfPattern.Library[0].Description.IsNull() {
+					options.SetDescription(tfPattern.Library[0].Description.ValueString())
+				}
 				if !tfPattern.Library[0].UseRecommendedKeywords.IsNull() {
 					options.SetUseRecommendedKeywords(tfPattern.Library[0].UseRecommendedKeywords.ValueBool())
 				}

--- a/datadog/tests/resource_datadog_observability_pipeline_test.go
+++ b/datadog/tests/resource_datadog_observability_pipeline_test.go
@@ -1945,6 +1945,7 @@ resource "datadog_observability_pipeline" "sds" {
             pattern {
               custom {
                 rule = "\\bsecret-[a-z0-9]+\\b"
+                description = "secret"
               }
             }
 
@@ -2012,6 +2013,7 @@ resource "datadog_observability_pipeline" "sds" {
             pattern {
               library {
                 id = "email_address"
+                description = "email address"
               }
             }
 

--- a/docs/resources/observability_pipeline.md
+++ b/docs/resources/observability_pipeline.md
@@ -1004,6 +1004,7 @@ Optional:
 
 Optional:
 
+- `description` (String) Human-readable description providing context about a sensitive data scanner rule
 - `rule` (String) A regular expression used to detect sensitive values. Must be a valid regex.
 
 
@@ -1012,6 +1013,7 @@ Optional:
 
 Optional:
 
+- `description` (String) Human-readable description providing context about a sensitive data scanner rule
 - `id` (String) Identifier for a predefined pattern from the sensitive data scanner pattern library.
 - `use_recommended_keywords` (Boolean) Whether to augment the pattern with recommended keywords (optional).
 


### PR DESCRIPTION
tested manually with https://github.com/DataDog/datadog-api-client-go/pull/3552
