### PR TITLE
fix: revert changelog changes to resolve conflicts with master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 4.0.0 (Unreleased)
-
-This is a major release with breaking changes. Please refer to the [v4.0.0 Upgrade Guide](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/guides/v4-upgrade-guide) for migration instructions.
-
 ## 3.84.0 (January 8, 2026)
 
 ### BUGFIXES


### PR DESCRIPTION
## Summary

Reverts the premature "4.0.0 (Unreleased)" changelog header to resolve merge conflicts between the 4.x branch and master.

## Motivation

The 4.x branch had a changelog header for the unreleased 4.0.0 version, which caused conflicts when merging changes from master. Since version 4.0.0 hasn't been released yet and the changelog should be updated closer to release, removing this header now simplifies the merge workflow and keeps the 4.x branch in sync with master.

## Changes

- Removed section related to the 4.0.0 release from CHANGELOG.md
