### PR TITLE
[datadog_dashboard_json] Fix 401 for SDKv2 resources with cloud provider auth

### DIFF
--- a/datadog/internal/utils/custom_request.go
+++ b/datadog/internal/utils/custom_request.go
@@ -90,6 +90,16 @@ func buildRequest(ctx context.Context, client *datadog.APIClient, method, path s
 			}
 		}
 	}
+	// Handle cloud-provider-based (delegated token) authentication.
+	// Generated API methods call UseDelegatedTokenAuth explicitly; buildRequest
+	// bypasses generated code so we must do the same here.
+	if ctx != nil {
+		if _, ok := ctx.Value(datadog.ContextDelegatedToken).(*datadog.DelegatedTokenCredentials); ok {
+			if err := datadog.UseDelegatedTokenAuth(ctx, &localVarHeaderParams, client.GetConfig().DelegatedTokenConfig); err != nil {
+				return nil, err
+			}
+		}
+	}
 
 	req, err := client.PrepareRequest(ctx, localVarPath, method, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormQueryParams, localVarFormFile)
 	if err != nil {

--- a/datadog/internal/utils/custom_request.go
+++ b/datadog/internal/utils/custom_request.go
@@ -71,31 +71,25 @@ func buildRequest(ctx context.Context, client *datadog.APIClient, method, path s
 		if err := datadog.UseDelegatedTokenAuth(ctx, &localVarHeaderParams, client.GetConfig().DelegatedTokenConfig); err != nil {
 			return nil, err
 		}
-	} else {
-		if ctx != nil {
-			if auth, ok := ctx.Value(datadog.ContextAPIKeys).(map[string]datadog.APIKey); ok {
-				if apiKey, ok := auth["apiKeyAuth"]; ok {
-					var key string
-					if apiKey.Prefix != "" {
-						key = apiKey.Prefix + " " + apiKey.Key
-					} else {
-						key = apiKey.Key
-					}
-					localVarHeaderParams["DD-API-KEY"] = key
+	} else if ctx != nil {
+		if auth, ok := ctx.Value(datadog.ContextAPIKeys).(map[string]datadog.APIKey); ok {
+			if apiKey, ok := auth["apiKeyAuth"]; ok {
+				var key string
+				if apiKey.Prefix != "" {
+					key = apiKey.Prefix + " " + apiKey.Key
+				} else {
+					key = apiKey.Key
 				}
+				localVarHeaderParams["DD-API-KEY"] = key
 			}
-		}
-		if ctx != nil {
-			if auth, ok := ctx.Value(datadog.ContextAPIKeys).(map[string]datadog.APIKey); ok {
-				if apiKey, ok := auth["appKeyAuth"]; ok {
-					var key string
-					if apiKey.Prefix != "" {
-						key = apiKey.Prefix + " " + apiKey.Key
-					} else {
-						key = apiKey.Key
-					}
-					localVarHeaderParams["DD-APPLICATION-KEY"] = key
+			if apiKey, ok := auth["appKeyAuth"]; ok {
+				var key string
+				if apiKey.Prefix != "" {
+					key = apiKey.Prefix + " " + apiKey.Key
+				} else {
+					key = apiKey.Key
 				}
+				localVarHeaderParams["DD-APPLICATION-KEY"] = key
 			}
 		}
 	}

--- a/datadog/internal/utils/custom_request.go
+++ b/datadog/internal/utils/custom_request.go
@@ -64,39 +64,38 @@ func buildRequest(ctx context.Context, client *datadog.APIClient, method, path s
 		localVarPostBody = body
 	}
 
-	if ctx != nil {
-		if auth, ok := ctx.Value(datadog.ContextAPIKeys).(map[string]datadog.APIKey); ok {
-			if apiKey, ok := auth["apiKeyAuth"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
+	// Mirror the auth pattern used by every generated API method:
+	// prefer delegated token (cloud provider auth) when configured, otherwise
+	// fall back to API + App key. The two are mutually exclusive.
+	if client.GetConfig().DelegatedTokenConfig != nil {
+		if err := datadog.UseDelegatedTokenAuth(ctx, &localVarHeaderParams, client.GetConfig().DelegatedTokenConfig); err != nil {
+			return nil, err
+		}
+	} else {
+		if ctx != nil {
+			if auth, ok := ctx.Value(datadog.ContextAPIKeys).(map[string]datadog.APIKey); ok {
+				if apiKey, ok := auth["apiKeyAuth"]; ok {
+					var key string
+					if apiKey.Prefix != "" {
+						key = apiKey.Prefix + " " + apiKey.Key
+					} else {
+						key = apiKey.Key
+					}
+					localVarHeaderParams["DD-API-KEY"] = key
 				}
-				localVarHeaderParams["DD-API-KEY"] = key
 			}
 		}
-	}
-	if ctx != nil {
-		if auth, ok := ctx.Value(datadog.ContextAPIKeys).(map[string]datadog.APIKey); ok {
-			if apiKey, ok := auth["appKeyAuth"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
+		if ctx != nil {
+			if auth, ok := ctx.Value(datadog.ContextAPIKeys).(map[string]datadog.APIKey); ok {
+				if apiKey, ok := auth["appKeyAuth"]; ok {
+					var key string
+					if apiKey.Prefix != "" {
+						key = apiKey.Prefix + " " + apiKey.Key
+					} else {
+						key = apiKey.Key
+					}
+					localVarHeaderParams["DD-APPLICATION-KEY"] = key
 				}
-				localVarHeaderParams["DD-APPLICATION-KEY"] = key
-			}
-		}
-	}
-	// Handle cloud-provider-based (delegated token) authentication.
-	// Generated API methods call UseDelegatedTokenAuth explicitly; buildRequest
-	// bypasses generated code so we must do the same here.
-	if ctx != nil {
-		if _, ok := ctx.Value(datadog.ContextDelegatedToken).(*datadog.DelegatedTokenCredentials); ok {
-			if err := datadog.UseDelegatedTokenAuth(ctx, &localVarHeaderParams, client.GetConfig().DelegatedTokenConfig); err != nil {
-				return nil, err
 			}
 		}
 	}

--- a/datadog/internal/utils/custom_request_test.go
+++ b/datadog/internal/utils/custom_request_test.go
@@ -1,0 +1,160 @@
+package utils
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+)
+
+// newTestClientAndCtx returns an APIClient pointed at srv, plus a base context
+// configured to route requests there via ContextServerIndex=1 / ContextServerVariables.
+func newTestClientAndCtx(srv *httptest.Server) (*datadog.APIClient, context.Context) {
+	cfg := datadog.NewConfiguration()
+	cfg.HTTPClient = srv.Client()
+	client := datadog.NewAPIClient(cfg)
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, datadog.ContextServerIndex, 1)
+	ctx = context.WithValue(ctx, datadog.ContextServerVariables, map[string]string{
+		"name":     srv.Listener.Addr().String(),
+		"protocol": "http",
+	})
+	return client, ctx
+}
+
+func TestBuildRequest_APIKeyAuth(t *testing.T) {
+	var gotAPIKey, gotAppKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAPIKey = r.Header.Get("DD-API-KEY")
+		gotAppKey = r.Header.Get("DD-APPLICATION-KEY")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client, ctx := newTestClientAndCtx(srv)
+	ctx = context.WithValue(ctx, datadog.ContextAPIKeys, map[string]datadog.APIKey{
+		"apiKeyAuth": {Key: "test-api-key"},
+		"appKeyAuth": {Key: "test-app-key"},
+	})
+
+	req, err := buildRequest(ctx, client, "GET", "/api/v1/dashboard", nil)
+	if err != nil {
+		t.Fatalf("buildRequest error: %v", err)
+	}
+	if _, err := client.CallAPI(req); err != nil {
+		t.Fatalf("CallAPI error: %v", err)
+	}
+
+	if gotAPIKey != "test-api-key" {
+		t.Errorf("DD-API-KEY: want %q, got %q", "test-api-key", gotAPIKey)
+	}
+	if gotAppKey != "test-app-key" {
+		t.Errorf("DD-APPLICATION-KEY: want %q, got %q", "test-app-key", gotAppKey)
+	}
+}
+
+// TestBuildRequest_DelegatedTokenAuth is the regression test for the cloud-auth bug:
+// buildRequest was not calling UseDelegatedTokenAuth, so POST /api/v1/dashboard
+// (and other SendRequest callers) went out with no Authorization header when
+// cloud_provider_type = "aws" was set.
+func TestBuildRequest_DelegatedTokenAuth(t *testing.T) {
+	var gotAuthorization string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthorization = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client, ctx := newTestClientAndCtx(srv)
+
+	// Pre-seed a valid, non-expired delegated token so UseDelegatedTokenAuth
+	// doesn't try to reach out to the external-token-servicer.
+	creds := &datadog.DelegatedTokenCredentials{
+		DelegatedToken: "test-delegated-bearer-token",
+		Expiration:     time.Now().Add(15 * time.Minute),
+	}
+	ctx = context.WithValue(ctx, datadog.ContextDelegatedToken, creds)
+
+	req, err := buildRequest(ctx, client, "POST", "/api/v1/dashboard", nil)
+	if err != nil {
+		t.Fatalf("buildRequest error: %v", err)
+	}
+	if _, err := client.CallAPI(req); err != nil {
+		t.Fatalf("CallAPI error: %v", err)
+	}
+
+	want := "Bearer test-delegated-bearer-token"
+	if gotAuthorization != want {
+		t.Errorf("Authorization: want %q, got %q", want, gotAuthorization)
+	}
+}
+
+// TestBuildRequest_DelegatedTokenAuth_NoAPIKeyLeakage ensures that when cloud
+// auth is active, no DD-API-KEY or DD-APPLICATION-KEY headers are emitted.
+func TestBuildRequest_DelegatedTokenAuth_NoAPIKeyLeakage(t *testing.T) {
+	var gotAPIKey, gotAppKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAPIKey = r.Header.Get("DD-API-KEY")
+		gotAppKey = r.Header.Get("DD-APPLICATION-KEY")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client, ctx := newTestClientAndCtx(srv)
+	creds := &datadog.DelegatedTokenCredentials{
+		DelegatedToken: "test-delegated-bearer-token",
+		Expiration:     time.Now().Add(15 * time.Minute),
+	}
+	ctx = context.WithValue(ctx, datadog.ContextDelegatedToken, creds)
+
+	req, err := buildRequest(ctx, client, "POST", "/api/v1/dashboard", nil)
+	if err != nil {
+		t.Fatalf("buildRequest error: %v", err)
+	}
+	if _, err := client.CallAPI(req); err != nil {
+		t.Fatalf("CallAPI error: %v", err)
+	}
+
+	if gotAPIKey != "" {
+		t.Errorf("DD-API-KEY should be absent with cloud auth, got %q", gotAPIKey)
+	}
+	if gotAppKey != "" {
+		t.Errorf("DD-APPLICATION-KEY should be absent with cloud auth, got %q", gotAppKey)
+	}
+}
+
+func TestBuildRequest_NoAuth(t *testing.T) {
+	var gotAuthorization, gotAPIKey, gotAppKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthorization = r.Header.Get("Authorization")
+		gotAPIKey = r.Header.Get("DD-API-KEY")
+		gotAppKey = r.Header.Get("DD-APPLICATION-KEY")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client, ctx := newTestClientAndCtx(srv)
+	// No auth values in context.
+
+	req, err := buildRequest(ctx, client, "GET", "/api/v1/dashboard", nil)
+	if err != nil {
+		t.Fatalf("buildRequest error: %v", err)
+	}
+	if _, err := client.CallAPI(req); err != nil {
+		t.Fatalf("CallAPI error: %v", err)
+	}
+
+	if gotAuthorization != "" {
+		t.Errorf("Authorization should be absent, got %q", gotAuthorization)
+	}
+	if gotAPIKey != "" {
+		t.Errorf("DD-API-KEY should be absent, got %q", gotAPIKey)
+	}
+	if gotAppKey != "" {
+		t.Errorf("DD-APPLICATION-KEY should be absent, got %q", gotAppKey)
+	}
+}

--- a/datadog/internal/utils/custom_request_test.go
+++ b/datadog/internal/utils/custom_request_test.go
@@ -15,6 +15,19 @@ func newTestClient() *datadog.APIClient {
 	return datadog.NewAPIClient(datadog.NewConfiguration())
 }
 
+// newDelegatedTokenTestClient returns an APIClient with DelegatedTokenConfig set,
+// mirroring the production setup in providerConfigure when cloud_provider_type is set.
+func newDelegatedTokenTestClient() *datadog.APIClient {
+	cfg := datadog.NewConfiguration()
+	cfg.DelegatedTokenConfig = &datadog.DelegatedTokenConfig{
+		OrgUUID:  "test-org-uuid",
+		Provider: "aws",
+		// ProviderAuth intentionally nil: tests pre-seed the token in the
+		// context so UseDelegatedTokenAuth never calls out to the token servicer.
+	}
+	return datadog.NewAPIClient(cfg)
+}
+
 func TestBuildRequest_APIKeyAuth(t *testing.T) {
 	ctx := context.WithValue(context.Background(), datadog.ContextAPIKeys, map[string]datadog.APIKey{
 		"apiKeyAuth": {Key: "test-api-key"},
@@ -42,15 +55,17 @@ func TestBuildRequest_APIKeyAuth(t *testing.T) {
 // Also verifies that no DD-API-KEY / DD-APPLICATION-KEY headers are emitted
 // under cloud auth (no key leakage).
 func TestBuildRequest_DelegatedTokenAuth(t *testing.T) {
-	// Pre-seed a valid, non-expired delegated token so UseDelegatedTokenAuth
-	// doesn't try to reach out to the external-token-servicer.
+	// In production, providerConfigure always sets both DelegatedTokenConfig on
+	// the client and ContextDelegatedToken in the context. Mirrors that here.
+	// Pre-seed a valid, non-expired token so UseDelegatedTokenAuth doesn't call
+	// out to the external-token-servicer.
 	creds := &datadog.DelegatedTokenCredentials{
 		DelegatedToken: "test-delegated-bearer-token",
 		Expiration:     time.Now().Add(15 * time.Minute),
 	}
 	ctx := context.WithValue(context.Background(), datadog.ContextDelegatedToken, creds)
 
-	req, err := buildRequest(ctx, newTestClient(), "POST", "/api/v1/dashboard", nil)
+	req, err := buildRequest(ctx, newDelegatedTokenTestClient(), "POST", "/api/v1/dashboard", nil)
 	if err != nil {
 		t.Fatalf("buildRequest error: %v", err)
 	}

--- a/datadog/internal/utils/custom_request_test.go
+++ b/datadog/internal/utils/custom_request_test.go
@@ -2,58 +2,35 @@ package utils
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 )
 
-// newTestClientAndCtx returns an APIClient pointed at srv, plus a base context
-// configured to route requests there via ContextServerIndex=1 / ContextServerVariables.
-func newTestClientAndCtx(srv *httptest.Server) (*datadog.APIClient, context.Context) {
-	cfg := datadog.NewConfiguration()
-	cfg.HTTPClient = srv.Client()
-	client := datadog.NewAPIClient(cfg)
-
-	ctx := context.Background()
-	ctx = context.WithValue(ctx, datadog.ContextServerIndex, 1)
-	ctx = context.WithValue(ctx, datadog.ContextServerVariables, map[string]string{
-		"name":     srv.Listener.Addr().String(),
-		"protocol": "http",
-	})
-	return client, ctx
+// newTestClient returns an APIClient with the default configuration.
+// Tests use this to call buildRequest without making real HTTP calls;
+// they inspect the returned *http.Request headers directly.
+func newTestClient() *datadog.APIClient {
+	return datadog.NewAPIClient(datadog.NewConfiguration())
 }
 
 func TestBuildRequest_APIKeyAuth(t *testing.T) {
-	var gotAPIKey, gotAppKey string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotAPIKey = r.Header.Get("DD-API-KEY")
-		gotAppKey = r.Header.Get("DD-APPLICATION-KEY")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	client, ctx := newTestClientAndCtx(srv)
-	ctx = context.WithValue(ctx, datadog.ContextAPIKeys, map[string]datadog.APIKey{
+	ctx := context.WithValue(context.Background(), datadog.ContextAPIKeys, map[string]datadog.APIKey{
 		"apiKeyAuth": {Key: "test-api-key"},
 		"appKeyAuth": {Key: "test-app-key"},
 	})
 
-	req, err := buildRequest(ctx, client, "GET", "/api/v1/dashboard", nil)
+	req, err := buildRequest(ctx, newTestClient(), "GET", "/api/v1/dashboard", nil)
 	if err != nil {
 		t.Fatalf("buildRequest error: %v", err)
 	}
-	if _, err := client.CallAPI(req); err != nil {
-		t.Fatalf("CallAPI error: %v", err)
-	}
 
-	if gotAPIKey != "test-api-key" {
-		t.Errorf("DD-API-KEY: want %q, got %q", "test-api-key", gotAPIKey)
+	if got := req.Header.Get("DD-API-KEY"); got != "test-api-key" {
+		t.Errorf("DD-API-KEY: want %q, got %q", "test-api-key", got)
 	}
-	if gotAppKey != "test-app-key" {
-		t.Errorf("DD-APPLICATION-KEY: want %q, got %q", "test-app-key", gotAppKey)
+	if got := req.Header.Get("DD-APPLICATION-KEY"); got != "test-app-key" {
+		t.Errorf("DD-APPLICATION-KEY: want %q, got %q", "test-app-key", got)
 	}
 }
 
@@ -61,100 +38,48 @@ func TestBuildRequest_APIKeyAuth(t *testing.T) {
 // buildRequest was not calling UseDelegatedTokenAuth, so POST /api/v1/dashboard
 // (and other SendRequest callers) went out with no Authorization header when
 // cloud_provider_type = "aws" was set.
+//
+// Also verifies that no DD-API-KEY / DD-APPLICATION-KEY headers are emitted
+// under cloud auth (no key leakage).
 func TestBuildRequest_DelegatedTokenAuth(t *testing.T) {
-	var gotAuthorization string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotAuthorization = r.Header.Get("Authorization")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	client, ctx := newTestClientAndCtx(srv)
-
 	// Pre-seed a valid, non-expired delegated token so UseDelegatedTokenAuth
 	// doesn't try to reach out to the external-token-servicer.
 	creds := &datadog.DelegatedTokenCredentials{
 		DelegatedToken: "test-delegated-bearer-token",
 		Expiration:     time.Now().Add(15 * time.Minute),
 	}
-	ctx = context.WithValue(ctx, datadog.ContextDelegatedToken, creds)
+	ctx := context.WithValue(context.Background(), datadog.ContextDelegatedToken, creds)
 
-	req, err := buildRequest(ctx, client, "POST", "/api/v1/dashboard", nil)
+	req, err := buildRequest(ctx, newTestClient(), "POST", "/api/v1/dashboard", nil)
 	if err != nil {
 		t.Fatalf("buildRequest error: %v", err)
-	}
-	if _, err := client.CallAPI(req); err != nil {
-		t.Fatalf("CallAPI error: %v", err)
 	}
 
 	want := "Bearer test-delegated-bearer-token"
-	if gotAuthorization != want {
-		t.Errorf("Authorization: want %q, got %q", want, gotAuthorization)
+	if got := req.Header.Get("Authorization"); got != want {
+		t.Errorf("Authorization: want %q, got %q", want, got)
 	}
-}
-
-// TestBuildRequest_DelegatedTokenAuth_NoAPIKeyLeakage ensures that when cloud
-// auth is active, no DD-API-KEY or DD-APPLICATION-KEY headers are emitted.
-func TestBuildRequest_DelegatedTokenAuth_NoAPIKeyLeakage(t *testing.T) {
-	var gotAPIKey, gotAppKey string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotAPIKey = r.Header.Get("DD-API-KEY")
-		gotAppKey = r.Header.Get("DD-APPLICATION-KEY")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	client, ctx := newTestClientAndCtx(srv)
-	creds := &datadog.DelegatedTokenCredentials{
-		DelegatedToken: "test-delegated-bearer-token",
-		Expiration:     time.Now().Add(15 * time.Minute),
+	if got := req.Header.Get("DD-API-KEY"); got != "" {
+		t.Errorf("DD-API-KEY should be absent with cloud auth, got %q", got)
 	}
-	ctx = context.WithValue(ctx, datadog.ContextDelegatedToken, creds)
-
-	req, err := buildRequest(ctx, client, "POST", "/api/v1/dashboard", nil)
-	if err != nil {
-		t.Fatalf("buildRequest error: %v", err)
-	}
-	if _, err := client.CallAPI(req); err != nil {
-		t.Fatalf("CallAPI error: %v", err)
-	}
-
-	if gotAPIKey != "" {
-		t.Errorf("DD-API-KEY should be absent with cloud auth, got %q", gotAPIKey)
-	}
-	if gotAppKey != "" {
-		t.Errorf("DD-APPLICATION-KEY should be absent with cloud auth, got %q", gotAppKey)
+	if got := req.Header.Get("DD-APPLICATION-KEY"); got != "" {
+		t.Errorf("DD-APPLICATION-KEY should be absent with cloud auth, got %q", got)
 	}
 }
 
 func TestBuildRequest_NoAuth(t *testing.T) {
-	var gotAuthorization, gotAPIKey, gotAppKey string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotAuthorization = r.Header.Get("Authorization")
-		gotAPIKey = r.Header.Get("DD-API-KEY")
-		gotAppKey = r.Header.Get("DD-APPLICATION-KEY")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	client, ctx := newTestClientAndCtx(srv)
-	// No auth values in context.
-
-	req, err := buildRequest(ctx, client, "GET", "/api/v1/dashboard", nil)
+	req, err := buildRequest(context.Background(), newTestClient(), "GET", "/api/v1/dashboard", nil)
 	if err != nil {
 		t.Fatalf("buildRequest error: %v", err)
 	}
-	if _, err := client.CallAPI(req); err != nil {
-		t.Fatalf("CallAPI error: %v", err)
-	}
 
-	if gotAuthorization != "" {
-		t.Errorf("Authorization should be absent, got %q", gotAuthorization)
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Errorf("Authorization should be absent, got %q", got)
 	}
-	if gotAPIKey != "" {
-		t.Errorf("DD-API-KEY should be absent, got %q", gotAPIKey)
+	if got := req.Header.Get("DD-API-KEY"); got != "" {
+		t.Errorf("DD-API-KEY should be absent, got %q", got)
 	}
-	if gotAppKey != "" {
-		t.Errorf("DD-APPLICATION-KEY should be absent, got %q", gotAppKey)
+	if got := req.Header.Get("DD-APPLICATION-KEY"); got != "" {
+		t.Errorf("DD-APPLICATION-KEY should be absent, got %q", got)
 	}
 }

--- a/datadog/internal/utils/custom_request_test.go
+++ b/datadog/internal/utils/custom_request_test.go
@@ -82,6 +82,59 @@ func TestBuildRequest_DelegatedTokenAuth(t *testing.T) {
 	}
 }
 
+// TestBuildRequest_APIKeyOnlyAuth verifies that providing only an API key (no app
+// key) still sets DD-API-KEY and leaves DD-APPLICATION-KEY absent.
+func TestBuildRequest_APIKeyOnlyAuth(t *testing.T) {
+	ctx := context.WithValue(context.Background(), datadog.ContextAPIKeys, map[string]datadog.APIKey{
+		"apiKeyAuth": {Key: "test-api-key"},
+	})
+
+	req, err := buildRequest(ctx, newTestClient(), "GET", "/api/v1/validate", nil)
+	if err != nil {
+		t.Fatalf("buildRequest error: %v", err)
+	}
+
+	if got := req.Header.Get("DD-API-KEY"); got != "test-api-key" {
+		t.Errorf("DD-API-KEY: want %q, got %q", "test-api-key", got)
+	}
+	if got := req.Header.Get("DD-APPLICATION-KEY"); got != "" {
+		t.Errorf("DD-APPLICATION-KEY should be absent when not provided, got %q", got)
+	}
+}
+
+// TestBuildRequest_DelegatedTokenAuthTakesPrecedence verifies that when both
+// DelegatedTokenConfig and ContextAPIKeys are present, delegated token auth wins
+// and no API/app key headers are emitted. This matches the if/else pattern in
+// generated API methods.
+func TestBuildRequest_DelegatedTokenAuthTakesPrecedence(t *testing.T) {
+	creds := &datadog.DelegatedTokenCredentials{
+		DelegatedToken: "test-delegated-bearer-token",
+		Expiration:     time.Now().Add(15 * time.Minute),
+	}
+	ctx := context.WithValue(context.Background(), datadog.ContextDelegatedToken, creds)
+	// Also put API keys in context to confirm they are ignored.
+	ctx = context.WithValue(ctx, datadog.ContextAPIKeys, map[string]datadog.APIKey{
+		"apiKeyAuth": {Key: "should-not-appear-api-key"},
+		"appKeyAuth": {Key: "should-not-appear-app-key"},
+	})
+
+	req, err := buildRequest(ctx, newDelegatedTokenTestClient(), "POST", "/api/v1/dashboard", nil)
+	if err != nil {
+		t.Fatalf("buildRequest error: %v", err)
+	}
+
+	want := "Bearer test-delegated-bearer-token"
+	if got := req.Header.Get("Authorization"); got != want {
+		t.Errorf("Authorization: want %q, got %q", want, got)
+	}
+	if got := req.Header.Get("DD-API-KEY"); got != "" {
+		t.Errorf("DD-API-KEY should be absent when delegated token auth is active, got %q", got)
+	}
+	if got := req.Header.Get("DD-APPLICATION-KEY"); got != "" {
+		t.Errorf("DD-APPLICATION-KEY should be absent when delegated token auth is active, got %q", got)
+	}
+}
+
 func TestBuildRequest_NoAuth(t *testing.T) {
 	req, err := buildRequest(context.Background(), newTestClient(), "GET", "/api/v1/dashboard", nil)
 	if err != nil {


### PR DESCRIPTION
## Summary

- `buildRequest` in `custom_request.go` — used by all legacy SDKv2 resources (`datadog_dashboard_json`, `datadog_monitor_json`, `datadog_service_definition_yaml`, etc.) — was not calling `UseDelegatedTokenAuth`, so requests sent under `cloud_provider_type = "aws"` went out with no `Authorization` header, producing `401 Unauthorized`
- Every generated API method in `datadog-api-client-go` calls `UseDelegatedTokenAuth` explicitly; `buildRequest` bypassed that generated code path entirely and only handled `ContextAPIKeys`
- Added the missing call to `UseDelegatedTokenAuth` in `buildRequest` when `ContextDelegatedToken` is present in the context, mirroring what generated methods do
- Added unit tests covering: API key auth (regression), delegated token auth (the bug), no key leakage with cloud auth, and no-auth baseline

## Root cause

```
providerConfigure sets:
  ctx = ContextDelegatedToken → &DelegatedTokenCredentials{}
  ctx = ContextAWSVariables   → { access key, secret, session token }
  config.DelegatedTokenConfig → { OrgUUID, provider: "aws" }

Generated API methods:  call UseDelegatedTokenAuth → sets Authorization: Bearer <token> ✓
buildRequest (SDKv2):   only checks ContextAPIKeys  → sends no auth headers         ✗
```

## Test plan
- [x] New unit tests in `datadog/internal/utils/custom_request_test.go` pass: `go test ./datadog/internal/utils/... -run TestBuildRequest -v`
- [x] Local `terraform apply` with `cloud_provider_type = "aws"` and a `datadog_dashboard_json` resource succeeds (previously 401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)