### PR TITLE
[oncall] clears UnparsedObject when type is escalation_policy (BGL-1498)

### DIFF
--- a/datadog/fwprovider/resource_datadog_on_call_team_routing_rules.go
+++ b/datadog/fwprovider/resource_datadog_on_call_team_routing_rules.go
@@ -262,6 +262,7 @@ func (r *onCallTeamRoutingRulesResource) Read(ctx context.Context, request resou
 		return
 	}
 
+	clearUnknownPolicyActions(&resp)
 	if err := utils.CheckForUnparsed(resp); err != nil {
 		response.Diagnostics.AddError("response contains unparsed object", err.Error())
 		return
@@ -299,6 +300,7 @@ func (r *onCallTeamRoutingRulesResource) Create(ctx context.Context, request res
 		return
 	}
 
+	clearUnknownPolicyActions(&resp)
 	if err := utils.CheckForUnparsed(resp); err != nil {
 		response.Diagnostics.AddError("response contains unparsed object", err.Error())
 		return
@@ -336,6 +338,7 @@ func (r *onCallTeamRoutingRulesResource) Update(ctx context.Context, request res
 		return
 	}
 
+	clearUnknownPolicyActions(&resp)
 	if err := utils.CheckForUnparsed(resp); err != nil {
 		response.Diagnostics.AddError("response contains unparsed object", err.Error())
 		return
@@ -368,6 +371,27 @@ func (r *onCallTeamRoutingRulesResource) Delete(ctx context.Context, request res
 		}
 		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error deleting on_call_team_routing_rules"))
 		return
+	}
+}
+
+// clearUnknownPolicyActions removes UnparsedObject from routing rule actions of type "escalation_policy".
+// The Go client does not yet know this type, so it lands in UnparsedObject and would cause
+// CheckForUnparsed to fail. The escalation policy is read from relationships.Policy, not from
+// the actions array, so it is safe to drop it here until the client is regenerated.
+func clearUnknownPolicyActions(resp *datadogV2.TeamRoutingRules) {
+	for i := range resp.Included {
+		rr := resp.Included[i].RoutingRule
+		if rr == nil || rr.Attributes == nil {
+			continue
+		}
+		for j := range rr.Attributes.Actions {
+			action := &rr.Attributes.Actions[j]
+			if unparsed, ok := action.UnparsedObject.(map[string]interface{}); ok {
+				if unparsed["type"] == "escalation_policy" {
+					action.UnparsedObject = nil
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This PR prevents the Terraform provider from failing when providing as escalation policy action in the routing rules endpoints response (GET / PUT)

See [here](https://datadoghq.atlassian.net/wiki/spaces/Bugle/pages/5625283411/API+definition+DB+schema+CaseM+changes#API-spec-and-Terraform-provider-update) for context and option taken (option C).

How this was tested:
- The cassette tests pass.
- When adding manually an escalation policy action to the cassette tests response payload: without this fix the test fail, with the fix it succeeds. The cassette will be recorded in another PR once the API returns an escalation policy action.

When the API is modified to return an escalation policy action without the `use_policy_action` query parameter, we will make sure that `oncall-monitoring` builds successfully on staging. [Link](https://mosaic.us1.ddbuild.io/deployments?query=service%3Aoncall-monitoring+status%3AFailed&page=1&serviceName=%2Boncall-monitoring&from_ts=1767826800000&to_ts=1768258799999&live=false&id=temporal%2Fv1%3Arelease-0%7C%7Cf8fa10bd-abff-4b40-99d5-4b5ba4b4b202%7C%7Cb46a70a6-a62c-4202-87a8-eb6e5d153b9c&viewOption=list&compareService=oncall-monitoring&selectedTaskId=f8eb517a37022ada640b1097b44b7e8af72f1f84) to the failing build that required to add the `use_policy_action` query parameter.