### PR TITLE
[datadog_security_monitoring_rule] Replace security monitoring rules with an updated detection method

### DIFF
--- a/datadog/resource_datadog_security_monitoring_rule.go
+++ b/datadog/resource_datadog_security_monitoring_rule.go
@@ -171,6 +171,7 @@ func datadogSecurityMonitoringRuleSchema(includeValidate bool) map[string]*schem
 						Optional:         true,
 						Description:      "The detection method.",
 						Default:          "threshold",
+						ForceNew:         true,
 					},
 
 					"evaluation_window": {


### PR DESCRIPTION
In the rule editor, we don't allow users to update the detection method once they've created a rule but the security monitoring terraform resource still allows it. This results in validation errors (see [this example](https://gitlab.ddbuild.io/DataDog/threat-detection/-/jobs/1320677397) updating a threshold rule to a sequence_detection rule) when updating the rule because the API is not expecting a change in detection method. This PR adds the ForceNew flag to the detection method field which will result in the resource being deleted and created rather than updated when the detection method changes