### PR TITLE
[datadog_synthetics_test] increase upper bound and set content encoding for base64 encoded file upload

### DIFF
--- a/datadog/resource_datadog_synthetics_file_upload_unit_test.go
+++ b/datadog/resource_datadog_synthetics_file_upload_unit_test.go
@@ -1,0 +1,131 @@
+package datadog
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	sdkschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildDatadogBodyFiles_EncodingAutoSet validates that buildDatadogBodyFiles
+// automatically sets encoding to "base64" when content is provided without an
+// explicit encoding. Without this, the worker sends base64 text to S3 instead
+// of the decoded binary.
+func TestBuildDatadogBodyFiles_EncodingAutoSet(t *testing.T) {
+	// Generate a small dummy binary payload and base64-encode it so the test
+	// doesn't require any real file fixture in the repo.
+	rawBytes := []byte("dummy binary content \x00\x01\x02\x03")
+	b64Content := base64.StdEncoding.EncodeToString(rawBytes)
+
+	tests := []struct {
+		name             string
+		encoding         string
+		expectedEncoding string
+	}{
+		{
+			name:             "no encoding set — should default to base64",
+			encoding:         "",
+			expectedEncoding: "base64",
+		},
+		{
+			name:             "explicit encoding preserved",
+			encoding:         "utf-8",
+			expectedEncoding: "utf-8",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attr := []interface{}{
+				map[string]interface{}{
+					"name":               "file.bin",
+					"original_file_name": "file.bin",
+					"type":               "application/octet-stream",
+					"size":               len(rawBytes),
+					"content":            b64Content,
+					"encoding":           tt.encoding,
+					"bucket_key":         "",
+				},
+			}
+
+			files := buildDatadogBodyFiles(attr)
+			require.Len(t, files, 1)
+			assert.Equal(t, tt.expectedEncoding, files[0].GetEncoding())
+		})
+	}
+}
+
+// TestBuildDatadogBodyFiles_NoContent validates that encoding is NOT set when no
+// content is provided (e.g., when the file was already uploaded and the bucket
+// key is being reused).
+func TestBuildDatadogBodyFiles_NoContent(t *testing.T) {
+	attr := []interface{}{
+		map[string]interface{}{
+			"name":               "file.bin",
+			"original_file_name": "file.bin",
+			"type":               "application/octet-stream",
+			"size":               42,
+			"content":            "",
+			"encoding":           "",
+			"bucket_key":         "some-bucket-key",
+		},
+	}
+
+	files := buildDatadogBodyFiles(attr)
+	require.Len(t, files, 1)
+	// Encoding must not be set — the HasEncoding helper returns false when unset.
+	assert.False(t, files[0].HasEncoding())
+}
+
+// TestSyntheticsRequestFileContentValidation verifies the content field's
+// ValidateFunc boundary: the upper bound is ceil(3,145,728 * 4/3) = 4,194,304
+// bytes — the maximum base64 string that decodes to ≤3 MB. The test generates
+// strings at the boundary in-memory; no real file fixtures are committed.
+func TestSyntheticsRequestFileContentValidation(t *testing.T) {
+	fileSchema := syntheticsTestRequestFile()
+	contentSchema := fileSchema.Elem.(*sdkschema.Resource).Schema["content"]
+	validateFunc := contentSchema.ValidateFunc
+
+	maxLen := 4194304
+
+	tests := []struct {
+		name      string
+		content   string
+		wantError bool
+	}{
+		{
+			name:      "empty string — below minimum",
+			content:   "",
+			wantError: true,
+		},
+		{
+			name:      "single byte — at minimum",
+			content:   "A",
+			wantError: false,
+		},
+		{
+			name:      "exactly at max length",
+			content:   strings.Repeat("A", maxLen),
+			wantError: false,
+		},
+		{
+			name:      "one byte over max length",
+			content:   strings.Repeat("A", maxLen+1),
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, errs := validateFunc(tt.content, "content")
+			if tt.wantError {
+				assert.NotEmpty(t, errs, "expected validation error but got none")
+			} else {
+				assert.Empty(t, errs, "expected no validation error but got: %v", errs)
+			}
+		})
+	}
+}

--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -1237,10 +1237,15 @@ func syntheticsTestRequestFile() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"content": {
-					Type:         schema.TypeString,
-					Description:  "Content of the file.",
-					Optional:     true,
-					ValidateFunc: validation.StringLenBetween(1, 3145728),
+					Type:        schema.TypeString,
+					Description: "Content of the file.",
+					Optional:    true,
+					// The backend enforces a 3 MB (3,145,728 byte) limit on the decoded file size.
+					// Content is always base64-encoded, which inflates the string length by ~33%
+					// (every 3 raw bytes become 4 base64 characters).
+					// The upper bound here is therefore ceil(3,145,728 * 4/3) = 4,194,304 bytes,
+					// giving the provider room for the largest base64 string that decodes to <=3 MB.
+					ValidateFunc: validation.StringLenBetween(1, 4194304),
 				},
 				"bucket_key": {
 					Type:        schema.TypeString,
@@ -4406,10 +4411,15 @@ func buildDatadogBodyFiles(attr []interface{}) []datadogV1.SyntheticsTestRequest
 
 		if content, ok := fileMap["content"]; ok && content != "" {
 			file.SetContent(content.(string))
-		}
-
-		if encoding, ok := fileMap["encoding"]; ok && encoding != "" {
-			file.SetEncoding(encoding.(string))
+			// When content is provided it is always base64-encoded (Terraform's
+			// local_file data source exposes content_base64 for binary files).
+			// Auto-set encoding so the backend and worker both know to decode it;
+			// without this the worker sends base64 text to S3 instead of binary.
+			encoding, _ := fileMap["encoding"].(string)
+			if encoding == "" {
+				encoding = "base64"
+			}
+			file.SetEncoding(encoding)
 		}
 
 		// We aren't sure yet how to let the provider check if the file content was updated to upload it again.


### PR DESCRIPTION
## Background
The previous limit `StringLenBetween(1, 3145728)` validated the length of the content string, but content is always `base64` encoded. `base64` inflates raw bytes by ~33% (every 3 bytes → 4 characters). i.e. a 2.31 MB APK becomes a 3.11 MB base64 string exceeding the 3 MB limit despite being within the advertised file size cap.

## What's in this PR
- increase content field size limit from 3 MB to 4 MB.  `4194304 = ceil(3,145,728 × 4/3)`
- set encoding to `base64` when content is provided

## JIRA
https://datadoghq.atlassian.net/browse/SYNTH-21651