### PR TITLE
[datadog_restriction_policy] Update migration doc with restriction policy changes

### DIFF
--- a/datadog/fwprovider/resource_datadog_restriction_policy.go
+++ b/datadog/fwprovider/resource_datadog_restriction_policy.go
@@ -61,8 +61,7 @@ func (r *RestrictionPolicyResource) Schema(_ context.Context, _ resource.SchemaR
 					"* [List of supported resources](https://docs.datadoghq.com/account_management/rbac/granular_access)\n" +
 					"* [Resource type definition](https://docs.datadoghq.com/api/latest/restriction-policies/#supported-resources)\n" +
 					"\nRestrictions :\n" +
-					"* Dashboards : support is in private beta. Reach out to your Datadog contact or support to enable this.\n" +
-					"* Monitors : Management of restriction policy through terraform is now available in Preview. Please request access via https://docs.datadoghq.com/help",
+					"* Dashboards : support is in private beta. Reach out to your Datadog contact or support to enable this.\n",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},

--- a/docs/guides/v4-upgrade-guide.md
+++ b/docs/guides/v4-upgrade-guide.md
@@ -143,6 +143,17 @@ to encourage users to migrate and manage monitor permissions through the `datado
 
 **Note:** Migrating off `restricted_roles` is not required. This field is still supported by the monitor provider. However, we
 strongly recommend migrating to `datadog_restriction_policy` as the preferred way to manage monitor permissions going forward.
+Additionally, this change to `restricted_roles` may cause a one-time diff during a resource update, even if the client does 
+not apply any changes to the monitor.
+```
+# module.datadog_monitor.foo will be updated in-place
+~ resource "datadog_monitor" "foo" {
+      id               = "12345678"
+      name             = "Test monitor"
+    + restricted_roles = (known after apply)
+      # (1 unchanged block hidden)
+  }
+```
 
 **Before (v3.x):**
 

--- a/docs/resources/restriction_policy.md
+++ b/docs/resources/restriction_policy.md
@@ -42,7 +42,6 @@ Resources to define `resource_type` :
 
 Restrictions :
 * Dashboards : support is in private beta. Reach out to your Datadog contact or support to enable this.
-* Monitors : Management of restriction policy through terraform is now available in Preview. Please request access via https://docs.datadoghq.com/help
 
 ### Optional
 


### PR DESCRIPTION
### What changed

* Updated the migration guide to add a note about a potential **one-time diff** when `restricted_roles` is present (even if the monitor config itself hasn’t changed).
* Updated the `datadog_restriction_policy` documentation to remove notes on **monitor preview** when using provider version **4.x+**.

