### PR TITLE
obs-pipelines: add support for buffer management in destinations

### DIFF
--- a/datadog/fwprovider/observability_pipeline/amazon_security_lake_destination.go
+++ b/datadog/fwprovider/observability_pipeline/amazon_security_lake_destination.go
@@ -10,11 +10,12 @@ import (
 
 // AmazonSecurityLakeDestinationModel represents the Terraform model for the AmazonSecurityLakeDestination
 type AmazonSecurityLakeDestinationModel struct {
-	Bucket           types.String   `tfsdk:"bucket"`
-	Region           types.String   `tfsdk:"region"`
-	CustomSourceName types.String   `tfsdk:"custom_source_name"`
-	Tls              []TlsModel     `tfsdk:"tls"`
-	Auth             []AwsAuthModel `tfsdk:"auth"`
+	Bucket           types.String         `tfsdk:"bucket"`
+	Region           types.String         `tfsdk:"region"`
+	CustomSourceName types.String         `tfsdk:"custom_source_name"`
+	Tls              []TlsModel           `tfsdk:"tls"`
+	Auth             []AwsAuthModel       `tfsdk:"auth"`
+	Buffer           []BufferOptionsModel `tfsdk:"buffer"`
 }
 
 func AmazonSecurityLakeDestinationSchema() schema.ListNestedBlock {
@@ -36,8 +37,9 @@ func AmazonSecurityLakeDestinationSchema() schema.ListNestedBlock {
 				},
 			},
 			Blocks: map[string]schema.Block{
-				"tls":  TlsSchema(),
-				"auth": AwsAuthSchema(),
+				"tls":    TlsSchema(),
+				"auth":   AwsAuthSchema(),
+				"buffer": BufferOptionsSchema(),
 			},
 		},
 	}
@@ -67,6 +69,13 @@ func ExpandObservabilityPipelinesAmazonSecurityLakeDestination(ctx context.Conte
 		dest.SetAuth(ExpandAwsAuth(src.Auth[0]))
 	}
 
+	if len(src.Buffer) > 0 {
+		buffer := ExpandBufferOptions(src.Buffer[0])
+		if buffer != nil {
+			dest.SetBuffer(*buffer)
+		}
+	}
+
 	return datadogV2.ObservabilityPipelineConfigDestinationItem{
 		ObservabilityPipelineAmazonSecurityLakeDestination: dest,
 	}
@@ -89,6 +98,13 @@ func FlattenObservabilityPipelinesAmazonSecurityLakeDestination(ctx context.Cont
 
 	if src.Auth != nil {
 		model.Auth = FlattenAwsAuth(src.Auth)
+	}
+
+	if buffer, ok := src.GetBufferOk(); ok {
+		outBuffer := FlattenBufferOptions(buffer)
+		if outBuffer != nil {
+			model.Buffer = []BufferOptionsModel{*outBuffer}
+		}
 	}
 
 	return model

--- a/datadog/fwprovider/observability_pipeline/buffer.go
+++ b/datadog/fwprovider/observability_pipeline/buffer.go
@@ -1,0 +1,154 @@
+package observability_pipeline
+
+import (
+	datadogV2 "github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	frameworkPath "github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type BufferOptionsModel struct {
+	DiskBuffer   []DiskBufferOptionsModel   `tfsdk:"disk"`
+	MemoryBuffer []MemoryBufferOptionsModel `tfsdk:"memory"`
+}
+
+type DiskBufferOptionsModel struct {
+	MaxSize types.Int64 `tfsdk:"max_size"`
+}
+
+type MemoryBufferOptionsModel struct {
+	MaxSize   types.Int64 `tfsdk:"max_size"`
+	MaxEvents types.Int64 `tfsdk:"max_events"`
+}
+
+func ExpandBufferOptions(src BufferOptionsModel) *datadogV2.ObservabilityPipelineBufferOptions {
+	if len(src.DiskBuffer) > 0 {
+		diskBuf := src.DiskBuffer[0]
+		buffer := datadogV2.NewObservabilityPipelineDiskBufferOptionsWithDefaults()
+
+		if !diskBuf.MaxSize.IsNull() {
+			buffer.SetMaxSize(diskBuf.MaxSize.ValueInt64())
+		}
+		buffer.SetType(datadogV2.ObservabilityPipelineBufferOptionsDiskType("disk"))
+
+		return &datadogV2.ObservabilityPipelineBufferOptions{
+			ObservabilityPipelineDiskBufferOptions: buffer,
+		}
+	}
+
+	if len(src.MemoryBuffer) > 0 {
+		memBuf := src.MemoryBuffer[0]
+
+		if !memBuf.MaxEvents.IsNull() {
+			buffer := datadogV2.NewObservabilityPipelineMemoryBufferSizeOptionsWithDefaults()
+			buffer.SetType(datadogV2.ObservabilityPipelineBufferOptionsMemoryType("memory"))
+			buffer.SetMaxEvents(memBuf.MaxEvents.ValueInt64())
+
+			return &datadogV2.ObservabilityPipelineBufferOptions{
+				ObservabilityPipelineMemoryBufferSizeOptions: buffer,
+			}
+		} else if !memBuf.MaxSize.IsNull() {
+			buffer := datadogV2.NewObservabilityPipelineMemoryBufferOptionsWithDefaults()
+			buffer.SetType(datadogV2.ObservabilityPipelineBufferOptionsMemoryType("memory"))
+			buffer.SetMaxSize(memBuf.MaxSize.ValueInt64())
+
+			return &datadogV2.ObservabilityPipelineBufferOptions{
+				ObservabilityPipelineMemoryBufferOptions: buffer,
+			}
+		}
+	}
+
+	return nil
+}
+
+func FlattenBufferOptions(src *datadogV2.ObservabilityPipelineBufferOptions) *BufferOptionsModel {
+	if src == nil {
+		return nil
+	}
+
+	if diskBuf := src.ObservabilityPipelineDiskBufferOptions; diskBuf != nil {
+		return &BufferOptionsModel{
+			DiskBuffer: []DiskBufferOptionsModel{
+				{
+					MaxSize: types.Int64Value(diskBuf.GetMaxSize()),
+				},
+			},
+		}
+	}
+
+	if memBufSize := src.ObservabilityPipelineMemoryBufferSizeOptions; memBufSize != nil {
+		return &BufferOptionsModel{
+			MemoryBuffer: []MemoryBufferOptionsModel{
+				{
+					MaxEvents: types.Int64Value(memBufSize.GetMaxEvents()),
+					MaxSize:   types.Int64Null(),
+				},
+			},
+		}
+	}
+
+	if memBuf := src.ObservabilityPipelineMemoryBufferOptions; memBuf != nil {
+		return &BufferOptionsModel{
+			MemoryBuffer: []MemoryBufferOptionsModel{
+				{
+					MaxSize:   types.Int64Value(memBuf.GetMaxSize()),
+					MaxEvents: types.Int64Null(),
+				},
+			},
+		}
+	}
+
+	return nil
+}
+
+func BufferOptionsSchema() schema.ListNestedBlock {
+	return schema.ListNestedBlock{
+		Description: "Configuration for buffer settings on destination components. Exactly one of `disk` or `memory` must be specified.",
+		NestedObject: schema.NestedBlockObject{
+			Blocks: map[string]schema.Block{
+				"disk": schema.ListNestedBlock{
+					Description: "Options for configuring a disk buffer. Cannot be used with `memory`.",
+					NestedObject: schema.NestedBlockObject{
+						Attributes: map[string]schema.Attribute{
+							"max_size": schema.Int64Attribute{
+								Optional:    true,
+								Description: "Maximum size of the disk buffer (in bytes).",
+							},
+						},
+					},
+					Validators: []validator.List{
+						listvalidator.SizeAtMost(1),
+						listvalidator.ExactlyOneOf(frameworkPath.MatchRelative().AtParent().AtName("memory")),
+					},
+				},
+				"memory": schema.ListNestedBlock{
+					Description: "Options for configuring a memory buffer. Cannot be used with `disk`.",
+					NestedObject: schema.NestedBlockObject{
+						Attributes: map[string]schema.Attribute{
+							"max_size": schema.Int64Attribute{
+								Optional:    true,
+								Description: "Maximum size of the memory buffer (in bytes).",
+								Validators: []validator.Int64{
+									int64validator.ExactlyOneOf(frameworkPath.MatchRelative().AtParent().AtName("max_events")),
+								},
+							},
+							"max_events": schema.Int64Attribute{
+								Optional:    true,
+								Description: "Maximum events for the memory buffer.",
+							},
+						},
+					},
+					Validators: []validator.List{
+						listvalidator.SizeAtMost(1),
+					},
+				},
+			},
+		},
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+	}
+}

--- a/datadog/fwprovider/observability_pipeline/crowdstrike_next_gen_siem_destination.go
+++ b/datadog/fwprovider/observability_pipeline/crowdstrike_next_gen_siem_destination.go
@@ -12,9 +12,10 @@ import (
 
 // CrowdStrikeNextGenSiemDestinationModel represents the Terraform model for the CrowdStrikeNextGenSiemDestination
 type CrowdStrikeNextGenSiemDestinationModel struct {
-	Encoding    types.String       `tfsdk:"encoding"`
-	Compression []compressionModel `tfsdk:"compression"`
-	Tls         []TlsModel         `tfsdk:"tls"`
+	Encoding    types.String         `tfsdk:"encoding"`
+	Compression []compressionModel   `tfsdk:"compression"`
+	Tls         []TlsModel           `tfsdk:"tls"`
+	Buffer      []BufferOptionsModel `tfsdk:"buffer"`
 }
 
 // CrowdStrikeNextGenSiemDestinationSchema returns the schema for the CrowdStrikeNextGenSiemDestination
@@ -34,6 +35,7 @@ func CrowdStrikeNextGenSiemDestinationSchema() schema.ListNestedBlock {
 			Blocks: map[string]schema.Block{
 				"compression": CompressionSchema(),
 				"tls":         TlsSchema(),
+				"buffer":      BufferOptionsSchema(),
 			},
 		},
 	}
@@ -56,6 +58,13 @@ func ExpandCrowdStrikeNextGenSiemDestination(ctx context.Context, id string, inp
 	}
 	if len(src.Tls) > 0 {
 		dest.Tls = ExpandTls(src.Tls)
+	}
+
+	if len(src.Buffer) > 0 {
+		buffer := ExpandBufferOptions(src.Buffer[0])
+		if buffer != nil {
+			dest.SetBuffer(*buffer)
+		}
 	}
 
 	return datadogV2.ObservabilityPipelineConfigDestinationItem{
@@ -81,6 +90,13 @@ func FlattenCrowdStrikeNextGenSiemDestination(ctx context.Context, src *datadogV
 	if src.Compression != nil {
 		compression := FlattenCompression(src.Compression)
 		out.Compression = []compressionModel{compression}
+	}
+
+	if buffer, ok := src.GetBufferOk(); ok {
+		outBuffer := FlattenBufferOptions(buffer)
+		if outBuffer != nil {
+			out.Buffer = []BufferOptionsModel{*outBuffer}
+		}
 	}
 
 	return out

--- a/datadog/fwprovider/observability_pipeline/socket_destination.go
+++ b/datadog/fwprovider/observability_pipeline/socket_destination.go
@@ -17,6 +17,7 @@ type SocketDestinationModel struct {
 	Encoding types.String         `tfsdk:"encoding"`
 	Framing  []SocketFramingModel `tfsdk:"framing"`
 	Tls      []TlsModel           `tfsdk:"tls"`
+	Buffer   []BufferOptionsModel `tfsdk:"buffer"`
 }
 
 // ExpandSocketDestination converts the Terraform model to the Datadog API model
@@ -57,6 +58,13 @@ func ExpandSocketDestination(ctx context.Context, id string, inputs types.List, 
 		s.Tls = ExpandTls(src.Tls)
 	}
 
+	if len(src.Buffer) > 0 {
+		buffer := ExpandBufferOptions(src.Buffer[0])
+		if buffer != nil {
+			s.SetBuffer(*buffer)
+		}
+	}
+
 	return datadogV2.ObservabilityPipelineConfigDestinationItem{
 		ObservabilityPipelineSocketDestination: s,
 	}
@@ -91,6 +99,13 @@ func FlattenSocketDestination(ctx context.Context, src *datadogV2.ObservabilityP
 	}
 	out.Framing = []SocketFramingModel{outFraming}
 
+	if buffer, ok := src.GetBufferOk(); ok {
+		outBuffer := FlattenBufferOptions(buffer)
+		if outBuffer != nil {
+			out.Buffer = []BufferOptionsModel{*outBuffer}
+		}
+	}
+
 	return out
 }
 
@@ -116,6 +131,7 @@ func SocketDestinationSchema() schema.ListNestedBlock {
 				},
 			},
 			Blocks: map[string]schema.Block{
+				"buffer": BufferOptionsSchema(),
 				"framing": schema.ListNestedBlock{
 					Description: "Defines the framing method for outgoing messages.",
 					NestedObject: schema.NestedBlockObject{

--- a/datadog/fwprovider/resource_datadog_observability_pipeline.go
+++ b/datadog/fwprovider/resource_datadog_observability_pipeline.go
@@ -324,8 +324,9 @@ type fieldValue struct {
 }
 
 type amazonOpenSearchDestinationModel struct {
-	BulkIndex types.String                `tfsdk:"bulk_index"`
-	Auth      []amazonOpenSearchAuthModel `tfsdk:"auth"`
+	BulkIndex types.String                                `tfsdk:"bulk_index"`
+	Auth      []amazonOpenSearchAuthModel                 `tfsdk:"auth"`
+	Buffer    []observability_pipeline.BufferOptionsModel `tfsdk:"buffer"`
 }
 
 type amazonOpenSearchAuthModel struct {
@@ -337,33 +338,39 @@ type amazonOpenSearchAuthModel struct {
 }
 
 type opensearchDestinationModel struct {
-	BulkIndex types.String `tfsdk:"bulk_index"`
+	BulkIndex types.String                                `tfsdk:"bulk_index"`
+	Buffer    []observability_pipeline.BufferOptionsModel `tfsdk:"buffer"`
 }
 
 type sentinelOneDestinationModel struct {
-	Region types.String `tfsdk:"region"`
+	Region types.String                                `tfsdk:"region"`
+	Buffer []observability_pipeline.BufferOptionsModel `tfsdk:"buffer"`
 }
 
 type newRelicDestinationModel struct {
-	Region types.String `tfsdk:"region"`
+	Region types.String                                `tfsdk:"region"`
+	Buffer []observability_pipeline.BufferOptionsModel `tfsdk:"buffer"`
 }
 
 type googleChronicleDestinationModel struct {
-	Auth       []gcpAuthModel `tfsdk:"auth"`
-	CustomerId types.String   `tfsdk:"customer_id"`
-	Encoding   types.String   `tfsdk:"encoding"`
-	LogType    types.String   `tfsdk:"log_type"`
+	Auth       []gcpAuthModel                              `tfsdk:"auth"`
+	CustomerId types.String                                `tfsdk:"customer_id"`
+	Encoding   types.String                                `tfsdk:"encoding"`
+	LogType    types.String                                `tfsdk:"log_type"`
+	Buffer     []observability_pipeline.BufferOptionsModel `tfsdk:"buffer"`
 }
 
 type googlePubSubDestinationModel struct {
-	Project  types.String                      `tfsdk:"project"`
-	Topic    types.String                      `tfsdk:"topic"`
-	Auth     []gcpAuthModel                    `tfsdk:"auth"`
-	Encoding types.String                      `tfsdk:"encoding"`
-	Tls      []observability_pipeline.TlsModel `tfsdk:"tls"`
+	Project  types.String                                `tfsdk:"project"`
+	Topic    types.String                                `tfsdk:"topic"`
+	Auth     []gcpAuthModel                              `tfsdk:"auth"`
+	Encoding types.String                                `tfsdk:"encoding"`
+	Tls      []observability_pipeline.TlsModel           `tfsdk:"tls"`
+	Buffer   []observability_pipeline.BufferOptionsModel `tfsdk:"buffer"`
 }
 
 type datadogLogsDestinationModel struct {
+	Buffer []observability_pipeline.BufferOptionsModel `tfsdk:"buffer"`
 }
 
 type parseGrokProcessorModel struct {
@@ -426,19 +433,21 @@ type splunkTcpSourceModel struct {
 }
 
 type splunkHecDestinationModel struct {
-	AutoExtractTimestamp types.Bool   `tfsdk:"auto_extract_timestamp"`
-	Encoding             types.String `tfsdk:"encoding"`
-	Sourcetype           types.String `tfsdk:"sourcetype"`
-	Index                types.String `tfsdk:"index"`
+	AutoExtractTimestamp types.Bool                                  `tfsdk:"auto_extract_timestamp"`
+	Encoding             types.String                                `tfsdk:"encoding"`
+	Sourcetype           types.String                                `tfsdk:"sourcetype"`
+	Index                types.String                                `tfsdk:"index"`
+	Buffer               []observability_pipeline.BufferOptionsModel `tfsdk:"buffer"`
 }
 
 type gcsDestinationModel struct {
-	Bucket       types.String    `tfsdk:"bucket"`
-	KeyPrefix    types.String    `tfsdk:"key_prefix"`
-	StorageClass types.String    `tfsdk:"storage_class"`
-	Acl          types.String    `tfsdk:"acl"`
-	Auth         []gcpAuthModel  `tfsdk:"auth"`
-	Metadata     []metadataEntry `tfsdk:"metadata"`
+	Bucket       types.String                                `tfsdk:"bucket"`
+	KeyPrefix    types.String                                `tfsdk:"key_prefix"`
+	StorageClass types.String                                `tfsdk:"storage_class"`
+	Acl          types.String                                `tfsdk:"acl"`
+	Auth         []gcpAuthModel                              `tfsdk:"auth"`
+	Metadata     []metadataEntry                             `tfsdk:"metadata"`
+	Buffer       []observability_pipeline.BufferOptionsModel `tfsdk:"buffer"`
 }
 
 type metadataEntry struct {
@@ -447,11 +456,12 @@ type metadataEntry struct {
 }
 
 type sumoLogicDestinationModel struct {
-	Encoding             types.String             `tfsdk:"encoding"`
-	HeaderHostName       types.String             `tfsdk:"header_host_name"`
-	HeaderSourceName     types.String             `tfsdk:"header_source_name"`
-	HeaderSourceCategory types.String             `tfsdk:"header_source_category"`
-	HeaderCustomFields   []headerCustomFieldModel `tfsdk:"header_custom_field"`
+	Encoding             types.String                                `tfsdk:"encoding"`
+	HeaderHostName       types.String                                `tfsdk:"header_host_name"`
+	HeaderSourceName     types.String                                `tfsdk:"header_source_name"`
+	HeaderSourceCategory types.String                                `tfsdk:"header_source_category"`
+	HeaderCustomFields   []headerCustomFieldModel                    `tfsdk:"header_custom_field"`
+	Buffer               []observability_pipeline.BufferOptionsModel `tfsdk:"buffer"`
 }
 
 type headerCustomFieldModel struct {
@@ -470,30 +480,35 @@ type syslogNgSourceModel struct {
 }
 
 type rsyslogDestinationModel struct {
-	Keepalive types.Int64                       `tfsdk:"keepalive"`
-	Tls       []observability_pipeline.TlsModel `tfsdk:"tls"`
+	Keepalive types.Int64                                 `tfsdk:"keepalive"`
+	Tls       []observability_pipeline.TlsModel           `tfsdk:"tls"`
+	Buffer    []observability_pipeline.BufferOptionsModel `tfsdk:"buffer"`
 }
 
 type syslogNgDestinationModel struct {
-	Keepalive types.Int64                       `tfsdk:"keepalive"`
-	Tls       []observability_pipeline.TlsModel `tfsdk:"tls"`
+	Keepalive types.Int64                                 `tfsdk:"keepalive"`
+	Tls       []observability_pipeline.TlsModel           `tfsdk:"tls"`
+	Buffer    []observability_pipeline.BufferOptionsModel `tfsdk:"buffer"`
 }
 
 type elasticsearchDestinationModel struct {
-	ApiVersion types.String `tfsdk:"api_version"`
-	BulkIndex  types.String `tfsdk:"bulk_index"`
+	ApiVersion types.String                                `tfsdk:"api_version"`
+	BulkIndex  types.String                                `tfsdk:"bulk_index"`
+	Buffer     []observability_pipeline.BufferOptionsModel `tfsdk:"buffer"`
 }
 
 type azureStorageDestinationModel struct {
-	ContainerName types.String `tfsdk:"container_name"`
-	BlobPrefix    types.String `tfsdk:"blob_prefix"`
+	ContainerName types.String                                `tfsdk:"container_name"`
+	BlobPrefix    types.String                                `tfsdk:"blob_prefix"`
+	Buffer        []observability_pipeline.BufferOptionsModel `tfsdk:"buffer"`
 }
 
 type microsoftSentinelDestinationModel struct {
-	ClientId       types.String `tfsdk:"client_id"`
-	TenantId       types.String `tfsdk:"tenant_id"`
-	DcrImmutableId types.String `tfsdk:"dcr_immutable_id"`
-	Table          types.String `tfsdk:"table"`
+	ClientId       types.String                                `tfsdk:"client_id"`
+	TenantId       types.String                                `tfsdk:"tenant_id"`
+	DcrImmutableId types.String                                `tfsdk:"dcr_immutable_id"`
+	Table          types.String                                `tfsdk:"table"`
+	Buffer         []observability_pipeline.BufferOptionsModel `tfsdk:"buffer"`
 }
 
 type sensitiveDataScannerProcessorModel struct {
@@ -1847,8 +1862,12 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 								},
 								Blocks: map[string]schema.Block{
 									"datadog_logs": schema.ListNestedBlock{
-										Description:  "The `datadog_logs` destination forwards logs to Datadog Log Management.",
-										NestedObject: schema.NestedBlockObject{},
+										Description: "The `datadog_logs` destination forwards logs to Datadog Log Management.",
+										NestedObject: schema.NestedBlockObject{
+											Blocks: map[string]schema.Block{
+												"buffer": observability_pipeline.BufferOptionsSchema(),
+											},
+										},
 									},
 									"datadog_metrics": schema.ListNestedBlock{
 										Description:  "The `datadog_metrics` destination forwards metrics to Datadog.",
@@ -1933,6 +1952,7 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 														},
 													},
 												},
+												"buffer": observability_pipeline.BufferOptionsSchema(),
 											},
 										},
 									},
@@ -1954,8 +1974,9 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 												},
 											},
 											Blocks: map[string]schema.Block{
-												"auth": gcpAuthSchema(),
-												"tls":  observability_pipeline.TlsSchema(),
+												"auth":   gcpAuthSchema(),
+												"tls":    observability_pipeline.TlsSchema(),
+												"buffer": observability_pipeline.BufferOptionsSchema(),
 											},
 										},
 									},
@@ -1979,6 +2000,9 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 													Optional:    true,
 													Description: "Optional name of the Splunk index where logs are written.",
 												},
+											},
+											Blocks: map[string]schema.Block{
+												"buffer": observability_pipeline.BufferOptionsSchema(),
 											},
 										},
 									},
@@ -2019,6 +2043,7 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 														},
 													},
 												},
+												"buffer": observability_pipeline.BufferOptionsSchema(),
 											},
 										},
 									},
@@ -2032,7 +2057,8 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 												},
 											},
 											Blocks: map[string]schema.Block{
-												"tls": observability_pipeline.TlsSchema(),
+												"tls":    observability_pipeline.TlsSchema(),
+												"buffer": observability_pipeline.BufferOptionsSchema(),
 											},
 										},
 									},
@@ -2046,7 +2072,8 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 												},
 											},
 											Blocks: map[string]schema.Block{
-												"tls": observability_pipeline.TlsSchema(),
+												"tls":    observability_pipeline.TlsSchema(),
+												"buffer": observability_pipeline.BufferOptionsSchema(),
 											},
 										},
 									},
@@ -2063,6 +2090,9 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 													Description: "The index or datastream to write logs to in Elasticsearch.",
 												},
 											},
+											Blocks: map[string]schema.Block{
+												"buffer": observability_pipeline.BufferOptionsSchema(),
+											},
 										},
 									},
 									"opensearch": schema.ListNestedBlock{
@@ -2073,6 +2103,9 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 													Optional:    true,
 													Description: "The index or datastream to write logs to.",
 												},
+											},
+											Blocks: map[string]schema.Block{
+												"buffer": observability_pipeline.BufferOptionsSchema(),
 											},
 										},
 									},
@@ -2116,6 +2149,7 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 														listvalidator.SizeAtMost(1),
 													},
 												},
+												"buffer": observability_pipeline.BufferOptionsSchema(),
 											},
 										},
 									},
@@ -2131,6 +2165,9 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 													Optional:    true,
 													Description: "Optional prefix for blobs written to the container.",
 												},
+											},
+											Blocks: map[string]schema.Block{
+												"buffer": observability_pipeline.BufferOptionsSchema(),
 											},
 										},
 									},
@@ -2155,6 +2192,9 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 													Description: "The name of the Log Analytics table where logs will be sent.",
 												},
 											},
+											Blocks: map[string]schema.Block{
+												"buffer": observability_pipeline.BufferOptionsSchema(),
+											},
 										},
 									},
 									"google_chronicle": schema.ListNestedBlock{
@@ -2175,7 +2215,8 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 												},
 											},
 											Blocks: map[string]schema.Block{
-												"auth": gcpAuthSchema(),
+												"auth":   gcpAuthSchema(),
+												"buffer": observability_pipeline.BufferOptionsSchema(),
 											},
 										},
 									},
@@ -2188,6 +2229,9 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 													Description: "The New Relic region.",
 												},
 											},
+											Blocks: map[string]schema.Block{
+												"buffer": observability_pipeline.BufferOptionsSchema(),
+											},
 										},
 									},
 									"sentinel_one": schema.ListNestedBlock{
@@ -2198,6 +2242,9 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 													Required:    true,
 													Description: "The SentinelOne region to send logs to.",
 												},
+											},
+											Blocks: map[string]schema.Block{
+												"buffer": observability_pipeline.BufferOptionsSchema(),
 											},
 										},
 									},
@@ -4229,7 +4276,16 @@ func flattenDatadogLogsDestination(ctx context.Context, src *datadogV2.Observabi
 	if src == nil {
 		return nil
 	}
-	return &datadogLogsDestinationModel{}
+
+	model := &datadogLogsDestinationModel{}
+	if buffer, ok := src.GetBufferOk(); ok {
+		outBuffer := observability_pipeline.FlattenBufferOptions(buffer)
+		if outBuffer != nil {
+			model.Buffer = []observability_pipeline.BufferOptionsModel{*outBuffer}
+		}
+	}
+
+	return model
 }
 
 func expandDatadogLogsDestination(ctx context.Context, dest *destinationModel, src *datadogLogsDestinationModel) datadogV2.ObservabilityPipelineConfigDestinationItem {
@@ -4238,6 +4294,14 @@ func expandDatadogLogsDestination(ctx context.Context, dest *destinationModel, s
 	var inputs []string
 	dest.Inputs.ElementsAs(ctx, &inputs, false)
 	d.SetInputs(inputs)
+
+	if len(src.Buffer) > 0 {
+		buffer := observability_pipeline.ExpandBufferOptions(src.Buffer[0])
+		if buffer != nil {
+			d.SetBuffer(*buffer)
+		}
+	}
+
 	return datadogV2.ObservabilityPipelineConfigDestinationItem{
 		ObservabilityPipelineDatadogLogsDestination: d,
 	}
@@ -4468,6 +4532,13 @@ func expandGoogleCloudStorageDestination(ctx context.Context, destModel *destina
 	destModel.Inputs.ElementsAs(ctx, &inputs, false)
 	dest.SetInputs(inputs)
 
+	if len(d.Buffer) > 0 {
+		buffer := observability_pipeline.ExpandBufferOptions(d.Buffer[0])
+		if buffer != nil {
+			dest.SetBuffer(*buffer)
+		}
+	}
+
 	return datadogV2.ObservabilityPipelineConfigDestinationItem{
 		ObservabilityPipelineGoogleCloudStorageDestination: dest,
 	}
@@ -4501,6 +4572,13 @@ func flattenGoogleCloudStorageDestination(ctx context.Context, src *datadogV2.Ob
 		out.Auth = flattenGcpAuth(auth)
 	}
 
+	if buffer, ok := src.GetBufferOk(); ok {
+		outBuffer := observability_pipeline.FlattenBufferOptions(buffer)
+		if outBuffer != nil {
+			out.Buffer = []observability_pipeline.BufferOptionsModel{*outBuffer}
+		}
+	}
+
 	return out
 }
 
@@ -4525,6 +4603,13 @@ func expandGooglePubSubDestination(ctx context.Context, dest *destinationModel, 
 	var inputs []string
 	dest.Inputs.ElementsAs(ctx, &inputs, false)
 	pubsub.SetInputs(inputs)
+
+	if len(d.Buffer) > 0 {
+		buffer := observability_pipeline.ExpandBufferOptions(d.Buffer[0])
+		if buffer != nil {
+			pubsub.SetBuffer(*buffer)
+		}
+	}
 
 	return datadogV2.ObservabilityPipelineConfigDestinationItem{
 		ObservabilityPipelineGooglePubSubDestination: pubsub,
@@ -4551,6 +4636,13 @@ func flattenGooglePubSubDestination(ctx context.Context, src *datadogV2.Observab
 
 	if auth, ok := src.GetAuthOk(); ok {
 		out.Auth = flattenGcpAuth(auth)
+	}
+
+	if buffer, ok := src.GetBufferOk(); ok {
+		outBuffer := observability_pipeline.FlattenBufferOptions(buffer)
+		if outBuffer != nil {
+			out.Buffer = []observability_pipeline.BufferOptionsModel{*outBuffer}
+		}
 	}
 
 	return out
@@ -4603,6 +4695,13 @@ func expandSplunkHecDestination(ctx context.Context, dest *destinationModel, d *
 		splunk.SetIndex(d.Index.ValueString())
 	}
 
+	if len(d.Buffer) > 0 {
+		buffer := observability_pipeline.ExpandBufferOptions(d.Buffer[0])
+		if buffer != nil {
+			splunk.SetBuffer(*buffer)
+		}
+	}
+
 	return datadogV2.ObservabilityPipelineConfigDestinationItem{
 		ObservabilityPipelineSplunkHecDestination: splunk,
 	}
@@ -4613,12 +4712,21 @@ func flattenSplunkHecDestination(ctx context.Context, src *datadogV2.Observabili
 		return nil
 	}
 
-	return &splunkHecDestinationModel{
+	out := splunkHecDestinationModel{
 		AutoExtractTimestamp: types.BoolValue(src.GetAutoExtractTimestamp()),
 		Encoding:             types.StringValue(string(*src.Encoding)),
 		Sourcetype:           types.StringPointerValue(src.Sourcetype),
 		Index:                types.StringPointerValue(src.Index),
 	}
+
+	if buffer, ok := src.GetBufferOk(); ok {
+		outBuffer := observability_pipeline.FlattenBufferOptions(buffer)
+		if outBuffer != nil {
+			out.Buffer = []observability_pipeline.BufferOptionsModel{*outBuffer}
+		}
+	}
+
+	return &out
 }
 
 func expandAmazonS3Source(src *amazonS3SourceModel, id string) datadogV2.ObservabilityPipelineConfigSourceItem {
@@ -4690,6 +4798,13 @@ func expandSumoLogicDestination(ctx context.Context, dest *destinationModel, src
 		sumo.SetHeaderCustomFields(fields)
 	}
 
+	if len(src.Buffer) > 0 {
+		buffer := observability_pipeline.ExpandBufferOptions(src.Buffer[0])
+		if buffer != nil {
+			sumo.SetBuffer(*buffer)
+		}
+	}
+
 	return datadogV2.ObservabilityPipelineConfigDestinationItem{
 		ObservabilityPipelineSumoLogicDestination: sumo,
 	}
@@ -4720,6 +4835,12 @@ func flattenSumoLogicDestination(ctx context.Context, src *datadogV2.Observabili
 				Name:  types.StringValue(f.Name),
 				Value: types.StringValue(f.Value),
 			})
+		}
+	}
+	if buffer, ok := src.GetBufferOk(); ok {
+		outBuffer := observability_pipeline.FlattenBufferOptions(buffer)
+		if outBuffer != nil {
+			out.Buffer = []observability_pipeline.BufferOptionsModel{*outBuffer}
 		}
 	}
 
@@ -4791,6 +4912,14 @@ func expandRsyslogDestination(ctx context.Context, dest *destinationModel, src *
 		obj.SetKeepalive(src.Keepalive.ValueInt64())
 	}
 	obj.Tls = observability_pipeline.ExpandTls(src.Tls)
+
+	if len(src.Buffer) > 0 {
+		buffer := observability_pipeline.ExpandBufferOptions(src.Buffer[0])
+		if buffer != nil {
+			obj.SetBuffer(*buffer)
+		}
+	}
+
 	return datadogV2.ObservabilityPipelineConfigDestinationItem{
 		ObservabilityPipelineRsyslogDestination: obj,
 	}
@@ -4806,6 +4935,12 @@ func flattenRsyslogDestination(ctx context.Context, src *datadogV2.Observability
 	}
 	if v, ok := src.GetKeepaliveOk(); ok {
 		out.Keepalive = types.Int64Value(*v)
+	}
+	if buffer, ok := src.GetBufferOk(); ok {
+		outBuffer := observability_pipeline.FlattenBufferOptions(buffer)
+		if outBuffer != nil {
+			out.Buffer = []observability_pipeline.BufferOptionsModel{*outBuffer}
+		}
 	}
 	return out
 }
@@ -4823,6 +4958,13 @@ func expandSyslogNgDestination(ctx context.Context, dest *destinationModel, src 
 	}
 	obj.Tls = observability_pipeline.ExpandTls(src.Tls)
 
+	if len(src.Buffer) > 0 {
+		buffer := observability_pipeline.ExpandBufferOptions(src.Buffer[0])
+		if buffer != nil {
+			obj.SetBuffer(*buffer)
+		}
+	}
+
 	return datadogV2.ObservabilityPipelineConfigDestinationItem{
 		ObservabilityPipelineSyslogNgDestination: obj,
 	}
@@ -4838,6 +4980,12 @@ func flattenSyslogNgDestination(ctx context.Context, src *datadogV2.Observabilit
 	}
 	if v, ok := src.GetKeepaliveOk(); ok {
 		out.Keepalive = types.Int64Value(*v)
+	}
+	if buffer, ok := src.GetBufferOk(); ok {
+		outBuffer := observability_pipeline.FlattenBufferOptions(buffer)
+		if outBuffer != nil {
+			out.Buffer = []observability_pipeline.BufferOptionsModel{*outBuffer}
+		}
 	}
 	return out
 }
@@ -4857,6 +5005,13 @@ func expandElasticsearchDestination(ctx context.Context, dest *destinationModel,
 		obj.SetBulkIndex(src.BulkIndex.ValueString())
 	}
 
+	if len(src.Buffer) > 0 {
+		buffer := observability_pipeline.ExpandBufferOptions(src.Buffer[0])
+		if buffer != nil {
+			obj.SetBuffer(*buffer)
+		}
+	}
+
 	return datadogV2.ObservabilityPipelineConfigDestinationItem{
 		ObservabilityPipelineElasticsearchDestination: obj,
 	}
@@ -4872,6 +5027,12 @@ func flattenElasticsearchDestination(ctx context.Context, src *datadogV2.Observa
 	}
 	if v, ok := src.GetBulkIndexOk(); ok {
 		out.BulkIndex = types.StringValue(*v)
+	}
+	if buffer, ok := src.GetBufferOk(); ok {
+		outBuffer := observability_pipeline.FlattenBufferOptions(buffer)
+		if outBuffer != nil {
+			out.Buffer = []observability_pipeline.BufferOptionsModel{*outBuffer}
+		}
 	}
 	return out
 }
@@ -4890,6 +5051,13 @@ func expandAzureStorageDestination(ctx context.Context, dest *destinationModel, 
 		obj.SetBlobPrefix(src.BlobPrefix.ValueString())
 	}
 
+	if len(src.Buffer) > 0 {
+		buffer := observability_pipeline.ExpandBufferOptions(src.Buffer[0])
+		if buffer != nil {
+			obj.SetBuffer(*buffer)
+		}
+	}
+
 	return datadogV2.ObservabilityPipelineConfigDestinationItem{
 		AzureStorageDestination: obj,
 	}
@@ -4904,6 +5072,13 @@ func flattenAzureStorageDestination(ctx context.Context, src *datadogV2.AzureSto
 	}
 	if v, ok := src.GetBlobPrefixOk(); ok {
 		out.BlobPrefix = types.StringValue(*v)
+	}
+
+	if buffer, ok := src.GetBufferOk(); ok {
+		outBuffer := observability_pipeline.FlattenBufferOptions(buffer)
+		if outBuffer != nil {
+			out.Buffer = []observability_pipeline.BufferOptionsModel{*outBuffer}
+		}
 	}
 	return out
 }
@@ -4921,6 +5096,13 @@ func expandMicrosoftSentinelDestination(ctx context.Context, dest *destinationMo
 	obj.SetDcrImmutableId(src.DcrImmutableId.ValueString())
 	obj.SetTable(src.Table.ValueString())
 
+	if len(src.Buffer) > 0 {
+		buffer := observability_pipeline.ExpandBufferOptions(src.Buffer[0])
+		if buffer != nil {
+			obj.SetBuffer(*buffer)
+		}
+	}
+
 	return datadogV2.ObservabilityPipelineConfigDestinationItem{
 		MicrosoftSentinelDestination: obj,
 	}
@@ -4930,12 +5112,20 @@ func flattenMicrosoftSentinelDestination(ctx context.Context, src *datadogV2.Mic
 	if src == nil {
 		return nil
 	}
-	return &microsoftSentinelDestinationModel{
+	out := microsoftSentinelDestinationModel{
 		ClientId:       types.StringValue(src.GetClientId()),
 		TenantId:       types.StringValue(src.GetTenantId()),
 		DcrImmutableId: types.StringValue(src.GetDcrImmutableId()),
 		Table:          types.StringValue(src.GetTable()),
 	}
+	if buffer, ok := src.GetBufferOk(); ok {
+		outBuffer := observability_pipeline.FlattenBufferOptions(buffer)
+		if outBuffer != nil {
+			out.Buffer = []observability_pipeline.BufferOptionsModel{*outBuffer}
+		}
+	}
+
+	return &out
 }
 
 func expandSumoLogicSource(src *sumoLogicSourceModel, id string) datadogV2.ObservabilityPipelineConfigSourceItem {
@@ -5123,6 +5313,13 @@ func expandGoogleChronicleDestination(ctx context.Context, dest *destinationMode
 		chronicle.SetLogType(src.LogType.ValueString())
 	}
 
+	if len(src.Buffer) > 0 {
+		buffer := observability_pipeline.ExpandBufferOptions(src.Buffer[0])
+		if buffer != nil {
+			chronicle.SetBuffer(*buffer)
+		}
+	}
+
 	return datadogV2.ObservabilityPipelineConfigDestinationItem{
 		ObservabilityPipelineGoogleChronicleDestination: chronicle,
 	}
@@ -5142,6 +5339,12 @@ func flattenGoogleChronicleDestination(ctx context.Context, src *datadogV2.Obser
 	if auth, ok := src.GetAuthOk(); ok {
 		out.Auth = flattenGcpAuth(auth)
 	}
+	if buffer, ok := src.GetBufferOk(); ok {
+		outBuffer := observability_pipeline.FlattenBufferOptions(buffer)
+		if outBuffer != nil {
+			out.Buffer = []observability_pipeline.BufferOptionsModel{*outBuffer}
+		}
+	}
 
 	return out
 }
@@ -5156,6 +5359,13 @@ func expandNewRelicDestination(ctx context.Context, dest *destinationModel, src 
 
 	newrelic.SetRegion(datadogV2.ObservabilityPipelineNewRelicDestinationRegion(src.Region.ValueString()))
 
+	if len(src.Buffer) > 0 {
+		buffer := observability_pipeline.ExpandBufferOptions(src.Buffer[0])
+		if buffer != nil {
+			newrelic.SetBuffer(*buffer)
+		}
+	}
+
 	return datadogV2.ObservabilityPipelineConfigDestinationItem{
 		ObservabilityPipelineNewRelicDestination: newrelic,
 	}
@@ -5166,9 +5376,17 @@ func flattenNewRelicDestination(ctx context.Context, src *datadogV2.Observabilit
 		return nil
 	}
 
-	return &newRelicDestinationModel{
+	out := newRelicDestinationModel{
 		Region: types.StringValue(string(src.GetRegion())),
 	}
+	if buffer, ok := src.GetBufferOk(); ok {
+		outBuffer := observability_pipeline.FlattenBufferOptions(buffer)
+		if outBuffer != nil {
+			out.Buffer = []observability_pipeline.BufferOptionsModel{*outBuffer}
+		}
+	}
+
+	return &out
 }
 
 func expandSentinelOneDestination(ctx context.Context, dest *destinationModel, src *sentinelOneDestinationModel) datadogV2.ObservabilityPipelineConfigDestinationItem {
@@ -5181,6 +5399,13 @@ func expandSentinelOneDestination(ctx context.Context, dest *destinationModel, s
 
 	sentinel.SetRegion(datadogV2.ObservabilityPipelineSentinelOneDestinationRegion(src.Region.ValueString()))
 
+	if len(src.Buffer) > 0 {
+		buffer := observability_pipeline.ExpandBufferOptions(src.Buffer[0])
+		if buffer != nil {
+			sentinel.SetBuffer(*buffer)
+		}
+	}
+
 	return datadogV2.ObservabilityPipelineConfigDestinationItem{
 		ObservabilityPipelineSentinelOneDestination: sentinel,
 	}
@@ -5191,9 +5416,17 @@ func flattenSentinelOneDestination(ctx context.Context, src *datadogV2.Observabi
 		return nil
 	}
 
-	return &sentinelOneDestinationModel{
+	out := sentinelOneDestinationModel{
 		Region: types.StringValue(string(src.GetRegion())),
 	}
+	if buffer, ok := src.GetBufferOk(); ok {
+		outBuffer := observability_pipeline.FlattenBufferOptions(buffer)
+		if outBuffer != nil {
+			out.Buffer = []observability_pipeline.BufferOptionsModel{*outBuffer}
+		}
+	}
+
+	return &out
 }
 
 func expandOpenSearchDestination(ctx context.Context, dest *destinationModel, src *opensearchDestinationModel) datadogV2.ObservabilityPipelineConfigDestinationItem {
@@ -5206,6 +5439,13 @@ func expandOpenSearchDestination(ctx context.Context, dest *destinationModel, sr
 
 	if !src.BulkIndex.IsNull() {
 		opensearch.SetBulkIndex(src.BulkIndex.ValueString())
+	}
+
+	if len(src.Buffer) > 0 {
+		buffer := observability_pipeline.ExpandBufferOptions(src.Buffer[0])
+		if buffer != nil {
+			opensearch.SetBuffer(*buffer)
+		}
 	}
 
 	return datadogV2.ObservabilityPipelineConfigDestinationItem{
@@ -5221,6 +5461,12 @@ func flattenOpenSearchDestination(ctx context.Context, src *datadogV2.Observabil
 	out := &opensearchDestinationModel{}
 	if v, ok := src.GetBulkIndexOk(); ok {
 		out.BulkIndex = types.StringValue(*v)
+	}
+	if buffer, ok := src.GetBufferOk(); ok {
+		outBuffer := observability_pipeline.FlattenBufferOptions(buffer)
+		if outBuffer != nil {
+			out.Buffer = []observability_pipeline.BufferOptionsModel{*outBuffer}
+		}
 	}
 
 	return out
@@ -5258,6 +5504,13 @@ func expandAmazonOpenSearchDestination(ctx context.Context, dest *destinationMod
 		amazonopensearch.SetAuth(auth)
 	}
 
+	if len(src.Buffer) > 0 {
+		buffer := observability_pipeline.ExpandBufferOptions(src.Buffer[0])
+		if buffer != nil {
+			amazonopensearch.SetBuffer(*buffer)
+		}
+	}
+
 	return datadogV2.ObservabilityPipelineConfigDestinationItem{
 		ObservabilityPipelineAmazonOpenSearchDestination: amazonopensearch,
 	}
@@ -5282,6 +5535,12 @@ func flattenAmazonOpenSearchDestination(src *datadogV2.ObservabilityPipelineAmaz
 			ExternalId:  types.StringPointerValue(src.Auth.ExternalId),
 			SessionName: types.StringPointerValue(src.Auth.SessionName),
 		},
+	}
+	if buffer, ok := src.GetBufferOk(); ok {
+		outBuffer := observability_pipeline.FlattenBufferOptions(buffer)
+		if outBuffer != nil {
+			model.Buffer = []observability_pipeline.BufferOptionsModel{*outBuffer}
+		}
 	}
 
 	return model

--- a/docs/resources/observability_pipeline.md
+++ b/docs/resources/observability_pipeline.md
@@ -141,6 +141,7 @@ Optional:
 Optional:
 
 - `auth` (Block List) (see [below for nested schema](#nestedblock--config--destination--amazon_opensearch--auth))
+- `buffer` (Block List) Configuration for buffer settings on destination components. Exactly one of `disk` or `memory` must be specified. (see [below for nested schema](#nestedblock--config--destination--amazon_opensearch--buffer))
 - `bulk_index` (String) The index or datastream to write logs to.
 
 <a id="nestedblock--config--destination--amazon_opensearch--auth"></a>
@@ -158,6 +159,32 @@ Optional:
 - `session_name` (String) Session name for assumed role.
 
 
+<a id="nestedblock--config--destination--amazon_opensearch--buffer"></a>
+### Nested Schema for `config.destination.amazon_opensearch.buffer`
+
+Optional:
+
+- `disk` (Block List) Options for configuring a disk buffer. Cannot be used with `memory`. (see [below for nested schema](#nestedblock--config--destination--amazon_opensearch--buffer--disk))
+- `memory` (Block List) Options for configuring a memory buffer. Cannot be used with `disk`. (see [below for nested schema](#nestedblock--config--destination--amazon_opensearch--buffer--memory))
+
+<a id="nestedblock--config--destination--amazon_opensearch--buffer--disk"></a>
+### Nested Schema for `config.destination.amazon_opensearch.buffer.disk`
+
+Optional:
+
+- `max_size` (Number) Maximum size of the disk buffer (in bytes).
+
+
+<a id="nestedblock--config--destination--amazon_opensearch--buffer--memory"></a>
+### Nested Schema for `config.destination.amazon_opensearch.buffer.memory`
+
+Optional:
+
+- `max_events` (Number) Maximum events for the memory buffer.
+- `max_size` (Number) Maximum size of the memory buffer (in bytes).
+
+
+
 
 <a id="nestedblock--config--destination--amazon_s3"></a>
 ### Nested Schema for `config.destination.amazon_s3`
@@ -172,6 +199,7 @@ Required:
 Optional:
 
 - `auth` (Block List) AWS authentication credentials used for accessing AWS services. If omitted, the system's default credentials are used (for example, the IAM role and environment variables). (see [below for nested schema](#nestedblock--config--destination--amazon_s3--auth))
+- `buffer` (Block List) Configuration for buffer settings on destination components. Exactly one of `disk` or `memory` must be specified. (see [below for nested schema](#nestedblock--config--destination--amazon_s3--buffer))
 
 <a id="nestedblock--config--destination--amazon_s3--auth"></a>
 ### Nested Schema for `config.destination.amazon_s3.auth`
@@ -181,6 +209,32 @@ Optional:
 - `assume_role` (String) The Amazon Resource Name (ARN) of the role to assume.
 - `external_id` (String) A unique identifier for cross-account role assumption.
 - `session_name` (String) A session identifier used for logging and tracing the assumed role session.
+
+
+<a id="nestedblock--config--destination--amazon_s3--buffer"></a>
+### Nested Schema for `config.destination.amazon_s3.buffer`
+
+Optional:
+
+- `disk` (Block List) Options for configuring a disk buffer. Cannot be used with `memory`. (see [below for nested schema](#nestedblock--config--destination--amazon_s3--buffer--disk))
+- `memory` (Block List) Options for configuring a memory buffer. Cannot be used with `disk`. (see [below for nested schema](#nestedblock--config--destination--amazon_s3--buffer--memory))
+
+<a id="nestedblock--config--destination--amazon_s3--buffer--disk"></a>
+### Nested Schema for `config.destination.amazon_s3.buffer.disk`
+
+Optional:
+
+- `max_size` (Number) Maximum size of the disk buffer (in bytes).
+
+
+<a id="nestedblock--config--destination--amazon_s3--buffer--memory"></a>
+### Nested Schema for `config.destination.amazon_s3.buffer.memory`
+
+Optional:
+
+- `max_events` (Number) Maximum events for the memory buffer.
+- `max_size` (Number) Maximum size of the memory buffer (in bytes).
+
 
 
 
@@ -196,6 +250,7 @@ Required:
 Optional:
 
 - `auth` (Block List) AWS authentication credentials used for accessing AWS services. If omitted, the system's default credentials are used (for example, the IAM role and environment variables). (see [below for nested schema](#nestedblock--config--destination--amazon_security_lake--auth))
+- `buffer` (Block List) Configuration for buffer settings on destination components. Exactly one of `disk` or `memory` must be specified. (see [below for nested schema](#nestedblock--config--destination--amazon_security_lake--buffer))
 - `tls` (Block List) Configuration for enabling TLS encryption between the pipeline component and external services. (see [below for nested schema](#nestedblock--config--destination--amazon_security_lake--tls))
 
 <a id="nestedblock--config--destination--amazon_security_lake--auth"></a>
@@ -206,6 +261,32 @@ Optional:
 - `assume_role` (String) The Amazon Resource Name (ARN) of the role to assume.
 - `external_id` (String) A unique identifier for cross-account role assumption.
 - `session_name` (String) A session identifier used for logging and tracing the assumed role session.
+
+
+<a id="nestedblock--config--destination--amazon_security_lake--buffer"></a>
+### Nested Schema for `config.destination.amazon_security_lake.buffer`
+
+Optional:
+
+- `disk` (Block List) Options for configuring a disk buffer. Cannot be used with `memory`. (see [below for nested schema](#nestedblock--config--destination--amazon_security_lake--buffer--disk))
+- `memory` (Block List) Options for configuring a memory buffer. Cannot be used with `disk`. (see [below for nested schema](#nestedblock--config--destination--amazon_security_lake--buffer--memory))
+
+<a id="nestedblock--config--destination--amazon_security_lake--buffer--disk"></a>
+### Nested Schema for `config.destination.amazon_security_lake.buffer.disk`
+
+Optional:
+
+- `max_size` (Number) Maximum size of the disk buffer (in bytes).
+
+
+<a id="nestedblock--config--destination--amazon_security_lake--buffer--memory"></a>
+### Nested Schema for `config.destination.amazon_security_lake.buffer.memory`
+
+Optional:
+
+- `max_events` (Number) Maximum events for the memory buffer.
+- `max_size` (Number) Maximum size of the memory buffer (in bytes).
+
 
 
 <a id="nestedblock--config--destination--amazon_security_lake--tls"></a>
@@ -232,6 +313,33 @@ Required:
 Optional:
 
 - `blob_prefix` (String) Optional prefix for blobs written to the container.
+- `buffer` (Block List) Configuration for buffer settings on destination components. Exactly one of `disk` or `memory` must be specified. (see [below for nested schema](#nestedblock--config--destination--azure_storage--buffer))
+
+<a id="nestedblock--config--destination--azure_storage--buffer"></a>
+### Nested Schema for `config.destination.azure_storage.buffer`
+
+Optional:
+
+- `disk` (Block List) Options for configuring a disk buffer. Cannot be used with `memory`. (see [below for nested schema](#nestedblock--config--destination--azure_storage--buffer--disk))
+- `memory` (Block List) Options for configuring a memory buffer. Cannot be used with `disk`. (see [below for nested schema](#nestedblock--config--destination--azure_storage--buffer--memory))
+
+<a id="nestedblock--config--destination--azure_storage--buffer--disk"></a>
+### Nested Schema for `config.destination.azure_storage.buffer.disk`
+
+Optional:
+
+- `max_size` (Number) Maximum size of the disk buffer (in bytes).
+
+
+<a id="nestedblock--config--destination--azure_storage--buffer--memory"></a>
+### Nested Schema for `config.destination.azure_storage.buffer.memory`
+
+Optional:
+
+- `max_events` (Number) Maximum events for the memory buffer.
+- `max_size` (Number) Maximum size of the memory buffer (in bytes).
+
+
 
 
 <a id="nestedblock--config--destination--crowdstrike_next_gen_siem"></a>
@@ -243,8 +351,35 @@ Required:
 
 Optional:
 
+- `buffer` (Block List) Configuration for buffer settings on destination components. Exactly one of `disk` or `memory` must be specified. (see [below for nested schema](#nestedblock--config--destination--crowdstrike_next_gen_siem--buffer))
 - `compression` (Block List) Compression configuration for log events. (see [below for nested schema](#nestedblock--config--destination--crowdstrike_next_gen_siem--compression))
 - `tls` (Block List) Configuration for enabling TLS encryption between the pipeline component and external services. (see [below for nested schema](#nestedblock--config--destination--crowdstrike_next_gen_siem--tls))
+
+<a id="nestedblock--config--destination--crowdstrike_next_gen_siem--buffer"></a>
+### Nested Schema for `config.destination.crowdstrike_next_gen_siem.buffer`
+
+Optional:
+
+- `disk` (Block List) Options for configuring a disk buffer. Cannot be used with `memory`. (see [below for nested schema](#nestedblock--config--destination--crowdstrike_next_gen_siem--buffer--disk))
+- `memory` (Block List) Options for configuring a memory buffer. Cannot be used with `disk`. (see [below for nested schema](#nestedblock--config--destination--crowdstrike_next_gen_siem--buffer--memory))
+
+<a id="nestedblock--config--destination--crowdstrike_next_gen_siem--buffer--disk"></a>
+### Nested Schema for `config.destination.crowdstrike_next_gen_siem.buffer.disk`
+
+Optional:
+
+- `max_size` (Number) Maximum size of the disk buffer (in bytes).
+
+
+<a id="nestedblock--config--destination--crowdstrike_next_gen_siem--buffer--memory"></a>
+### Nested Schema for `config.destination.crowdstrike_next_gen_siem.buffer.memory`
+
+Optional:
+
+- `max_events` (Number) Maximum events for the memory buffer.
+- `max_size` (Number) Maximum size of the memory buffer (in bytes).
+
+
 
 <a id="nestedblock--config--destination--crowdstrike_next_gen_siem--compression"></a>
 ### Nested Schema for `config.destination.crowdstrike_next_gen_siem.compression`
@@ -275,6 +410,36 @@ Optional:
 <a id="nestedblock--config--destination--datadog_logs"></a>
 ### Nested Schema for `config.destination.datadog_logs`
 
+Optional:
+
+- `buffer` (Block List) Configuration for buffer settings on destination components. Exactly one of `disk` or `memory` must be specified. (see [below for nested schema](#nestedblock--config--destination--datadog_logs--buffer))
+
+<a id="nestedblock--config--destination--datadog_logs--buffer"></a>
+### Nested Schema for `config.destination.datadog_logs.buffer`
+
+Optional:
+
+- `disk` (Block List) Options for configuring a disk buffer. Cannot be used with `memory`. (see [below for nested schema](#nestedblock--config--destination--datadog_logs--buffer--disk))
+- `memory` (Block List) Options for configuring a memory buffer. Cannot be used with `disk`. (see [below for nested schema](#nestedblock--config--destination--datadog_logs--buffer--memory))
+
+<a id="nestedblock--config--destination--datadog_logs--buffer--disk"></a>
+### Nested Schema for `config.destination.datadog_logs.buffer.disk`
+
+Optional:
+
+- `max_size` (Number) Maximum size of the disk buffer (in bytes).
+
+
+<a id="nestedblock--config--destination--datadog_logs--buffer--memory"></a>
+### Nested Schema for `config.destination.datadog_logs.buffer.memory`
+
+Optional:
+
+- `max_events` (Number) Maximum events for the memory buffer.
+- `max_size` (Number) Maximum size of the memory buffer (in bytes).
+
+
+
 
 <a id="nestedblock--config--destination--elasticsearch"></a>
 ### Nested Schema for `config.destination.elasticsearch`
@@ -282,7 +447,34 @@ Optional:
 Optional:
 
 - `api_version` (String) The Elasticsearch API version to use. Set to `auto` to auto-detect.
+- `buffer` (Block List) Configuration for buffer settings on destination components. Exactly one of `disk` or `memory` must be specified. (see [below for nested schema](#nestedblock--config--destination--elasticsearch--buffer))
 - `bulk_index` (String) The index or datastream to write logs to in Elasticsearch.
+
+<a id="nestedblock--config--destination--elasticsearch--buffer"></a>
+### Nested Schema for `config.destination.elasticsearch.buffer`
+
+Optional:
+
+- `disk` (Block List) Options for configuring a disk buffer. Cannot be used with `memory`. (see [below for nested schema](#nestedblock--config--destination--elasticsearch--buffer--disk))
+- `memory` (Block List) Options for configuring a memory buffer. Cannot be used with `disk`. (see [below for nested schema](#nestedblock--config--destination--elasticsearch--buffer--memory))
+
+<a id="nestedblock--config--destination--elasticsearch--buffer--disk"></a>
+### Nested Schema for `config.destination.elasticsearch.buffer.disk`
+
+Optional:
+
+- `max_size` (Number) Maximum size of the disk buffer (in bytes).
+
+
+<a id="nestedblock--config--destination--elasticsearch--buffer--memory"></a>
+### Nested Schema for `config.destination.elasticsearch.buffer.memory`
+
+Optional:
+
+- `max_events` (Number) Maximum events for the memory buffer.
+- `max_size` (Number) Maximum size of the memory buffer (in bytes).
+
+
 
 
 <a id="nestedblock--config--destination--google_chronicle"></a>
@@ -291,6 +483,7 @@ Optional:
 Optional:
 
 - `auth` (Block List) GCP credentials used to authenticate with Google Cloud services. (see [below for nested schema](#nestedblock--config--destination--google_chronicle--auth))
+- `buffer` (Block List) Configuration for buffer settings on destination components. Exactly one of `disk` or `memory` must be specified. (see [below for nested schema](#nestedblock--config--destination--google_chronicle--buffer))
 - `customer_id` (String) The Google Chronicle customer ID.
 - `encoding` (String) The encoding format for the logs sent to Chronicle.
 - `log_type` (String) The log type metadata associated with the Chronicle destination.
@@ -301,6 +494,32 @@ Optional:
 Required:
 
 - `credentials_file` (String) Path to the GCP service account key file.
+
+
+<a id="nestedblock--config--destination--google_chronicle--buffer"></a>
+### Nested Schema for `config.destination.google_chronicle.buffer`
+
+Optional:
+
+- `disk` (Block List) Options for configuring a disk buffer. Cannot be used with `memory`. (see [below for nested schema](#nestedblock--config--destination--google_chronicle--buffer--disk))
+- `memory` (Block List) Options for configuring a memory buffer. Cannot be used with `disk`. (see [below for nested schema](#nestedblock--config--destination--google_chronicle--buffer--memory))
+
+<a id="nestedblock--config--destination--google_chronicle--buffer--disk"></a>
+### Nested Schema for `config.destination.google_chronicle.buffer.disk`
+
+Optional:
+
+- `max_size` (Number) Maximum size of the disk buffer (in bytes).
+
+
+<a id="nestedblock--config--destination--google_chronicle--buffer--memory"></a>
+### Nested Schema for `config.destination.google_chronicle.buffer.memory`
+
+Optional:
+
+- `max_events` (Number) Maximum events for the memory buffer.
+- `max_size` (Number) Maximum size of the memory buffer (in bytes).
+
 
 
 
@@ -316,6 +535,7 @@ Optional:
 
 - `acl` (String) Access control list setting for objects written to the bucket.
 - `auth` (Block List) GCP credentials used to authenticate with Google Cloud services. (see [below for nested schema](#nestedblock--config--destination--google_cloud_storage--auth))
+- `buffer` (Block List) Configuration for buffer settings on destination components. Exactly one of `disk` or `memory` must be specified. (see [below for nested schema](#nestedblock--config--destination--google_cloud_storage--buffer))
 - `key_prefix` (String) Optional prefix for object keys within the GCS bucket.
 - `metadata` (Block List) Custom metadata key-value pairs added to each object. (see [below for nested schema](#nestedblock--config--destination--google_cloud_storage--metadata))
 
@@ -325,6 +545,32 @@ Optional:
 Required:
 
 - `credentials_file` (String) Path to the GCP service account key file.
+
+
+<a id="nestedblock--config--destination--google_cloud_storage--buffer"></a>
+### Nested Schema for `config.destination.google_cloud_storage.buffer`
+
+Optional:
+
+- `disk` (Block List) Options for configuring a disk buffer. Cannot be used with `memory`. (see [below for nested schema](#nestedblock--config--destination--google_cloud_storage--buffer--disk))
+- `memory` (Block List) Options for configuring a memory buffer. Cannot be used with `disk`. (see [below for nested schema](#nestedblock--config--destination--google_cloud_storage--buffer--memory))
+
+<a id="nestedblock--config--destination--google_cloud_storage--buffer--disk"></a>
+### Nested Schema for `config.destination.google_cloud_storage.buffer.disk`
+
+Optional:
+
+- `max_size` (Number) Maximum size of the disk buffer (in bytes).
+
+
+<a id="nestedblock--config--destination--google_cloud_storage--buffer--memory"></a>
+### Nested Schema for `config.destination.google_cloud_storage.buffer.memory`
+
+Optional:
+
+- `max_events` (Number) Maximum events for the memory buffer.
+- `max_size` (Number) Maximum size of the memory buffer (in bytes).
+
 
 
 <a id="nestedblock--config--destination--google_cloud_storage--metadata"></a>
@@ -348,6 +594,7 @@ Required:
 Optional:
 
 - `auth` (Block List) GCP credentials used to authenticate with Google Cloud services. (see [below for nested schema](#nestedblock--config--destination--google_pubsub--auth))
+- `buffer` (Block List) Configuration for buffer settings on destination components. Exactly one of `disk` or `memory` must be specified. (see [below for nested schema](#nestedblock--config--destination--google_pubsub--buffer))
 - `encoding` (String) Encoding format for log events. Valid values: `json`, `raw_message`.
 - `tls` (Block List) Configuration for enabling TLS encryption between the pipeline component and external services. (see [below for nested schema](#nestedblock--config--destination--google_pubsub--tls))
 
@@ -357,6 +604,32 @@ Optional:
 Required:
 
 - `credentials_file` (String) Path to the GCP service account key file.
+
+
+<a id="nestedblock--config--destination--google_pubsub--buffer"></a>
+### Nested Schema for `config.destination.google_pubsub.buffer`
+
+Optional:
+
+- `disk` (Block List) Options for configuring a disk buffer. Cannot be used with `memory`. (see [below for nested schema](#nestedblock--config--destination--google_pubsub--buffer--disk))
+- `memory` (Block List) Options for configuring a memory buffer. Cannot be used with `disk`. (see [below for nested schema](#nestedblock--config--destination--google_pubsub--buffer--memory))
+
+<a id="nestedblock--config--destination--google_pubsub--buffer--disk"></a>
+### Nested Schema for `config.destination.google_pubsub.buffer.disk`
+
+Optional:
+
+- `max_size` (Number) Maximum size of the disk buffer (in bytes).
+
+
+<a id="nestedblock--config--destination--google_pubsub--buffer--memory"></a>
+### Nested Schema for `config.destination.google_pubsub.buffer.memory`
+
+Optional:
+
+- `max_events` (Number) Maximum events for the memory buffer.
+- `max_size` (Number) Maximum size of the memory buffer (in bytes).
+
 
 
 <a id="nestedblock--config--destination--google_pubsub--tls"></a>
@@ -383,6 +656,36 @@ Required:
 - `table` (String) The name of the Log Analytics table where logs will be sent.
 - `tenant_id` (String) Azure AD tenant ID.
 
+Optional:
+
+- `buffer` (Block List) Configuration for buffer settings on destination components. Exactly one of `disk` or `memory` must be specified. (see [below for nested schema](#nestedblock--config--destination--microsoft_sentinel--buffer))
+
+<a id="nestedblock--config--destination--microsoft_sentinel--buffer"></a>
+### Nested Schema for `config.destination.microsoft_sentinel.buffer`
+
+Optional:
+
+- `disk` (Block List) Options for configuring a disk buffer. Cannot be used with `memory`. (see [below for nested schema](#nestedblock--config--destination--microsoft_sentinel--buffer--disk))
+- `memory` (Block List) Options for configuring a memory buffer. Cannot be used with `disk`. (see [below for nested schema](#nestedblock--config--destination--microsoft_sentinel--buffer--memory))
+
+<a id="nestedblock--config--destination--microsoft_sentinel--buffer--disk"></a>
+### Nested Schema for `config.destination.microsoft_sentinel.buffer.disk`
+
+Optional:
+
+- `max_size` (Number) Maximum size of the disk buffer (in bytes).
+
+
+<a id="nestedblock--config--destination--microsoft_sentinel--buffer--memory"></a>
+### Nested Schema for `config.destination.microsoft_sentinel.buffer.memory`
+
+Optional:
+
+- `max_events` (Number) Maximum events for the memory buffer.
+- `max_size` (Number) Maximum size of the memory buffer (in bytes).
+
+
+
 
 <a id="nestedblock--config--destination--new_relic"></a>
 ### Nested Schema for `config.destination.new_relic`
@@ -391,13 +694,70 @@ Required:
 
 - `region` (String) The New Relic region.
 
+Optional:
+
+- `buffer` (Block List) Configuration for buffer settings on destination components. Exactly one of `disk` or `memory` must be specified. (see [below for nested schema](#nestedblock--config--destination--new_relic--buffer))
+
+<a id="nestedblock--config--destination--new_relic--buffer"></a>
+### Nested Schema for `config.destination.new_relic.buffer`
+
+Optional:
+
+- `disk` (Block List) Options for configuring a disk buffer. Cannot be used with `memory`. (see [below for nested schema](#nestedblock--config--destination--new_relic--buffer--disk))
+- `memory` (Block List) Options for configuring a memory buffer. Cannot be used with `disk`. (see [below for nested schema](#nestedblock--config--destination--new_relic--buffer--memory))
+
+<a id="nestedblock--config--destination--new_relic--buffer--disk"></a>
+### Nested Schema for `config.destination.new_relic.buffer.disk`
+
+Optional:
+
+- `max_size` (Number) Maximum size of the disk buffer (in bytes).
+
+
+<a id="nestedblock--config--destination--new_relic--buffer--memory"></a>
+### Nested Schema for `config.destination.new_relic.buffer.memory`
+
+Optional:
+
+- `max_events` (Number) Maximum events for the memory buffer.
+- `max_size` (Number) Maximum size of the memory buffer (in bytes).
+
+
+
 
 <a id="nestedblock--config--destination--opensearch"></a>
 ### Nested Schema for `config.destination.opensearch`
 
 Optional:
 
+- `buffer` (Block List) Configuration for buffer settings on destination components. Exactly one of `disk` or `memory` must be specified. (see [below for nested schema](#nestedblock--config--destination--opensearch--buffer))
 - `bulk_index` (String) The index or datastream to write logs to.
+
+<a id="nestedblock--config--destination--opensearch--buffer"></a>
+### Nested Schema for `config.destination.opensearch.buffer`
+
+Optional:
+
+- `disk` (Block List) Options for configuring a disk buffer. Cannot be used with `memory`. (see [below for nested schema](#nestedblock--config--destination--opensearch--buffer--disk))
+- `memory` (Block List) Options for configuring a memory buffer. Cannot be used with `disk`. (see [below for nested schema](#nestedblock--config--destination--opensearch--buffer--memory))
+
+<a id="nestedblock--config--destination--opensearch--buffer--disk"></a>
+### Nested Schema for `config.destination.opensearch.buffer.disk`
+
+Optional:
+
+- `max_size` (Number) Maximum size of the disk buffer (in bytes).
+
+
+<a id="nestedblock--config--destination--opensearch--buffer--memory"></a>
+### Nested Schema for `config.destination.opensearch.buffer.memory`
+
+Optional:
+
+- `max_events` (Number) Maximum events for the memory buffer.
+- `max_size` (Number) Maximum size of the memory buffer (in bytes).
+
+
 
 
 <a id="nestedblock--config--destination--rsyslog"></a>
@@ -405,8 +765,35 @@ Optional:
 
 Optional:
 
+- `buffer` (Block List) Configuration for buffer settings on destination components. Exactly one of `disk` or `memory` must be specified. (see [below for nested schema](#nestedblock--config--destination--rsyslog--buffer))
 - `keepalive` (Number) Optional socket keepalive duration in milliseconds.
 - `tls` (Block List) Configuration for enabling TLS encryption between the pipeline component and external services. (see [below for nested schema](#nestedblock--config--destination--rsyslog--tls))
+
+<a id="nestedblock--config--destination--rsyslog--buffer"></a>
+### Nested Schema for `config.destination.rsyslog.buffer`
+
+Optional:
+
+- `disk` (Block List) Options for configuring a disk buffer. Cannot be used with `memory`. (see [below for nested schema](#nestedblock--config--destination--rsyslog--buffer--disk))
+- `memory` (Block List) Options for configuring a memory buffer. Cannot be used with `disk`. (see [below for nested schema](#nestedblock--config--destination--rsyslog--buffer--memory))
+
+<a id="nestedblock--config--destination--rsyslog--buffer--disk"></a>
+### Nested Schema for `config.destination.rsyslog.buffer.disk`
+
+Optional:
+
+- `max_size` (Number) Maximum size of the disk buffer (in bytes).
+
+
+<a id="nestedblock--config--destination--rsyslog--buffer--memory"></a>
+### Nested Schema for `config.destination.rsyslog.buffer.memory`
+
+Optional:
+
+- `max_events` (Number) Maximum events for the memory buffer.
+- `max_size` (Number) Maximum size of the memory buffer (in bytes).
+
+
 
 <a id="nestedblock--config--destination--rsyslog--tls"></a>
 ### Nested Schema for `config.destination.rsyslog.tls`
@@ -429,6 +816,36 @@ Required:
 
 - `region` (String) The SentinelOne region to send logs to.
 
+Optional:
+
+- `buffer` (Block List) Configuration for buffer settings on destination components. Exactly one of `disk` or `memory` must be specified. (see [below for nested schema](#nestedblock--config--destination--sentinel_one--buffer))
+
+<a id="nestedblock--config--destination--sentinel_one--buffer"></a>
+### Nested Schema for `config.destination.sentinel_one.buffer`
+
+Optional:
+
+- `disk` (Block List) Options for configuring a disk buffer. Cannot be used with `memory`. (see [below for nested schema](#nestedblock--config--destination--sentinel_one--buffer--disk))
+- `memory` (Block List) Options for configuring a memory buffer. Cannot be used with `disk`. (see [below for nested schema](#nestedblock--config--destination--sentinel_one--buffer--memory))
+
+<a id="nestedblock--config--destination--sentinel_one--buffer--disk"></a>
+### Nested Schema for `config.destination.sentinel_one.buffer.disk`
+
+Optional:
+
+- `max_size` (Number) Maximum size of the disk buffer (in bytes).
+
+
+<a id="nestedblock--config--destination--sentinel_one--buffer--memory"></a>
+### Nested Schema for `config.destination.sentinel_one.buffer.memory`
+
+Optional:
+
+- `max_events` (Number) Maximum events for the memory buffer.
+- `max_size` (Number) Maximum size of the memory buffer (in bytes).
+
+
+
 
 <a id="nestedblock--config--destination--socket"></a>
 ### Nested Schema for `config.destination.socket`
@@ -440,8 +857,35 @@ Required:
 
 Optional:
 
+- `buffer` (Block List) Configuration for buffer settings on destination components. Exactly one of `disk` or `memory` must be specified. (see [below for nested schema](#nestedblock--config--destination--socket--buffer))
 - `framing` (Block List) Defines the framing method for outgoing messages. (see [below for nested schema](#nestedblock--config--destination--socket--framing))
 - `tls` (Block List) Configuration for enabling TLS encryption between the pipeline component and external services. (see [below for nested schema](#nestedblock--config--destination--socket--tls))
+
+<a id="nestedblock--config--destination--socket--buffer"></a>
+### Nested Schema for `config.destination.socket.buffer`
+
+Optional:
+
+- `disk` (Block List) Options for configuring a disk buffer. Cannot be used with `memory`. (see [below for nested schema](#nestedblock--config--destination--socket--buffer--disk))
+- `memory` (Block List) Options for configuring a memory buffer. Cannot be used with `disk`. (see [below for nested schema](#nestedblock--config--destination--socket--buffer--memory))
+
+<a id="nestedblock--config--destination--socket--buffer--disk"></a>
+### Nested Schema for `config.destination.socket.buffer.disk`
+
+Optional:
+
+- `max_size` (Number) Maximum size of the disk buffer (in bytes).
+
+
+<a id="nestedblock--config--destination--socket--buffer--memory"></a>
+### Nested Schema for `config.destination.socket.buffer.memory`
+
+Optional:
+
+- `max_events` (Number) Maximum events for the memory buffer.
+- `max_size` (Number) Maximum size of the memory buffer (in bytes).
+
+
 
 <a id="nestedblock--config--destination--socket--framing"></a>
 ### Nested Schema for `config.destination.socket.framing`
@@ -483,9 +927,36 @@ Optional:
 Optional:
 
 - `auto_extract_timestamp` (Boolean) If `true`, Splunk tries to extract timestamps from incoming log events.
+- `buffer` (Block List) Configuration for buffer settings on destination components. Exactly one of `disk` or `memory` must be specified. (see [below for nested schema](#nestedblock--config--destination--splunk_hec--buffer))
 - `encoding` (String) Encoding format for log events. Valid values: `json`, `raw_message`.
 - `index` (String) Optional name of the Splunk index where logs are written.
 - `sourcetype` (String) The Splunk sourcetype to assign to log events.
+
+<a id="nestedblock--config--destination--splunk_hec--buffer"></a>
+### Nested Schema for `config.destination.splunk_hec.buffer`
+
+Optional:
+
+- `disk` (Block List) Options for configuring a disk buffer. Cannot be used with `memory`. (see [below for nested schema](#nestedblock--config--destination--splunk_hec--buffer--disk))
+- `memory` (Block List) Options for configuring a memory buffer. Cannot be used with `disk`. (see [below for nested schema](#nestedblock--config--destination--splunk_hec--buffer--memory))
+
+<a id="nestedblock--config--destination--splunk_hec--buffer--disk"></a>
+### Nested Schema for `config.destination.splunk_hec.buffer.disk`
+
+Optional:
+
+- `max_size` (Number) Maximum size of the disk buffer (in bytes).
+
+
+<a id="nestedblock--config--destination--splunk_hec--buffer--memory"></a>
+### Nested Schema for `config.destination.splunk_hec.buffer.memory`
+
+Optional:
+
+- `max_events` (Number) Maximum events for the memory buffer.
+- `max_size` (Number) Maximum size of the memory buffer (in bytes).
+
+
 
 
 <a id="nestedblock--config--destination--sumo_logic"></a>
@@ -493,11 +964,38 @@ Optional:
 
 Optional:
 
+- `buffer` (Block List) Configuration for buffer settings on destination components. Exactly one of `disk` or `memory` must be specified. (see [below for nested schema](#nestedblock--config--destination--sumo_logic--buffer))
 - `encoding` (String) The output encoding format.
 - `header_custom_field` (Block List) A list of custom headers to include in the request to Sumo Logic. (see [below for nested schema](#nestedblock--config--destination--sumo_logic--header_custom_field))
 - `header_host_name` (String) Optional override for the host name header.
 - `header_source_category` (String) Optional override for the source category header.
 - `header_source_name` (String) Optional override for the source name header.
+
+<a id="nestedblock--config--destination--sumo_logic--buffer"></a>
+### Nested Schema for `config.destination.sumo_logic.buffer`
+
+Optional:
+
+- `disk` (Block List) Options for configuring a disk buffer. Cannot be used with `memory`. (see [below for nested schema](#nestedblock--config--destination--sumo_logic--buffer--disk))
+- `memory` (Block List) Options for configuring a memory buffer. Cannot be used with `disk`. (see [below for nested schema](#nestedblock--config--destination--sumo_logic--buffer--memory))
+
+<a id="nestedblock--config--destination--sumo_logic--buffer--disk"></a>
+### Nested Schema for `config.destination.sumo_logic.buffer.disk`
+
+Optional:
+
+- `max_size` (Number) Maximum size of the disk buffer (in bytes).
+
+
+<a id="nestedblock--config--destination--sumo_logic--buffer--memory"></a>
+### Nested Schema for `config.destination.sumo_logic.buffer.memory`
+
+Optional:
+
+- `max_events` (Number) Maximum events for the memory buffer.
+- `max_size` (Number) Maximum size of the memory buffer (in bytes).
+
+
 
 <a id="nestedblock--config--destination--sumo_logic--header_custom_field"></a>
 ### Nested Schema for `config.destination.sumo_logic.header_custom_field`
@@ -514,8 +1012,35 @@ Optional:
 
 Optional:
 
+- `buffer` (Block List) Configuration for buffer settings on destination components. Exactly one of `disk` or `memory` must be specified. (see [below for nested schema](#nestedblock--config--destination--syslog_ng--buffer))
 - `keepalive` (Number) Optional socket keepalive duration in milliseconds.
 - `tls` (Block List) Configuration for enabling TLS encryption between the pipeline component and external services. (see [below for nested schema](#nestedblock--config--destination--syslog_ng--tls))
+
+<a id="nestedblock--config--destination--syslog_ng--buffer"></a>
+### Nested Schema for `config.destination.syslog_ng.buffer`
+
+Optional:
+
+- `disk` (Block List) Options for configuring a disk buffer. Cannot be used with `memory`. (see [below for nested schema](#nestedblock--config--destination--syslog_ng--buffer--disk))
+- `memory` (Block List) Options for configuring a memory buffer. Cannot be used with `disk`. (see [below for nested schema](#nestedblock--config--destination--syslog_ng--buffer--memory))
+
+<a id="nestedblock--config--destination--syslog_ng--buffer--disk"></a>
+### Nested Schema for `config.destination.syslog_ng.buffer.disk`
+
+Optional:
+
+- `max_size` (Number) Maximum size of the disk buffer (in bytes).
+
+
+<a id="nestedblock--config--destination--syslog_ng--buffer--memory"></a>
+### Nested Schema for `config.destination.syslog_ng.buffer.memory`
+
+Optional:
+
+- `max_events` (Number) Maximum events for the memory buffer.
+- `max_size` (Number) Maximum size of the memory buffer (in bytes).
+
+
 
 <a id="nestedblock--config--destination--syslog_ng--tls"></a>
 ### Nested Schema for `config.destination.syslog_ng.tls`


### PR DESCRIPTION
Note: i’ll include support for `when_full` in a separate commit since it has not been released yet in OPW, and adding it to TF would always send the default value, even when not defined.