### PR TITLE
[TEST] Update DashboardListDeleteItemsRequest to DashboardListRemoveItemsRequest

### DIFF
--- a/datadog/fwprovider/resource_datadog_dashboard_list.go
+++ b/datadog/fwprovider/resource_datadog_dashboard_list.go
@@ -277,7 +277,7 @@ func buildDatadogDashboardListUpdateItemsV2(state *dashboardListResourceModel) (
 	return dashboardListV2Items, nil
 }
 
-func buildDatadogDashboardListDeleteItemsV2(dashboardListItems *datadogV2.DashboardListItems) (*datadogV2.DashboardListDeleteItemsRequest, error) {
+func buildDatadogDashboardListDeleteItemsV2(dashboardListItems *datadogV2.DashboardListItems) (*datadogV2.DashboardListRemoveItemsRequest, error) {
 	dashboardListV2ItemsArr := make([]datadogV2.DashboardListItemRequest, 0)
 	for _, dashItem := range dashboardListItems.GetDashboards() {
 		dashType := dashItem.GetType()
@@ -285,7 +285,7 @@ func buildDatadogDashboardListDeleteItemsV2(dashboardListItems *datadogV2.Dashbo
 		dashItem := datadogV2.NewDashboardListItemRequest(dashID, dashType)
 		dashboardListV2ItemsArr = append(dashboardListV2ItemsArr, *dashItem)
 	}
-	dashboardListV2Items := datadogV2.NewDashboardListDeleteItemsRequest()
+	dashboardListV2Items := datadogV2.NewDashboardListRemoveItemsRequest()
 	dashboardListV2Items.SetDashboards(dashboardListV2ItemsArr)
 	return dashboardListV2Items, nil
 }

--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -268,7 +268,7 @@ func updateDashboardLists(d *schema.ResourceData, providerConf *ProviderConfigur
 	}
 
 	if v, ok := d.GetOk("dashboard_lists_removed"); ok && v.(*schema.Set).Len() > 0 {
-		items := datadogV2.NewDashboardListDeleteItemsRequest()
+		items := datadogV2.NewDashboardListRemoveItemsRequest()
 		items.SetDashboards(itemsRequest)
 
 		for _, id := range v.(*schema.Set).List() {


### PR DESCRIPTION
### What does this PR do?

Adapts the terraform provider to the breaking rename `DashboardListDeleteItemsRequest` → `DashboardListRemoveItemsRequest` introduced in [datadog-api-spec#5370](https://github.com/DataDog/datadog-api-spec/pull/5370) and generated into [datadog-api-client-go#3903](https://github.com/DataDog/datadog-api-client-go/pull/3903).

This is a **test-only change** to validate the `build-terraform-provider` CI step (from [datadog-api-client-go#3894](https://github.com/DataDog/datadog-api-client-go/pull/3894)). It will not be merged.

### Changes

- `datadog/resource_datadog_dashboard.go`: `NewDashboardListDeleteItemsRequest()` → `NewDashboardListRemoveItemsRequest()`
- `datadog/fwprovider/resource_datadog_dashboard_list.go`: Updated return type and constructor call