### PR TITLE
Fix test_integration.yml: use Python skip-regex script

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -58,7 +58,7 @@ jobs:
         id: skip-list
         if: github.event_name == 'pull_request'
         run: |
-          SKIP_REGEX=$(bash scripts/build-skip-regex.sh)
+          SKIP_REGEX=$(python3 scripts/build_skip_regex.py)
           if [ -n "$SKIP_REGEX" ]; then
             echo "test_args=-skip '${SKIP_REGEX}'" >> "$GITHUB_OUTPUT"
             echo "Skipping flaky tests: ${SKIP_REGEX}"


### PR DESCRIPTION
## Summary

The \`build-skip-regex.sh\` bash script was deleted in commit b78c8124 when scripts were converted to Python, but \`test_integration.yml\` was not updated to reference the replacement \`build_skip_regex.py\`. This broke the "Build skip list for label-triggered runs" step for all PR-triggered integration runs (\`ci/integrations\` label).

Scheduled (cron) runs were unaffected since the step is gated on \`github.event_name == 'pull_request'\`.

## Fix

Replace \`bash scripts/build-skip-regex.sh\` with \`python3 scripts/build_skip_regex.py\` in the workflow, matching how \`test_pr_integration.yml\` already calls it.