### PR TITLE
[datadog_reference_table] Fix null vs empty string inconsistency for description on import

### DIFF
--- a/datadog/fwprovider/resource_datadog_reference_table.go
+++ b/datadog/fwprovider/resource_datadog_reference_table.go
@@ -563,7 +563,11 @@ func (r *referenceTableResource) updateState(ctx context.Context, state *referen
 	}
 
 	if description, ok := attributes.GetDescriptionOk(); ok {
-		state.Description = types.StringValue(*description)
+		if *description != "" {
+			state.Description = types.StringValue(*description)
+		} else {
+			state.Description = types.StringNull()
+		}
 	}
 
 	if lastUpdatedBy, ok := attributes.GetLastUpdatedByOk(); ok {


### PR DESCRIPTION
## Summary

- Fixes a bug introduced in v3.88.0 where `terraform apply` fails with **"Provider produced inconsistent result after apply"** when importing a `datadog_reference_table` resource that has no description set.
- Root cause: the Datadog API returns `""` (empty string) for a missing description, but the `description` attribute is `Optional`-only (not `Computed`), so Terraform expects `null` in state when the user hasn't set it in their config. The provider was unconditionally setting `state.Description = types.StringValue("")`, causing a `null` → `""` flip that Terraform rejects.
- Fix: treat an empty-string description from the API as `null`, since they are semantically identical (no description set).

## Test plan

All tests run manually with a locally built provider against staging (dd.datad0g.com):

- [x] **Import table with no description, no `description` in config** — ran `terraform import` then `terraform plan`: **"No changes."** ✅
- [x] **Import table with a real description** — ran `terraform import` then `terraform plan`: **"No changes."** ✅  Description read back from API matches the value set in config exactly.
- [x] **Import table with `description = ""` in config** — ran `terraform import` then `terraform plan`: `description` shows **no drift** ✅  (Some computed fields like `row_count`/`status` show `(known after apply)` which is normal post-import behavior, unrelated to this fix.)

## Labels

changelog/bugfix

Made with [Cursor](https://cursor.com)