### PR TITLE
Skip flaky tests on nightly runs and add new failures

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -54,9 +54,8 @@ jobs:
         env:
           DD_TEST_CLIENT_API_KEY: ${{ secrets.DD_CLIENT_API_KEY }}
           DD_TEST_CLIENT_APP_KEY: ${{ secrets.DD_CLIENT_APP_KEY }}
-      - name: Build skip list for label-triggered runs
+      - name: Build skip list for flaky tests
         id: skip-list
-        if: github.event_name == 'pull_request'
         run: |
           SKIP_REGEX=$(python3 scripts/build_skip_regex.py)
           if [ -n "$SKIP_REGEX" ]; then

--- a/flaky_tests.yaml
+++ b/flaky_tests.yaml
@@ -49,7 +49,11 @@ skipped_tests:
     added: "2026-03-04"
     author: LiuVII
 
-  # User/Team datasource — Eventual consistency (8 tests)
+  # User/Team datasource — Eventual consistency (9 tests)
+  - test: TestAccDatadogUserDatasourceExactMatch
+    reason: "Eventual consistency — user not found immediately after creation"
+    added: "2026-04-24"
+    author: fpighi
   - test: TestAccDatadogUserDatasourceWithExactMatch
     reason: "Initial sync of tests failing on master branch"
     added: "2026-03-02"
@@ -191,7 +195,7 @@ skipped_tests:
     added: "2026-03-04"
     author: LiuVII
 
-  # Non-empty plan after apply — provider read bug (2 tests)
+  # Non-empty plan after apply — provider read bug (3 tests)
   - test: TestAccDatadogAuthNMapping_CreateUpdate
     reason: "Non-empty plan after apply + 404 on destroy — provider read returns empty state after create"
     added: "2026-03-04"
@@ -200,6 +204,10 @@ skipped_tests:
     reason: "Non-empty plan after apply — provider fails to read back created custom destination"
     added: "2026-03-04"
     author: LiuVII
+  - test: TestAccDatadogSensitiveDataScannerGroup_Basic
+    reason: "Non-empty plan after apply — is_enabled read back as false instead of true after create"
+    added: "2026-04-24"
+    author: fpighi
 
   # Provider bugs (3 tests)
   - test: TestAccDatadogApmRetentionFilterOrder
@@ -265,4 +273,34 @@ skipped_tests:
   - test: TestAccDatadogCustomAllocationRules_OverrideFalseUnmanagedAtEnd
     reason: "Intermittent 429 Too Many Requests — rate limiting on CustomAllocationRules API"
     added: "2026-04-10"
+    author: fpighi
+  - test: TestAccMonitor_Fwprovider_FormulaFunction_Cost
+    reason: "Intermittent 503 Service Unavailable from /api/v1/monitor/validate"
+    added: "2026-04-24"
+    author: fpighi
+  - test: TestAccDatadogTagPipelineRulesets_OverrideFalseUnmanagedAtEnd
+    reason: "Intermittent 429 Too Many Requests — rate limiting on ccm_list_tag_enrichment_rulesets"
+    added: "2026-04-24"
+    author: fpighi
+
+  # Azure integration — 500 Internal Server Error on list (2 tests)
+  - test: TestAccDatadogIntegrationAzure
+    reason: "500 Internal Server Error from list azure integration endpoint"
+    added: "2026-04-24"
+    author: fpighi
+  - test: TestAccDatadogIntegrationAzure_import
+    reason: "500 Internal Server Error from list azure integration endpoint"
+    added: "2026-04-24"
+    author: fpighi
+
+  # OnCall routing rules — 500 from user_invitations (1 test)
+  - test: TestAccOnCallTeamRoutingRulesCreateAndUpdate
+    reason: "500 Internal Server Error from /api/v2/user_invitations during user creation"
+    added: "2026-04-24"
+    author: fpighi
+
+  # RUM retention filter order — wrong count (1 test)
+  - test: TestAccRumRetentionFilterOrder
+    reason: "retention_filter_ids count mismatch — expected 3, got 2 — pre-existing filters in org"
+    added: "2026-04-24"
     author: fpighi


### PR DESCRIPTION
- Remove `if: github.event_name == 'pull_request'` guard from the build-skip-list step so flaky tests are also skipped in scheduled runs
- Add 8 new failures observed in the 2026-04-24 master build: TestAccDatadogUserDatasourceExactMatch, TestAccDatadogSensitiveDataScannerGroup_Basic, TestAccMonitor_Fwprovider_FormulaFunction_Cost, TestAccDatadogTagPipelineRulesets_OverrideFalseUnmanagedAtEnd, TestAccDatadogIntegrationAzure, TestAccDatadogIntegrationAzure_import, TestAccOnCallTeamRoutingRulesCreateAndUpdate, TestAccRumRetentionFilterOrder