### PR TITLE
Fix release STS policy job_workflow_ref

### DIFF
--- a/.github/chainguard/self.release.create-release.sts.yaml
+++ b/.github/chainguard/self.release.create-release.sts.yaml
@@ -6,7 +6,7 @@ subject: repo:DataDog/terraform-provider-datadog:pull_request
 
 claim_pattern:
   event_name: pull_request
-  job_workflow_ref: DataDog/terraform-provider-datadog/\.github/workflows/release\.yml@refs/pull/[0-9]+/merge
+  job_workflow_ref: DataDog/terraform-provider-datadog/\.github/workflows/release\.yml@refs/heads/(master|v3)
   repository: DataDog/terraform-provider-datadog
 
 permissions:


### PR DESCRIPTION
## Summary

- Fix `job_workflow_ref` pattern in `.github/chainguard/self.release.create-release.sts.yaml`
- The release workflow runs on the base branch (`master`/`v3`) after PR merge, so the OIDC `job_workflow_ref` claim is `@refs/heads/master`, not `@refs/pull/N/merge`
- This caused the v4.5.0 release to fail with a 403 from octo-sts ([failed run](https://github.com/DataDog/terraform-provider-datadog/actions/runs/24462858940/job/71595180194))

Follows up on #3706.

## Test plan

- [x] Merge this PR, then re-run the release for v4.5.0
- [ ] Verify the octo-sts token exchange succeeds and tag creation completes