### PR TITLE
Update codeowners with correct ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,82 +11,101 @@ datadog/tests/cassettes/
 
 /docs/                                    @DataDog/api-reliability @DataDog/documentation
 
-# Terraform plugin sdk resources/data-sources
-datadog/*datadog_dashboard*                @DataDog/api-reliability @DataDog/dashboards-backend
-datadog/*datadog_downtime*                 @DataDog/api-reliability @DataDog/monitor-app
-datadog/*datadog_integration_aws*          @DataDog/api-reliability @DataDog/aws-integrations
-datadog/*datadog_integration_pagerduty*    @DataDog/api-reliability @DataDog/collaboration-integrations
-datadog/*datadog_integration_opsgenie*     @DataDog/api-reliability @Datadog/collaboration-integrations
-datadog/*datadog_logs*                     @DataDog/api-reliability @DataDog/logs-backend @DataDog/logs-core @DataDog/logs-forwarding @DataDog/logs-app
-datadog/*datadog_metric*                   @DataDog/api-reliability @DataDog/metrics-intake @DataDog/timeseries-query @DataDog/metrics-storage-platform
-datadog/*datadog_metric_tags*              @DataDog/api-reliability @DataDog/metrics-index
-datadog/*datadog_metric_metadata*          @DataDog/api-reliability @DataDog/metrics-experience
-datadog/*datadog_metric_tag_configuration* @DataDog/api-reliability @DataDog/metrics-experience
-datadog/*datadog_monitor*                  @DataDog/api-reliability @DataDog/monitor-app
-datadog/*datadog_screenboard*              @DataDog/api-reliability @DataDog/dashboards-backend
-datadog/*datadog_security*                 @DataDog/api-reliability @DataDog/k9-cloud-security-platform
-datadog/*datadog_service_definition*       @DataDog/api-reliability @DataDog/service-catalog
-datadog/*datadog_service_level_objective*  @DataDog/api-reliability @DataDog/slo-app
-datadog/*datadog_synthetics*               @DataDog/api-reliability @DataDog/synthetics-managing
-datadog/*datadog_timeboard*                @DataDog/api-reliability @DataDog/dashboards-backend
-datadog/*datadog_permissions*              @DataDog/api-reliability @DataDog/team-aaa
-datadog/*datadog_user*                     @DataDog/api-reliability @DataDog/team-aaa
-datadog/*cloud_configuration*              @DataDog/api-reliability @DataDog/k9-cloud-security-posture-management
-datadog/*service_account*                  @DataDog/api-reliability @DataDog/team-aaa
-datadog/*datadog_authn*                    @DataDog/api-reliability @DataDog/team-aaa
-datadog/*datadog_child_organization*       @DataDog/api-reliability @DataDog/team-aaa
-datadog/*datadog_domain_allowlist*         @DataDog/api-reliability @DataDog/team-aaa
-datadog/*datadog_integration_slack*        @DataDog/api-reliability @DataDog/chat-integrations
-datadog/*datadog_integration_slack*        @DataDog/api-reliability @DataDog/chat-integrations
-datadog/*datadog_powerpack*                @DataDog/api-reliability @DataDog/dashboards-backend
-datadog/*datadog_role*                     @DataDog/api-reliability @DataDog/team-aaa
+# Terraform SDKv2 resources/data-sources
+datadog/*datadog_dashboard*                @DataDog/dashboards-backend
+datadog/*datadog_downtime*                 @DataDog/monitor-app
+datadog/*datadog_integration_aws*          @DataDog/aws-integrations
+datadog/*datadog_integration_pagerduty*    @DataDog/collaboration-integrations
+datadog/*datadog_integration_opsgenie*     @Datadog/collaboration-integrations
+datadog/*datadog_logs*                     @DataDog/logs-backend @DataDog/logs-core @DataDog/logs-forwarding @DataDog/logs-app
+datadog/*datadog_metric*                   @DataDog/metrics-intake @DataDog/timeseries-query @DataDog/metrics-storage-platform
+datadog/*datadog_metric_tags*              @DataDog/metrics-index
+datadog/*datadog_metric_metadata*          @DataDog/metrics-experience
+datadog/*datadog_metric_tag_configuration* @DataDog/metrics-experience
+datadog/*datadog_monitor*                  @DataDog/monitor-app
+datadog/*datadog_screenboard*              @DataDog/dashboards-backend
+datadog/*datadog_security*                 @DataDog/k9-cloud-security-platform
+datadog/*datadog_service_definition*       @DataDog/service-catalog
+datadog/*datadog_service_level_objective*  @DataDog/slo-app
+datadog/*datadog_synthetics*               @DataDog/synthetics-managing
+datadog/*datadog_timeboard*                @DataDog/dashboards-backend
+datadog/*datadog_permissions*              @DataDog/team-aaa
+datadog/*datadog_user*                     @DataDog/team-aaa
+datadog/*cloud_configuration*              @DataDog/k9-cloud-security-posture-management
+datadog/*service_account*                  @DataDog/team-aaa
+datadog/*datadog_authn*                    @DataDog/team-aaa
+datadog/*datadog_child_organization*       @DataDog/team-aaa
+datadog/*datadog_domain_allowlist*         @DataDog/team-aaa
+datadog/*datadog_integration_slack*        @DataDog/chat-integrations
+datadog/*datadog_integration_slack*        @DataDog/chat-integrations
+datadog/*datadog_powerpack*                @DataDog/dashboards-backend
+datadog/*datadog_role*                     @DataDog/team-aaa
+datadog/*datadog_slo_correction*           @DataDog/slo-app
 
-# Framework resources/data-sources
-
-datadog/**/*datadog_action_connection*           @DataDog/api-reliability @DataDog/action-platform
-datadog/**/*datadog_agentless*                   @DataDog/api-reliability @DataDog/k9-agentless
-datadog/**/*datadog_app_key_registration*        @DataDog/api-reliability @DataDog/action-platform @DataDog/workflow-automation-backend
-datadog/**/*datadog_api_key*                     @DataDog/api-reliability @DataDog/credentials-management
-datadog/**/*datadog_apm_retention_filter*        @DataDog/api-reliability @DataDog/apm-trace-intake
-datadog/**/*datadog_application_key*             @DataDog/api-reliability @DataDog/credentials-management
-datadog/**/*datadog_hosts*                       @DataDog/api-reliability @DataDog/redapl-storage @DataDog/redapl-ingest
-datadog/**/*datadog_integration_aws*             @DataDog/api-reliability @DataDog/aws-ints-core
-datadog/**/*datadog_integration_azure*           @DataDog/api-reliability @DataDog/azure-integrations
-datadog/**/*datadog_integration_cloudflare*      @DataDog/api-reliability @DataDog/saas-integrations
-datadog/**/*datadog_integration_confluent*       @DataDog/api-reliability @DataDog/saas-integrations
-datadog/**/*datadog_integration_fastly*          @DataDog/api-reliability @DataDog/saas-integrations
-datadog/**/*datadog_integration_gcp*             @DataDog/api-reliability @DataDog/gcp-integrations
-datadog/**/*datadog_integration_microsoft_teams* @DataDog/api-reliability @DataDog/chat-integrations
-datadog/**/*datadog_integration_ms_teams*        @DataDog/api-reliability @DataDog/chat-integrations
-datadog/**/*datadog_ip_ranges*                   @DataDog/api-reliability @DataDog/team-aaa
+# Plugin Framework resources/data-sources
+datadog/**/*datadog_dashboard*                   @DataDog/dashboards-backend
+datadog/**/*datadog_downtime*                    @DataDog/monitor-app
+datadog/**/*datadog_domain_allowlist*            @DataDog/team-aaa
+datadog/**/*datadog_logs*                        @DataDog/logs-backend @DataDog/logs-core @DataDog/logs-forwarding @DataDog/logs-app
+datadog/**/*datadog_metric*                      @DataDog/metrics-intake @DataDog/timeseries-query @DataDog/metrics-storage-platform
+datadog/**/*datadog_monitor*                     @DataDog/monitor-app
+datadog/**/*datadog_appsec*                      @DataDog/asm-backend
+datadog/**/*datadog_azure_integration*           @DataDog/azure-integrations
+datadog/**/*datadog_cloud_inventory*             @DataDog/k9-cloud-security-platform
+datadog/**/*datadog_compliance*                  @DataDog/k9-cloud-security-platform
+datadog/**/*datadog_dataset*                     @DataDog/aaa-granular-access
+datadog/**/*datadog_datastore*                   @DataDog/action-platform @DataDog/workflow-automation-backend
+datadog/**/*datadog_incident*                    @DataDog/incident-app
+datadog/**/*datadog_ip_allowlist*                @DataDog/team-aaa
+datadog/**/*datadog_openapi*                     @DataDog/service-catalog
+datadog/**/*datadog_org_connection*              @DataDog/aaa-granular-access
+datadog/**/*datadog_reference_table*             @DataDog/redapl-experiences
+datadog/**/*datadog_action_connection*           @DataDog/action-platform
+datadog/**/*datadog_agentless*                   @DataDog/k9-agentless
+datadog/**/*datadog_app_key_registration*        @DataDog/action-platform @DataDog/workflow-automation-backend
+datadog/**/*datadog_api_key*                     @DataDog/credentials-management
+datadog/**/*datadog_apm_retention_filter*        @DataDog/apm-trace-intake
+datadog/**/*datadog_application_key*             @DataDog/credentials-management
+datadog/**/*datadog_hosts*                       @DataDog/redapl-storage @DataDog/redapl-ingest
+datadog/**/*datadog_integration_aws*             @DataDog/aws-ints-core
+datadog/**/*datadog_integration_azure*           @DataDog/azure-integrations
+datadog/**/*datadog_integration_cloudflare*      @DataDog/saas-integrations
+datadog/**/*datadog_integration_confluent*       @DataDog/saas-integrations
+datadog/**/*datadog_integration_fastly*          @DataDog/saas-integrations
+datadog/**/*datadog_integration_gcp*             @DataDog/gcp-integrations
+datadog/**/*datadog_integration_microsoft_teams* @DataDog/chat-integrations
+datadog/**/*datadog_integration_ms_teams*        @DataDog/chat-integrations
+datadog/**/*datadog_ip_ranges*                   @DataDog/team-aaa
 datadog/**/*datadog_on_call*                     @DataDog/on-call
-datadog/**/*datadog_open_api*                    @DataDog/api-reliability @DataDog/service-catalog
-datadog/**/*datadog_organization_settings*       @DataDog/api-reliability @DataDog/aaa-omg @DataDog/trust-and-safety
-datadog/**/*datadog_restriction_policy*          @DataDog/api-reliability @DataDog/aaa-granular-access
-datadog/**/*datadog_logs_restriction_query*      @DataDog/api-reliability @DataDog/aaa-granular-access
-datadog/**/*datadog_sensitive_data_scanner*      @DataDog/api-reliability @DataDog/sensitive-data-scanner
-datadog/**/*datadog_service_account*             @DataDog/api-reliability @DataDog/team-aaa
-datadog/**/*datadog_software_catalog*            @DataDog/api-reliability @DataDog/service-catalog
-datadog/**/*datadog_spans_metric*                @DataDog/api-reliability @DataDog/apm-trace-intake
-datadog/**/*datadog_synthetics*                  @DataDog/api-reliability @DataDog/synthetics-managing
-datadog/**/*datadog_team*                        @DataDog/api-reliability @DataDog/aaa-omg
-datadog/**/*datadog_user*                        @DataDog/api-reliability @DataDog/team-aaa
-datadog/**/*datadog_webhook*                     @DataDog/api-reliability @DataDog/collaboration-integrations
-datadog/**/*datadog_workflow_automation*         @DataDog/api-reliability @DataDog/workflow-automation-backend
-datadog/**/*datadog_powerpack*                   @DataDog/api-reliability @DataDog/dashboards-backend
-datadog/**/*datadog_role_users*                  @DataDog/api-reliability @DataDog/team-aaa
-datadog/**/*datadog_rum*                         @DataDog/api-reliability @DataDog/rum-backend
-datadog/**/*datadog_security*                    @DataDog/api-reliability @DataDog/k9-cloud-security-platform
-datadog/**/*datadog_csm_threats*                 @DataDog/api-reliability @DataDog/k9-cws-backend
-datadog/**/*datadog_cloud_workload_security*     @DataDog/api-reliability @DataDog/k9-cws-backend
-datadog/**/*datadog_app_builder_app*             @DataDog/api-reliability @DataDog/app-builder-backend
-datadog/**/*datadog_custom_allocation_rule*      @DataDog/api-reliability @DataDog/cloud-cost-management
-datadog/**/*datadog_aws_cur_config*              @DataDog/api-reliability @DataDog/cloud-cost-management
-datadog/**/*datadog_azure_uc_config*             @DataDog/api-reliability @DataDog/cloud-cost-management
-datadog/**/*datadog_gcp_uc_config*               @DataDog/api-reliability @DataDog/cloud-cost-management
-datadog/**/*datadog_cost_budget*                 @DataDog/api-reliability @DataDog/cloud-cost-management
-datadog/**/*datadog_tag_pipeline_ruleset*        @DataDog/api-reliability @DataDog/cloud-cost-management
-datadog/**/*datadog_deployment_gate*             @DataDog/api-reliability @DataDog/ci-app-backend
+datadog/**/*datadog_open_api*                    @DataDog/service-catalog
+datadog/**/*datadog_organization_settings*       @DataDog/aaa-omg @DataDog/trust-and-safety
+datadog/**/*datadog_restriction_policy*          @DataDog/aaa-granular-access
+datadog/**/*datadog_logs_restriction_query*      @DataDog/aaa-granular-access
+datadog/**/*datadog_sensitive_data_scanner*      @DataDog/sensitive-data-scanner
+datadog/**/*datadog_service_account*             @DataDog/team-aaa
+datadog/**/*datadog_software_catalog*            @DataDog/service-catalog
+datadog/**/*datadog_spans_metric*                @DataDog/apm-trace-intake
+datadog/**/*datadog_synthetics*                  @DataDog/synthetics-managing
+datadog/**/*datadog_team*                        @DataDog/aaa-omg
+datadog/**/*datadog_user*                        @DataDog/team-aaa
+datadog/**/*datadog_webhook*                     @DataDog/collaboration-integrations
+datadog/**/*datadog_workflow_automation*         @DataDog/workflow-automation-backend
+datadog/**/*datadog_powerpack*                   @DataDog/dashboards-backend
+datadog/**/*datadog_role_users*                  @DataDog/team-aaa
+datadog/**/*datadog_rum*                         @DataDog/rum-backend
+datadog/**/*datadog_security*                    @DataDog/k9-cloud-security-platform
+datadog/**/*datadog_csm_threats*                 @DataDog/k9-cws-backend
+datadog/**/*datadog_cloud_workload_security*     @DataDog/k9-cws-backend
+datadog/**/*datadog_app_builder_app*             @DataDog/app-builder-backend
+datadog/**/*datadog_custom_allocation_rule*      @DataDog/cloud-cost-management
+datadog/**/*datadog_aws_cur_config*              @DataDog/cloud-cost-management
+datadog/**/*datadog_azure_uc_config*             @DataDog/cloud-cost-management
+datadog/**/*datadog_gcp_uc_config*               @DataDog/cloud-cost-management
+datadog/**/*datadog_cost_budget*                 @DataDog/cloud-cost-management
+datadog/**/*datadog_tag_pipeline_ruleset*        @DataDog/cloud-cost-management
+datadog/**/*datadog_deployment_gate*             @DataDog/ci-app-backend
 datadog/**/*observability_pipeline*              @DataDog/observability-pipelines
+
+# Team-specific
 docs/resources/observability_pipeline.md         @DataDog/observability-pipelines
 scripts/*cloud-cost-import-existing-resources*   @DataDog/cloud-cost-management


### PR DESCRIPTION
* Remove api-reliability from team-specific resources
* Add missing resource/datasource patterns with correct owners
  * Added **18 new patterns** covering **36 previously-unowned files**:
    - 6 broad framework patterns (dashboard, downtime, domain_allowlist, logs, metric, monitor) - framework equivalents of existing SDKv2-only patterns
    - 11 additional new framework patterns (appsec, azure_integration, cloud_inventory, compliance, dataset, datastore, incident, ip_allowlist, openapi, org_connection, reference_table)
    - 1 SDKv2 pattern (slo_correction)