### PR TITLE
[datadog_monitor] Fix Read setting mutually exclusive on_missing_data attributes

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -170,7 +170,7 @@ func resourceDatadogMonitor() *schema.Resource {
 					Description:   "A boolean indicating whether this monitor will notify when data stops reporting.",
 					Type:          schema.TypeBool,
 					Optional:      true,
-					Default:       false,
+					Computed:      true,
 					ConflictsWith: []string{"on_missing_data"},
 				},
 				"on_missing_data": {
@@ -215,7 +215,7 @@ func resourceDatadogMonitor() *schema.Resource {
 					Description: "The number of minutes before a monitor will notify when data stops reporting.\n\nWe recommend at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks.",
 					Type:        schema.TypeInt,
 					Optional:    true,
-					Default:     defaultNoDataTimeframeMinutes,
+					Computed:    true,
 					DiffSuppressFunc: func(k, oldVal, newVal string, d *schema.ResourceData) bool {
 						if !d.Get("notify_no_data").(bool) {
 							if newVal != oldVal {
@@ -832,9 +832,7 @@ func buildMonitorStruct(d utils.Resource) (*datadogV1.Monitor, *datadogV1.Monito
 	if onMissingDataOk {
 		o.SetOnMissingData(datadogV1.OnMissingDataOption(attr.(string)))
 	}
-	// no_data_timeframe cannot be combined with on_missing_data. This provider
-	// defaults no_data_timeframe to 10, so we need this extra logic to exclude
-	// no_data_timeframe from the monitor definition when on_missing_data is set.
+	// no_data_timeframe cannot be combined with on_missing_data.
 	if attr, ok := d.GetOk("no_data_timeframe"); ok && !onMissingDataOk && !hasCustomSchedule {
 		o.SetNoDataTimeframe(int64(attr.(int)))
 	}
@@ -1341,16 +1339,22 @@ func updateMonitorState(d *schema.ResourceData, meta interface{}, m *datadogV1.M
 	if err := d.Set("evaluation_delay", m.Options.GetEvaluationDelay()); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("notify_no_data", m.Options.GetNotifyNoData()); err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("on_missing_data", m.Options.GetOnMissingData()); err != nil {
-		return diag.FromErr(err)
+	// on_missing_data and notify_no_data/no_data_timeframe are mutually exclusive
+	// per ConflictsWith in the schema. Only populate the group actually in use.
+	onMissingData := m.Options.GetOnMissingData()
+	if onMissingData != "" {
+		if err := d.Set("on_missing_data", onMissingData); err != nil {
+			return diag.FromErr(err)
+		}
+	} else {
+		if err := d.Set("notify_no_data", m.Options.GetNotifyNoData()); err != nil {
+			return diag.FromErr(err)
+		}
+		if err := d.Set("no_data_timeframe", m.Options.NoDataTimeframe.Get()); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 	if err := d.Set("group_retention_duration", m.Options.GetGroupRetentionDuration()); err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("no_data_timeframe", m.Options.NoDataTimeframe.Get()); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("renotify_interval", m.Options.GetRenotifyInterval()); err != nil {

--- a/datadog/resource_datadog_monitor_read_test.go
+++ b/datadog/resource_datadog_monitor_read_test.go
@@ -1,0 +1,186 @@
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateMonitorState_OnMissingData_MutualExclusion verifies that when the API
+// returns on_missing_data, the Read function does NOT set notify_no_data or
+// no_data_timeframe in state. These fields are declared ConflictsWith in the schema.
+//
+// Strategy: seed ResourceData with sentinel values for the conflicting fields.
+// After updateMonitorState, check whether those sentinels were overwritten.
+func TestUpdateMonitorState_OnMissingData_MutualExclusion(t *testing.T) {
+	tests := []struct {
+		name            string
+		onMissingData   string
+		notifyNoData    bool
+		noDataTimeframe *int64
+		// Expected behavior of Read for conflicting fields
+		expectReadSetsOnMissingData   bool
+		expectReadSetsNotifyNoData    bool
+		expectReadSetsNoDataTimeframe bool
+	}{
+		{
+			name:                          "on_missing_data set — Read must NOT touch notify_no_data or no_data_timeframe",
+			onMissingData:                 "show_no_data",
+			notifyNoData:                  false,
+			noDataTimeframe:               nil,
+			expectReadSetsOnMissingData:   true,
+			expectReadSetsNotifyNoData:    false,
+			expectReadSetsNoDataTimeframe: false,
+		},
+		{
+			name:                          "on_missing_data empty — Read must set notify_no_data and no_data_timeframe",
+			onMissingData:                 "",
+			notifyNoData:                  true,
+			noDataTimeframe:               int64Ptr(15),
+			expectReadSetsOnMissingData:   false,
+			expectReadSetsNotifyNoData:    true,
+			expectReadSetsNoDataTimeframe: true,
+		},
+		{
+			name:                          "on_missing_data resolve — Read must NOT touch notify_no_data or no_data_timeframe",
+			onMissingData:                 "resolve",
+			notifyNoData:                  false,
+			noDataTimeframe:               nil,
+			expectReadSetsOnMissingData:   true,
+			expectReadSetsNotifyNoData:    false,
+			expectReadSetsNoDataTimeframe: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			monitor := buildMockMonitor(tc.onMissingData, tc.notifyNoData, tc.noDataTimeframe)
+
+			resourceSchema := resourceDatadogMonitor()
+
+			// Seed with sentinel values that differ from the mock monitor's values.
+			// If updateMonitorState incorrectly calls d.Set() for these fields,
+			// the sentinels will be overwritten — proving state pollution.
+			sentinelNotifyNoData := true  // mock returns false → overwrite detectable
+			sentinelNoDataTimeframe := 99 // mock returns nil (→0) → overwrite detectable
+			d := schema.TestResourceDataRaw(t, resourceSchema.SchemaFunc(), map[string]interface{}{
+				"name":              "test-monitor",
+				"message":           "test",
+				"query":             "avg(last_5m):avg:system.cpu.user{*} > 90",
+				"type":              "query alert",
+				"notify_no_data":    sentinelNotifyNoData,
+				"no_data_timeframe": sentinelNoDataTimeframe,
+			})
+			d.SetId("12345")
+
+			diags := updateMonitorState(d, nil, monitor)
+			require.False(t, diags.HasError(), "updateMonitorState returned errors: %v", diags)
+
+			// Check on_missing_data
+			onMissingVal := d.Get("on_missing_data").(string)
+			if tc.expectReadSetsOnMissingData {
+				assert.Equal(t, tc.onMissingData, onMissingVal,
+					"on_missing_data should be set by Read")
+			}
+
+			// Check notify_no_data — sentinel detection
+			notifyVal := d.Get("notify_no_data").(bool)
+			if tc.expectReadSetsNotifyNoData {
+				assert.Equal(t, tc.notifyNoData, notifyVal,
+					"notify_no_data should be set by Read from API value")
+			} else {
+				assert.Equal(t, sentinelNotifyNoData, notifyVal,
+					"notify_no_data must NOT be touched by Read when on_missing_data is set")
+			}
+
+			// Check no_data_timeframe — sentinel detection
+			noDataVal := d.Get("no_data_timeframe").(int)
+			if tc.expectReadSetsNoDataTimeframe {
+				assert.Equal(t, int(*tc.noDataTimeframe), noDataVal,
+					"no_data_timeframe should be set by Read from API value")
+			} else {
+				assert.Equal(t, sentinelNoDataTimeframe, noDataVal,
+					"no_data_timeframe must NOT be touched by Read when on_missing_data is set")
+			}
+		})
+	}
+}
+
+// buildMockMonitor creates a datadogV1.Monitor with minimal options
+// needed to test the Read mutual exclusion logic.
+func buildMockMonitor(onMissingData string, notifyNoData bool, noDataTimeframe *int64) *datadogV1.Monitor {
+	monitorType := datadogV1.MONITORTYPE_QUERY_ALERT
+	m := datadogV1.NewMonitor("avg(last_5m):avg:system.cpu.user{*} > 90", monitorType)
+	m.SetName("test-monitor")
+	m.SetMessage("test")
+	m.SetId(12345)
+
+	opts := datadogV1.MonitorOptions{}
+	opts.SetNotifyNoData(notifyNoData)
+	opts.SetIncludeTags(true)
+	opts.SetNewHostDelay(300)
+
+	if onMissingData != "" {
+		opts.SetOnMissingData(datadogV1.OnMissingDataOption(onMissingData))
+	}
+
+	if noDataTimeframe != nil {
+		opts.SetNoDataTimeframe(*noDataTimeframe)
+	}
+
+	// Required: thresholds (updateMonitorState reads these)
+	thresholds := datadogV1.MonitorThresholds{}
+	thresholds.SetCritical(90.0)
+	opts.SetThresholds(thresholds)
+
+	// Required: threshold_windows (updateMonitorState reads these)
+	thresholdWindows := datadogV1.MonitorThresholdWindowOptions{}
+	opts.SetThresholdWindows(thresholdWindows)
+
+	m.SetOptions(opts)
+	return m
+}
+
+func int64Ptr(v int64) *int64 {
+	return &v
+}
+
+// TestUpdateMonitorState_OnMissingData_SchemaDefaultsLeak is a regression test
+// verifying that notify_no_data and no_data_timeframe do not leak into
+// InstanceState when on_missing_data is set. These fields use Computed: true
+// (not Default) so they only appear in state when explicitly set via d.Set().
+// Leaking defaults into state causes generate-config-out to emit conflicting
+// attributes in the generated HCL.
+func TestUpdateMonitorState_OnMissingData_SchemaDefaultsLeak(t *testing.T) {
+	monitor := buildMockMonitor("show_no_data", false, nil)
+	resourceSchema := resourceDatadogMonitor()
+
+	// Simulate import: only set the required fields, let schema handle the rest.
+	d := schema.TestResourceDataRaw(t, resourceSchema.SchemaFunc(), map[string]interface{}{
+		"name":    "test-monitor",
+		"message": "test",
+		"query":   "avg(last_5m):avg:system.cpu.user{*} > 90",
+		"type":    "query alert",
+	})
+	d.SetId("12345")
+
+	diags := updateMonitorState(d, nil, monitor)
+	require.False(t, diags.HasError(), "updateMonitorState returned errors: %v", diags)
+
+	assert.Equal(t, "show_no_data", d.Get("on_missing_data").(string))
+
+	// Verify that conflicting fields do NOT appear in InstanceState.
+	// If they do, generate-config-out will emit them alongside on_missing_data,
+	// triggering ConflictsWith validation errors.
+	instanceState := d.State()
+	_, notifyInState := instanceState.Attributes["notify_no_data"]
+	_, noDataTFInState := instanceState.Attributes["no_data_timeframe"]
+
+	assert.False(t, notifyInState,
+		"notify_no_data must not appear in InstanceState when on_missing_data is set")
+	assert.False(t, noDataTFInState,
+		"no_data_timeframe must not appear in InstanceState when on_missing_data is set")
+}

--- a/datadog/tests/resource_datadog_monitor_test.go
+++ b/datadog/tests/resource_datadog_monitor_test.go
@@ -602,8 +602,8 @@ func TestAccDatadogMonitor_Log(t *testing.T) {
 						"datadog_monitor.foo", "query", "logs(\"service:foo AND type:error\").index(\"main\").rollup(\"count\").by(\"source\").last(\"5m\") > 2"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "notify_no_data", "false"),
-					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "on_missing_data", ""),
+					resource.TestCheckNoResourceAttr(
+						"datadog_monitor.foo", "on_missing_data"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "group_retention_duration", ""),
 					resource.TestCheckResourceAttr(


### PR DESCRIPTION
## Summary

Closes https://github.com/DataDog/terraform-provider-datadog/issues/3617

The `Read` function (`updateMonitorState`) unconditionally sets `on_missing_data`, `notify_no_data`, and `no_data_timeframe` into Terraform state, even when the API only returns one group. Since these fields are declared `ConflictsWith`, this causes `terraform plan -generate-config-out` (Terraform 1.5+ import blocks) to emit conflicting HCL:

```
Error: Conflicting configuration arguments

  with datadog_monitor.hits_anomaly_fee-config_service,
  on generated-monitors.tf line 13:
  (source code not available)

"no_data_timeframe": conflicts with on_missing_data
```

### Root cause

Datadog's API migrated monitors from `notify_no_data`/`no_data_timeframe` to `on_missing_data` (see [on_missing_data migration guide](https://docs.datadoghq.com/monitors/guide/on_missing_data/)). When a monitor uses `on_missing_data`, the old fields are absent from the API response. However, the Read function still calls `d.Set()` for all three fields, and the schema `Default` values (`false` for `notify_no_data`, `10` for `no_data_timeframe`) leak into `InstanceState.Attributes` during import — triggering `ConflictsWith` validation.

### Changes

**Read (`updateMonitorState`):**
- Conditionally set only the attribute group the API actually returned
- If `on_missing_data` is non-empty → set only `on_missing_data`, skip `notify_no_data` and `no_data_timeframe`
- If `on_missing_data` is empty → set `notify_no_data` and `no_data_timeframe` as before

**Schema:**
- `notify_no_data`: changed from `Default: false` to `Computed: true`
- `no_data_timeframe`: changed from `Default: 10` to `Computed: true`
- This prevents phantom default values from leaking into `InstanceState` during import/generate-config

**Tests:**
- New unit test `TestUpdateMonitorState_OnMissingData_MutualExclusion`: sentinel-based verification that Read respects mutual exclusion across 3 scenarios
- New regression test `TestUpdateMonitorState_OnMissingData_SchemaDefaultsLeak`: verifies no `InstanceState` leakage when `on_missing_data` is set
- Updated `TestAccDatadogMonitor_Log`: use `TestCheckNoResourceAttr` for `on_missing_data` when not in use

### Note on cassettes

~30 existing acceptance tests will fail with `RECORD=false` because the VCR cassettes contain request bodies recorded with the old `Default` values. The schema change from `Default` to `Computed` alters what `CustomizeDiff` sends to `/api/v1/monitor/validate`. These aren't regressions — the tests just need cassettes re-recorded with `RECORD=true` using sandbox credentials to match the new (correct) behavior.


### Scope

This PR covers the **SDKv2 code path** only. The same bug exists in the Framework path (`datadog/fwprovider/resource_datadog_monitor.go`) and will be addressed in a separate PR.
