### PR TITLE
[DRAFT] Terraform support for SaaS generic integration API

### DIFF
--- a/datadog/fwprovider/framework_provider.go
+++ b/datadog/fwprovider/framework_provider.go
@@ -52,6 +52,7 @@ var Resources = []func() resource.Resource{
 	NewIntegrationConfluentResourceResource,
 	NewIntegrationFastlyAccountResource,
 	NewIntegrationFastlyServiceResource,
+	NewWebIntegrationAccountResource,
 	NewIntegrationGcpResource,
 	NewIntegrationGcpStsResource,
 	NewCloudInventorySyncConfigResource,

--- a/datadog/fwprovider/resource_datadog_web_integration_account.go
+++ b/datadog/fwprovider/resource_datadog_web_integration_account.go
@@ -1,0 +1,323 @@
+package fwprovider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	frameworkPath "github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+)
+
+var (
+	_ resource.ResourceWithConfigure   = &webIntegrationAccountResource{}
+	_ resource.ResourceWithImportState = &webIntegrationAccountResource{}
+)
+
+// API request/response types for Web Integrations (matches spec/v2/web_integrations.yaml)
+type webIntegrationAccountCreateAttributes struct {
+	Name     string                 `json:"name"`
+	Settings map[string]interface{} `json:"settings"`
+	Secrets  map[string]interface{} `json:"secrets"`
+}
+
+type webIntegrationAccountUpdateAttributes struct {
+	Name     string                 `json:"name,omitempty"`
+	Settings map[string]interface{} `json:"settings,omitempty"`
+	Secrets  map[string]interface{} `json:"secrets,omitempty"`
+}
+
+type webIntegrationAccountCreateRequest struct {
+	Data struct {
+		Type       string                            `json:"type"`
+		Attributes webIntegrationAccountCreateAttributes `json:"attributes"`
+	} `json:"data"`
+}
+
+type webIntegrationAccountUpdateRequest struct {
+	Data struct {
+		Type       string                            `json:"type"`
+		Attributes webIntegrationAccountUpdateAttributes `json:"attributes"`
+	} `json:"data"`
+}
+
+type webIntegrationAccountAttributes struct {
+	Name     string                 `json:"name"`
+	Settings map[string]interface{} `json:"settings"`
+	// Secrets are never returned by the API (write-only)
+}
+
+type webIntegrationAccountResponse struct {
+	IntegrationName string `json:"integration_name"`
+	Data            struct {
+		ID         string                        `json:"id"`
+		Type       string                        `json:"type"`
+		Attributes webIntegrationAccountAttributes `json:"attributes"`
+	} `json:"data"`
+}
+
+type webIntegrationAccountResource struct {
+	Client *datadog.APIClient
+	Auth   context.Context
+}
+
+type webIntegrationAccountModel struct {
+	ID              types.String       `tfsdk:"id"`
+	IntegrationName types.String       `tfsdk:"integration_name"`
+	Name            types.String       `tfsdk:"name"`
+	SettingsJson    jsontypes.Normalized `tfsdk:"settings_json"`
+	SecretsJson     jsontypes.Normalized `tfsdk:"secrets_json"`
+}
+
+func NewWebIntegrationAccountResource() resource.Resource {
+	return &webIntegrationAccountResource{}
+}
+
+func (r *webIntegrationAccountResource) Configure(_ context.Context, request resource.ConfigureRequest, response *resource.ConfigureResponse) {
+	providerData := request.ProviderData.(*FrameworkProvider)
+	r.Client = providerData.DatadogApiInstances.HttpClient
+	r.Auth = providerData.Auth
+}
+
+func (r *webIntegrationAccountResource) Metadata(_ context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = "web_integration_account"
+}
+
+func (r *webIntegrationAccountResource) Schema(_ context.Context, _ resource.SchemaRequest, response *resource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Description: "Provides a Datadog Web Integration Account resource. This can be used to create and manage accounts for third-party web integrations (e.g., Twilio, Snowflake, Databricks). The account name must be unique within each integration.",
+		Attributes: map[string]schema.Attribute{
+			"id": utils.ResourceIDAttribute(),
+			"integration_name": schema.StringAttribute{
+				Required:    true,
+				Description: "The name of the integration (e.g., twilio, snowflake-web, databricks). Changing this forces recreation of the resource.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "A human-readable name for the account. Must be unique among accounts of the same integration. Used for display and drift detection.",
+			},
+			"settings_json": schema.StringAttribute{
+				Required:    true,
+				Description: "Integration-specific settings as JSON. Structure varies by integration; use GET /api/v2/web-integrations/{integration_name}/accounts/schema to retrieve the schema.",
+				CustomType:  jsontypes.NormalizedType{},
+			},
+			"secrets_json": schema.StringAttribute{
+				Required:    true,
+				Sensitive:   true,
+				Description: "Sensitive credentials as JSON. Structure varies by integration. Values are write-only and never returned; changes outside Terraform will not be drift-detected.",
+				CustomType:  jsontypes.NormalizedType{},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *webIntegrationAccountResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
+	parts := strings.SplitN(request.ID, ":", 2)
+	if len(parts) != 2 {
+		response.Diagnostics.AddError(
+			"Invalid import ID",
+			`Expected ID in format "integration_name:account_id". Example: terraform import datadog_web_integration_account.example "twilio:abc123def456"`,
+		)
+		return
+	}
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, frameworkPath.Root("integration_name"), parts[0])...)
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, frameworkPath.Root("id"), parts[1])...)
+}
+
+func (r *webIntegrationAccountResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	var state webIntegrationAccountModel
+	response.Diagnostics.Append(request.State.Get(ctx, &state)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	path := fmt.Sprintf("/api/v2/web-integrations/%s/accounts/%s",
+		state.IntegrationName.ValueString(),
+		state.ID.ValueString())
+
+	body, httpResp, err := utils.SendRequest(r.Auth, r.Client, "GET", path, nil)
+	if err != nil {
+		if httpResp != nil && httpResp.StatusCode == 404 {
+			response.State.RemoveResource(ctx)
+			return
+		}
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving Web Integration Account"))
+		if apiErr, ok := err.(utils.CustomRequestAPIError); ok && len(apiErr.Body()) > 0 {
+			response.Diagnostics.AddError("API response", string(apiErr.Body()))
+		}
+		return
+	}
+
+	var apiResp webIntegrationAccountResponse
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		response.Diagnostics.AddError("error parsing API response", err.Error())
+		return
+	}
+
+	state.ID = types.StringValue(apiResp.Data.ID)
+	state.IntegrationName = types.StringValue(apiResp.IntegrationName)
+	state.Name = types.StringValue(apiResp.Data.Attributes.Name)
+
+	settingsBytes, _ := json.Marshal(apiResp.Data.Attributes.Settings)
+	state.SettingsJson = jsontypes.NewNormalizedValue(string(settingsBytes))
+
+	// Secrets are never returned by the API; already in state, no need to overwrite
+
+	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
+}
+
+func (r *webIntegrationAccountResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	var plan webIntegrationAccountModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	var settings, secrets map[string]interface{}
+	if err := json.Unmarshal([]byte(plan.SettingsJson.ValueString()), &settings); err != nil {
+		response.Diagnostics.AddError("invalid settings_json", err.Error())
+		return
+	}
+	if err := json.Unmarshal([]byte(plan.SecretsJson.ValueString()), &secrets); err != nil {
+		response.Diagnostics.AddError("invalid secrets_json", err.Error())
+		return
+	}
+
+	reqBody := webIntegrationAccountCreateRequest{}
+	reqBody.Data.Type = "Account"
+	reqBody.Data.Attributes = webIntegrationAccountCreateAttributes{
+		Name:     plan.Name.ValueString(),
+		Settings: settings,
+		Secrets:  secrets,
+	}
+
+	path := fmt.Sprintf("/api/v2/web-integrations/%s/accounts", plan.IntegrationName.ValueString())
+	body, httpResp, err := utils.SendRequest(r.Auth, r.Client, "POST", path, reqBody)
+	if err != nil {
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating Web Integration Account"))
+		if apiErr, ok := err.(utils.CustomRequestAPIError); ok && len(apiErr.Body()) > 0 {
+			response.Diagnostics.AddError("API response", string(apiErr.Body()))
+		}
+		return
+	}
+
+	if httpResp.StatusCode != 201 {
+		response.Diagnostics.AddError("unexpected status", fmt.Sprintf("expected 201, got %d", httpResp.StatusCode))
+		return
+	}
+
+	var apiResp webIntegrationAccountResponse
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		response.Diagnostics.AddError("error parsing API response", err.Error())
+		return
+	}
+
+	plan.ID = types.StringValue(apiResp.Data.ID)
+	plan.IntegrationName = types.StringValue(apiResp.IntegrationName)
+	plan.Name = types.StringValue(apiResp.Data.Attributes.Name)
+	settingsBytes, _ := json.Marshal(apiResp.Data.Attributes.Settings)
+	plan.SettingsJson = jsontypes.NewNormalizedValue(string(settingsBytes))
+	// Secrets: keep from plan (never returned)
+
+	response.Diagnostics.Append(response.State.Set(ctx, &plan)...)
+}
+
+func (r *webIntegrationAccountResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+	var plan, priorState webIntegrationAccountModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...)
+	response.Diagnostics.Append(request.State.Get(ctx, &priorState)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	attrs := webIntegrationAccountUpdateAttributes{}
+	attrs.Name = plan.Name.ValueString()
+
+	var settings map[string]interface{}
+	if err := json.Unmarshal([]byte(plan.SettingsJson.ValueString()), &settings); err != nil {
+		response.Diagnostics.AddError("invalid settings_json", err.Error())
+		return
+	}
+	attrs.Settings = settings
+
+	// Preserve secrets from prior state if plan has UseStateForUnknown (e.g. no change)
+	secretsJson := plan.SecretsJson.ValueString()
+	if secretsJson == "" || plan.SecretsJson.IsNull() {
+		secretsJson = priorState.SecretsJson.ValueString()
+	}
+	var secrets map[string]interface{}
+	if err := json.Unmarshal([]byte(secretsJson), &secrets); err != nil {
+		response.Diagnostics.AddError("invalid secrets_json", err.Error())
+		return
+	}
+	attrs.Secrets = secrets
+
+	reqBody := webIntegrationAccountUpdateRequest{}
+	reqBody.Data.Type = "Account"
+	reqBody.Data.Attributes = attrs
+
+	path := fmt.Sprintf("/api/v2/web-integrations/%s/accounts/%s",
+		plan.IntegrationName.ValueString(),
+		plan.ID.ValueString())
+
+	body, _, err := utils.SendRequest(r.Auth, r.Client, "PATCH", path, reqBody)
+	if err != nil {
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating Web Integration Account"))
+		if apiErr, ok := err.(utils.CustomRequestAPIError); ok && len(apiErr.Body()) > 0 {
+			response.Diagnostics.AddError("API response", string(apiErr.Body()))
+		}
+		return
+	}
+
+	var apiResp webIntegrationAccountResponse
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		response.Diagnostics.AddError("error parsing API response", err.Error())
+		return
+	}
+
+	plan.Name = types.StringValue(apiResp.Data.Attributes.Name)
+	settingsBytes, _ := json.Marshal(apiResp.Data.Attributes.Settings)
+	plan.SettingsJson = jsontypes.NewNormalizedValue(string(settingsBytes))
+	plan.SecretsJson = priorState.SecretsJson // preserve; never returned
+
+	response.Diagnostics.Append(response.State.Set(ctx, &plan)...)
+}
+
+func (r *webIntegrationAccountResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+	var state webIntegrationAccountModel
+	response.Diagnostics.Append(request.State.Get(ctx, &state)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	path := fmt.Sprintf("/api/v2/web-integrations/%s/accounts/%s",
+		state.IntegrationName.ValueString(),
+		state.ID.ValueString())
+
+	_, httpResp, err := utils.SendRequest(r.Auth, r.Client, "DELETE", path, nil)
+	if err != nil {
+		if httpResp != nil && httpResp.StatusCode == 404 {
+			return // already deleted
+		}
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error deleting Web Integration Account"))
+		if apiErr, ok := err.(utils.CustomRequestAPIError); ok && len(apiErr.Body()) > 0 {
+			response.Diagnostics.AddError("API response", string(apiErr.Body()))
+		}
+		return
+	}
+}

--- a/examples/resources/datadog_web_integration_account/import.sh
+++ b/examples/resources/datadog_web_integration_account/import.sh
@@ -1,0 +1,14 @@
+# Import using the composite ID format: integration_name:account_id
+# The account_id is the UUID returned when creating the resource (e.g., from terraform state or API)
+
+# Twilio
+terraform import datadog_web_integration_account.twilio "twilio:abc123def456"
+
+# Snowflake
+terraform import datadog_web_integration_account.snowflake "snowflake-web:abc123def456"
+
+# Databricks (OAuth)
+terraform import datadog_web_integration_account.databricks "databricks:abc123def456"
+
+# Databricks (legacy PAT)
+terraform import datadog_web_integration_account.databricks_legacy "databricks:def456abc123"

--- a/examples/resources/datadog_web_integration_account/resource.tf
+++ b/examples/resources/datadog_web_integration_account/resource.tf
@@ -1,0 +1,159 @@
+# Web Integration Account examples for Twilio, Snowflake, and Databricks
+#
+# The settings_json and secrets_json structure varies by integration.
+# Use GET /api/v2/web-integrations/{integration_name}/accounts/schema
+# to retrieve the schema for your integration.
+#
+# Schema reference: dd-source/domains/web-integrations/shared/libs/go/schemas/schemas/
+
+# --- Twilio ---
+resource "datadog_web_integration_account" "twilio" {
+  integration_name = "twilio"
+  name             = "My Twilio Production Account"
+
+  settings_json = jsonencode({
+    api_key       = "SKxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    account_sid   = "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    events        = true
+    messages      = true
+    alerts        = true
+    call_summaries = true
+    ccm_enabled   = true
+    censor_logs   = true
+  })
+
+  secrets_json = jsonencode({
+    api_key_token = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  })
+}
+
+# --- Snowflake (snowflake-web) ---
+resource "datadog_web_integration_account" "snowflake" {
+  integration_name = "snowflake-web"
+  name             = "My Snowflake Account"
+
+  settings_json = jsonencode({
+    username                     = "DATADOG_MONITOR_USER"
+    snowflake_account_identifier = "myorg-account123.us-east-1.aws"
+    private_key_name             = "datadog_rsa_key"
+    query_tags                   = "env,team,cost_center"
+    do_table_crawler_cron        = "0 * * * *"
+
+    # Logs and traces
+    query_history_logs_enabled                = true
+    task_history_logs_enabled                 = true
+    task_history_traces_enabled                = true
+    join_query_history_with_access_history_enabled = true
+    event_table_logs_enabled                   = true
+    event_table_events_enabled                 = true
+    login_history_logs_enabled                 = true
+    sessions_logs_enabled                      = true
+
+    # Metrics
+    account_usage_metrics_enabled              = true
+    organization_usage_metrics_enabled         = true
+    event_table_metrics_enabled                = false
+    account_usage_metrics_aggregate_last_24h    = false
+    organization_usage_metrics_aggregate_last_24h = false
+
+    # Data Observability and CCM
+    datasets_enabled             = true
+    ccm_enabled                  = true
+    ccm_only_monitor_account     = true
+    ccm_has_orgadmin             = true
+    ccm_credit_dollar_override   = 2.6
+    ccm_terrabyte_month_override = 23.0
+    ccm_query_tags               = ["env", "team"]
+
+    # Other features
+    grants_to_users_enabled      = true
+    data_transfer_history_enabled = true
+    stages_enabled              = true
+    snowpark_traces              = false
+    product_analytics_enabled   = false
+    data_observability_enabled  = true
+
+    # Collection intervals (minutes)
+    security_logs_interval_min        = 5
+    query_history_logs_interval_min   = 15
+    task_history_logs_interval_min    = 15
+    task_history_traces_interval_min  = 15
+    event_table_logs_interval_min     = 15
+  })
+
+  secrets_json = jsonencode({
+    private_key = "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBg...\n-----END PRIVATE KEY-----"
+  })
+}
+
+# --- Databricks (OAuth, preferred) ---
+resource "datadog_web_integration_account" "databricks" {
+  integration_name = "databricks"
+  name             = "my-databricks-workspace"
+
+  settings_json = jsonencode({
+    workspace_url = "https://my-workspace.cloud.databricks.com"
+
+    # OAuth authentication (preferred over token)
+    client_id             = "my-client-id"
+    databricks_account_id = "my-databricks-account-id"
+
+    # Datadog API key pair (for lineage/DO event ingestion)
+    dd_api_key_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+    # System tables (required for Cloud Cost Management)
+    system_tables_sql_warehouse_id = "my-warehouse-id"
+    model_serving_endpoint_name   = "my-model-endpoint"
+
+    # Product toggles
+    djm_enabled                    = true
+    djm_global_init_script_enabled = false
+    ccm_enabled                    = true
+    do_enabled                     = true
+    do_crawlers_cron               = "0 * * * *"
+    model_serving_metrics_enabled  = true
+    script_logs_enabled            = true
+    script_gpum_enabled            = false
+    table_lineage_enabled          = true
+    serverless_jobs_enabled        = true
+
+    # Private Action Runner (for executing actions in Databricks)
+    private_action_runner_configuration = {
+      connection_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      user_uuid     = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      secret_path   = "path/to/databricks/credentials"
+    }
+  })
+
+  secrets_json = jsonencode({
+    client_secret     = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    dd_api_key_secret = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  })
+}
+
+# --- Databricks (legacy: Personal Access Token) ---
+resource "datadog_web_integration_account" "databricks_legacy" {
+  integration_name = "databricks"
+  name             = "my-legacy-workspace"
+
+  settings_json = jsonencode({
+    workspace_url                  = "https://legacy-workspace.cloud.databricks.com"
+    dd_api_key_id                  = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+    system_tables_sql_warehouse_id = "my-warehouse-id"
+    djm_enabled                    = true
+    djm_global_init_script_enabled = false
+    ccm_enabled                    = true
+    do_enabled                     = false
+    do_crawlers_cron               = "0 * * * *"
+    model_serving_metrics_enabled  = false
+    script_logs_enabled            = false
+    script_gpum_enabled            = false
+    table_lineage_enabled          = false
+    serverless_jobs_enabled        = true
+  })
+
+  secrets_json = jsonencode({
+    token           = "dapixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    dd_api_key_secret = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  })
+}


### PR DESCRIPTION
### Summary

This PR adds Terraform support for the Datadog Web Integrations API, allowing users to manage third-party integration accounts (Twilio, Snowflake, Databricks, etc.) as Terraform resources.

### What's being introduced

#### New resource: `datadog_web_integration_account`

A Terraform resource that maps to the Web Integrations API (`/api/v2/web-integrations/{integration_name}/accounts`).

**Schema attributes:**

| Attribute         | Type   | Required | Description |
|------------------|--------|----------|-------------|
| `id`             | string | computed | Account UUID from the API |
| `integration_name` | string | yes | Integration type (e.g. `twilio`, `snowflake-web`, `databricks`). Changing this forces replacement |
| `name`           | string | yes | Display name for the account. Must be unique per integration |
| `settings_json`  | string | yes | Integration-specific settings as JSON |
| `secrets_json`   | string | yes (sensitive) | Integration-specific credentials as JSON |

**Implementation details:**

- Uses `utils.SendRequest` with the provider HTTP client (no generated Web Integrations client yet)
- `integration_name` has `RequiresReplace()` (it is part of the API path)
- `secrets_json` has `UseStateForUnknown()` and is preserved from prior state on update (API never returns secrets)
- `settings_json` and `secrets_json` use `jsontypes.NormalizedType{}` for JSON handling
- 404 handling: Read removes the resource from state; Delete treats 404 as success

**Files changed/added:**

- `datadog/fwprovider/resource_datadog_web_integration_account.go` – resource implementation
- `datadog/fwprovider/framework_provider.go` – resource registration
- `examples/resources/datadog_web_integration_account/resource.tf` – Twilio, Snowflake, Databricks examples
- `examples/resources/datadog_web_integration_account/import.sh` – import examples

---

### Expected behavior

#### Create

- Sends `name`, `settings`, and `secrets` to `POST /api/v2/web-integrations/{integration_name}/accounts`
- Stores the returned account `id` in state
- Fails with clear errors if `settings_json` or `secrets_json` are invalid or do not match the integration schema

#### Read

- Calls `GET /api/v2/web-integrations/{integration_name}/accounts/{account_id}`
- Updates state with `id`, `integration_name`, `name`, and `settings_json` from the response
- Keeps `secrets_json` from state (API does not return secrets)
- If the account is 404, removes the resource from state

#### Update

- Calls `PATCH /api/v2/web-integrations/{integration_name}/accounts/{account_id}` with `name`, `settings`, and `secrets`
- Uses prior state for `secrets_json` when the plan does not change it (e.g. `UseStateForUnknown`)
- Updates state with the response; `secrets_json` remains from prior state

#### Delete

- Calls `DELETE /api/v2/web-integrations/{integration_name}/accounts/{account_id}`
- Treats 404 as success (idempotent delete)

#### Import

- Import ID format: `integration_name:account_id` (e.g. `twilio:abc123def456`)
- Example: `terraform import datadog_web_integration_account.example "twilio:abc123def456"`

---

### Supported integrations

- **twilio** – Twilio logs and metrics
- **snowflake-web** – Snowflake logs, metrics, and cost data
- **databricks** – Databricks jobs, clusters, and cost data

Each integration has its own schema for `settings` and `secrets`. Users can fetch the schema with:

`GET /api/v2/web-integrations/{integration_name}/accounts/schema`

---

### Notes for users

1. **Account name uniqueness** – `name` must be unique per integration; the API enforces this.
2. **Secrets are write-only** – Secrets are never returned by the API; Terraform cannot detect drift on them.
3. **JSON validation** – `settings_json` and `secrets_json` must be valid JSON and match the integration schema; schema violations surface as API errors (e.g. 422).
4. **Schema discovery** – Use the schema endpoint or the examples for Twilio, Snowflake, and Databricks as a reference.

---

### Testing

- [ ] Manual create/read/update/delete for at least one integration
- [ ] Import of an existing account
- [ ] Plan with `integration_name` change shows replacement
- [ ] Update without changing `secrets_json` does not clear secrets