### PR TITLE
[ACCESS-3859] Include permission name aliases in permissions data source

### DIFF
--- a/datadog/data_source_datadog_permissions.go
+++ b/datadog/data_source_datadog_permissions.go
@@ -56,15 +56,20 @@ func dataSourceDatadogPermissionsRead(ctx context.Context, d *schema.ResourceDat
 			continue
 		}
 
+		permId := perm.GetId()
 		if err := utils.CheckForUnparsed(perm); err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Warning,
-				Summary:  fmt.Sprintf("skipping permission with id: %s", perm.GetId()),
+				Summary:  fmt.Sprintf("skipping permission with id: %s", permId),
 				Detail:   fmt.Sprintf("permission contains unparsed object: %v", err),
 			})
 			continue
 		}
-		permsNameToID[perm.Attributes.GetName()] = perm.GetId()
+		permsNameToID[perm.Attributes.GetName()] = permId
+		nameAliases := perm.Attributes.GetNameAliases()
+		for _, alias := range nameAliases {
+			permsNameToID[alias] = permId
+		}
 	}
 	if err := d.Set("permissions", permsNameToID); err != nil {
 		return diag.FromErr(err)

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-datadog
 
 require (
-	github.com/DataDog/datadog-api-client-go/v2 v2.56.1-0.20260311092123-dcd19a5f8599
+	github.com/DataDog/datadog-api-client-go/v2 v2.56.1-0.20260313211508-8a1e1dceb6e8
 	github.com/DataDog/dd-sdk-go-testing v0.0.0-20211116174033-1cd082e322ad
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/datadog-api-client-go/v2 v2.56.1-0.20260311092123-dcd19a5f8599 h1:F+a/8bi/kF+WoZbLpCUIvHjovi9f7OHRN93J46FYTaw=
-github.com/DataDog/datadog-api-client-go/v2 v2.56.1-0.20260311092123-dcd19a5f8599/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
+github.com/DataDog/datadog-api-client-go/v2 v2.56.1-0.20260313211508-8a1e1dceb6e8 h1:81Mwk6e1BWzPn6fu5y5AmVaunrpLAnKFikH9PCMCWxM=
+github.com/DataDog/datadog-api-client-go/v2 v2.56.1-0.20260313211508-8a1e1dceb6e8/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/ACCESS-3859

I updated the go client to the most recent commit.

This allows terraform users to refer to permissions by any of their names, canonical or otherwise, in their configurations (for roles, mostly).

To test, you can create a role in terraform and give it the infrastructure_read permission, and plan/apply will work.