### PR TITLE
Skip plan-time locations emptiness check when value is unknown

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -1954,9 +1954,16 @@ func resourceDatadogSyntheticsTestCustomizeDiff(ctx context.Context, diff *schem
 	// validate locations are not empty for API and browser tests
 	type_, typeOk := diff.GetOk("type")
 	if typeOk && (type_.(string) == string(datadogV1.SYNTHETICSTESTDETAILSTYPE_API) || type_.(string) == string(datadogV1.SYNTHETICSTESTDETAILSTYPE_BROWSER)) {
-		if locations := diff.Get("locations"); locations != nil {
-			if locations.(*schema.Set).Len() == 0 {
-				return fmt.Errorf("locations must not be empty for synthetics API and browser tests")
+		// Skip the emptiness check when the value is not yet known — e.g. when
+		// locations contains the id of a datadog_synthetics_private_location
+		// being created in the same apply. schema.Set.Len() reports 0 in that
+		// case even though the list is non-empty; Terraform re-validates once
+		// the value is known. Fixes #3273.
+		if diff.NewValueKnown("locations") {
+			if locations := diff.Get("locations"); locations != nil {
+				if locations.(*schema.Set).Len() == 0 {
+					return fmt.Errorf("locations must not be empty for synthetics API and browser tests")
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## What

The `CustomizeDiff` validation added in #3253 rejects synthetic API/browser tests with `Error: locations must not be empty for synthetics API and browser tests` whenever `locations` contains a value that is "known after apply" — e.g. the id of a `datadog_synthetics_private_location` being created in the same Terraform run, or any expression resolved from a sensitive/computed source.

In those cases `schema.Set.Len()` returns `0` even though the list is non-empty after apply. The check should defer to apply-time validation when the value isn't yet known.

## Fix

Guards the existing block with `diff.NewValueKnown(\"locations\")`:

```go
if diff.NewValueKnown(\"locations\") {
    if locations := diff.Get(\"locations\"); locations != nil {
        if locations.(*schema.Set).Len() == 0 {
            return fmt.Errorf(\"locations must not be empty for synthetics API and browser tests\")
        }
    }
}
```

- Literal `locations = []` still fails fast at plan (existing behaviour, `TestAccDatadogSyntheticsAPITest_EmptyLocations` and `TestAccDatadogSyntheticsBrowserTest_EmptyLocations` are unaffected).
- Computed/unknown values pass plan; Terraform re-validates at apply once the value is concrete.

## Repro

```hcl
resource \"datadog_synthetics_private_location\" \"pl\" {
  name = \"internal-sin\"
}

resource \"datadog_synthetics_test\" \"http\" {
  type      = \"api\"
  subtype   = \"http\"
  status    = \"live\"
  locations = [datadog_synthetics_private_location.pl.id]
  # ...
}
```

`terraform plan` on a clean state:

```
Plan: 1 to add, 1 to change, 0 to destroy.
│ Error: locations must not be empty for synthetics API and browser tests
│   with datadog_synthetics_test.http,
│   on main.tf line N, in resource \"datadog_synthetics_test\" \"http\":
│      resource \"datadog_synthetics_test\" \"http\" {
```

With this patch, the plan completes and apply proceeds normally.

## Fixes

- Fixes #3273

## Notes on tests

Adding an acceptance test for the unknown-value path needs new VCR cassettes (create a PL + a test that references its id, both in the same apply). Happy to record cassettes if a maintainer can grant API access, or leave this follow-up to the team that already has `make testacc` credentials — let me know which you'd prefer.