### PR TITLE
[datadog_team_permission_setting] Fix panic in Read after import

### DIFF
--- a/datadog/fwprovider/resource_datadog_team_permission_setting.go
+++ b/datadog/fwprovider/resource_datadog_team_permission_setting.go
@@ -113,14 +113,20 @@ func (r *teamPermissionSettingResource) Read(ctx context.Context, request resour
 
 	found := false
 	for _, permission := range permissions.Data {
-		if permission.Id == state.ID.ValueString() {
+		if permission.Id == state.ID.ValueString() ||
+			(state.ID.ValueString() == "" && string(permission.Attributes.GetAction()) == state.Action.ValueString()) {
 			r.updateState(ctx, &state, &permission)
 			found = true
+			break
 		}
 	}
 
 	if !found {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, fmt.Sprintf("error getting team permission setting with id %s", state.ID.ValueString())))
+		response.Diagnostics.AddError(
+			fmt.Sprintf("error getting team permission setting with id %s", state.ID.ValueString()),
+			"team permission setting not found",
+		)
+		return
 	}
 
 	// Save data into Terraform state


### PR DESCRIPTION
### Description

Fixes #3629 — a panic (nil pointer dereference / SIGSEGV) in `teamPermissionSettingResource.Read()` that occurs after every `ImportState` call. This is a regression introduced in #3490 (v3.90.0) and still present in v3.91.0+.

### How the panic occurs — step by step

**Step 1:** `ImportState` correctly sets `team_id` and `action`, but NOT `id`:
```go
// ImportState parses "team_id:action" and sets both
response.State.SetAttribute(ctx, path.Root("team_id"), result[0])
response.State.SetAttribute(ctx, path.Root("action"), result[1])
// id is NOT set — it remains "" (empty string)
```
This is correct — the internal resource ID (e.g., `TeamPermission-{team_id}-{action}`) is not known at import time.

**Step 2:** Terraform automatically calls `Read` to populate the full state. The API call at line 104 **succeeds** (returns all permission settings for the team), so `err` is `nil`. The loop at line 116 tries to find the matching permission:
```go
for _, permission := range permissions.Data {
    if permission.Id == state.ID.ValueString() {  // compares against "" — never matches
```
`state.ID.ValueString()` is `""` after import. The API returns IDs like `TeamPermission-{team_id}-edit`. Empty string never matches → `found` stays `false`.

**Step 3:** The not-found path passes `nil` err to `FrameworkErrorDiag`:
```go
if !found {
    response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error getting..."))
}
```
`err` is `nil` (the API call succeeded). `FrameworkErrorDiag` at `utils.go:137` performs:
```go
switch v := err.(type) {
    ...
    default:
        summary = v.Error()  // nil pointer dereference → SIGSEGV
```

**Stack trace:**
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x18e7b8e]

goroutine 688 [running]:
github.com/.../datadog/internal/utils.FrameworkErrorDiag({0x0?, 0x0?}, ...)
    utils.go:140 +0x32e
github.com/.../datadog/fwprovider.(*teamPermissionSettingResource).Read(...)
    resource_datadog_team_permission_setting.go:123 +0x465
```

### What was missed in #3490 and why

During development of #3490, this risk was identified:

> *Note: May need to modify Read to also match by `action` field during import (since `ID` won't be set until after first read).*

This was noted but not implemented. The `ImportState` method was modeled after `team_membership`, which handles import correctly. However, the key difference was missed — `team_membership`'s `Read` at line 136 **already has a dual-match fallback**:
```go
// team_membership Read — correctly handles import with dual match
if userTeam.GetId() == state.ID.ValueString() ||
    state.UserId.ValueString() == userTeam.Relationships.User.Data.GetId() {
```

`team_permission_setting`'s `Read` only matches by `ID` — the equivalent fallback for `action` was never added.

Additionally, the import test cassette (`TestAccTeamPermissionSettingImport.yaml`) was created but left empty (`interactions: []`), so the import code path was never actually exercised in CI before the PR was merged.

### The fix — two targeted changes in `Read`

**Bug 1: Matching logic (line 116)** — Add fallback to match by `action` when `id` is empty (the import case), mirroring `team_membership`:
```go
// Before (only matches by ID — fails after import when ID is "")
if permission.Id == state.ID.ValueString() {

// After (also matches by action for import reads)
if permission.Id == state.ID.ValueString() ||
    (state.ID.ValueString() == "" && string(permission.Attributes.GetAction()) == state.Action.ValueString()) {
```

**Bug 2: Nil error handling (line 123)** — `FrameworkErrorDiag` performs `switch v := err.(type)` which panics on nil input. `err` is nil by design here (the API call succeeded; the "not found" is a logic condition, not an API error). Replace with `AddError()` for nil-safe error reporting:
```go
// Before (passes nil err → panic)
response.Diagnostics.Append(utils.FrameworkErrorDiag(err, ...))

// After (safe error reporting)
response.Diagnostics.AddError(
    fmt.Sprintf("error getting team permission setting with id %s", state.ID.ValueString()),
    "team permission setting not found",
)
return
```

Also adds `break` after finding a match (minor optimization — no need to continue iterating).

### Evidence

- CI failures with full stack traces: both v3.90.0 and v3.91.0 crash identically at `resource_datadog_team_permission_setting.go:123`
- Tested locally with `dev_overrides`: multiple team permission setting imports complete successfully with this fix (0 panics, plan completes as expected)

### Changes

Single file: `datadog/fwprovider/resource_datadog_team_permission_setting.go` (+8/-2)

### Related

- Bug issue: #3629
- Original import support PR that introduced the regression: #3490
- Original issue (closed): #3488