### PR TITLE
[datadog_role] Deprecate and stop setting user_count to fix unstoppable drift

### DIFF
--- a/datadog/resource_datadog_role.go
+++ b/datadog/resource_datadog_role.go
@@ -56,6 +56,7 @@ func resourceDatadogRole() *schema.Resource {
 					Type:        schema.TypeInt,
 					Computed:    true,
 					Description: "Number of users that have this role.",
+					Deprecated:  "This field is no longer set and will be removed in a future release.",
 				},
 				"validate": {
 					Description: "If set to `false`, skip the validation call done during plan.",
@@ -201,9 +202,6 @@ func updateRoleState(ctx context.Context, d *schema.ResourceData, roleAttrsI int
 	if roleAttrsI != nil {
 		switch roleAttrs := roleAttrsI.(type) {
 		case *datadogV2.RoleAttributes:
-			if err := d.Set("user_count", roleAttrs.GetUserCount()); err != nil {
-				return diag.FromErr(err)
-			}
 			if err := d.Set("name", roleAttrs.GetName()); err != nil {
 				return diag.FromErr(err)
 			}

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -44,7 +44,7 @@ resource "datadog_role" "api_key_manager" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `user_count` (Number) Number of users that have this role.
+- `user_count` (Number, Deprecated) Number of users that have this role. **Deprecated.** This field is no longer set and will be removed in a future release.
 
 <a id="nestedblock--permission"></a>
 ### Nested Schema for `permission`


### PR DESCRIPTION
## Summary
- Deprecate the `user_count` attribute on `datadog_role` resource and stop refreshing it from the API
- If anyone needs to rely on the user count, it can be done using the `datadog_role` [datasource](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/data-sources/role) instead.

## Motivation
- The read-only `user_count` field was updated on every Read, causing perpetual state drift when users were dynamically added to a role (e.g. via SCIM group mappings)
- Since the attribute is Computed-only, `lifecycle { ignore_changes }` cannot suppress the diff
- Fixes #3468

## Test plan
- [x] `make fmtcheck` passes
- [x] `make test` passes (1012 tests, 0 failures)
- [x] Acceptance tests: `RECORD=false TESTARGS="-run TestAccDatadogRole" make testacc` (9 tests, 0 failures)

