### PR TITLE
Fix GoReleaser to upload terraform-registry-manifest.json as release asset

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,6 +51,9 @@ signs:
           - "--detach-sign"
           - "${artifact}"
 release:
+    extra_files:
+        - glob: 'terraform-registry-manifest.json'
+          name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
     # Visit your project's GitHub Releases page to publish this release.
     draft: true
 changelog:


### PR DESCRIPTION
[APIR-2668]

## Summary
Add `terraform-registry-manifest.json` as a GitHub release asset in GoReleaser config so the Terraform Registry can ingest new provider versions.

## Motivation
The v4.0.0 release failed to appear on registry.terraform.io while showing correctly on OpenTofu and releases.hashicorp.com.
Root cause: `terraform-registry-manifest.json` was added to the repo for v4.0.0 (declaring protocol v6.0 support).
The GoReleaser config included it in `checksum.extra_files` (adding its hash to SHA256SUMS) but not in `release.extra_files` (uploading it as a release asset).
The registry couldn't download the manifest file referenced in SHA256SUMS, causing silent ingestion failure.

- This was never an issue before v4.0.0 because the manifest file didn't exist in the repo — the glob matched nothing and SHA256SUMS had no manifest entry.
- The [HashiCorp provider scaffolding](https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/main/.goreleaser.yml) includes the manifest in both `checksum.extra_files` and `release.extra_files`.
- v4.0.0 was manually fixed by uploading the manifest asset to the existing GitHub release and resyncing the registry.

## Changes
- Add `extra_files` to the `release:` section in `.goreleaser.yml` to upload `terraform-registry-manifest.json` as a properly-named release asset (`terraform-provider-datadog_<VERSION>_manifest.json`)

## Test Plan
- [ ] Verify next v4 release includes the manifest file in GitHub release assets
- [ ] Verify the release appears on registry.terraform.io without manual intervention


[APIR-2668]: https://datadoghq.atlassian.net/browse/APIR-2668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ