### PR TITLE
[datadog_action_connection] Fix edge case where reads lose SECRET tokens

### DIFF
--- a/datadog/fwprovider/resource_datadog_action_connection.go
+++ b/datadog/fwprovider/resource_datadog_action_connection.go
@@ -736,15 +736,23 @@ func readConnection(authCtx context.Context, api *datadogV2.ActionConnectionApi,
 		return nil, err
 	}
 
-	// The API response does not include the token value, so this code gets it from the state.
-	// This is used to determine whether the token value changed since the last update.
-	if currentState.HTTP != nil {
-		for _, stateToken := range currentState.HTTP.TokenAuth.Tokens {
-			for _, responseToken := range connModel.HTTP.TokenAuth.Tokens {
-				if stateToken.Name.Equal(responseToken.Name) {
-					responseToken.Value = stateToken.Value
+	// The API does not return SECRET token values, and may omit tokens entirely
+	// from the GET response. Since token values are write-only (sensitive), we
+	// must preserve token information from the prior state.
+	if currentState.HTTP != nil && currentState.HTTP.TokenAuth != nil &&
+		connModel.HTTP != nil && connModel.HTTP.TokenAuth != nil {
+		if len(connModel.HTTP.TokenAuth.Tokens) > 0 {
+			// API returned tokens — copy values from state for matching tokens
+			for _, stateToken := range currentState.HTTP.TokenAuth.Tokens {
+				for _, responseToken := range connModel.HTTP.TokenAuth.Tokens {
+					if stateToken.Name.Equal(responseToken.Name) {
+						responseToken.Value = stateToken.Value
+					}
 				}
 			}
+		} else {
+			// API did not return tokens — preserve them entirely from state
+			connModel.HTTP.TokenAuth.Tokens = currentState.HTTP.TokenAuth.Tokens
 		}
 	}
 

--- a/flaky_tests.yaml
+++ b/flaky_tests.yaml
@@ -320,10 +320,6 @@ skipped_tests:
     reason: "Initial sync of tests failing on master branch"
     added: "2026-03-02"
     author: fpighi
-  - test: TestAccDatadogActionConnectionResource_HTTP_TokenAuth
-    reason: "Initial sync of tests failing on master branch"
-    added: "2026-03-02"
-    author: fpighi
   - test: TestAccRumRetentionFiltersDatasource
     reason: "Initial sync of tests failing on master branch"
     added: "2026-03-02"


### PR DESCRIPTION
## Summary

- **Failing test:** `TestAccDatadogActionConnectionResource_HTTP_TokenAuth`
- **Root cause:** The Action Connection API no longer returns SECRET tokens in its GET response, causing the provider's Read function to lose all token state on refresh
- **Fix:** Preserve tokens from prior Terraform state when the API omits them

## Details

The test was failing with "After applying this test step, the refresh plan was not empty" because:

1. On Create, the token (type=SECRET, name, value) is sent to the API and stored in state
2. On Read (refresh), the API GET response no longer includes SECRET tokens
3. The existing code only copied token values from state when the API returned token metadata
4. With no tokens in the API response, the state lost all token information
5. Terraform detected a diff between config (has token) and state (no token), planning to re-add it

The fix updates `readConnection` to preserve tokens entirely from the prior Terraform state when the API omits them. This is the standard Terraform pattern for write-only/sensitive fields that cannot be read back from the API. Proper nil checks for the `TokenAuth` nested model are also added.

This is a provider correctness fix, not just a test fix. Without it, any user with an `action_connection` resource using SECRET tokens would see a perpetual diff on every `terraform plan`.

## Test plan

- [x] `make fmtcheck` passes
- [x] `make test` passes
- [x] Cassette replay (`RECORD=false`) passes locally
- [x] Tests pass with `RECORD=none` in CI integration run