### PR TITLE
[observability_piplines] Clarify use_legacy_search_syntax only applies to logs pipelines

### DIFF
--- a/datadog/fwprovider/resource_datadog_observability_pipeline.go
+++ b/datadog/fwprovider/resource_datadog_observability_pipeline.go
@@ -774,6 +774,7 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 								"After migrating all queries to the new syntax, set to `false`. " +
 								"The legacy syntax is deprecated and will eventually be removed. " +
 								"Requires Observability Pipelines Worker 2.11 or later. " +
+								"Only applies to `logs` pipelines. This field is ignored for `metrics` pipelines. " +
 								"See https://docs.datadoghq.com/observability_pipelines/guide/upgrade_your_filter_queries_to_the_new_search_syntax/ for more information.",
 						},
 					},

--- a/docs/resources/observability_pipeline.md
+++ b/docs/resources/observability_pipeline.md
@@ -93,7 +93,7 @@ Optional:
 - `pipeline_type` (String) The type of data being ingested. Defaults to `logs` if not specified. Valid values are `logs`, `metrics`.
 - `processor_group` (Block List) A processor group containing common configuration and nested processors. (see [below for nested schema](#nestedblock--config--processor_group))
 - `source` (Block List) List of sources. (see [below for nested schema](#nestedblock--config--source))
-- `use_legacy_search_syntax` (Boolean) Set to `true` to continue using the legacy search syntax while migrating filter queries. After migrating all queries to the new syntax, set to `false`. The legacy syntax is deprecated and will eventually be removed. Requires Observability Pipelines Worker 2.11 or later. See https://docs.datadoghq.com/observability_pipelines/guide/upgrade_your_filter_queries_to_the_new_search_syntax/ for more information.
+- `use_legacy_search_syntax` (Boolean) Set to `true` to continue using the legacy search syntax while migrating filter queries. After migrating all queries to the new syntax, set to `false`. The legacy syntax is deprecated and will eventually be removed. Requires Observability Pipelines Worker 2.11 or later. Only applies to `logs` pipelines. This field is ignored for `metrics` pipelines. See https://docs.datadoghq.com/observability_pipelines/guide/upgrade_your_filter_queries_to_the_new_search_syntax/ for more information.
 
 <a id="nestedblock--config--destination"></a>
 ### Nested Schema for `config.destination`


### PR DESCRIPTION
## Summary
- Update schema description and generated docs for `use_legacy_search_syntax` to clarify it only applies to `logs` pipelines and is ignored for `metrics` pipelines