### PR TITLE
Fix PR changelog label names in docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,5 +62,5 @@ Some docs are manually maintained and excluded from auto generation. Check `scri
 
 ## PR Labels
 
-- Changelog: `improvement`, `feature`, `bugfix`, `note`, or `no-changelog`
+- Changelog: `changelog/improvement`, `changelog/feature`, `changelog/bugfix`, `changelog/note`, `changelog/documentation` or `changelog/no-changelog`
 - Title prefix: `[datadog_resource_name] Description`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -117,7 +117,7 @@ where:
 
 To help with changelog documentation, all pull requests must be labelled properly.
 
-It needs one changelog label (among `improvement`, `feature`, `bugfix`, `note` and `no-changelog`), and one resource mentioned in the title as a prefix (if not `no-changelog`) corresponding to the resource being changed (For example `[datadog_dashboard] Fix issue`).
+It needs one changelog label (among `changelog/improvement`, `changelog/feature`, `changelog/bugfix`, `changelog/note` and `changelog/no-changelog`), and one resource mentioned in the title as a prefix (if not `changelog/no-changelog`) corresponding to the resource being changed (For example `[datadog_dashboard] Fix issue`).
 
 [1]: https://www.terraform.io/docs/extend/index.html
 [2]: https://www.terraform.io/downloads.html


### PR DESCRIPTION
## Summary

Including the full label names for "changelog" PR labels in documentation and AGENTS.md to help claude accurately label new PR's.

- Update AGENTS.md and DEVELOPMENT.md to use the full `changelog/` prefix for PR labels (e.g., `changelog/improvement` instead of `improvement`)
- Also adds `changelog/documentation` as a valid label option

## Test plan
- No code changes, documentation only