### PR TITLE
Add 'no-op' option to severity validator

### DIFF
--- a/datadog/fwprovider/resource_datadog_security_monitoring_critical_asset.go
+++ b/datadog/fwprovider/resource_datadog_security_monitoring_critical_asset.go
@@ -72,7 +72,7 @@ func (r *securityMonitoringCriticalAssetResource) Schema(_ context.Context, _ re
 				Required:    true,
 				Description: "The severity change applied to signals matching this critical asset.",
 				Validators: []validator.String{
-					stringvalidator.OneOf("critical", "high", "medium", "low", "info", "increase", "decrease"),
+					stringvalidator.OneOf("critical", "high", "medium", "low", "info", "increase", "decrease", "no-op"),
 				},
 			},
 			"tags": schema.ListAttribute{


### PR DESCRIPTION
Follow up from https://github.com/DataDog/logs-backend/pull/124526 