### PR TITLE
[datadog_security_monitoring_rule] Fix panic when notifications list contains nil values

### DIFF
--- a/datadog/resource_datadog_security_monitoring_rule.go
+++ b/datadog/resource_datadog_security_monitoring_rule.go
@@ -1240,10 +1240,18 @@ func buildRootQueryPayload(rootQuery map[string]interface{}) *datadogV2.Security
 }
 
 func parseStringArray(array []interface{}) []string {
-	parsed := make([]string, len(array))
+	// Pre-allocate with capacity but zero length to filter out invalid values
+	parsed := make([]string, 0, len(array))
 
-	for idx, value := range array {
-		parsed[idx] = value.(string)
+	for _, value := range array {
+		// Skip nil values to prevent panic
+		if value == nil {
+			continue
+		}
+		// Use safe type assertion to prevent panic on non-string values
+		if strVal, ok := value.(string); ok {
+			parsed = append(parsed, strVal)
+		}
 	}
 
 	return parsed

--- a/datadog/resource_datadog_security_monitoring_rule_test.go
+++ b/datadog/resource_datadog_security_monitoring_rule_test.go
@@ -1,0 +1,92 @@
+package datadog
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseStringArray(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    []interface{}
+		expected []string
+	}{
+		{
+			name:     "normal_strings",
+			input:    []interface{}{"@user", "@admin"},
+			expected: []string{"@user", "@admin"},
+		},
+		{
+			name:     "empty_array",
+			input:    []interface{}{},
+			expected: []string{},
+		},
+		{
+			name:     "nil_values_filtered",
+			input:    []interface{}{"@user", nil, "@admin"},
+			expected: []string{"@user", "@admin"},
+		},
+		{
+			name:     "all_nil_values",
+			input:    []interface{}{nil, nil, nil},
+			expected: []string{},
+		},
+		{
+			name:     "empty_string_kept",
+			input:    []interface{}{"@user", "", "@admin"},
+			expected: []string{"@user", "", "@admin"},
+		},
+		{
+			name:     "only_empty_string",
+			input:    []interface{}{""},
+			expected: []string{""},
+		},
+		{
+			name:     "mixed_nil_and_empty",
+			input:    []interface{}{nil, "", nil, "@user"},
+			expected: []string{"", "@user"},
+		},
+		{
+			name:     "single_valid_string",
+			input:    []interface{}{"@slack-channel"},
+			expected: []string{"@slack-channel"},
+		},
+		{
+			name:     "single_nil",
+			input:    []interface{}{nil},
+			expected: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := parseStringArray(tc.input)
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("parseStringArray(%v) = %v, expected %v", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+// TestParseStringArrayNoPanic ensures the function doesn't panic on nil values
+// This is the specific fix for GitHub issue #3322
+func TestParseStringArrayNoPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("parseStringArray panicked with input containing nil: %v", r)
+		}
+	}()
+
+	// These inputs previously caused a panic before the fix
+	panicInputs := [][]interface{}{
+		{nil},
+		{"", nil},
+		{nil, nil, nil},
+		{"@user", nil, "@admin"},
+	}
+
+	for _, input := range panicInputs {
+		parseStringArray(input)
+	}
+}
+


### PR DESCRIPTION
## Description

Fixes a panic that occurs when the `notifications` list in `case` or `third_party_case` blocks contains `nil` or empty values.

Closes #3322

## Changes

- Modified `parseStringArray()` to use safe type assertion pattern
- Added nil check before type conversion to prevent runtime panic
- Added unit tests to verify the fix

## Root Cause

The `parseStringArray()` function used direct type assertion (`value.(string)`) which panics when the value is `nil`. This happens when users specify `notifications = [""]` or `notifications = [null]` in their Terraform configuration.

## Solution

Applied safe type assertion pattern with nil check:
```go
// Before (panic prone)
parsed[idx] = value.(string)

// After (safe)
if value == nil {
    continue
}
if strVal, ok := value.(string); ok {
    parsed = append(parsed, strVal)
}
```

## Testing

- [x] Unit tests for `parseStringArray()` - all pass
- [x] Existing acceptance tests - no regression