### PR TITLE
[datadog_sensitive_data_scanner_rule] compute included_keyword_configuration when not explicitly defined

### DIFF
--- a/datadog/resource_datadog_sensitive_data_scanner_rule.go
+++ b/datadog/resource_datadog_sensitive_data_scanner_rule.go
@@ -80,6 +80,7 @@ func resourceDatadogSensitiveDataScannerRule() *schema.Resource {
 				"included_keyword_configuration": {
 					Type:        schema.TypeList,
 					Optional:    true,
+					Computed:    true,
 					MaxItems:    1,
 					Description: "Object defining a set of keywords and a number of characters that help reduce noise. You can provide a list of keywords you would like to check within a defined proximity of the matching pattern. If any of the keywords are found within the proximity check then the match is kept. If none are found, the match is discarded. If the rule has the `standard_pattern_id` field, then discarding this field will apply the recommended keywords. Setting the `create_before_destroy` lifecycle Meta-argument to `true` is highly recommended if modifying this field to avoid unexpectedly disabling Sensitive Data Scanner groups.",
 					Elem: &schema.Resource{


### PR DESCRIPTION
#3355 made the custom rules default to an empty list with character count set to 30 for the `included_keyword_configuration` (to align with the UI requests) _-- [see the else logic here](https://github.com/DataDog/terraform-provider-datadog/pull/3355/changes#diff-39734247e933fb39b6e70ad59fa0b9dd4fdfb7a16e667d721321a36a674187bdR363-R367) --_

However, it wasn't reflecting the default value in the state, and we had use-cases internally where we needed to update existing rules through the UI and kept resulting in changes detected in the TF `plan` (even after `apply`)

### Suggested change
Setting `included_keyword_configuration` attribute as `Computed` (it's already `Optional`), so that when it's not explicitly set in the resource, it would fallback to the API response when updating the state