### PR TITLE
[datadog_observability_pipelines] Make datadog_tags keys required to contain at least one element

### DIFF
--- a/datadog/fwprovider/observability_pipeline/datadog_tags_processor.go
+++ b/datadog/fwprovider/observability_pipeline/datadog_tags_processor.go
@@ -49,6 +49,9 @@ func DatadogTagsProcessorSchema() schema.ListNestedBlock {
 				"keys": schema.ListAttribute{
 					ElementType: types.StringType,
 					Required:    true,
+					Validators: []validator.List{
+						listvalidator.SizeAtLeast(1),
+					},
 				},
 			},
 		},

--- a/datadog/fwprovider/resource_datadog_observability_pipeline.go
+++ b/datadog/fwprovider/resource_datadog_observability_pipeline.go
@@ -1878,6 +1878,9 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 																			ElementType: types.StringType,
 																			Required:    true,
 																			Description: "A list of tag keys to include or exclude.",
+																			Validators: []validator.List{
+																				listvalidator.SizeAtLeast(1),
+																			},
 																		},
 																	},
 																},


### PR DESCRIPTION
The API Client already enforces it, now we'd like to have this validation already at the "plan" step.

This is low priority: we just want a consistent experience between "plan" and "apply"