### PR TITLE
[datadog_reference_table] Fix null vs empty string inconsistency for description on import

### DIFF
--- a/datadog/tests/resource_datadog_reference_table_test.go
+++ b/datadog/tests/resource_datadog_reference_table_test.go
@@ -163,7 +163,6 @@ func TestAccReferenceTable_Import(t *testing.T) {
 	})
 }
 
-
 func testAccCheckDatadogReferenceTableS3(uniq string) string {
 	// Sanitize: replace dashes with underscores and convert to lowercase
 	sanitized := strings.ToLower(strings.ReplaceAll(uniq, "-", "_"))
@@ -207,7 +206,6 @@ resource "datadog_reference_table" "s3_table" {
   tags = ["test:terraform", "env:test"]
 }`, sanitized)
 }
-
 
 func testAccCheckDatadogReferenceTableSchemaInitial(uniq string) string {
 	// Sanitize: replace dashes with underscores and convert to lowercase


### PR DESCRIPTION
## Summary

- Fixes a bug introduced in v3.88.0 where \`terraform apply\` fails with **"Provider produced inconsistent result after apply"** when importing a \`datadog_reference_table\` resource that has no description set.
- Root cause: the Datadog API returns \`""\` (empty string) for a missing description, but the \`description\` attribute is \`Optional\`-only (not \`Computed\`), so Terraform expects \`null\` in state when the user hasn't set it in their config. The provider was unconditionally setting \`state.Description = types.StringValue("")\`, causing a \`null\` → \`""\` flip that Terraform rejects.
- Fix: treat an empty-string description from the API as \`null\`, since they are semantically identical (no description set).

## Test plan

All tests run manually with a locally built provider against staging (dd.datad0g.com):

- [x] **Import table with no description, no \`description\` in config** — ran \`terraform import\` then \`terraform plan\`: **"No changes."** ✅
- [x] **Import table with a real description** — ran \`terraform import\` then \`terraform plan\`: **"No changes."** ✅  Description read back from API matches the value set in config exactly.
- [x] **Import table with \`description = ""\` in config** — ran \`terraform import\` then \`terraform plan\`: \`description\` shows **no drift** ✅  (Some computed fields like \`row_count\`/\`status\` show \`(known after apply)\` which is normal post-import behavior, unrelated to this fix.)

## Labels

changelog/bugfix