### PR TITLE
[docs] clarify disable_daily_limit behavior

### DIFF
--- a/datadog/resource_datadog_logs_index.go
+++ b/datadog/resource_datadog_logs_index.go
@@ -24,7 +24,7 @@ var indexSchema = map[string]*schema.Schema{
 		ForceNew:    true,
 	},
 	"disable_daily_limit": {
-		Description: "If true, sets the daily_limit value to null and the index is not limited on a daily basis (any specified daily_limit value in the request is ignored). If false or omitted, the index's current daily_limit is maintained.",
+		Description: "If true, disables the daily limit and sets `daily_limit` to null. If false, enables the daily limit. When creating an index, if this attribute is omitted, the daily limit is enabled by default. When updating an index, if this attribute is omitted, the existing value is preserved. Providing a `daily_limit` value does not re-enable the limit if it was previously disabled unless `disable_daily_limit` is explicitly set to false.",
 		Type:        schema.TypeBool,
 		Optional:    true,
 		Computed:    true,

--- a/docs/resources/logs_index.md
+++ b/docs/resources/logs_index.md
@@ -61,7 +61,7 @@ resource "datadog_logs_index" "sample_index" {
 - `daily_limit` (Number) The number of log events you can send in this index per day before you are rate-limited.
 - `daily_limit_reset` (Block List, Max: 1) Object containing options to override the default daily limit reset time. (see [below for nested schema](#nestedblock--daily_limit_reset))
 - `daily_limit_warning_threshold_percentage` (Number) A percentage threshold of the daily quota at which a Datadog warning event is generated.
-- `disable_daily_limit` (Boolean) If true, sets the daily_limit value to null and the index is not limited on a daily basis (any specified daily_limit value in the request is ignored). If false or omitted, the index's current daily_limit is maintained.
+- `disable_daily_limit` (Boolean) If true, disables the daily limit and sets `daily_limit` to null. If false, enables the daily limit. When creating an index, if this attribute is omitted, the daily limit is enabled by default. When updating an index, if this attribute is omitted, the existing value is preserved. Providing a `daily_limit` value does not re-enable the limit if it was previously disabled unless `disable_daily_limit` is explicitly set to false.
 - `exclusion_filter` (Block List) List of exclusion filters. (see [below for nested schema](#nestedblock--exclusion_filter))
 - `flex_retention_days` (Number) The total number of days logs are stored in Standard and Flex Tier before being deleted from the index.
 - `retention_days` (Number) The number of days logs are stored in Standard Tier before aging into the Flex Tier or being deleted from the index.


### PR DESCRIPTION
## Summary

- Updates `disable_daily_limit` schema description to clarify create vs update semantics
- Clarifies that providing `daily_limit` alone does not re-enable the limit if previously disabled
- Regenerated docs via `make docs`

## Test plan

- [x] Verify `docs/resources/logs_index.md` reflects the updated description after `make docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)