### PR TITLE
fix: handle enrichment table Field type change from string to oneOf union

### DIFF
--- a/datadog/fwprovider/resource_datadog_observability_pipeline.go
+++ b/datadog/fwprovider/resource_datadog_observability_pipeline.go
@@ -4025,7 +4025,13 @@ func flattenEnrichmentTableProcessor(ctx context.Context, src *datadogV2.Observa
 			enrichment.File[0].Key = append(enrichment.File[0].Key, fileKeyItemModel{
 				Column:     types.StringValue(k.GetColumn()),
 				Comparison: types.StringValue(string(k.GetComparison())),
-				Field:      types.StringValue(k.GetField()),
+				Field:      types.StringValue(func() string {
+					f := k.GetField()
+					if f.ObservabilityPipelineEnrichmentTableFieldStringPath != nil {
+						return *f.ObservabilityPipelineEnrichmentTableFieldStringPath
+					}
+					return ""
+				}()),
 			})
 		}
 	}
@@ -4407,10 +4413,11 @@ func expandEnrichmentTableProcessorItem(ctx context.Context, common observabilit
 		file.Schema = []datadogV2.ObservabilityPipelineEnrichmentTableFileSchemaItems{}
 
 		for _, k := range src.File[0].Key {
+			fieldStr := k.Field.ValueString()
 			file.Key = append(file.Key, datadogV2.ObservabilityPipelineEnrichmentTableFileKeyItems{
 				Column:     k.Column.ValueString(),
 				Comparison: datadogV2.ObservabilityPipelineEnrichmentTableFileKeyItemsComparison(k.Comparison.ValueString()),
-				Field:      k.Field.ValueString(),
+				Field:      datadogV2.ObservabilityPipelineEnrichmentTableFieldStringPathAsObservabilityPipelineEnrichmentTableFileKeyItemField(&fieldStr),
 			})
 		}
 


### PR DESCRIPTION
## Summary

Fixes the build break caused by the `ObservabilityPipelineEnrichmentTableFileKeyItems.Field` type changing from `string` to `ObservabilityPipelineEnrichmentTableFileKeyItemField` (a `oneOf` union type).

## Changes

- **Read path** (line ~4028): Extract string from `Field.ObservabilityPipelineEnrichmentTableFieldStringPath` instead of using `GetField()` directly as string
- **Write path** (line ~4419): Wrap string using `ObservabilityPipelineEnrichmentTableFieldStringPathAsObservabilityPipelineEnrichmentTableFileKeyItemField()` constructor

## Related

- API spec PR: [DataDog/datadog-api-spec#5427](https://github.com/DataDog/datadog-api-spec/pull/5427)
- Go client PR: [DataDog/datadog-api-client-go#3947](https://github.com/DataDog/datadog-api-client-go/pull/3947)

🤖 Generated with [Claude Code](https://claude.com/claude-code)