### PR TITLE
[datadog_security_monitoring_rule] Fix validation for forget_after and learning_duration to accept values 1-30

### DIFF
--- a/datadog/resource_datadog_security_monitoring_rule.go
+++ b/datadog/resource_datadog_security_monitoring_rule.go
@@ -213,11 +213,11 @@ func datadogSecurityMonitoringRuleSchema(includeValidate bool) map[string]*schem
 									Description:      "The learning method used to determine when signals should be generated for values that weren't learned.",
 								},
 								"learning_duration": {
-									Type:             schema.TypeInt,
-									ValidateDiagFunc: validators.ValidateEnumValue(datadogV2.NewSecurityMonitoringRuleNewValueOptionsLearningDurationFromValue),
-									Optional:         true,
-									Default:          1,
-									Description:      "The duration in days during which values are learned, and after which signals will be generated for values that weren't learned. If set to 0, a signal will be generated for all new values after the first value is learned.",
+									Type:         schema.TypeInt,
+									ValidateFunc: validation.IntBetween(0, 30),
+									Optional:     true,
+									Default:      1,
+									Description:  "The duration in days during which values are learned, and after which signals will be generated for values that weren't learned. If set to 0, a signal will be generated for all new values after the first value is learned. Valid values are between 0 and 30.",
 								},
 								"learning_threshold": {
 									Type:             schema.TypeInt,
@@ -227,10 +227,10 @@ func datadogSecurityMonitoringRuleSchema(includeValidate bool) map[string]*schem
 									Description:      "A number of occurrences after which signals are generated for values that weren't learned.",
 								},
 								"forget_after": {
-									Type:             schema.TypeInt,
-									ValidateDiagFunc: validators.ValidateEnumValue(datadogV2.NewSecurityMonitoringRuleNewValueOptionsForgetAfterFromValue),
-									Required:         true,
-									Description:      "The duration in days after which a learned value is forgotten.",
+									Type:         schema.TypeInt,
+									ValidateFunc: validation.IntBetween(1, 30),
+									Required:     true,
+									Description:  "The duration in days after which a learned value is forgotten. Valid values are between 1 and 30.",
 								},
 								"instantaneous_baseline": {
 									Type:        schema.TypeBool,

--- a/datadog/tests/resource_datadog_security_monitoring_rule_test.go
+++ b/datadog/tests/resource_datadog_security_monitoring_rule_test.go
@@ -85,6 +85,10 @@ func TestAccDatadogSecurityMonitoringRule_NewValueRule(t *testing.T) {
 				Config: testAccCheckDatadogSecurityMonitoringUpdatedConfigNewValueRule(ruleName),
 				Check:  testAccCheckDatadogSecurityMonitoringUpdateCheckNewValueRule(accProvider, ruleName),
 			},
+			{
+				Config: testAccCheckDatadogSecurityMonitoringUpdatedConfigNewValueRuleExtendedRange(ruleName),
+				Check:  testAccCheckDatadogSecurityMonitoringUpdateCheckNewValueRuleExtendedRange(accProvider, ruleName),
+			},
 		},
 	})
 }
@@ -1826,6 +1830,99 @@ func testAccCheckDatadogSecurityMonitoringUpdateCheckNewValueRule(accProvider fu
 			tfSecurityRuleName, "options.0.new_value_options.0.learning_method", "duration"),
 		resource.TestCheckResourceAttr(
 			tfSecurityRuleName, "options.0.new_value_options.0.learning_duration", "0"),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "options.0.new_value_options.0.learning_threshold", "0"),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "options.0.new_value_options.0.instantaneous_baseline", "true"),
+		resource.TestCheckTypeSetElemAttr(
+			tfSecurityRuleName, "tags.*", "u:tomato"),
+		resource.TestCheckTypeSetElemAttr(
+			tfSecurityRuleName, "tags.*", "i:tomato"),
+	)
+}
+
+func testAccCheckDatadogSecurityMonitoringUpdatedConfigNewValueRuleExtendedRange(name string) string {
+	return fmt.Sprintf(`
+resource "datadog_security_monitoring_rule" "acceptance_test" {
+    name = "%s - extended range"
+    message = "acceptance rule triggered (extended range)"
+    enabled = true
+	validate = true
+
+    query {
+        name = "first"
+        query = "does not really match much (extended range)"
+        aggregation = "new_value"
+        data_source = "logs"
+        group_by_fields = ["service"]
+        metric = "@network.bytes_read"
+		has_optional_group_by_fields = false
+    }
+
+    case {
+        name = "high case (extended range)"
+        status = "medium"
+        condition = ""
+        notifications = ["@user"]
+    }
+
+     options {
+		detection_method = "new_value"
+        keep_alive = 600
+        max_signal_duration = 900
+		new_value_options {
+			forget_after = 30
+			learning_duration = 30
+			instantaneous_baseline = true
+		}
+    }
+
+    tags = ["u:tomato", "i:tomato"]
+}
+`, name)
+}
+
+func testAccCheckDatadogSecurityMonitoringUpdateCheckNewValueRuleExtendedRange(accProvider func() (*schema.Provider, error), ruleName string) resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		testAccCheckDatadogSecurityMonitoringRuleExists(accProvider, tfSecurityRuleName),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "name", ruleName+" - extended range"),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "message", "acceptance rule triggered (extended range)"),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "enabled", "true"),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "query.0.name", "first"),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "query.0.query", "does not really match much (extended range)"),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "query.0.aggregation", "new_value"),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "query.0.data_source", "logs"),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "query.0.has_optional_group_by_fields", "false"),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "query.0.group_by_fields.0", "service"),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "query.0.metric", "@network.bytes_read"),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "case.0.name", "high case (extended range)"),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "case.0.status", "medium"),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "case.0.notifications.0", "@user"),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "options.0.keep_alive", "600"),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "options.0.max_signal_duration", "900"),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "options.0.detection_method", "new_value"),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "options.0.new_value_options.0.forget_after", "30"),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "options.0.new_value_options.0.learning_method", "duration"),
+		resource.TestCheckResourceAttr(
+			tfSecurityRuleName, "options.0.new_value_options.0.learning_duration", "30"),
 		resource.TestCheckResourceAttr(
 			tfSecurityRuleName, "options.0.new_value_options.0.learning_threshold", "0"),
 		resource.TestCheckResourceAttr(


### PR DESCRIPTION
## Problem

The `new_value_options` block validators for `forget_after` and `learning_duration` use `ValidateEnumValue` which pulls allowed values from `datadog-api-client-go` v2.57.0 enums. These enums are narrower than what the Datadog API accepts:
- `ForgetAfter`: only {1, 2, 7, 14, 21, 28} (missing values up to 30)
- `LearningDuration`: only {0, 1, 7} (missing values up to 30)

This prevents managing existing security monitoring rules that use `forget_after=30` or `learning_duration=30`, which are valid API values.

Fixes #3699

## Changes

- Replace `ValidateDiagFunc: validators.ValidateEnumValue(...)` with `ValidateFunc: validation.IntBetween(1, 30)` for `forget_after`
- Replace `ValidateDiagFunc: validators.ValidateEnumValue(...)` with `ValidateFunc: validation.IntBetween(0, 30)` for `learning_duration`
- Add test step 3 to `TestAccDatadogSecurityMonitoringRule_NewValueRule` covering `forget_after=30` and `learning_duration=30`

## Note

The `datadog-api-client-go` also has a client-side `IsValid()` check on these enums that rejects value 30 during deserialization, causing `CheckForUnparsed` to fail on import/read. A companion PR is open: DataDog/datadog-api-client-go#3962

Until the client fix is released and the provider bumps `go.mod`, value 30 will pass provider validation but fail on API response deserialization during import. Both PRs need to land for the full fix.

## Test plan

- [ ] Existing test steps 1-2 continue to pass (values 7/1 and 1/0)
- [ ] New test step 3 passes with `forget_after=30` and `learning_duration=30`
- [ ] Cassette re-recording with `RECORD=true` (requires live API)
- [ ] `make docs` regenerates with updated valid value descriptions