### PR TITLE
Remove obsolete `ref_protected` from STS trust policies

### DIFF
--- a/.github/chainguard/self.release.prepare-release.sts.yaml
+++ b/.github/chainguard/self.release.prepare-release.sts.yaml
@@ -6,7 +6,6 @@ claim_pattern:
   event_name: workflow_dispatch
   job_workflow_ref: DataDog/terraform-provider-datadog/\.github/workflows/prepare_release\.yml@.*
   ref: refs/heads/master
-  ref_protected: "true"
 
 permissions:
   contents: write

--- a/.github/chainguard/self.sync-feature.sts.yaml
+++ b/.github/chainguard/self.sync-feature.sts.yaml
@@ -6,7 +6,6 @@ claim_pattern:
   event_name: schedule|workflow_dispatch
   job_workflow_ref: DataDog/terraform-provider-datadog/\.github/workflows/sync_feature\.yml@.*
   ref: refs/heads/master
-  ref_protected: "true"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Remove `ref_protected: "true"` from dd-octo-sts trust policy claim patterns

The `ref_protected` OIDC claim is now obsolete in the DataDog org:

- **GitHub**: The org-level "incompatible file paths on windows" push ruleset causes ALL branches to report `ref_protected: true` in OIDC tokens, making it useless as a security signal
- **GitLab**: All branches on `gitlab.ddbuild.io` report `ref_protected: true` due to org-level `pushAccessLevels: 40` config

Since the claim is universally `true`, it provides no actual filtering — only a false sense of security. Removing it has zero functional impact on policy enforcement.

All other constraints (subject, ref, job_workflow_ref, project_path, pipeline_source, etc.) remain unchanged and continue to provide the real security boundaries.

Ticket: https://datadoghq.atlassian.net/browse/SINT-4732

## Test plan

- [ ] Verify that the remaining policy constraints are sufficient (ref, job_workflow_ref, etc. are unchanged)
- [ ] No functional change expected since ref_protected was already always true

🤖 Generated with [Claude Code](https://claude.com/claude-code)
