### PR TITLE
Correctly set up HttpClientRetryBackoffBase in fwprovider resources

### DIFF
--- a/datadog/fwprovider/framework_provider.go
+++ b/datadog/fwprovider/framework_provider.go
@@ -698,7 +698,7 @@ func defaultConfigureFunc(p *FrameworkProvider, request *provider.ConfigureReque
 		}
 
 		if !config.HttpClientRetryBackoffBase.IsNull() {
-			ddClientConfig.RetryConfiguration.BackOffBase = float64(config.HttpClientRetryBackoffMultiplier.ValueInt64())
+			ddClientConfig.RetryConfiguration.BackOffBase = float64(config.HttpClientRetryBackoffBase.ValueInt64())
 		}
 
 		if !config.HttpClientRetryMaxRetries.IsNull() {


### PR DESCRIPTION
This was likely a copy/paste bug from the past, which could lead to no retries at all, causing potentially unexpected retry behavior.