### PR TITLE
[docs] Add write-only argument helper documentation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -21,6 +21,10 @@ Terraform provides helpful [Extending Terraform][1] documentation for best pract
   - One that will have a singular name (ex: `datadog_user`) which returns exactly one objects (and fails if there is 0 or more than 0)
   - One that will have a plural name (ex: `datadog_users`) which returns a list of objects and succeed in all cases (0, 1 or more than 1 objects)
 
+## Write-Only Arguments
+
+When adding secret/sensitive attributes to Framework resources, use the write-only helpers in [`datadog/internal/fwutils`](./datadog/internal/fwutils/README.md#write-only-secret-helpers-writeonly_helpersgo). These generate the three-attribute pattern (`<attr>`, `<attr>_wo`, `<attr>_wo_version`) required by Terraform 1.11+ write-only support while maintaining backwards compatibility.
+
 ## Makefile
 
 The root of this project contains a `GNUmakefile` with the purpose of making each development step easier. While some commands are outlined here, please see [GNUmakefile][5] for all available commands.

--- a/datadog/internal/fwutils/README.md
+++ b/datadog/internal/fwutils/README.md
@@ -1,0 +1,53 @@
+# fwutils
+
+Shared utilities for Terraform Plugin Framework resources.
+
+## Write-Only Secret Helpers (`writeonly_helpers.go`)
+
+Helpers for adding write-only attributes (Terraform 1.11+) to resources while maintaining backwards compatibility with plaintext attributes.
+
+### Schema
+
+`CreateWriteOnlySecretAttributes` generates the three-attribute pattern (`<attr>`, `<attr>_wo`, `<attr>_wo_version`) with proper validators (ExactlyOneOf, AlsoRequires, PreferWriteOnlyAttribute). Use `MergeAttributes` to combine with your other attributes:
+
+```go
+var secretConfig = fwutils.WriteOnlySecretConfig{
+    OriginalAttr:         "value",
+    WriteOnlyAttr:        "value_wo",
+    TriggerAttr:          "value_wo_version",
+    OriginalDescription:  "The secret value.",
+    WriteOnlyDescription: "Write-only secret value (not stored in state).",
+    TriggerDescription:   "Version trigger for value_wo rotation.",
+}
+
+Attributes: fwutils.MergeAttributes(
+    fwutils.CreateWriteOnlySecretAttributes(secretConfig),
+    map[string]schema.Attribute{
+        "id":   schema.StringAttribute{Computed: true},
+        "name": schema.StringAttribute{Required: true},
+    },
+)
+```
+
+### CRUD Operations
+
+`WriteOnlySecretHandler` retrieves the secret from whichever mode the user chose:
+
+```go
+var secretHandler = &fwutils.WriteOnlySecretHandler{
+    Config:                 secretConfig,
+    SecretRequiredOnUpdate: false, // true if API requires secret on every update
+}
+
+// In Create:
+result := secretHandler.GetSecretForCreate(ctx, &req.Config)
+
+// In Update (checks version trigger to detect rotation):
+result := secretHandler.GetSecretForUpdate(ctx, &req.Config, &req)
+
+if result.ShouldSetValue {
+    body.SetValue(result.Value)
+}
+```
+
+See `resource_datadog_synthetics_global_variable.go` for a complete working example.


### PR DESCRIPTION
[APIR-2462]

## Summary
Add developer documentation for write-only argument helpers in `fwutils`, making them discoverable for engineers adding secret/sensitive attributes to Framework resources.

## Motivation
The write-only helpers (`writeonly_helpers.go`) already exist but lacked usage documentation. Engineers adding new write-only attributes had to reverse-engineer the pattern from existing resources. This adds a README with examples next to the helpers and links to it from `DEVELOPMENT.md`.

## Changes
- Add `datadog/internal/fwutils/README.md` with schema and CRUD usage examples for write-only secret helpers
- Add "Write-Only Arguments" section to `DEVELOPMENT.md` linking to the fwutils README


[APIR-2462]: https://datadoghq.atlassian.net/browse/APIR-2462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ