### PR TITLE
Update CODEOWNERS: split k9-cloud-security-platform ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,8 @@ datadog/*datadog_metric_metadata*          @DataDog/metrics-experience
 datadog/*datadog_metric_tag_configuration* @DataDog/metrics-experience
 datadog/*datadog_monitor*                  @DataDog/monitor-app
 datadog/*datadog_screenboard*              @DataDog/dashboards-backend
-datadog/*datadog_security*                 @DataDog/k9-cloud-security-platform
+datadog/*datadog_security_monitoring*       @DataDog/k9-cloud-siem
+datadog/*datadog_security_notification_rule* @DataDog/k9-shared-capabilities
 datadog/*datadog_service_definition*       @DataDog/service-catalog
 datadog/*datadog_service_level_objective*  @DataDog/slo-app
 datadog/*datadog_synthetics*               @DataDog/synthetics-managing
@@ -51,8 +52,7 @@ datadog/**/*datadog_metric*                      @DataDog/metrics-intake @DataDo
 datadog/**/*datadog_monitor*                     @DataDog/monitor-app
 datadog/**/*datadog_appsec*                      @DataDog/asm-backend
 datadog/**/*datadog_azure_integration*           @DataDog/azure-integrations
-datadog/**/*datadog_cloud_inventory*             @DataDog/k9-cloud-security-platform
-datadog/**/*datadog_compliance*                  @DataDog/k9-cloud-security-platform
+datadog/**/*datadog_compliance*                  @DataDog/k9-misconfigs
 datadog/**/*datadog_dataset*                     @DataDog/aaa-granular-access
 datadog/**/*datadog_datastore*                   @DataDog/action-platform @DataDog/workflow-automation-backend
 datadog/**/*datadog_incident*                    @DataDog/incident-app
@@ -93,7 +93,8 @@ datadog/**/*datadog_workflow_automation*         @DataDog/workflow-automation-ba
 datadog/**/*datadog_powerpack*                   @DataDog/dashboards-backend
 datadog/**/*datadog_role_users*                  @DataDog/team-aaa
 datadog/**/*datadog_rum*                         @DataDog/rum-backend
-datadog/**/*datadog_security*                    @DataDog/k9-cloud-security-platform
+datadog/**/*datadog_security_monitoring*          @DataDog/k9-cloud-siem
+datadog/**/*datadog_security_notification_rule*   @DataDog/k9-shared-capabilities
 datadog/**/*datadog_csm_threats*                 @DataDog/k9-cws-backend
 datadog/**/*datadog_cloud_workload_security*     @DataDog/k9-cws-backend
 datadog/**/*datadog_app_builder_app*             @DataDog/app-builder-backend


### PR DESCRIPTION
## Summary
- `datadog_security_monitoring*` ownership changed from `@DataDog/k9-cloud-security-platform` to `@DataDog/k9-cloud-siem`
- `datadog_security_notification_rule*` ownership changed from `@DataDog/k9-cloud-security-platform` to `@DataDog/k9-shared-capabilities`
- `datadog_compliance*` ownership changed from `@DataDog/k9-cloud-security-platform` to `@DataDog/k9-misconfigs`
- `datadog_cloud_inventory*` ownership entry removed (it was wrongly attributed)
- Applied to both SDKv2 (`datadog/*`) and Plugin Framework (`datadog/**/*`) patterns


