### PR TITLE
[CCR-3007] AWS action connection for Workflow Automation

### DIFF
--- a/examples/resources/datadog_action_connection_aws/.terraform.lock.hcl
+++ b/examples/resources/datadog_action_connection_aws/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/datadog/datadog" {
+  version = "4.0.0"
+  hashes = [
+    "h1:tt6PF2GsUsQJTzhxglpMG1DiDlKqwNoPOWpHwiqJPBo=",
+    "zh:1a4ba16ba9770e9a6f8f3f00b1146ad3f5909be0efac37e0d668354a8dd76cf7",
+    "zh:2f3e2b340380343feeb6747559347af91cb1326fc840ffd42c2b515781178c3e",
+    "zh:49e1654ff70fbc19e07ccf256cfa4710a868f539cbec92dfd1e514ac8c8c31c5",
+    "zh:6d616459076ddc2117f9c748d331411ebcc1a2052bfd9e7f2d3a7a74bb212445",
+    "zh:6d96a69bb5c3fd484e1c92fd29a9db4f9eb3dcb86828292975637baac013db31",
+    "zh:744d9b99c4fa9b3f8615053a49cb6bac226b4f0aced480f485c704e711a9a5d9",
+    "zh:7b70cfe5060a375ba00e10c9232ef69c5897f7662a71c6c3724dca121d4736ee",
+    "zh:7ca4069dad1867b70d390c1a4a90f8cb555d66809e82cd206df98be85b2f068f",
+    "zh:90c3a167f3ddbac79a779d3b45c14833a54dd9fc7d66359ea60acfea30e2aaac",
+    "zh:9404dfce05407dba4d93a473ea61bf75ff049c2947f5bff94718908e9b8c9448",
+    "zh:b5c89d16739d63559e792d8973a1368050bd24560ce56a2a62e4913713c0fbd2",
+    "zh:c94400d3284dbaaa0dc7b73c2aacb03ee2c254e606614278a152adb7ab084243",
+    "zh:d7985a0c5329b61ff4510948ca008257d9dea06a02d4b927df5e5c7dac51fcf0",
+    "zh:dfe6bb58e5208634506d80038fb219daa0ec4dd49b4ce6a9716582a867fd6272",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/examples/resources/datadog_action_connection_aws/README.md
+++ b/examples/resources/datadog_action_connection_aws/README.md
@@ -1,0 +1,19 @@
+# AWS Action Connection
+
+Example for creating a Datadog AWS action connection (e.g. for Workflow Automation). Requires an app key [registered for the Actions API](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/app_key_registration).
+
+**Run:**
+
+```bash
+export TF_VAR_datadog_api_key="your_api_key"
+export TF_VAR_datadog_app_key="your_registered_app_key"
+terraform init
+terraform plan
+terraform apply
+```
+
+Override connection name, account ID, or role via `terraform.tfvars` or `TF_VAR_*` if needed (defaults are in `variables.tf`).
+
+**After apply:** Get `external_id` for the IAM role trust policy from the connection in Datadog (Workflow Automation → Connections → open the connection) 
+
+Then use the connection in your workflow (Workflow Automation → workflow → step → Connection).

--- a/examples/resources/datadog_action_connection_aws/main.tf
+++ b/examples/resources/datadog_action_connection_aws/main.tf
@@ -1,0 +1,10 @@
+resource "datadog_action_connection" "aws" {
+  name = var.connection_name
+
+  aws {
+    assume_role {
+      account_id = var.aws_account_id
+      role       = var.aws_role_name
+    }
+  }
+}

--- a/examples/resources/datadog_action_connection_aws/provider.tf
+++ b/examples/resources/datadog_action_connection_aws/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    datadog = {
+      source = "DataDog/datadog"
+    }
+  }
+}
+
+provider "datadog" {
+  api_key = var.datadog_api_key
+  app_key = var.datadog_app_key
+}

--- a/examples/resources/datadog_action_connection_aws/terraform.tfvars
+++ b/examples/resources/datadog_action_connection_aws/terraform.tfvars
@@ -1,0 +1,4 @@
+
+connection_name  = "My AWS Connection"
+aws_account_id   = "087496745774"
+aws_role_name    = "datadog-aws-integration-role-zeina"

--- a/examples/resources/datadog_action_connection_aws/terraform.tfvars.example
+++ b/examples/resources/datadog_action_connection_aws/terraform.tfvars.example
@@ -1,0 +1,5 @@
+# Optional: copy to terraform.tfvars to override. Credentials via TF_VAR_datadog_api_key / TF_VAR_datadog_app_key.
+
+connection_name  = "My AWS Connection"
+aws_account_id   = "087496745774"
+aws_role_name    = "datadog-aws-integration-role-zeina"

--- a/examples/resources/datadog_action_connection_aws/variables.tf
+++ b/examples/resources/datadog_action_connection_aws/variables.tf
@@ -1,0 +1,24 @@
+variable "datadog_api_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "datadog_app_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "connection_name" {
+  type    = string
+  default = "My AWS Connection"
+}
+
+variable "aws_account_id" {
+  type    = string
+  default = "087496745774"
+}
+
+variable "aws_role_name" {
+  type    = string
+  default = "datadog-aws-integration-role-zeina"
+}


### PR DESCRIPTION
**[DO NOT MERGE, FOR DEMO AND REFERENCE PURPOSES]**

Adds a minimal example for creating a Datadog AWS action connection (Workflow Automation / EBS workflows) via Terraform

**How to use it**

**Credentials via env**

```
   export TF_VAR_datadog_api_key="your_api_key"
   export TF_VAR_datadog_app_key="your_registered_app_key"
``` 

The app key must be registered for the Actions API 

**Apply:**

```
   cd examples/resources/datadog_action_connection_aws
   terraform init
   terraform plan
   terraform apply
```

IAM: Use terraform output `external_id` in the IAM role trust policy for the role you specified, then use the connection in Workflow Automation 

See `README.md` in the example directory for full steps
