### PR TITLE
[datadog_dashboard_v2] Add missing fields on existing widgets

### DIFF
--- a/datadog/dashboardmapping/field_groups.go
+++ b/datadog/dashboardmapping/field_groups.go
@@ -141,6 +141,8 @@ var widgetMarkerFields = []FieldSpec{
 		Description: "Combination of a severity (`error`, `warning`, `ok`, or `info`) and a line type (`dashed`, `solid`, or `bold`). For Distribution widgets, this can be set to `percentile`. Example: `error dashed`."},
 	{HCLKey: "label", Type: TypeString, OmitEmpty: true,
 		Description: "Label to display over the marker."},
+	{HCLKey: "time", Type: TypeString, OmitEmpty: true,
+		Description: "Timestamp for the marker position."},
 }
 
 // widgetEventFields corresponds to OpenAPI components/schemas/WidgetEvent.

--- a/datadog/dashboardmapping/widgets.go
+++ b/datadog/dashboardmapping/widgets.go
@@ -109,6 +109,12 @@ var FreeTextWidgetSpec = WidgetSpec{
 			Description: "The alignment of the text in the widget.",
 			ValidValues: []string{"center", "left", "right"},
 		},
+		{
+			HCLKey:      "background_color",
+			Type:        TypeString,
+			OmitEmpty:   true,
+			Description: "The background color of the text widget.",
+		},
 	},
 }
 
@@ -816,6 +822,9 @@ var DistributionWidgetSpec = WidgetSpec{
 		{HCLKey: "request", JSONKey: "requests", Type: TypeBlockList, OmitEmpty: false,
 			Description: "A nested block describing the request to use when displaying the widget. Multiple request blocks are allowed using the structure below (exactly one of `q`, `apm_query`, `log_query`, `rum_query`, `security_query` or `process_query` is required within the request block).",
 			Children:    distributionWidgetRequestFields},
+		{HCLKey: "marker", JSONKey: "markers", Type: TypeBlockList, OmitEmpty: true,
+			Description: "A nested block describing the marker to use when displaying the widget. The structure of this block is described below. Multiple `marker` blocks are allowed within a given `distribution_definition` block.",
+			Children:    widgetMarkerFields},
 	},
 }
 
@@ -859,6 +868,9 @@ var HeatmapWidgetSpec = WidgetSpec{
 		{HCLKey: "request", JSONKey: "requests", Type: TypeBlockList, OmitEmpty: false,
 			Description: "A nested block describing the request to use when displaying the widget. Multiple `request` blocks are allowed using the structure below (exactly one of `q`, `apm_query`, `log_query`, `rum_query`, `security_query` or `process_query` is required within the request block).",
 			Children:    heatmapWidgetRequestFields},
+		{HCLKey: "marker", JSONKey: "markers", Type: TypeBlockList, OmitEmpty: true,
+			Description: "A nested block describing the marker to use when displaying the widget. The structure of this block is described below. Multiple `marker` blocks are allowed within a given `heatmap_definition` block.",
+			Children:    widgetMarkerFields},
 		widgetCustomLinkField,
 	},
 }
@@ -897,6 +909,8 @@ var HostmapWidgetSpec = WidgetSpec{
 		{HCLKey: "style", Type: TypeBlock, OmitEmpty: true,
 			Description: "The style of the widget graph. One nested block is allowed using the structure below.",
 			Children:    hostmapStyleFields},
+		{HCLKey: "notes", Type: TypeString, OmitEmpty: true,
+			Description: "Notes/description text for the host map widget."},
 		widgetCustomLinkField,
 	},
 }
@@ -1212,6 +1226,10 @@ var ListStreamWidgetSpec = WidgetSpec{
 	JSONType:    "list_stream",
 	Description: "The definition for a List Stream widget.",
 	Fields: []FieldSpec{
+		{HCLKey: "show_legend", Type: TypeBool, OmitEmpty: true,
+			Description: "Whether or not to show the legend on this widget."},
+		{HCLKey: "legend_size", Type: TypeString, OmitEmpty: true,
+			Description: "The size of the legend displayed in the widget."},
 		// request: HCL singular "request" → JSON plural "requests"
 		{
 			HCLKey:      "request",

--- a/docs/resources/dashboard_v2.md
+++ b/docs/resources/dashboard_v2.md
@@ -1079,6 +1079,7 @@ Optional:
 - `hide_incomplete_cost_data` (Boolean) Hide any portion of the widget's timeframe that is incomplete due to cost data not being available.
 - `legend_size` (String) The size of the legend displayed in the widget.
 - `live_span` (String) The timeframe to use when displaying the widget. Valid values are `1m`, `5m`, `10m`, `15m`, `30m`, `1h`, `4h`, `1d`, `2d`, `1w`, `1mo`, `3mo`, `6mo`, `week_to_date`, `month_to_date`, `1y`, `alert`.
+- `marker` (Block List) A nested block describing the marker to use when displaying the widget. The structure of this block is described below. Multiple `marker` blocks are allowed within a given `distribution_definition` block. (see [below for nested schema](#nestedblock--widget--distribution_definition--marker))
 - `request` (Block List) A nested block describing the request to use when displaying the widget. Multiple request blocks are allowed using the structure below (exactly one of `q`, `apm_query`, `log_query`, `rum_query`, `security_query` or `process_query` is required within the request block). (see [below for nested schema](#nestedblock--widget--distribution_definition--request))
 - `show_legend` (Boolean) Whether or not to show the legend on this widget.
 - `time` (Block List, Max: 1) A nested block used to specify a time span for the widget. Use this or `live_span`, not both. (see [below for nested schema](#nestedblock--widget--distribution_definition--time))
@@ -1087,6 +1088,20 @@ Optional:
 - `title_size` (String) The size of the widget's title (defaults to 16).
 - `xaxis` (Block List, Max: 1) A nested block describing the X-Axis Controls. Exactly one nested block is allowed using the structure below. (see [below for nested schema](#nestedblock--widget--distribution_definition--xaxis))
 - `yaxis` (Block List, Max: 1) A nested block describing the Y-Axis Controls. Exactly one nested block is allowed using the structure below. (see [below for nested schema](#nestedblock--widget--distribution_definition--yaxis))
+
+<a id="nestedblock--widget--distribution_definition--marker"></a>
+### Nested Schema for `widget.distribution_definition.marker`
+
+Required:
+
+- `value` (String) Value to apply. Can be a single value `y = 15` or a range of values `0 < y < 10`. For Distribution widgets with `display_type` set to `percentile`, this should be a numeric percentile value (for example, `90` for P90).
+
+Optional:
+
+- `display_type` (String) Combination of a severity (`error`, `warning`, `ok`, or `info`) and a line type (`dashed`, `solid`, or `bold`). For Distribution widgets, this can be set to `percentile`. Example: `error dashed`.
+- `label` (String) Label to display over the marker.
+- `time` (String) Timestamp for the marker position.
+
 
 <a id="nestedblock--widget--distribution_definition--request"></a>
 ### Nested Schema for `widget.distribution_definition.request`
@@ -1896,6 +1911,7 @@ Required:
 
 Optional:
 
+- `background_color` (String) The background color of the text widget.
 - `color` (String) The color of the text in the widget.
 - `description` (String) The description of the widget.
 - `font_size` (String) The size of the text in the widget.
@@ -3458,6 +3474,7 @@ Optional:
 - `hide_incomplete_cost_data` (Boolean) Hide any portion of the widget's timeframe that is incomplete due to cost data not being available.
 - `legend_size` (String) The size of the legend displayed in the widget.
 - `live_span` (String) The timeframe to use when displaying the widget. Valid values are `1m`, `5m`, `10m`, `15m`, `30m`, `1h`, `4h`, `1d`, `2d`, `1w`, `1mo`, `3mo`, `6mo`, `week_to_date`, `month_to_date`, `1y`, `alert`.
+- `marker` (Block List) A nested block describing the marker to use when displaying the widget. The structure of this block is described below. Multiple `marker` blocks are allowed within a given `distribution_definition` block. (see [below for nested schema](#nestedblock--widget--group_definition--widget--distribution_definition--marker))
 - `request` (Block List) A nested block describing the request to use when displaying the widget. Multiple request blocks are allowed using the structure below (exactly one of `q`, `apm_query`, `log_query`, `rum_query`, `security_query` or `process_query` is required within the request block). (see [below for nested schema](#nestedblock--widget--group_definition--widget--distribution_definition--request))
 - `show_legend` (Boolean) Whether or not to show the legend on this widget.
 - `time` (Block List, Max: 1) A nested block used to specify a time span for the widget. Use this or `live_span`, not both. (see [below for nested schema](#nestedblock--widget--group_definition--widget--distribution_definition--time))
@@ -3466,6 +3483,20 @@ Optional:
 - `title_size` (String) The size of the widget's title (defaults to 16).
 - `xaxis` (Block List, Max: 1) A nested block describing the X-Axis Controls. Exactly one nested block is allowed using the structure below. (see [below for nested schema](#nestedblock--widget--group_definition--widget--distribution_definition--xaxis))
 - `yaxis` (Block List, Max: 1) A nested block describing the Y-Axis Controls. Exactly one nested block is allowed using the structure below. (see [below for nested schema](#nestedblock--widget--group_definition--widget--distribution_definition--yaxis))
+
+<a id="nestedblock--widget--group_definition--widget--distribution_definition--marker"></a>
+### Nested Schema for `widget.group_definition.widget.distribution_definition.marker`
+
+Required:
+
+- `value` (String) Value to apply. Can be a single value `y = 15` or a range of values `0 < y < 10`. For Distribution widgets with `display_type` set to `percentile`, this should be a numeric percentile value (for example, `90` for P90).
+
+Optional:
+
+- `display_type` (String) Combination of a severity (`error`, `warning`, `ok`, or `info`) and a line type (`dashed`, `solid`, or `bold`). For Distribution widgets, this can be set to `percentile`. Example: `error dashed`.
+- `label` (String) Label to display over the marker.
+- `time` (String) Timestamp for the marker position.
+
 
 <a id="nestedblock--widget--group_definition--widget--distribution_definition--request"></a>
 ### Nested Schema for `widget.group_definition.widget.distribution_definition.request`
@@ -4275,6 +4306,7 @@ Required:
 
 Optional:
 
+- `background_color` (String) The background color of the text widget.
 - `color` (String) The color of the text in the widget.
 - `description` (String) The description of the widget.
 - `font_size` (String) The size of the text in the widget.
@@ -4937,6 +4969,7 @@ Optional:
 - `hide_incomplete_cost_data` (Boolean) Hide any portion of the widget's timeframe that is incomplete due to cost data not being available.
 - `legend_size` (String) The size of the legend displayed in the widget.
 - `live_span` (String) The timeframe to use when displaying the widget. Valid values are `1m`, `5m`, `10m`, `15m`, `30m`, `1h`, `4h`, `1d`, `2d`, `1w`, `1mo`, `3mo`, `6mo`, `week_to_date`, `month_to_date`, `1y`, `alert`.
+- `marker` (Block List) A nested block describing the marker to use when displaying the widget. The structure of this block is described below. Multiple `marker` blocks are allowed within a given `heatmap_definition` block. (see [below for nested schema](#nestedblock--widget--group_definition--widget--heatmap_definition--marker))
 - `request` (Block List) A nested block describing the request to use when displaying the widget. Multiple `request` blocks are allowed using the structure below (exactly one of `q`, `apm_query`, `log_query`, `rum_query`, `security_query` or `process_query` is required within the request block). (see [below for nested schema](#nestedblock--widget--group_definition--widget--heatmap_definition--request))
 - `show_legend` (Boolean) Whether or not to show the legend on this widget.
 - `time` (Block List, Max: 1) A nested block used to specify a time span for the widget. Use this or `live_span`, not both. (see [below for nested schema](#nestedblock--widget--group_definition--widget--heatmap_definition--time))
@@ -4967,6 +5000,20 @@ Required:
 Optional:
 
 - `tags_execution` (String) The execution method for multi-value filters.
+
+
+<a id="nestedblock--widget--group_definition--widget--heatmap_definition--marker"></a>
+### Nested Schema for `widget.group_definition.widget.heatmap_definition.marker`
+
+Required:
+
+- `value` (String) Value to apply. Can be a single value `y = 15` or a range of values `0 < y < 10`. For Distribution widgets with `display_type` set to `percentile`, this should be a numeric percentile value (for example, `90` for P90).
+
+Optional:
+
+- `display_type` (String) Combination of a severity (`error`, `warning`, `ok`, or `info`) and a line type (`dashed`, `solid`, or `bold`). For Distribution widgets, this can be set to `percentile`. Example: `error dashed`.
+- `label` (String) Label to display over the marker.
+- `time` (String) Timestamp for the marker position.
 
 
 <a id="nestedblock--widget--group_definition--widget--heatmap_definition--request"></a>
@@ -5652,6 +5699,7 @@ Optional:
 - `no_group_hosts` (Boolean) A Boolean indicating whether to show the hosts that don't fit in a group.
 - `no_metric_hosts` (Boolean) A Boolean indicating whether to show nodes with no metrics.
 - `node_type` (String) The type of node used. Valid values are `host`, `container`.
+- `notes` (String) Notes/description text for the host map widget.
 - `request` (Block List, Max: 1) A nested block describing the request to use when displaying the widget. Multiple `request` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--group_definition--widget--hostmap_definition--request))
 - `scope` (List of String) The list of tags used to filter the map.
 - `style` (Block List, Max: 1) The style of the widget graph. One nested block is allowed using the structure below. (see [below for nested schema](#nestedblock--widget--group_definition--widget--hostmap_definition--style))
@@ -7051,7 +7099,9 @@ Optional:
 
 - `description` (String) The description of the widget.
 - `hide_incomplete_cost_data` (Boolean) Hide any portion of the widget's timeframe that is incomplete due to cost data not being available.
+- `legend_size` (String) The size of the legend displayed in the widget.
 - `live_span` (String) The timeframe to use when displaying the widget. Valid values are `1m`, `5m`, `10m`, `15m`, `30m`, `1h`, `4h`, `1d`, `2d`, `1w`, `1mo`, `3mo`, `6mo`, `week_to_date`, `month_to_date`, `1y`, `alert`.
+- `show_legend` (Boolean) Whether or not to show the legend on this widget.
 - `time` (Block List, Max: 1) A nested block used to specify a time span for the widget. Use this or `live_span`, not both. (see [below for nested schema](#nestedblock--widget--group_definition--widget--list_stream_definition--time))
 - `title` (String) The title of the widget.
 - `title_align` (String) The alignment of the widget's title. Valid values are `center`, `left`, `right`.
@@ -11547,6 +11597,7 @@ Optional:
 
 - `display_type` (String) Combination of a severity (`error`, `warning`, `ok`, or `info`) and a line type (`dashed`, `solid`, or `bold`). For Distribution widgets, this can be set to `percentile`. Example: `error dashed`.
 - `label` (String) Label to display over the marker.
+- `time` (String) Timestamp for the marker position.
 
 
 <a id="nestedblock--widget--group_definition--widget--timeseries_definition--request"></a>
@@ -13880,6 +13931,7 @@ Optional:
 - `hide_incomplete_cost_data` (Boolean) Hide any portion of the widget's timeframe that is incomplete due to cost data not being available.
 - `legend_size` (String) The size of the legend displayed in the widget.
 - `live_span` (String) The timeframe to use when displaying the widget. Valid values are `1m`, `5m`, `10m`, `15m`, `30m`, `1h`, `4h`, `1d`, `2d`, `1w`, `1mo`, `3mo`, `6mo`, `week_to_date`, `month_to_date`, `1y`, `alert`.
+- `marker` (Block List) A nested block describing the marker to use when displaying the widget. The structure of this block is described below. Multiple `marker` blocks are allowed within a given `heatmap_definition` block. (see [below for nested schema](#nestedblock--widget--heatmap_definition--marker))
 - `request` (Block List) A nested block describing the request to use when displaying the widget. Multiple `request` blocks are allowed using the structure below (exactly one of `q`, `apm_query`, `log_query`, `rum_query`, `security_query` or `process_query` is required within the request block). (see [below for nested schema](#nestedblock--widget--heatmap_definition--request))
 - `show_legend` (Boolean) Whether or not to show the legend on this widget.
 - `time` (Block List, Max: 1) A nested block used to specify a time span for the widget. Use this or `live_span`, not both. (see [below for nested schema](#nestedblock--widget--heatmap_definition--time))
@@ -13910,6 +13962,20 @@ Required:
 Optional:
 
 - `tags_execution` (String) The execution method for multi-value filters.
+
+
+<a id="nestedblock--widget--heatmap_definition--marker"></a>
+### Nested Schema for `widget.heatmap_definition.marker`
+
+Required:
+
+- `value` (String) Value to apply. Can be a single value `y = 15` or a range of values `0 < y < 10`. For Distribution widgets with `display_type` set to `percentile`, this should be a numeric percentile value (for example, `90` for P90).
+
+Optional:
+
+- `display_type` (String) Combination of a severity (`error`, `warning`, `ok`, or `info`) and a line type (`dashed`, `solid`, or `bold`). For Distribution widgets, this can be set to `percentile`. Example: `error dashed`.
+- `label` (String) Label to display over the marker.
+- `time` (String) Timestamp for the marker position.
 
 
 <a id="nestedblock--widget--heatmap_definition--request"></a>
@@ -14595,6 +14661,7 @@ Optional:
 - `no_group_hosts` (Boolean) A Boolean indicating whether to show the hosts that don't fit in a group.
 - `no_metric_hosts` (Boolean) A Boolean indicating whether to show nodes with no metrics.
 - `node_type` (String) The type of node used. Valid values are `host`, `container`.
+- `notes` (String) Notes/description text for the host map widget.
 - `request` (Block List, Max: 1) A nested block describing the request to use when displaying the widget. Multiple `request` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--hostmap_definition--request))
 - `scope` (List of String) The list of tags used to filter the map.
 - `style` (Block List, Max: 1) The style of the widget graph. One nested block is allowed using the structure below. (see [below for nested schema](#nestedblock--widget--hostmap_definition--style))
@@ -15994,7 +16061,9 @@ Optional:
 
 - `description` (String) The description of the widget.
 - `hide_incomplete_cost_data` (Boolean) Hide any portion of the widget's timeframe that is incomplete due to cost data not being available.
+- `legend_size` (String) The size of the legend displayed in the widget.
 - `live_span` (String) The timeframe to use when displaying the widget. Valid values are `1m`, `5m`, `10m`, `15m`, `30m`, `1h`, `4h`, `1d`, `2d`, `1w`, `1mo`, `3mo`, `6mo`, `week_to_date`, `month_to_date`, `1y`, `alert`.
+- `show_legend` (Boolean) Whether or not to show the legend on this widget.
 - `time` (Block List, Max: 1) A nested block used to specify a time span for the widget. Use this or `live_span`, not both. (see [below for nested schema](#nestedblock--widget--list_stream_definition--time))
 - `title` (String) The title of the widget.
 - `title_align` (String) The alignment of the widget's title. Valid values are `center`, `left`, `right`.
@@ -24991,6 +25060,7 @@ Optional:
 
 - `display_type` (String) Combination of a severity (`error`, `warning`, `ok`, or `info`) and a line type (`dashed`, `solid`, or `bold`). For Distribution widgets, this can be set to `percentile`. Example: `error dashed`.
 - `label` (String) Label to display over the marker.
+- `time` (String) Timestamp for the marker position.
 
 
 <a id="nestedblock--widget--split_graph_definition--source_widget_definition--timeseries_definition--request"></a>
@@ -28081,6 +28151,7 @@ Optional:
 
 - `display_type` (String) Combination of a severity (`error`, `warning`, `ok`, or `info`) and a line type (`dashed`, `solid`, or `bold`). For Distribution widgets, this can be set to `percentile`. Example: `error dashed`.
 - `label` (String) Label to display over the marker.
+- `time` (String) Timestamp for the marker position.
 
 
 <a id="nestedblock--widget--timeseries_definition--request"></a>

--- a/docs/resources/powerpack_v2.md
+++ b/docs/resources/powerpack_v2.md
@@ -956,6 +956,7 @@ Optional:
 - `hide_incomplete_cost_data` (Boolean) Hide any portion of the widget's timeframe that is incomplete due to cost data not being available.
 - `legend_size` (String) The size of the legend displayed in the widget.
 - `live_span` (String) The timeframe to use when displaying the widget. Valid values are `1m`, `5m`, `10m`, `15m`, `30m`, `1h`, `4h`, `1d`, `2d`, `1w`, `1mo`, `3mo`, `6mo`, `week_to_date`, `month_to_date`, `1y`, `alert`.
+- `marker` (Block List) A nested block describing the marker to use when displaying the widget. The structure of this block is described below. Multiple `marker` blocks are allowed within a given `distribution_definition` block. (see [below for nested schema](#nestedblock--widget--distribution_definition--marker))
 - `request` (Block List) A nested block describing the request to use when displaying the widget. Multiple request blocks are allowed using the structure below (exactly one of `q`, `apm_query`, `log_query`, `rum_query`, `security_query` or `process_query` is required within the request block). (see [below for nested schema](#nestedblock--widget--distribution_definition--request))
 - `show_legend` (Boolean) Whether or not to show the legend on this widget.
 - `time` (Block List, Max: 1) A nested block used to specify a time span for the widget. Use this or `live_span`, not both. (see [below for nested schema](#nestedblock--widget--distribution_definition--time))
@@ -964,6 +965,20 @@ Optional:
 - `title_size` (String) The size of the widget's title (defaults to 16).
 - `xaxis` (Block List, Max: 1) A nested block describing the X-Axis Controls. Exactly one nested block is allowed using the structure below. (see [below for nested schema](#nestedblock--widget--distribution_definition--xaxis))
 - `yaxis` (Block List, Max: 1) A nested block describing the Y-Axis Controls. Exactly one nested block is allowed using the structure below. (see [below for nested schema](#nestedblock--widget--distribution_definition--yaxis))
+
+<a id="nestedblock--widget--distribution_definition--marker"></a>
+### Nested Schema for `widget.distribution_definition.marker`
+
+Required:
+
+- `value` (String) Value to apply. Can be a single value `y = 15` or a range of values `0 < y < 10`. For Distribution widgets with `display_type` set to `percentile`, this should be a numeric percentile value (for example, `90` for P90).
+
+Optional:
+
+- `display_type` (String) Combination of a severity (`error`, `warning`, `ok`, or `info`) and a line type (`dashed`, `solid`, or `bold`). For Distribution widgets, this can be set to `percentile`. Example: `error dashed`.
+- `label` (String) Label to display over the marker.
+- `time` (String) Timestamp for the marker position.
+
 
 <a id="nestedblock--widget--distribution_definition--request"></a>
 ### Nested Schema for `widget.distribution_definition.request`
@@ -1773,6 +1788,7 @@ Required:
 
 Optional:
 
+- `background_color` (String) The background color of the text widget.
 - `color` (String) The color of the text in the widget.
 - `description` (String) The description of the widget.
 - `font_size` (String) The size of the text in the widget.
@@ -3335,6 +3351,7 @@ Optional:
 - `hide_incomplete_cost_data` (Boolean) Hide any portion of the widget's timeframe that is incomplete due to cost data not being available.
 - `legend_size` (String) The size of the legend displayed in the widget.
 - `live_span` (String) The timeframe to use when displaying the widget. Valid values are `1m`, `5m`, `10m`, `15m`, `30m`, `1h`, `4h`, `1d`, `2d`, `1w`, `1mo`, `3mo`, `6mo`, `week_to_date`, `month_to_date`, `1y`, `alert`.
+- `marker` (Block List) A nested block describing the marker to use when displaying the widget. The structure of this block is described below. Multiple `marker` blocks are allowed within a given `distribution_definition` block. (see [below for nested schema](#nestedblock--widget--group_definition--widget--distribution_definition--marker))
 - `request` (Block List) A nested block describing the request to use when displaying the widget. Multiple request blocks are allowed using the structure below (exactly one of `q`, `apm_query`, `log_query`, `rum_query`, `security_query` or `process_query` is required within the request block). (see [below for nested schema](#nestedblock--widget--group_definition--widget--distribution_definition--request))
 - `show_legend` (Boolean) Whether or not to show the legend on this widget.
 - `time` (Block List, Max: 1) A nested block used to specify a time span for the widget. Use this or `live_span`, not both. (see [below for nested schema](#nestedblock--widget--group_definition--widget--distribution_definition--time))
@@ -3343,6 +3360,20 @@ Optional:
 - `title_size` (String) The size of the widget's title (defaults to 16).
 - `xaxis` (Block List, Max: 1) A nested block describing the X-Axis Controls. Exactly one nested block is allowed using the structure below. (see [below for nested schema](#nestedblock--widget--group_definition--widget--distribution_definition--xaxis))
 - `yaxis` (Block List, Max: 1) A nested block describing the Y-Axis Controls. Exactly one nested block is allowed using the structure below. (see [below for nested schema](#nestedblock--widget--group_definition--widget--distribution_definition--yaxis))
+
+<a id="nestedblock--widget--group_definition--widget--distribution_definition--marker"></a>
+### Nested Schema for `widget.group_definition.widget.distribution_definition.marker`
+
+Required:
+
+- `value` (String) Value to apply. Can be a single value `y = 15` or a range of values `0 < y < 10`. For Distribution widgets with `display_type` set to `percentile`, this should be a numeric percentile value (for example, `90` for P90).
+
+Optional:
+
+- `display_type` (String) Combination of a severity (`error`, `warning`, `ok`, or `info`) and a line type (`dashed`, `solid`, or `bold`). For Distribution widgets, this can be set to `percentile`. Example: `error dashed`.
+- `label` (String) Label to display over the marker.
+- `time` (String) Timestamp for the marker position.
+
 
 <a id="nestedblock--widget--group_definition--widget--distribution_definition--request"></a>
 ### Nested Schema for `widget.group_definition.widget.distribution_definition.request`
@@ -4152,6 +4183,7 @@ Required:
 
 Optional:
 
+- `background_color` (String) The background color of the text widget.
 - `color` (String) The color of the text in the widget.
 - `description` (String) The description of the widget.
 - `font_size` (String) The size of the text in the widget.
@@ -4814,6 +4846,7 @@ Optional:
 - `hide_incomplete_cost_data` (Boolean) Hide any portion of the widget's timeframe that is incomplete due to cost data not being available.
 - `legend_size` (String) The size of the legend displayed in the widget.
 - `live_span` (String) The timeframe to use when displaying the widget. Valid values are `1m`, `5m`, `10m`, `15m`, `30m`, `1h`, `4h`, `1d`, `2d`, `1w`, `1mo`, `3mo`, `6mo`, `week_to_date`, `month_to_date`, `1y`, `alert`.
+- `marker` (Block List) A nested block describing the marker to use when displaying the widget. The structure of this block is described below. Multiple `marker` blocks are allowed within a given `heatmap_definition` block. (see [below for nested schema](#nestedblock--widget--group_definition--widget--heatmap_definition--marker))
 - `request` (Block List) A nested block describing the request to use when displaying the widget. Multiple `request` blocks are allowed using the structure below (exactly one of `q`, `apm_query`, `log_query`, `rum_query`, `security_query` or `process_query` is required within the request block). (see [below for nested schema](#nestedblock--widget--group_definition--widget--heatmap_definition--request))
 - `show_legend` (Boolean) Whether or not to show the legend on this widget.
 - `time` (Block List, Max: 1) A nested block used to specify a time span for the widget. Use this or `live_span`, not both. (see [below for nested schema](#nestedblock--widget--group_definition--widget--heatmap_definition--time))
@@ -4844,6 +4877,20 @@ Required:
 Optional:
 
 - `tags_execution` (String) The execution method for multi-value filters.
+
+
+<a id="nestedblock--widget--group_definition--widget--heatmap_definition--marker"></a>
+### Nested Schema for `widget.group_definition.widget.heatmap_definition.marker`
+
+Required:
+
+- `value` (String) Value to apply. Can be a single value `y = 15` or a range of values `0 < y < 10`. For Distribution widgets with `display_type` set to `percentile`, this should be a numeric percentile value (for example, `90` for P90).
+
+Optional:
+
+- `display_type` (String) Combination of a severity (`error`, `warning`, `ok`, or `info`) and a line type (`dashed`, `solid`, or `bold`). For Distribution widgets, this can be set to `percentile`. Example: `error dashed`.
+- `label` (String) Label to display over the marker.
+- `time` (String) Timestamp for the marker position.
 
 
 <a id="nestedblock--widget--group_definition--widget--heatmap_definition--request"></a>
@@ -5529,6 +5576,7 @@ Optional:
 - `no_group_hosts` (Boolean) A Boolean indicating whether to show the hosts that don't fit in a group.
 - `no_metric_hosts` (Boolean) A Boolean indicating whether to show nodes with no metrics.
 - `node_type` (String) The type of node used. Valid values are `host`, `container`.
+- `notes` (String) Notes/description text for the host map widget.
 - `request` (Block List, Max: 1) A nested block describing the request to use when displaying the widget. Multiple `request` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--group_definition--widget--hostmap_definition--request))
 - `scope` (List of String) The list of tags used to filter the map.
 - `style` (Block List, Max: 1) The style of the widget graph. One nested block is allowed using the structure below. (see [below for nested schema](#nestedblock--widget--group_definition--widget--hostmap_definition--style))
@@ -6928,7 +6976,9 @@ Optional:
 
 - `description` (String) The description of the widget.
 - `hide_incomplete_cost_data` (Boolean) Hide any portion of the widget's timeframe that is incomplete due to cost data not being available.
+- `legend_size` (String) The size of the legend displayed in the widget.
 - `live_span` (String) The timeframe to use when displaying the widget. Valid values are `1m`, `5m`, `10m`, `15m`, `30m`, `1h`, `4h`, `1d`, `2d`, `1w`, `1mo`, `3mo`, `6mo`, `week_to_date`, `month_to_date`, `1y`, `alert`.
+- `show_legend` (Boolean) Whether or not to show the legend on this widget.
 - `time` (Block List, Max: 1) A nested block used to specify a time span for the widget. Use this or `live_span`, not both. (see [below for nested schema](#nestedblock--widget--group_definition--widget--list_stream_definition--time))
 - `title` (String) The title of the widget.
 - `title_align` (String) The alignment of the widget's title. Valid values are `center`, `left`, `right`.
@@ -11424,6 +11474,7 @@ Optional:
 
 - `display_type` (String) Combination of a severity (`error`, `warning`, `ok`, or `info`) and a line type (`dashed`, `solid`, or `bold`). For Distribution widgets, this can be set to `percentile`. Example: `error dashed`.
 - `label` (String) Label to display over the marker.
+- `time` (String) Timestamp for the marker position.
 
 
 <a id="nestedblock--widget--group_definition--widget--timeseries_definition--request"></a>
@@ -13757,6 +13808,7 @@ Optional:
 - `hide_incomplete_cost_data` (Boolean) Hide any portion of the widget's timeframe that is incomplete due to cost data not being available.
 - `legend_size` (String) The size of the legend displayed in the widget.
 - `live_span` (String) The timeframe to use when displaying the widget. Valid values are `1m`, `5m`, `10m`, `15m`, `30m`, `1h`, `4h`, `1d`, `2d`, `1w`, `1mo`, `3mo`, `6mo`, `week_to_date`, `month_to_date`, `1y`, `alert`.
+- `marker` (Block List) A nested block describing the marker to use when displaying the widget. The structure of this block is described below. Multiple `marker` blocks are allowed within a given `heatmap_definition` block. (see [below for nested schema](#nestedblock--widget--heatmap_definition--marker))
 - `request` (Block List) A nested block describing the request to use when displaying the widget. Multiple `request` blocks are allowed using the structure below (exactly one of `q`, `apm_query`, `log_query`, `rum_query`, `security_query` or `process_query` is required within the request block). (see [below for nested schema](#nestedblock--widget--heatmap_definition--request))
 - `show_legend` (Boolean) Whether or not to show the legend on this widget.
 - `time` (Block List, Max: 1) A nested block used to specify a time span for the widget. Use this or `live_span`, not both. (see [below for nested schema](#nestedblock--widget--heatmap_definition--time))
@@ -13787,6 +13839,20 @@ Required:
 Optional:
 
 - `tags_execution` (String) The execution method for multi-value filters.
+
+
+<a id="nestedblock--widget--heatmap_definition--marker"></a>
+### Nested Schema for `widget.heatmap_definition.marker`
+
+Required:
+
+- `value` (String) Value to apply. Can be a single value `y = 15` or a range of values `0 < y < 10`. For Distribution widgets with `display_type` set to `percentile`, this should be a numeric percentile value (for example, `90` for P90).
+
+Optional:
+
+- `display_type` (String) Combination of a severity (`error`, `warning`, `ok`, or `info`) and a line type (`dashed`, `solid`, or `bold`). For Distribution widgets, this can be set to `percentile`. Example: `error dashed`.
+- `label` (String) Label to display over the marker.
+- `time` (String) Timestamp for the marker position.
 
 
 <a id="nestedblock--widget--heatmap_definition--request"></a>
@@ -14472,6 +14538,7 @@ Optional:
 - `no_group_hosts` (Boolean) A Boolean indicating whether to show the hosts that don't fit in a group.
 - `no_metric_hosts` (Boolean) A Boolean indicating whether to show nodes with no metrics.
 - `node_type` (String) The type of node used. Valid values are `host`, `container`.
+- `notes` (String) Notes/description text for the host map widget.
 - `request` (Block List, Max: 1) A nested block describing the request to use when displaying the widget. Multiple `request` blocks are allowed using the structure below. (see [below for nested schema](#nestedblock--widget--hostmap_definition--request))
 - `scope` (List of String) The list of tags used to filter the map.
 - `style` (Block List, Max: 1) The style of the widget graph. One nested block is allowed using the structure below. (see [below for nested schema](#nestedblock--widget--hostmap_definition--style))
@@ -15871,7 +15938,9 @@ Optional:
 
 - `description` (String) The description of the widget.
 - `hide_incomplete_cost_data` (Boolean) Hide any portion of the widget's timeframe that is incomplete due to cost data not being available.
+- `legend_size` (String) The size of the legend displayed in the widget.
 - `live_span` (String) The timeframe to use when displaying the widget. Valid values are `1m`, `5m`, `10m`, `15m`, `30m`, `1h`, `4h`, `1d`, `2d`, `1w`, `1mo`, `3mo`, `6mo`, `week_to_date`, `month_to_date`, `1y`, `alert`.
+- `show_legend` (Boolean) Whether or not to show the legend on this widget.
 - `time` (Block List, Max: 1) A nested block used to specify a time span for the widget. Use this or `live_span`, not both. (see [below for nested schema](#nestedblock--widget--list_stream_definition--time))
 - `title` (String) The title of the widget.
 - `title_align` (String) The alignment of the widget's title. Valid values are `center`, `left`, `right`.
@@ -20367,6 +20436,7 @@ Optional:
 
 - `display_type` (String) Combination of a severity (`error`, `warning`, `ok`, or `info`) and a line type (`dashed`, `solid`, or `bold`). For Distribution widgets, this can be set to `percentile`. Example: `error dashed`.
 - `label` (String) Label to display over the marker.
+- `time` (String) Timestamp for the marker position.
 
 
 <a id="nestedblock--widget--timeseries_definition--request"></a>


### PR DESCRIPTION
## Summary

Adds fields present in the OpenAPI dashboard spec but missing from existing FieldSpec widget declarations:

- **distribution + heatmap**: `markers` block — reuses the existing `widgetMarkerFields` group (already on timeseries)
- **free_text**: `background_color` — background color of the text widget
- **hostmap**: `notes` — notes/description text
- **list_stream**: `show_legend`, `legend_size` — legend display controls
- **widgetMarkerFields**: `time` — marker timestamp (affects timeseries, distribution, heatmap)

Skipped treemap `color_by`/`group_by`/`size_by` — all three are deprecated in the OpenAPI spec.

## Test plan

- [x] All 31 existing v2 cassette replay tests pass (`RECORD=false`)
- [x] `go build ./...` and `go vet ./datadog/dashboardmapping/...` pass
- [x] `make docs` regenerated
- [ ] CI passes