### PR TITLE
[datadog_monitor_json] add with_restriction_policy to the request

### DIFF
--- a/datadog/resource_datadog_monitor_json.go
+++ b/datadog/resource_datadog_monitor_json.go
@@ -132,6 +132,11 @@ func resourceDatadogMonitorJSONRead(_ context.Context, d *schema.ResourceData, m
 		params = append(params, "with_restricted_roles=false")
 	}
 
+	// only query for monitor restriction policy if they are explicitly defined in the JSON
+	if _, ok := attrMap["restriction_policy"]; ok {
+		params = append(params, "with_restriction_policy=true")
+	}
+
 	// only query for monitor assets if they are explicitly defined in the JSON
 	if _, ok := attrMap["assets"]; ok {
 		params = append(params, "with_assets=true")


### PR DESCRIPTION
Working on [support issue](https://datadoghq.atlassian.net/browse/MNTS-93167). We should query for restriction policy when it is in the json request