### PR TITLE
Migrate release workflow to dd-octo-sts

### DIFF
--- a/.github/chainguard/self.release.create-release.sts.yaml
+++ b/.github/chainguard/self.release.create-release.sts.yaml
@@ -1,0 +1,13 @@
+---
+# Policy for: .github/workflows/release.yml in DataDog/terraform-provider-datadog
+# Allows the release workflow to create tags and GitHub releases
+issuer: https://token.actions.githubusercontent.com
+subject: repo:DataDog/terraform-provider-datadog:pull_request
+
+claim_pattern:
+  event_name: pull_request
+  job_workflow_ref: DataDog/terraform-provider-datadog/\.github/workflows/release\.yml@refs/pull/[0-9]+/merge
+  repository: DataDog/terraform-provider-datadog
+
+permissions:
+  contents: write

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -25,7 +25,7 @@ jobs:
     name: Create release PR
     runs-on: ubuntu-latest
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts
         with:
           scope: DataDog/terraform-provider-datadog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ name: release
 permissions:
   contents: write
   pull-requests: write
+  id-token: write # Required for dd-octo-sts action
 
 on:
   pull_request:
@@ -20,10 +21,10 @@ jobs:
     steps:
       - name: Get GitHub App token
         id: get_token
-        uses: actions/create-github-app-token@c1a285145b9d317df6ced56c09f525b5c2b6f755
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         with:
-          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
+          scope: DataDog/terraform-provider-datadog
+          policy: self.release.create-release
 
       - name: Create tag
         id: create_tag


### PR DESCRIPTION
## Summary

- Replace `actions/create-github-app-token` with `DataDog/dd-octo-sts-action` in the release workflow — the GitHub App JWT can no longer authenticate, blocking releases (see [failed run](https://github.com/DataDog/terraform-provider-datadog/actions/runs/24456595121))
- Add new STS policy `.github/chainguard/self.release.create-release.sts.yaml` for OIDC-based token exchange
- Bump `dd-octo-sts-action` from v1.0.3 to v1.0.4 in `prepare_release.yml` for consistency

## Test plan

- [ ] Merge this PR, then re-run the release process for v4.5.0
- [ ] Verify the `create_release` job obtains a token via octo-sts and successfully creates the tag
- [ ] Verify GoReleaser completes and publishes the draft release