### PR TITLE
[MA] Remove run_as and restricted from response

### DIFF
--- a/datadog/resource_datadog_monitor_json.go
+++ b/datadog/resource_datadog_monitor_json.go
@@ -34,6 +34,8 @@ var monitorComputedFields = []string{
 	"overall_state_modified",
 	"url",
 	"draft_status",
+	"restricted",
+	"run_as",
 }
 
 const monitorPath = "/api/v1/monitor"


### PR DESCRIPTION
This PR omits both `restricted` and `run_as` from determining difference when running `terraform apply`. `restricted` is returned if a user has view access to a monitor and `run_as` isn't currently supported in terraform. 