### PR TITLE
[datadog_integration_aws_account] Update v4 upgrade guide for deprecated resources in 4.x

### DIFF
--- a/docs/guides/v4-upgrade-guide.md
+++ b/docs/guides/v4-upgrade-guide.md
@@ -199,7 +199,7 @@ The following deprecated AWS integration resources have been removed in v4.0.0:
 - `datadog_integration_aws_log_collection`
 - `datadog_integration_aws_lambda_arn`
 
-These resources have been replaced by the `datadog_integration_aws_account` resource, which provides a unified way to manage AWS integrations.
+These resources have been replaced by the [`datadog_integration_aws_account`](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/integration_aws_account) resource, which provides a unified way to manage AWS integrations.
 
 **Before (v3.x):**
 


### PR DESCRIPTION
We are deleting the following resources in the 4.x release and need to update the migration instructions for them (https://github.com/DataDog/terraform-provider-datadog/pull/3450):
- datadog_integration_aws
- datadog_integration_aws_tag_filter
- datadog_integration_aws_log_collection
- datadog_integration_aws_lambda_arn