### PR TITLE
[datadog_synthetics_test] Accept variables in header names and/or values

### DIFF
--- a/datadog/internal/validators/validators.go
+++ b/datadog/internal/validators/validators.go
@@ -307,23 +307,24 @@ func Float64Between(min, max float64) validator.String {
 	}
 }
 
-func ValidateHttpRequestHeader(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(map[string]interface{})
-	for headerField, headerValue := range value {
-		if !isValidToken(headerField) && !isRequestPseudoHeader(headerField) {
+func ValidateHttpRequestHeaders(v interface{}, k string) (ws []string, errors []error) {
+	headersMap := v.(map[string]interface{})
+	for headerField, headerValue := range headersMap {
+		if !isValidToken(headerField) && !isRequestPseudoHeader(headerField) && !containsDatadogVariableSyntax(headerField) {
 			errors = append(errors, fmt.Errorf("invalid value for %s (header field must be a valid token or a http/2 request pseudo-header)", k))
 			return
 		}
+
 		headerStringValue, ok := headerValue.(string)
 		if !ok {
 			errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
 			return
-		} else {
-			for _, r := range headerStringValue {
-				if (unicode.IsControl(r) && r != '\t') || (r == '\r' || r == '\n') {
-					errors = append(errors, fmt.Errorf("invalid value for %s (header value must not contain invisible characters)", k))
-					return
-				}
+		}
+
+		for _, r := range headerStringValue {
+			if (unicode.IsControl(r) && r != '\t') || (r == '\r' || r == '\n') {
+				errors = append(errors, fmt.Errorf("invalid value for %s (header value must not contain invisible characters)", k))
+				return
 			}
 		}
 	}
@@ -333,6 +334,10 @@ func ValidateHttpRequestHeader(v interface{}, k string) (ws []string, errors []e
 func isRequestPseudoHeader(header string) bool {
 	// :status is a response pseudo-header, and :protocol may only be used internally in websockets
 	return header == ":method" || header == ":scheme" || header == ":authority" || header == ":path"
+}
+
+func containsDatadogVariableSyntax(header string) bool {
+	return regexp.MustCompile(`{{\s*([^{}]*?)\s*}}`).MatchString(header)
 }
 
 func isValidToken(token string) bool {

--- a/datadog/internal/validators/validators_test.go
+++ b/datadog/internal/validators/validators_test.go
@@ -218,7 +218,7 @@ func TestValidateFloat64Between(t *testing.T) {
 	}
 }
 
-func TestValidateHttpRequestHeader(t *testing.T) {
+func TestValidateHttpRequestHeaders(t *testing.T) {
 	cases := []struct {
 		Value    map[string]interface{}
 		ErrCount int
@@ -255,10 +255,22 @@ func TestValidateHttpRequestHeader(t *testing.T) {
 			Value:    map[string]interface{}{"foo": "\n"},
 			ErrCount: 1,
 		},
+		{
+			Value:    map[string]interface{}{"{{ VAR_HEADER_NAME }}": "value"},
+			ErrCount: 0,
+		},
+		{
+			Value:    map[string]interface{}{"foo": "{{ VAR_HEADER_VALUE }}"},
+			ErrCount: 0,
+		},
+		{
+			Value:    map[string]interface{}{"{{ VAR_HEADER_NAME }}": "{{ VAR_HEADER_VALUE }}"},
+			ErrCount: 0,
+		},
 	}
 
 	for _, tc := range cases {
-		_, errors := ValidateHttpRequestHeader(tc.Value, "request_headers")
+		_, errors := ValidateHttpRequestHeaders(tc.Value, "request_headers")
 
 		if len(errors) != tc.ErrCount {
 			t.Fatalf("Expected http request header validation to trigger %d error(s) for value %q - instead saw %d",

--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -333,7 +333,7 @@ func syntheticsTestRequestHeaders() *schema.Schema {
 		Description:  "Header name and value map.",
 		Type:         schema.TypeMap,
 		Optional:     true,
-		ValidateFunc: validators.ValidateHttpRequestHeader,
+		ValidateFunc: validators.ValidateHttpRequestHeaders,
 	}
 }
 


### PR DESCRIPTION
We support variables in header names and values in the UI, but not in Terraform due to our headers validation.

<img width="1363" height="251" alt="image" src="https://github.com/user-attachments/assets/5c3043d3-cfe9-4fa2-8793-773e53de4536" />

This PR updates `ValidateHttpRequestHeader` (which is only used by Synthetics) to bypass validation when `{{ }}` syntax is detected.