### PR TITLE
[datadog_powerpack] Add sweeper to fix datasource test timeout

### DIFF
--- a/datadog/tests/data_source_datadog_powerpack_test.go
+++ b/datadog/tests/data_source_datadog_powerpack_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccDatadogPowerpackDatasource(t *testing.T) {
+	cleanupPowerpacks(t)
 	t.Parallel()
 	ctx, _, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
 	uniq := uniqueEntityName(ctx, t)

--- a/datadog/tests/powerpack_sweep_test.go
+++ b/datadog/tests/powerpack_sweep_test.go
@@ -1,0 +1,91 @@
+package test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+// cleanupPowerpacks removes stale powerpacks left behind by failed test runs.
+// Call this at the top of powerpack test functions, before resource.Test().
+func cleanupPowerpacks(t *testing.T) {
+	t.Helper()
+
+	if isReplaying() {
+		return
+	}
+
+	doSweepPowerpacks(t)
+}
+
+// TestSweepPowerpacks is a standalone sweep test for CI / manual invocation.
+func TestSweepPowerpacks(t *testing.T) {
+	doSweepPowerpacks(t)
+}
+
+func doSweepPowerpacks(t *testing.T) {
+	t.Helper()
+
+	ctx, client := newSweepAPIClient(t)
+	if client == nil {
+		return
+	}
+
+	api := datadogV2.NewPowerpackApi(client)
+
+	// Use small page sizes and retry to handle 504 timeouts on large orgs
+	var offset int64
+	pageSize := int64(5)
+	for {
+		opts := datadogV2.NewListPowerpacksOptionalParameters().
+			WithPageLimit(pageSize).
+			WithPageOffset(offset)
+
+		var data []datadogV2.PowerpackData
+		var listErr error
+		for attempt := 0; attempt < 3; attempt++ {
+			resp, _, err := api.ListPowerpacks(ctx, *opts)
+			if err != nil {
+				listErr = err
+				t.Logf("Powerpack sweep: list attempt %d failed (offset=%d): %v", attempt+1, offset, err)
+				time.Sleep(5 * time.Second)
+				continue
+			}
+			data = resp.GetData()
+			listErr = nil
+			break
+		}
+		if listErr != nil {
+			t.Logf("Powerpack sweep: giving up listing after 3 attempts (offset=%d)", offset)
+			return
+		}
+
+		if len(data) == 0 {
+			break
+		}
+
+		for _, item := range data {
+			name := item.Attributes.GetName()
+			id := item.GetId()
+
+			if !strings.HasPrefix(name, "tf-") {
+				offset++
+				continue
+			}
+
+			t.Logf("Powerpack sweep: deleting stale powerpack %q (id=%s)", name, id)
+
+			_, err := api.DeletePowerpack(ctx, id)
+			if err != nil {
+				t.Logf("Powerpack sweep: failed to delete powerpack %q (id=%s): %v", name, id, err)
+				offset++
+			}
+		}
+
+		if int64(len(data)) < pageSize {
+			break
+		}
+	}
+}

--- a/flaky_tests.yaml
+++ b/flaky_tests.yaml
@@ -273,12 +273,6 @@ skipped_tests:
     added: "2026-04-10"
     author: fpighi
 
-  # PowerpackDatasource — Persistent 504 Gateway Timeout (1 test, APIR-2791)
-  - test: TestAccDatadogPowerpackDatasource
-    reason: "504 Gateway Timeout from ListPowerpacksWithPagination — too many powerpacks in org"
-    added: "2026-04-10"
-    author: fpighi
-
   # SDS quota regression — sweeper sync.Once prevents cleanup (7 tests, APIR-2570)
   - test: TestAccDatadogSensitiveDataScannerGroup_Basic
     reason: "429 Too Many Requests: max scanning groups — sweeper sync.Once regression"


### PR DESCRIPTION
## Summary

- The powerpack datasource test fails with `504 Gateway Timeout` because the test org has accumulated too many (and an unrealistic number of) powerpacks
- Added a powerpack sweeper (`powerpack_sweep_test.go`) that:
  - Lists powerpacks with small page sizes (5) to avoid 504 timeouts
  - Retries up to 3 times on 504
  - Deletes stale `tf-` prefixed powerpacks
- Added `cleanupPowerpacks(t)` call at the top of `TestAccDatadogPowerpackDatasource`

## Test plan

- [x] Sweeper compiles and lists powerpacks successfully (with retry)
- [x] Sweeper correctly identifies `tf-` prefixed powerpacks for deletion
- [x] `TestAccDatadogPowerpackDatasource` passes after cleanup