### PR TITLE
[datadog_dashboard] Add description field to widget definitions

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -1896,7 +1896,7 @@ func getAlertGraphDefinitionSchema() map[string]*schema.Schema {
 			ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewWidgetTextAlignFromValue),
 			Optional:         true,
 		},
-	}, getCommonTimeSpanSchema())
+	}, getCommonTimeSpanSchema(), getWidgetDescriptionSchema())
 }
 
 func buildDatadogAlertGraphDefinition(terraformDefinition map[string]interface{}) *datadogV1.AlertGraphWidgetDefinition {
@@ -1916,6 +1916,12 @@ func buildDatadogAlertGraphDefinition(terraformDefinition map[string]interface{}
 	}
 	if widgetTime := buildDatadogWidgetTime(terraformDefinition); widgetTime != nil {
 		datadogDefinition.Time = widgetTime
+	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
 	}
 	return datadogDefinition
 }
@@ -1938,6 +1944,9 @@ func buildTerraformAlertGraphDefinition(datadogDefinition *datadogV1.AlertGraphW
 	if v, ok := datadogDefinition.GetTimeOk(); ok {
 		buildTerraformWidgetTime(v, terraformDefinition)
 	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
+	}
 	return terraformDefinition
 }
 
@@ -1946,7 +1955,7 @@ func buildTerraformAlertGraphDefinition(datadogDefinition *datadogV1.AlertGraphW
 //
 
 func getAlertValueDefinitionSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
+	return mergeSchemas(map[string]*schema.Schema{
 		"alert_id": {
 			Description: "The ID of the monitor used by the widget.",
 			Type:        schema.TypeString,
@@ -1984,7 +1993,7 @@ func getAlertValueDefinitionSchema() map[string]*schema.Schema {
 			ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewWidgetTextAlignFromValue),
 			Optional:         true,
 		},
-	}
+	}, getWidgetDescriptionSchema())
 }
 
 func buildDatadogAlertValueDefinition(terraformDefinition map[string]interface{}) *datadogV1.AlertValueWidgetDefinition {
@@ -2009,6 +2018,12 @@ func buildDatadogAlertValueDefinition(terraformDefinition map[string]interface{}
 	}
 	if v, ok := terraformDefinition["title_align"].(string); ok && len(v) != 0 {
 		datadogDefinition.SetTitleAlign(datadogV1.WidgetTextAlign(v))
+	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
 	}
 	return datadogDefinition
 }
@@ -2035,6 +2050,9 @@ func buildTerraformAlertValueDefinition(datadogDefinition *datadogV1.AlertValueW
 	}
 	if v, ok := datadogDefinition.GetTitleAlignOk(); ok {
 		terraformDefinition["title_align"] = *v
+	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
 	}
 	return terraformDefinition
 }
@@ -2078,7 +2096,7 @@ func getChangeDefinitionSchema() map[string]*schema.Schema {
 			},
 		},
 	}
-	schema = mergeSchemas(schema, getCommonTimeSpanSchema())
+	schema = mergeSchemas(schema, getCommonTimeSpanSchema(), getWidgetDescriptionSchema())
 	return schema
 }
 func buildDatadogChangeDefinition(terraformDefinition map[string]interface{}) *datadogV1.ChangeWidgetDefinition {
@@ -2102,6 +2120,12 @@ func buildDatadogChangeDefinition(terraformDefinition map[string]interface{}) *d
 	if v, ok := terraformDefinition["custom_link"].([]interface{}); ok && len(v) > 0 {
 		datadogDefinition.SetCustomLinks(*buildDatadogWidgetCustomLinks(&v))
 	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
+	}
 	return datadogDefinition
 }
 func buildTerraformChangeDefinition(datadogDefinition *datadogV1.ChangeWidgetDefinition) map[string]interface{} {
@@ -2124,6 +2148,9 @@ func buildTerraformChangeDefinition(datadogDefinition *datadogV1.ChangeWidgetDef
 	}
 	if v, ok := datadogDefinition.GetCustomLinksOk(); ok {
 		terraformDefinition["custom_link"] = buildTerraformWidgetCustomLinks(v)
+	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
 	}
 	return terraformDefinition
 }
@@ -2370,7 +2397,7 @@ func getDistributionDefinitionSchema() map[string]*schema.Schema {
 			},
 		},
 	}
-	schema = mergeSchemas(schema, getCommonTimeSpanSchema())
+	schema = mergeSchemas(schema, getCommonTimeSpanSchema(), getWidgetDescriptionSchema())
 	return schema
 }
 func buildDatadogDistributionDefinition(terraformDefinition map[string]interface{}) *datadogV1.DistributionWidgetDefinition {
@@ -2407,6 +2434,12 @@ func buildDatadogDistributionDefinition(terraformDefinition map[string]interface
 			datadogDefinition.Yaxis = buildDatadogDistributionWidgetYAxis(v)
 		}
 	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
+	}
 	return datadogDefinition
 }
 func buildTerraformDistributionDefinition(datadogDefinition *datadogV1.DistributionWidgetDefinition) map[string]interface{} {
@@ -2440,6 +2473,9 @@ func buildTerraformDistributionDefinition(datadogDefinition *datadogV1.Distribut
 	if v, ok := datadogDefinition.GetYaxisOk(); ok {
 		axis := buildTerraformDistributionWidgetYAxis(*v)
 		terraformDefinition["yaxis"] = []map[string]interface{}{axis}
+	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
 	}
 	return terraformDefinition
 }
@@ -2579,7 +2615,7 @@ func getEventStreamDefinitionSchema() map[string]*schema.Schema {
 			Optional:    true,
 		},
 	}
-	schema = mergeSchemas(schema, getCommonTimeSpanSchema())
+	schema = mergeSchemas(schema, getCommonTimeSpanSchema(), getWidgetDescriptionSchema())
 	return schema
 }
 
@@ -2606,6 +2642,12 @@ func buildDatadogEventStreamDefinition(terraformDefinition map[string]interface{
 	if v, ok := terraformDefinition["tags_execution"].(string); ok && len(v) > 0 {
 		datadogDefinition.SetTagsExecution(v)
 	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
+	}
 	return datadogDefinition
 }
 
@@ -2631,6 +2673,9 @@ func buildTerraformEventStreamDefinition(datadogDefinition *datadogV1.EventStrea
 	}
 	if datadogDefinition.TagsExecution != nil {
 		terraformDefinition["tags_execution"] = *datadogDefinition.TagsExecution
+	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
 	}
 	return terraformDefinition
 }
@@ -2668,7 +2713,7 @@ func getEventTimelineDefinitionSchema() map[string]*schema.Schema {
 			Optional:    true,
 		},
 	}
-	schema = mergeSchemas(schema, getCommonTimeSpanSchema())
+	schema = mergeSchemas(schema, getCommonTimeSpanSchema(), getWidgetDescriptionSchema())
 	return schema
 }
 
@@ -2692,6 +2737,12 @@ func buildDatadogEventTimelineDefinition(terraformDefinition map[string]interfac
 	if v, ok := terraformDefinition["tags_execution"].(string); ok && len(v) > 0 {
 		datadogDefinition.SetTagsExecution(v)
 	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
+	}
 	return datadogDefinition
 }
 
@@ -2714,6 +2765,9 @@ func buildTerraformEventTimelineDefinition(datadogDefinition *datadogV1.EventTim
 	}
 	if v, ok := datadogDefinition.GetTagsExecutionOk(); ok {
 		terraformDefinition["tags_execution"] = *v
+	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
 	}
 	return terraformDefinition
 }
@@ -2769,7 +2823,7 @@ func getCheckStatusDefinitionSchema() map[string]*schema.Schema {
 			Optional:         true,
 		},
 	}
-	schema = mergeSchemas(schema, getCommonTimeSpanSchema())
+	schema = mergeSchemas(schema, getCommonTimeSpanSchema(), getWidgetDescriptionSchema())
 	return schema
 }
 
@@ -2808,6 +2862,12 @@ func buildDatadogCheckStatusDefinition(terraformDefinition map[string]interface{
 	if widgetTime := buildDatadogWidgetTime(terraformDefinition); widgetTime != nil {
 		datadogDefinition.Time = widgetTime
 	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
+	}
 	return datadogDefinition
 }
 
@@ -2845,6 +2905,9 @@ func buildTerraformCheckStatusDefinition(datadogDefinition *datadogV1.CheckStatu
 	}
 	if v, ok := datadogDefinition.GetTimeOk(); ok {
 		buildTerraformWidgetTime(v, terraformDefinition)
+	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
 	}
 	return terraformDefinition
 }
@@ -2980,7 +3043,7 @@ func getHeatmapDefinitionSchema() map[string]*schema.Schema {
 			},
 		},
 	}
-	schema = mergeSchemas(schema, getCommonTimeSpanSchema())
+	schema = mergeSchemas(schema, getCommonTimeSpanSchema(), getWidgetDescriptionSchema())
 	return schema
 }
 func buildDatadogHeatmapDefinition(terraformDefinition map[string]interface{}) *datadogV1.HeatMapWidgetDefinition {
@@ -3018,6 +3081,12 @@ func buildDatadogHeatmapDefinition(terraformDefinition map[string]interface{}) *
 	if v, ok := terraformDefinition["custom_link"].([]interface{}); ok && len(v) > 0 {
 		datadogDefinition.SetCustomLinks(*buildDatadogWidgetCustomLinks(&v))
 	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
+	}
 	return datadogDefinition
 }
 func buildTerraformHeatmapDefinition(datadogDefinition *datadogV1.HeatMapWidgetDefinition) map[string]interface{} {
@@ -3052,6 +3121,9 @@ func buildTerraformHeatmapDefinition(datadogDefinition *datadogV1.HeatMapWidgetD
 	}
 	if v, ok := datadogDefinition.GetCustomLinksOk(); ok {
 		terraformDefinition["custom_link"] = buildTerraformWidgetCustomLinks(v)
+	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
 	}
 	return terraformDefinition
 }
@@ -3183,7 +3255,7 @@ func buildTerraformHeatmapRequests(datadogHeatmapRequests *[]datadogV1.HeatMapWi
 //
 
 func getHostmapDefinitionSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
+	return mergeSchemas(map[string]*schema.Schema{
 		"request": {
 			Description: "A nested block describing the request to use when displaying the widget. Multiple `request` blocks are allowed using the structure below.",
 			Type:        schema.TypeList,
@@ -3293,7 +3365,7 @@ func getHostmapDefinitionSchema() map[string]*schema.Schema {
 				Schema: getWidgetCustomLinkSchema(),
 			},
 		},
-	}
+	}, getWidgetDescriptionSchema())
 }
 func buildDatadogHostmapDefinition(terraformDefinition map[string]interface{}) *datadogV1.HostMapWidgetDefinition {
 
@@ -3354,6 +3426,12 @@ func buildDatadogHostmapDefinition(terraformDefinition map[string]interface{}) *
 	if v, ok := terraformDefinition["custom_link"].([]interface{}); ok && len(v) > 0 {
 		datadogDefinition.SetCustomLinks(*buildDatadogWidgetCustomLinks(&v))
 	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
+	}
 	return datadogDefinition
 }
 func buildTerraformHostmapDefinition(datadogDefinition *datadogV1.HostMapWidgetDefinition) map[string]interface{} {
@@ -3410,6 +3488,9 @@ func buildTerraformHostmapDefinition(datadogDefinition *datadogV1.HostMapWidgetD
 	}
 	if v, ok := datadogDefinition.GetCustomLinksOk(); ok {
 		terraformDefinition["custom_link"] = buildTerraformWidgetCustomLinks(v)
+	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
 	}
 	return terraformDefinition
 }
@@ -3505,7 +3586,7 @@ func buildTerraformIframeDefinition(datadogDefinition *datadogV1.IFrameWidgetDef
 //
 
 func getImageDefinitionSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
+	return mergeSchemas(map[string]*schema.Schema{
 		"url": {
 			Description: "The URL to use as a data source for the widget.",
 			Type:        schema.TypeString,
@@ -3552,7 +3633,7 @@ func getImageDefinitionSchema() map[string]*schema.Schema {
 			ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewWidgetVerticalAlignFromValue),
 			Optional:         true,
 		},
-	}
+	}, getWidgetDescriptionSchema())
 }
 
 func buildDatadogImageDefinition(terraformDefinition map[string]interface{}) *datadogV1.ImageWidgetDefinition {
@@ -3580,6 +3661,12 @@ func buildDatadogImageDefinition(terraformDefinition map[string]interface{}) *da
 	}
 	if v, ok := terraformDefinition["vertical_align"].(string); ok && len(v) != 0 {
 		datadogDefinition.SetVerticalAlign(datadogV1.WidgetVerticalAlign(v))
+	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
 	}
 	return datadogDefinition
 }
@@ -3609,6 +3696,9 @@ func buildTerraformImageDefinition(datadogDefinition *datadogV1.ImageWidgetDefin
 	}
 	if v, ok := datadogDefinition.GetVerticalAlignOk(); ok {
 		terraformDefinition["vertical_align"] = *v
+	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
 	}
 	return terraformDefinition
 }
@@ -3678,7 +3768,7 @@ func getLogStreamDefinitionSchema() map[string]*schema.Schema {
 			Optional:         true,
 		},
 	}
-	schema = mergeSchemas(schema, getCommonTimeSpanSchema())
+	schema = mergeSchemas(schema, getCommonTimeSpanSchema(), getWidgetDescriptionSchema())
 	return schema
 }
 
@@ -3743,6 +3833,12 @@ func buildDatadogLogStreamDefinition(terraformDefinition map[string]interface{})
 	if widgetTime := buildDatadogWidgetTime(terraformDefinition); widgetTime != nil {
 		datadogDefinition.Time = widgetTime
 	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
+	}
 	return datadogDefinition
 }
 
@@ -3799,6 +3895,9 @@ func buildTerraformLogStreamDefinition(datadogDefinition *datadogV1.LogStreamWid
 	if v, ok := datadogDefinition.GetTimeOk(); ok {
 		buildTerraformWidgetTime(v, terraformDefinition)
 	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
+	}
 	return terraformDefinition
 }
 
@@ -3818,7 +3917,7 @@ func buildTerraformWidgetFieldSort(datadogWidgetFieldSort *datadogV1.WidgetField
 //
 
 func getManageStatusDefinitionSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
+	return mergeSchemas(map[string]*schema.Schema{
 		"query": {
 			Description: "The query to use in the widget.",
 			Type:        schema.TypeString,
@@ -3879,7 +3978,7 @@ func getManageStatusDefinitionSchema() map[string]*schema.Schema {
 			ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewWidgetTextAlignFromValue),
 			Optional:         true,
 		},
-	}
+	}, getWidgetDescriptionSchema())
 }
 
 func buildDatadogManageStatusDefinition(terraformDefinition map[string]interface{}) *datadogV1.MonitorSummaryWidgetDefinition {
@@ -3916,6 +4015,12 @@ func buildDatadogManageStatusDefinition(terraformDefinition map[string]interface
 	}
 	if v, ok := terraformDefinition["title_align"].(string); ok && len(v) != 0 {
 		datadogDefinition.SetTitleAlign(datadogV1.WidgetTextAlign(v))
+	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
 	}
 	return datadogDefinition
 }
@@ -3954,6 +4059,9 @@ func buildTerraformManageStatusDefinition(datadogDefinition *datadogV1.MonitorSu
 	}
 	if v, ok := datadogDefinition.GetTitleAlignOk(); ok {
 		terraformDefinition["title_align"] = *v
+	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
 	}
 	return terraformDefinition
 }
@@ -4150,7 +4258,7 @@ func getQueryValueDefinitionSchema() map[string]*schema.Schema {
 			},
 		},
 	}
-	schema = mergeSchemas(schema, getCommonTimeSpanSchema())
+	schema = mergeSchemas(schema, getCommonTimeSpanSchema(), getWidgetDescriptionSchema())
 	return schema
 }
 func buildDatadogQueryValueDefinition(terraformDefinition map[string]interface{}) *datadogV1.QueryValueWidgetDefinition {
@@ -4190,6 +4298,12 @@ func buildDatadogQueryValueDefinition(terraformDefinition map[string]interface{}
 	}
 	if v, ok := terraformDefinition["custom_link"].([]interface{}); ok && len(v) > 0 {
 		datadogDefinition.SetCustomLinks(*buildDatadogWidgetCustomLinks(&v))
+	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
 	}
 	return datadogDefinition
 }
@@ -4245,6 +4359,9 @@ func buildTerraformQueryValueDefinition(datadogDefinition *datadogV1.QueryValueW
 	}
 	if v, ok := datadogDefinition.GetCustomLinksOk(); ok {
 		terraformDefinition["custom_link"] = buildTerraformWidgetCustomLinks(v)
+	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
 	}
 	return terraformDefinition
 }
@@ -4457,7 +4574,7 @@ func getQueryTableDefinitionSchema() map[string]*schema.Schema {
 			Optional:         true,
 		},
 	}
-	schema = mergeSchemas(schema, getCommonTimeSpanSchema())
+	schema = mergeSchemas(schema, getCommonTimeSpanSchema(), getWidgetDescriptionSchema())
 	return schema
 }
 func buildDatadogQueryTableDefinition(terraformDefinition map[string]interface{}) *datadogV1.TableWidgetDefinition {
@@ -4484,6 +4601,12 @@ func buildDatadogQueryTableDefinition(terraformDefinition map[string]interface{}
 	if v, ok := terraformDefinition["has_search_bar"].(string); ok && len(v) != 0 {
 		datadogDefinition.SetHasSearchBar(datadogV1.TableWidgetHasSearchBar(v))
 	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
+	}
 	return datadogDefinition
 }
 func buildTerraformQueryTableDefinition(datadogDefinition *datadogV1.TableWidgetDefinition) map[string]interface{} {
@@ -4509,6 +4632,9 @@ func buildTerraformQueryTableDefinition(datadogDefinition *datadogV1.TableWidget
 	}
 	if v, ok := datadogDefinition.GetHasSearchBarOk(); ok {
 		terraformDefinition["has_search_bar"] = *v
+	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
 	}
 	return terraformDefinition
 }
@@ -4999,7 +5125,7 @@ func getScatterplotDefinitionSchema() map[string]*schema.Schema {
 			},
 		},
 	}
-	schema = mergeSchemas(schema, getCommonTimeSpanSchema())
+	schema = mergeSchemas(schema, getCommonTimeSpanSchema(), getWidgetDescriptionSchema())
 	return schema
 }
 func buildDatadogScatterplotDefinition(terraformDefinition map[string]interface{}) *datadogV1.ScatterPlotWidgetDefinition {
@@ -5058,6 +5184,12 @@ func buildDatadogScatterplotDefinition(terraformDefinition map[string]interface{
 	if v, ok := terraformDefinition["custom_link"].([]interface{}); ok && len(v) > 0 {
 		datadogDefinition.SetCustomLinks(*buildDatadogWidgetCustomLinks(&v))
 	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
+	}
 	return datadogDefinition
 }
 func buildTerraformScatterplotDefinition(datadogDefinition *datadogV1.ScatterPlotWidgetDefinition) map[string]interface{} {
@@ -5111,6 +5243,9 @@ func buildTerraformScatterplotDefinition(datadogDefinition *datadogV1.ScatterPlo
 	}
 	if v, ok := datadogDefinition.GetCustomLinksOk(); ok {
 		terraformDefinition["custom_link"] = buildTerraformWidgetCustomLinks(v)
+	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
 	}
 	return terraformDefinition
 }
@@ -5250,7 +5385,7 @@ func buildTerraformScatterplotRequest(datadogScatterplotRequest *datadogV1.Scatt
 //
 
 func getServiceMapDefinitionSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
+	return mergeSchemas(map[string]*schema.Schema{
 		"service": {
 			Description: "The ID of the service to map.",
 			Type:        schema.TypeString,
@@ -5286,7 +5421,7 @@ func getServiceMapDefinitionSchema() map[string]*schema.Schema {
 				Schema: getWidgetCustomLinkSchema(),
 			},
 		},
-	}
+	}, getWidgetDescriptionSchema())
 }
 func buildDatadogServiceMapDefinition(terraformDefinition map[string]interface{}) *datadogV1.ServiceMapWidgetDefinition {
 	datadogDefinition := datadogV1.NewServiceMapWidgetDefinitionWithDefaults()
@@ -5313,6 +5448,12 @@ func buildDatadogServiceMapDefinition(terraformDefinition map[string]interface{}
 	if v, ok := terraformDefinition["custom_link"].([]interface{}); ok && len(v) > 0 {
 		datadogDefinition.SetCustomLinks(*buildDatadogWidgetCustomLinks(&v))
 	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
+	}
 	return datadogDefinition
 }
 func buildTerraformServiceMapDefinition(datadogDefinition *datadogV1.ServiceMapWidgetDefinition) map[string]interface{} {
@@ -5335,6 +5476,9 @@ func buildTerraformServiceMapDefinition(datadogDefinition *datadogV1.ServiceMapW
 	if v, ok := datadogDefinition.GetCustomLinksOk(); ok {
 		terraformDefinition["custom_link"] = buildTerraformWidgetCustomLinks(v)
 	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
+	}
 	return terraformDefinition
 }
 
@@ -5343,7 +5487,7 @@ func buildTerraformServiceMapDefinition(datadogDefinition *datadogV1.ServiceMapW
 //
 
 func getTopologyMapDefinitionSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
+	return mergeSchemas(map[string]*schema.Schema{
 		"request": {
 			Description: "A nested block describing the request to use when displaying the widget. Multiple request blocks are allowed using the structure below (`query` and `request_type` are required within the request).",
 			Type:        schema.TypeList,
@@ -5376,7 +5520,7 @@ func getTopologyMapDefinitionSchema() map[string]*schema.Schema {
 				Schema: getWidgetCustomLinkSchema(),
 			},
 		},
-	}
+	}, getWidgetDescriptionSchema())
 }
 
 func getTopologyRequestSchema() map[string]*schema.Schema {
@@ -5439,6 +5583,12 @@ func buildDatadogTopologyMapDefinition(terraformDefinition map[string]interface{
 	if v, ok := terraformDefinition["custom_link"].([]interface{}); ok && len(v) > 0 {
 		datadogDefinition.SetCustomLinks(*buildDatadogWidgetCustomLinks(&v))
 	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
+	}
 	return datadogDefinition
 }
 func buildDatadogTopologyRequests(terraformRequests *[]interface{}) *[]datadogV1.TopologyRequest {
@@ -5496,6 +5646,9 @@ func buildTerraformTopologyMapDefinition(datadogDefinition *datadogV1.TopologyMa
 	if v, ok := datadogDefinition.GetCustomLinksOk(); ok {
 		terraformDefinition["custom_link"] = buildTerraformWidgetCustomLinks(v)
 	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
+	}
 	return terraformDefinition
 }
 func buildTerraformTopologyRequests(datadogTopologyRequests *[]datadogV1.TopologyRequest) *[]map[string]interface{} {
@@ -5529,7 +5682,7 @@ func buildTerraformTopologyQuery(datadogQuery *datadogV1.TopologyQuery) map[stri
 //
 
 func getServiceLevelObjectiveDefinitionSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
+	return mergeSchemas(map[string]*schema.Schema{
 		"title": {
 			Description: "The title of the widget.",
 			Type:        schema.TypeString,
@@ -5586,7 +5739,7 @@ func getServiceLevelObjectiveDefinitionSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Optional:    true,
 		},
-	}
+	}, getWidgetDescriptionSchema())
 }
 
 func buildDatadogServiceLevelObjectiveDefinition(terraformDefinition map[string]interface{}) *datadogV1.SLOWidgetDefinition {
@@ -5625,6 +5778,12 @@ func buildDatadogServiceLevelObjectiveDefinition(terraformDefinition map[string]
 	}
 	if v, ok := terraformDefinition["additional_query_filters"].(string); ok && len(v) != 0 {
 		datadogDefinition.SetAdditionalQueryFilters(v)
+	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
 	}
 	return datadogDefinition
 }
@@ -5668,6 +5827,9 @@ func buildTerraformServiceLevelObjectiveDefinition(datadogDefinition *datadogV1.
 	if AdditionalQueryFilters, ok := datadogDefinition.GetAdditionalQueryFiltersOk(); ok {
 		terraformDefinition["additional_query_filters"] = AdditionalQueryFilters
 	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
+	}
 	return terraformDefinition
 }
 
@@ -5676,7 +5838,7 @@ func buildTerraformServiceLevelObjectiveDefinition(datadogDefinition *datadogV1.
 //
 
 func getSloListDefinitionSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
+	return mergeSchemas(map[string]*schema.Schema{
 		"request": {
 			Description: "A nested block describing the request to use when displaying the widget. Exactly one `request` block is allowed.",
 			Type:        schema.TypeList,
@@ -5703,7 +5865,7 @@ func getSloListDefinitionSchema() map[string]*schema.Schema {
 			ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewWidgetTextAlignFromValue),
 			Optional:         true,
 		},
-	}
+	}, getWidgetDescriptionSchema())
 }
 
 func getSloListRequestSchema() map[string]*schema.Schema {
@@ -5761,6 +5923,12 @@ func buildDatadogSloListDefinition(terraformDefinition map[string]interface{}) *
 	}
 	if v, ok := terraformDefinition["title_align"].(string); ok && len(v) != 0 {
 		datadogDefinition.SetTitleAlign(datadogV1.WidgetTextAlign(v))
+	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
 	}
 	return datadogDefinition
 }
@@ -5828,6 +5996,9 @@ func buildTerraformSloListDefinition(datadogDefinition *datadogV1.SLOListWidgetD
 	if titleAlign, ok := datadogDefinition.GetTitleAlignOk(); ok {
 		terraformDefinition["title_align"] = titleAlign
 	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
+	}
 	return terraformDefinition
 }
 
@@ -5876,7 +6047,7 @@ func buildTerraformSloListSort(datadogSorts *[]datadogV1.WidgetFieldSort) *[]map
 //
 
 func getListStreamDefinitionSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
+	return mergeSchemas(map[string]*schema.Schema{
 		"request": {
 			Description: "Nested block describing the requests to use when displaying the widget. Multiple `request` blocks are allowed with the structure below.",
 			Type:        schema.TypeList,
@@ -5902,7 +6073,7 @@ func getListStreamDefinitionSchema() map[string]*schema.Schema {
 			ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewWidgetTextAlignFromValue),
 			Optional:         true,
 		},
-	}
+	}, getWidgetDescriptionSchema())
 }
 
 func getListStreamRequestSchema() map[string]*schema.Schema {
@@ -6021,6 +6192,12 @@ func buildDatadogListStreamDefinition(terraformDefinition map[string]interface{}
 	}
 	if v, ok := terraformDefinition["title_align"].(string); ok && len(v) != 0 {
 		datadogDefinition.SetTitleAlign(datadogV1.WidgetTextAlign(v))
+	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
 	}
 	return datadogDefinition, nil
 }
@@ -6194,7 +6371,7 @@ func getGeomapDefinitionSchema() map[string]*schema.Schema {
 			},
 		},
 	}
-	schema = mergeSchemas(schema, getCommonTimeSpanSchema())
+	schema = mergeSchemas(schema, getCommonTimeSpanSchema(), getWidgetDescriptionSchema())
 	return schema
 }
 
@@ -6249,6 +6426,12 @@ func buildDatadogGeomapDefinition(terraformDefinition map[string]interface{}) *d
 		datadogDefinition.SetCustomLinks(*buildDatadogWidgetCustomLinks(&v))
 	}
 
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
+	}
 	return datadogDefinition
 }
 
@@ -6427,7 +6610,7 @@ func getTimeseriesDefinitionSchema() map[string]*schema.Schema {
 			},
 		},
 	}
-	schema = mergeSchemas(schema, getCommonTimeSpanSchema())
+	schema = mergeSchemas(schema, getCommonTimeSpanSchema(), getWidgetDescriptionSchema())
 	return schema
 }
 
@@ -6494,6 +6677,12 @@ func buildDatadogTimeseriesDefinition(terraformDefinition map[string]interface{}
 	if v, ok := terraformDefinition["custom_link"].([]interface{}); ok && len(v) > 0 {
 		datadogDefinition.SetCustomLinks(*buildDatadogWidgetCustomLinks(&v))
 	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
+	}
 	return datadogDefinition
 }
 
@@ -6547,6 +6736,9 @@ func buildTerraformTimeseriesDefinition(datadogDefinition *datadogV1.TimeseriesW
 	}
 	if v, ok := datadogDefinition.GetCustomLinksOk(); ok {
 		terraformDefinition["custom_link"] = buildTerraformWidgetCustomLinks(v)
+	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
 	}
 	return terraformDefinition
 }
@@ -6637,7 +6829,7 @@ func getSunburstDefinitionschema() map[string]*schema.Schema {
 			},
 		},
 	}
-	schema = mergeSchemas(schema, getCommonTimeSpanSchema())
+	schema = mergeSchemas(schema, getCommonTimeSpanSchema(), getWidgetDescriptionSchema())
 	return schema
 }
 
@@ -6745,6 +6937,12 @@ func buildDatadogSunburstDefinition(terraformDefinition map[string]interface{}) 
 		datadogDefinition.SetCustomLinks(*buildDatadogWidgetCustomLinks(&v))
 	}
 
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
+	}
 	return datadogDefinition
 }
 
@@ -6934,6 +7132,9 @@ func buildTerraformSunburstDefinition(datadogDefinition *datadogV1.SunburstWidge
 		buildTerraformWidgetTime(v, terraformDefinition)
 	}
 
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
+	}
 	return terraformDefinition
 }
 
@@ -8277,7 +8478,7 @@ func getToplistDefinitionSchema() map[string]*schema.Schema {
 			},
 		},
 	}
-	schema = mergeSchemas(schema, getCommonTimeSpanSchema())
+	schema = mergeSchemas(schema, getCommonTimeSpanSchema(), getWidgetDescriptionSchema())
 	return schema
 }
 func buildDatadogToplistDefinition(terraformDefinition map[string]interface{}) *datadogV1.ToplistWidgetDefinition {
@@ -8306,6 +8507,12 @@ func buildDatadogToplistDefinition(terraformDefinition map[string]interface{}) *
 		if v, ok := style[0].(map[string]interface{}); ok && len(v) > 0 {
 			datadogDefinition.SetStyle(buildDatadogToplistStyle(v))
 		}
+	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
 	}
 	return datadogDefinition
 }
@@ -8364,6 +8571,9 @@ func buildTerraformToplistDefinition(datadogDefinition *datadogV1.ToplistWidgetD
 	}
 	if v, ok := datadogDefinition.GetStyleOk(); ok {
 		terraformDefinition["style"] = buildTerraformToplistWidgetStyle(v)
+	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
 	}
 	return terraformDefinition
 }
@@ -8621,7 +8831,7 @@ func getTraceServiceDefinitionSchema() map[string]*schema.Schema {
 			Optional:         true,
 		},
 	}
-	schema = mergeSchemas(schema, getCommonTimeSpanSchema())
+	schema = mergeSchemas(schema, getCommonTimeSpanSchema(), getWidgetDescriptionSchema())
 	return schema
 }
 
@@ -8669,6 +8879,12 @@ func buildDatadogTraceServiceDefinition(terraformDefinition map[string]interface
 		datadogDefinition.Time = widgetTime
 	}
 
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
+	}
 	return datadogDefinition
 }
 
@@ -9210,7 +9426,7 @@ func getRunWorkflowDefinitionSchema() map[string]*schema.Schema {
 			},
 		},
 	}
-	schema = mergeSchemas(schema, getCommonTimeSpanSchema())
+	schema = mergeSchemas(schema, getCommonTimeSpanSchema(), getWidgetDescriptionSchema())
 	return schema
 }
 
@@ -9236,6 +9452,12 @@ func buildDatadogRunWorkflowDefinition(terraformDefinition map[string]interface{
 	}
 	if v, ok := terraformDefinition["custom_link"].([]interface{}); ok && len(v) > 0 {
 		datadogDefinition.SetCustomLinks(*buildDatadogWidgetCustomLinks(&v))
+	}
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
 	}
 	return datadogDefinition
 }
@@ -9275,6 +9497,9 @@ func buildTerraformRunWorkflowDefinition(datadogDefinition *datadogV1.RunWorkflo
 	if v, ok := datadogDefinition.GetCustomLinksOk(); ok {
 		terraformDefinition["custom_link"] = buildTerraformWidgetCustomLinks(v)
 	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
+	}
 	return terraformDefinition
 }
 func buildTerraformRunWorkflowInputs(datadogInputs *[]datadogV1.RunWorkflowWidgetInput) *[]map[string]interface{} {
@@ -9294,7 +9519,7 @@ func buildTerraformRunWorkflowInputs(datadogInputs *[]datadogV1.RunWorkflowWidge
 //
 
 func getTreemapDefinitionSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
+	return mergeSchemas(map[string]*schema.Schema{
 		"request": {
 			Description: "Nested block describing the request to use when displaying the widget.",
 			Type:        schema.TypeList,
@@ -9316,7 +9541,7 @@ func getTreemapDefinitionSchema() map[string]*schema.Schema {
 				Schema: getWidgetCustomLinkSchema(),
 			},
 		},
-	}
+	}, getWidgetDescriptionSchema())
 }
 
 func getTreemapRequestSchema() map[string]*schema.Schema {
@@ -9341,6 +9566,12 @@ func buildDatadogTreemapDefinition(terraformDefinition map[string]interface{}) *
 		datadogDefinition.SetCustomLinks(*buildDatadogWidgetCustomLinks(&v))
 	}
 
+	if v, ok := terraformDefinition["description"].(string); ok && len(v) != 0 {
+		if datadogDefinition.AdditionalProperties == nil {
+			datadogDefinition.AdditionalProperties = make(map[string]interface{})
+		}
+		datadogDefinition.AdditionalProperties["description"] = v
+	}
 	return datadogDefinition
 }
 
@@ -9416,6 +9647,9 @@ func buildTerraformTreemapDefinition(datadogDefinition *datadogV1.TreeMapWidgetD
 		terraformDefinition["custom_links"] = buildTerraformWidgetCustomLinks(v)
 	}
 
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
+	}
 	return terraformDefinition
 }
 
@@ -9454,6 +9688,9 @@ func buildTerraformGeomapDefinition(datadogDefinition *datadogV1.GeomapWidgetDef
 		buildTerraformWidgetTime(v, terraformDefinition)
 	}
 
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
+	}
 	return terraformDefinition
 }
 
@@ -9470,6 +9707,9 @@ func buildTerraformListStreamDefinition(datadogDefinition *datadogV1.ListStreamW
 	}
 	if datadogDefinition.TitleAlign != nil {
 		terraformDefinition["title_align"] = *datadogDefinition.TitleAlign
+	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
 	}
 	return terraformDefinition
 }
@@ -9565,6 +9805,9 @@ func buildTerraformTraceServiceDefinition(datadogDefinition *datadogV1.ServiceSu
 	}
 	if v, ok := datadogDefinition.GetTimeOk(); ok {
 		buildTerraformWidgetTime(v, terraformDefinition)
+	}
+	if v, ok := datadogDefinition.AdditionalProperties["description"]; ok {
+		terraformDefinition["description"] = v
 	}
 	return terraformDefinition
 }
@@ -9966,6 +10209,16 @@ func getCommonTimeSpanSchema() map[string]*schema.Schema {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Computed:    true,
+		},
+	}
+}
+
+func getWidgetDescriptionSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"description": {
+			Description: "The description of the widget.",
+			Type:        schema.TypeString,
+			Optional:    true,
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Closes #3595

The Datadog dashboard UI supports adding a **description** to individual widgets (shown as a tooltip on the widget's `?` icon). This PR exposes that field in the Terraform provider for all applicable widget definition types.

- The Datadog REST API already supports `description` inside each widget's `definition` JSON object — confirmed via `GET /api/v1/dashboard/{id}`. The Go API client surfaces it through `AdditionalProperties` since it's not yet in the typed spec.
- Added `getWidgetDescriptionSchema()` helper returning an optional `TypeString` field
- Updated **27 widget definition types**: schema, `buildDatadog*Definition`, and `buildTerraform*Definition` for each
- Skipped container widgets (`group`, `powerpack`, `split_graph`) and text-only widgets (`note`, `free_text`)

**Example usage:**
```hcl
widget {
  query_value_definition {
    title       = "Active Users"
    description = "Unique users who had at least one session in the selected time window."
    request { ... }
  }
}
```

## Affected widget types

`alert_graph`, `alert_value`, `change`, `check_status`, `distribution`, `event_stream`, `event_timeline`, `geomap`, `heatmap`, `hostmap`, `image`, `list_stream`, `log_stream`, `manage_status`, `query_table`, `query_value`, `run_workflow`, `scatterplot`, `service_level_objective`, `servicemap`, `slo_list`, `timeseries`, `toplist`, `topology_map`, `trace_service`, `treemap`, `sunburst`

## Test plan

- [ ] Run acceptance test for `datadog_dashboard` with a `query_value_definition` that includes a `description`
- [ ] Verify `terraform apply` sets the description on the widget in the Datadog UI
- [ ] Verify `terraform plan` shows no drift when description is set
- [ ] Verify existing dashboards without descriptions continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)