### PR TITLE
[datadog_application_key] Remove previously deprecated import functionality

### DIFF
--- a/datadog/fwprovider/resource_datadog_application_key.go
+++ b/datadog/fwprovider/resource_datadog_application_key.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
-	frameworkPath "github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -17,8 +16,7 @@ import (
 )
 
 var (
-	_ resource.ResourceWithConfigure   = &applicationKeyResource{}
-	_ resource.ResourceWithImportState = &applicationKeyResource{}
+	_ resource.ResourceWithConfigure = &applicationKeyResource{}
 )
 
 func NewApplicationKeyResource() resource.Resource {
@@ -37,17 +35,9 @@ type applicationKeyResource struct {
 	Auth context.Context
 }
 
-func (r *applicationKeyResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
-	response.Diagnostics.AddWarning(
-		"Deprecated",
-		"The import functionality for datadog_application_key resources is deprecated and will be removed in a future release with prior notice. Securely store your application keys using a secret management system or use the datadog_application_key resource to create and manage new application keys.",
-	)
-	resource.ImportStatePassthroughID(ctx, frameworkPath.Root("id"), request, response)
-}
-
 func (r *applicationKeyResource) Schema(_ context.Context, _ resource.SchemaRequest, response *resource.SchemaResponse) {
 	response.Schema = schema.Schema{
-		Description: "Provides a Datadog Application Key resource. This can be used to create and manage Datadog Application Keys. Import functionality for this resource is deprecated and will be removed in a future release with prior notice. Securely store your application keys using a secret management system or use this resource to create and manage new application keys.",
+		Description: "Provides a Datadog Application Key resource. This can be used to create and manage Datadog Application Keys. Import is not supported for this resource. Securely store your application keys using a secret management system or use this resource to create and manage new application keys.",
 		Attributes: map[string]schema.Attribute{
 			"name": schema.StringAttribute{
 				Description: "Name for Application Key.",

--- a/datadog/tests/resource_datadog_application_key_test.go
+++ b/datadog/tests/resource_datadog_application_key_test.go
@@ -88,31 +88,26 @@ func TestAccDatadogApplicationKey_Error(t *testing.T) {
 	})
 }
 
-// func TestDatadogApplicationKey_import(t *testing.T) {
-// 	if isRecording() || isReplaying() {
-// 		t.Skip("This test doesn't support recording or replaying")
-// 	}
-// 	t.Parallel()
-// 	resourceName := "datadog_application_key.foo"
-// 	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
-// 	applicationKeyName := uniqueEntityName(ctx, t)
+func TestAccDatadogApplicationKey_ImportNotSupported(t *testing.T) {
+	if isRecording() || isReplaying() {
+		t.Skip("This test doesn't support recording or replaying")
+	}
+	t.Parallel()
+	_, _, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
 
-// 	resource.Test(t, resource.TestCase{
-// 		PreCheck:                 func() { testAccPreCheck(t) },
-// 		ProtoV6ProviderFactories: accProviders,
-// 		CheckDestroy:             testAccCheckDatadogApplicationKeyDestroy(providers.frameworkProvider),
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config: testAccCheckDatadogApplicationKeyConfigRequired(applicationKeyName),
-// 			},
-// 			{
-// 				ResourceName:      resourceName,
-// 				ImportState:       true,
-// 				ImportStateVerify: true,
-// 			},
-// 		},
-// 	})
-// }
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: accProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:        `resource "datadog_application_key" "test" { name = "test" }`,
+				ResourceName:  "datadog_application_key.test",
+				ImportState:   true,
+				ImportStateId: "fake-id",
+				ExpectError:   regexp.MustCompile(`Resource Import Not Implemented`),
+			},
+		},
+	})
+}
 
 func testAccCheckDatadogApplicationKeyConfigRequired(uniq string) string {
 	return fmt.Sprintf(`

--- a/docs/guides/v4-upgrade-guide.md
+++ b/docs/guides/v4-upgrade-guide.md
@@ -81,6 +81,45 @@ Brief description of the breaking change.
 ================================================================================
 -->
 
+### Removed import support for `datadog_application_key`
+
+Import functionality has been removed for the `datadog_application_key` resource. This was previously deprecated with a warning.
+
+Application keys contain sensitive credentials that cannot be retrieved after creation. When you import an existing application key, the `key` attribute cannot be populated from the API, which leads to state inconsistencies and potential security issues.
+
+**Note:** If your organization has [One-Time Read mode](https://docs.datadoghq.com/account_management/api-app-keys/#one-time-read-mode) enabled for Application Keys, then no action is needed to migrate for this resource because import is already unavailable.
+
+**Before (v3.x):**
+
+```shell
+# Import command
+terraform import datadog_application_key.foo 11111111-2222-3333-4444-555555555555
+```
+
+```terraform
+# Import block (Terraform 1.5+)
+import {
+  to = datadog_application_key.foo
+  id = "11111111-2222-3333-4444-555555555555"
+}
+```
+
+**After (v4.0.0):**
+
+Import is no longer supported. Attempting to import will result in:
+
+```
+Error: Resource Import Not Implemented
+
+This resource does not support import.
+```
+
+**Migration steps:**
+
+1. If you have `import` blocks for `datadog_application_key` resources, ensure they have been applied before upgrading, then remove the import blocks from your configuration.
+2. Previously imported application keys continue to work after upgrading. No action is required for keys already in your Terraform state.
+3. For new application keys, use the `datadog_application_key` resource to create them directly and securely store the key values using a secret management system.
+
 ### Removed `locked` on `datadog_monitor`
 
 Removed `locked` and changed the default behavior of `restricted_roles` on `datadog_monitor`. These changes are intended 

--- a/docs/resources/application_key.md
+++ b/docs/resources/application_key.md
@@ -3,12 +3,12 @@
 page_title: "datadog_application_key Resource - terraform-provider-datadog"
 subcategory: ""
 description: |-
-  Provides a Datadog Application Key resource. This can be used to create and manage Datadog Application Keys. Import functionality for this resource is deprecated and will be removed in a future release with prior notice. Securely store your application keys using a secret management system or use this resource to create and manage new application keys.
+  Provides a Datadog Application Key resource. This can be used to create and manage Datadog Application Keys. Import is not supported for this resource. Securely store your application keys using a secret management system or use this resource to create and manage new application keys.
 ---
 
 # datadog_application_key (Resource)
 
-Provides a Datadog Application Key resource. This can be used to create and manage Datadog Application Keys. Import functionality for this resource is deprecated and will be removed in a future release with prior notice. Securely store your application keys using a secret management system or use this resource to create and manage new application keys.
+Provides a Datadog Application Key resource. This can be used to create and manage Datadog Application Keys. Import is not supported for this resource. Securely store your application keys using a secret management system or use this resource to create and manage new application keys.
 
 ## Example Usage
 
@@ -47,13 +47,3 @@ resource "datadog_application_key" "monitor_management_key" {
 
 - `id` (String) The ID of this resource.
 - `key` (String, Sensitive) The value of the Application Key.
-
-## Import
-
-Import is supported using the following syntax:
-
-The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
-
-```shell
-terraform import datadog_application_key.foo 11111111-2222-3333-4444-555555555555
-```

--- a/examples/resources/datadog_application_key/import.sh
+++ b/examples/resources/datadog_application_key/import.sh
@@ -1,2 +1,0 @@
-terraform import datadog_application_key.foo 11111111-2222-3333-4444-555555555555
-


### PR DESCRIPTION
Remove previously deprecated import functionality for datadog_application_key resources. This functionality is no longer supported for datadog_application_key resources.