### PR TITLE
Add flaky integration tests to skip list, sorted by error type

### DIFF
--- a/flaky_tests.yaml
+++ b/flaky_tests.yaml
@@ -133,7 +133,7 @@ skipped_tests:
     added: "2026-03-02"
     author: fpighi
 
-  # Missing cloud integrations — AWS/Azure/GCP not configured (11 tests)
+  # Missing cloud integrations — AWS/Azure/GCP not configured (18 tests)
   - test: TestAccAwsCurConfigBasic
     reason: "Initial sync of tests failing on master branch"
     added: "2026-03-02"
@@ -178,6 +178,34 @@ skipped_tests:
     reason: "Initial sync of tests failing on master branch"
     added: "2026-03-02"
     author: fpighi
+  - test: TestAccDatadogAgentlessScanningGcpScanOptions_Basic
+    reason: "404 Not Found reading/deleting GCP scan options — GCP not configured in org"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogIntegrationGCP
+    reason: "Error retrieving GCP integration — GCP not configured in org"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: Test_ReplacingHostFiltersWithMRC
+    reason: "Error retrieving GCP integration — GCP not configured in org"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogIntegrationAzure
+    reason: "500 Internal Server Error listing Azure integration — Azure not configured in org"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccIntegrationAwsAccount_OptionalLogSourceConfig
+    reason: "500 Internal Server Error retrieving AWS account integration — AWS not configured in org"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccIntegrationAwsAccountKeyBased
+    reason: "404 Not Found: AWS account with provided id is not integrated"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccIntegrationAwsAccount_RoleBased
+    reason: "Non-empty plan after apply — provider cannot read back created AWS account (AWS not configured in org)"
+    added: "2026-03-04"
+    author: LiuVII
 
   # User/Team datasource — Eventual consistency (9 tests)
   - test: TestAccDatadogUserDatasourceExactMatch
@@ -293,7 +321,7 @@ skipped_tests:
     added: "2026-03-02"
     author: fpighi
 
-  # User/ServiceAccount state issues (2 tests)
+  # User/ServiceAccount state issues (3 tests)
   - test: TestAccDatadogUser_ReEnableRoleUpdate
     reason: "Initial sync of tests failing on master branch"
     added: "2026-03-02"
@@ -302,6 +330,10 @@ skipped_tests:
     reason: "Initial sync of tests failing on master branch"
     added: "2026-03-02"
     author: fpighi
+  - test: TestAccDatadogServiceAccountDatasourcePagination
+    reason: "Filter keyword returned no results — service account not visible yet (eventual consistency)"
+    added: "2026-03-04"
+    author: LiuVII
 
   # Dataset/IncidentNotificationRule — Rate limiting (2 tests)
   - test: TestAccDatadogDataset_Basic
@@ -313,7 +345,107 @@ skipped_tests:
     added: "2026-03-02"
     author: fpighi
 
-  # Provider bugs (4 tests)
+  # Incident state — resources not found or externally deleted (6 tests)
+  - test: TestAccDatadogIncidentNotificationTemplate_Import
+    reason: "Cannot import non-existent remote object — template deleted between create and import steps"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogIncidentNotificationTemplate_Updated
+    reason: "404 Not Found retrieving incident notification template — resource deleted externally"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogIncidentTypeDataSource_Basic
+    reason: "Incident type not found — resource deleted externally between steps"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogIncidentNotificationTemplateDataSource_ByName
+    reason: "Could not find incident notification template by name — resource deleted externally"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogIncidentNotificationTemplateDataSource_ByID
+    reason: "404 Not Found reading incident notification template — resource deleted externally"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogIncidentNotificationRuleDataSource_ByID
+    reason: "Non-empty plan — dependent incident_type deleted outside Terraform, triggering rule replacement"
+    added: "2026-03-04"
+    author: LiuVII
+
+  # OrgConnection — 409 Conflict: connection already exists (2 tests)
+  - test: TestAccDatadogOrgConnection_Basic
+    reason: "409 Conflict: connection between orgs already exists — pre-existing state in org"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogOrgConnection_Update
+    reason: "409 Conflict: connection between orgs already exists — pre-existing state in org"
+    added: "2026-03-04"
+    author: LiuVII
+
+  # RUM quota — 403 Reached maximum applications (5 tests)
+  - test: TestAccDatadogRUMApplication_Basic
+    reason: "403 Forbidden: Reached the maximum amount of RUM applications in org"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogRUMApplication_ProductScales
+    reason: "403 Forbidden: Reached the maximum amount of RUM applications in org"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogRUMApplicationDatasourceErrorMultiple
+    reason: "403 Forbidden: Reached the maximum amount of RUM applications in org"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogRUMApplicationDatasourceIDFilter
+    reason: "403 Forbidden: Reached the maximum amount of RUM applications in org"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogRUMApplicationDatasourceNameFilter
+    reason: "403 Forbidden: Reached the maximum amount of RUM applications in org"
+    added: "2026-03-04"
+    author: LiuVII
+
+  # User invite — 400 Bad Request: test org rejects user invitations (3 tests)
+  - test: TestAccDatadogRoleUsersDatasourceExactMatch
+    reason: "400 Bad Request: user does not have a valid email — test org rejects user invitations"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccOnCallEscalationPolicyCreateAndUpdate
+    reason: "400 Bad Request: user does not have a valid email — test org rejects user invitations"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogServiceAccountDatasourceError
+    reason: "Wrong error matched: got user invitation 400 instead of expected datasource error — blocked by org email restrictions"
+    added: "2026-03-04"
+    author: LiuVII
+
+  # OnCall — condition polling failure (1 test)
+  - test: TestOnCallUserPhoneNotificationRule
+    reason: "Failed to satisfy condition after 10 retries — OnCall resource not reaching expected state"
+    added: "2026-03-04"
+    author: LiuVII
+
+  # Non-empty plan after apply — provider read bug (5 tests)
+  - test: TestAccDatadogObservabilityPipeline_renameFieldsProcessor
+    reason: "Non-empty plan after apply — provider fails to read back pipeline_type and other computed fields"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogObservabilityPipeline_removeFieldsProcessor
+    reason: "Non-empty plan after apply — provider fails to read back pipeline_type and other computed fields"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogObservabilityPipeline_quotaProcessor
+    reason: "Non-empty plan after apply — provider fails to read back pipeline_type and other computed fields"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogAuthNMapping_CreateUpdate
+    reason: "Non-empty plan after apply + 404 on destroy — provider read returns empty state after create"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogLogsCustomDestination_forwarder_types
+    reason: "Non-empty plan after apply — provider fails to read back created custom destination"
+    added: "2026-03-04"
+    author: LiuVII
+
+  # Provider bugs (9 tests)
   - test: TestAccDatadogApmRetentionFilterOrder
     reason: "Initial sync of tests failing on master branch"
     added: "2026-03-02"
@@ -330,3 +462,23 @@ skipped_tests:
     reason: "Initial sync of tests failing on master branch"
     added: "2026-03-02"
     author: fpighi
+  - test: TestCustomFramework_DuplicateHandle
+    reason: "Expected API to reject duplicate framework handles with an error, but no error is returned"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogIPAllowlist_CreateUpdate
+    reason: "Post-test destroy fails: IP allowlist not disabled or empty — dangling resource"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogApplicationKey_Update
+    reason: "404 Not Found retrieving application key immediately after create — key not visible yet"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogSecurityNotificationRuleFull
+    reason: "400 Bad Request creating security notification rule — org may lack required detection rules"
+    added: "2026-03-04"
+    author: LiuVII
+  - test: TestAccDatadogSecurityNotificationRuleSignalRuleSimple
+    reason: "400 Bad Request creating security notification rule — org may lack required detection rules"
+    added: "2026-03-04"
+    author: LiuVII


### PR DESCRIPTION
[APIR-2666]

## Summary
Adds 35 new tests to the integration test skip list (`flaky_tests.yaml`), categorized by root cause based on actual failure output. Includes all tests identified by LiuVII as failing on the master branch.

## Motivation
The PR-scoped integration test workflow runs a subset of tests on each PR. Without an up-to-date skip list, consistently failing tests block CI on unrelated changes. These tests fail due to org-level constraints (missing cloud credentials, quota limits, pre-existing state) or known provider bugs, not due to the code under test.

## Changes
- **7 tests** added to "Missing cloud integrations": AWS/Azure/GCP integration tests failing with 404/500 due to unconfigured cloud accounts
- **6 tests** added to new "Incident state" category: notification templates/rules/types failing with 404 or external deletion
- **5 tests** added to new "Non-empty plan after apply" category: Observability Pipeline, AuthN mapping, and Logs custom destination provider read bugs
- **5 tests** added to new "RUM quota" category: 403 Reached maximum applications
- **3 tests** added to new "User invite" category: 400 Bad Request due to org email restrictions on user invitations
- **2 tests** added to new "OrgConnection conflict" category: 409 Conflict from pre-existing org connection
- **1 test** added to new "OnCall polling" category: condition not satisfied after retries
- **5 tests** added to existing "Provider bugs": duplicate handle, IP allowlist dangling resource, app key 404, security notification rule 400s
- **1 test** added to "User/ServiceAccount state issues": service account pagination eventual consistency
- Each entry includes a specific `reason` field describing the actual error

## Test Plan
- [x] Verify `flaky_tests.yaml` is valid YAML: `python3 -c "import yaml; yaml.safe_load(open('flaky_tests.yaml'))"`
- [x] Confirm all 35 new tests are present and none were duplicated from existing entries
- [ ] Run a PR integration test job and confirm the listed tests are skipped


[APIR-2666]: https://datadoghq.atlassian.net/browse/APIR-2666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ