### PR TITLE
Migrate credentials-management to credential-management GitHub team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,9 +63,9 @@ datadog/**/*datadog_reference_table*             @DataDog/redapl-experiences
 datadog/**/*datadog_action_connection*           @DataDog/action-platform
 datadog/**/*datadog_agentless*                   @DataDog/k9-agentless
 datadog/**/*datadog_app_key_registration*        @DataDog/action-platform @DataDog/workflow-automation-backend
-datadog/**/*datadog_api_key*                     @DataDog/credentials-management
+datadog/**/*datadog_api_key*                     @DataDog/credential-management
 datadog/**/*datadog_apm_retention_filter*        @DataDog/apm-trace-intake
-datadog/**/*datadog_application_key*             @DataDog/credentials-management
+datadog/**/*datadog_application_key*             @DataDog/credential-management
 datadog/**/*datadog_hosts*                       @DataDog/redapl-storage @DataDog/redapl-ingest
 datadog/**/*datadog_integration_aws*             @DataDog/aws-integrations
 datadog/**/*datadog_integration_azure*           @DataDog/azure-integrations


### PR DESCRIPTION
## Summary

- Renames all `@DataDog/credentials-management` references to `@DataDog/credential-management`, aligning with the standardized team naming convention.
- Part of a cross-repo migration (companion PRs in dd-source, dd-go, dogweb, datadog-api-spec, and other repos).

## Test plan

- [ ] Verify the `credential-management` GitHub team exists in the DataDog org with the same members
- [ ] Confirm CODEOWNERS validation passes in CI

Made with [Cursor](https://cursor.com)