### PR TITLE
chore(ci): rename branch references from 4.x to v3

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -18,7 +18,7 @@ on:
         type: choice
         options:
           - master
-          - "4.x"
+          - v3
 
 jobs:
   prepare_release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
     types: [closed]
     branches:
       - master
-      - "4.x"
+      - v3
 
 jobs:
   create_release:

--- a/.github/workflows/sdkv2_deprecation.yaml
+++ b/.github/workflows/sdkv2_deprecation.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - master
-      - 4.x
+      - v3
 
 jobs:
   check-sdkv2:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,13 @@ on:
   pull_request:
     branches:
       - master
-      - 4.x
+      - v3
   schedule:
     - cron: "0 1 * * *"
   push:
     branches:
       - mq-working-branch-master-**
-      - mq-working-branch-4.x-**
+      - mq-working-branch-v3-**
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}-test

--- a/.github/workflows/test_pr_integration.yml
+++ b/.github/workflows/test_pr_integration.yml
@@ -5,7 +5,7 @@ permissions:
 
 on: # yamllint disable-line rule:truthy
   pull_request:
-    branches: [master, 4.x]
+    branches: [master, v3]
     types: [opened, synchronize, reopened]
 
 concurrency:


### PR DESCRIPTION
[APIR-2321]

## Summary
Update CI/CD workflow branch references from `4.x` to `v3`.

## Motivation
With the release of v4 as the new default branch (`master`), the `v3` branch is now the long-term support branch for backporting critical fixes. The old `4.x` branch name is no longer relevant and CI workflows need to recognize `v3` as the supported non-master branch for tests, releases, and PR integration checks.

## Changes
- Replace all `4.x` branch references with `v3` in GitHub Actions workflows:
  - `prepare_release.yml`: v3 added as a release branch option
  - `release.yml`: trigger on PRs merged to `v3`
  - `sdkv2_deprecation.yaml`: check runs on PRs targeting `v3`
  - `test.yml`: tests run on PRs targeting `v3` and merge queue branches `mq-working-branch-v3-**`
  - `test_pr_integration.yml`: integration tests run on PRs targeting `v3`

## Test Plan
- [ ] Verify CI workflows trigger correctly on PRs targeting `v3`
- [ ] Verify release workflow triggers on tags from `v3` branch
