### PR TITLE
Release 4.5.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           scope: DataDog/terraform-provider-datadog
           policy: self.release.create-release
+          application_id: "38460"
 
       - name: Create tag
         id: create_tag


### PR DESCRIPTION
The default dd-octo-sts app cannot bypass tag protection rulesets, causing the 'Create tag' step to fail with 'Reference update failed'.