### PR TITLE
[datadog_security_monitoring_critical_asset] Add no-op to valid severities for critical assets

### DIFF
--- a/datadog/fwprovider/resource_datadog_security_monitoring_critical_asset.go
+++ b/datadog/fwprovider/resource_datadog_security_monitoring_critical_asset.go
@@ -72,7 +72,7 @@ func (r *securityMonitoringCriticalAssetResource) Schema(_ context.Context, _ re
 				Required:    true,
 				Description: "The severity change applied to signals matching this critical asset.",
 				Validators: []validator.String{
-					stringvalidator.OneOf("critical", "high", "medium", "low", "info", "increase", "decrease"),
+					stringvalidator.OneOf("critical", "high", "medium", "low", "info", "no-op", "increase", "decrease"),
 				},
 			},
 			"tags": schema.ListAttribute{

--- a/docs/resources/security_monitoring_critical_asset.md
+++ b/docs/resources/security_monitoring_critical_asset.md
@@ -29,7 +29,7 @@ resource "datadog_security_monitoring_critical_asset" "my_critical_asset" {
 
 - `query` (String) The query used to match a critical asset and the associated signals. Uses the same syntax as the search bar in the Security Signals Explorer.
 - `rule_query` (String) The rule query to filter which detection rules this critical asset applies to. Uses the same syntax as the search bar for detection rules.
-- `severity` (String) The severity change applied to signals matching this critical asset. Valid values are `critical`, `high`, `medium`, `low`, `info`, `increase`, `decrease`.
+- `severity` (String) The severity change applied to signals matching this critical asset. Valid values are `critical`, `high`, `medium`, `low`, `info`, `no-op`, `increase`, `decrease`.
 
 ### Optional
 


### PR DESCRIPTION
[SEC-29485](https://datadoghq.atlassian.net/browse/SEC-29485)
Add no-op severity as a supported severity for critical assets api


[SEC-29485]: https://datadoghq.atlassian.net/browse/SEC-29485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ