### PR TITLE
[datadog_integration_gcp] Fix import and post-import plan forcing recreation

### DIFF
--- a/datadog/fwprovider/resource_datadog_integration_gcp.go
+++ b/datadog/fwprovider/resource_datadog_integration_gcp.go
@@ -17,6 +17,32 @@ import (
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 )
 
+// requiresReplaceIfKnown is a plan modifier that requires replacement only when
+// the prior state value was known (non-null). This handles write-only credential
+// fields that the API never returns: after import the state is null, so we don't
+// force recreation just because the user has the value in their config. Once the
+// value is known in state (after create or a subsequent apply), a change will
+// correctly trigger replacement.
+type requiresReplaceIfKnown struct{}
+
+func (r requiresReplaceIfKnown) Description(_ context.Context) string {
+	return "Requires replacement if the previous state value was known (non-null)."
+}
+
+func (r requiresReplaceIfKnown) MarkdownDescription(_ context.Context) string {
+	return "Requires replacement if the previous state value was known (non-null)."
+}
+
+func (r requiresReplaceIfKnown) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// If there is no prior state value (e.g. during import), don't require replacement.
+	if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+		return
+	}
+	if !req.PlanValue.Equal(req.StateValue) {
+		resp.RequiresReplace = true
+	}
+}
+
 const (
 	defaultType                    = "service_account"
 	defaultAuthURI                 = "https://accounts.google.com/o/oauth2/auth"
@@ -86,7 +112,7 @@ func (r *integrationGcpResource) Schema(_ context.Context, _ resource.SchemaRequ
 				Description: "Your private key ID found in your JSON service account key.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+					requiresReplaceIfKnown{},
 				},
 			},
 			"private_key": schema.StringAttribute{
@@ -94,7 +120,7 @@ func (r *integrationGcpResource) Schema(_ context.Context, _ resource.SchemaRequ
 				Required:    true,
 				Sensitive:   true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+					requiresReplaceIfKnown{},
 				},
 			},
 			"client_email": schema.StringAttribute{
@@ -108,7 +134,7 @@ func (r *integrationGcpResource) Schema(_ context.Context, _ resource.SchemaRequ
 				Description: "Your ID found in your JSON service account key.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+					requiresReplaceIfKnown{},
 				},
 			},
 			"host_filters": schema.StringAttribute{
@@ -338,8 +364,14 @@ func (r *integrationGcpResource) getGCPIntegration(state integrationGcpModel) (*
 		return nil, err
 	}
 
+	// During import, only state.ID is set (via ImportStatePassthroughID); state.ProjectID is null.
+	projectId := state.ProjectID.ValueString()
+	if projectId == "" {
+		projectId = state.ID.ValueString()
+	}
+
 	for _, integration := range resp {
-		if integration.GetProjectId() == state.ProjectID.ValueString() &&
+		if integration.GetProjectId() == projectId &&
 			(state.ClientEmail.IsNull() || state.ClientEmail.IsUnknown() || state.ClientEmail.ValueString() == "" || integration.GetClientEmail() == state.ClientEmail.ValueString()) {
 			if err := utils.CheckForUnparsed(integration); err != nil {
 				return nil, err

--- a/datadog/fwprovider/resource_datadog_integration_gcp.go
+++ b/datadog/fwprovider/resource_datadog_integration_gcp.go
@@ -339,7 +339,8 @@ func (r *integrationGcpResource) getGCPIntegration(state integrationGcpModel) (*
 	}
 
 	for _, integration := range resp {
-		if integration.GetProjectId() == state.ProjectID.ValueString() && integration.GetClientEmail() == state.ClientEmail.ValueString() {
+		if integration.GetProjectId() == state.ProjectID.ValueString() &&
+			(state.ClientEmail.IsNull() || state.ClientEmail.IsUnknown() || state.ClientEmail.ValueString() == "" || integration.GetClientEmail() == state.ClientEmail.ValueString()) {
 			if err := utils.CheckForUnparsed(integration); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Problem

Two bugs prevented `datadog_integration_gcp` from working correctly after import.

### Bug 1 — Import fails to find the integration

`ImportStatePassthroughID` only sets `state.id`; `state.project_id` remains null. The `getGCPIntegration` lookup compared against `state.project_id`, so it never matched any integration — causing the resource to be immediately removed from state.

A previous partial fix relaxed the `client_email` condition, but `project_id` still had to match exactly (against an empty string), so the lookup still failed.

### Bug 2 — Post-import plan forces recreation of the resource

`client_id`, `private_key`, and `private_key_id` are **never returned by the GCP API** (write-only credentials). After import these fields remain null in state. The old `RequiresReplace()` plan modifier unconditionally treated `null → value` as a replacement trigger, so every `terraform plan` after import showed:

```
-/+ resource "datadog_integration_gcp" "..." {
  + client_id      = "..." # forces replacement
  + private_key    = (sensitive value) # forces replacement
  + private_key_id = "..." # forces replacement
  + project_id     = "..." # forces replacement
}
```

## Fix

### Fix 1 — Fall back to `state.id` in `getGCPIntegration`

When `state.project_id` is empty (as it always is right after `ImportStatePassthroughID`), use `state.id` as the lookup key instead. This makes the import's `Read` call correctly find the existing integration.

### Fix 2 — `requiresReplaceIfKnown` custom plan modifier

Replaced `stringplanmodifier.RequiresReplace()` on `client_id`, `private_key`, and `private_key_id` with a custom modifier that **only requires replacement when the prior state value was known (non-null)**:

- **After import** (state = null): no replacement is triggered. The subsequent apply writes the config values into state without calling any update API — correct, because the integration already has those credentials.
- **After a normal create / subsequent apply** (state = the original credential values): any change to these fields still correctly forces recreation, since the GCP update endpoint does not accept new credentials.

`project_id` and `client_email` keep `stringplanmodifier.RequiresReplace()` because the API always returns them, so they are always known in state after any successful read.
