### PR TITLE
[datadog_logs_integration_pipeline] Skip CheckForUnparsed in logs integration pipeline read/update

### DIFF
--- a/datadog/resource_datadog_logs_integration_pipeline.go
+++ b/datadog/resource_datadog_logs_integration_pipeline.go
@@ -56,9 +56,6 @@ func resourceDatadogLogsIntegrationPipelineRead(ctx context.Context, d *schema.R
 		}
 		return utils.TranslateClientErrorDiag(err, httpresp, "error getting logs integration pipeline")
 	}
-	if err := utils.CheckForUnparsed(ddPipeline); err != nil {
-		return diag.FromErr(err)
-	}
 	if !ddPipeline.GetIsReadOnly() {
 		d.SetId("")
 		return nil
@@ -76,9 +73,6 @@ func resourceDatadogLogsIntegrationPipelineUpdate(ctx context.Context, d *schema
 		UpdateLogsPipeline(auth, d.Id(), ddPipeline)
 	if err != nil {
 		return utils.TranslateClientErrorDiag(err, httpResponse, "error updating logs integration pipeline")
-	}
-	if err := utils.CheckForUnparsed(updatedPipeline); err != nil {
-		return diag.FromErr(err)
 	}
 	d.SetId(*updatedPipeline.Id)
 	return updateLogsIntegrationPipelineState(d, &updatedPipeline)


### PR DESCRIPTION
## What does this PR do?

Skip the \`CheckForUnparsed\` validation in the \`datadog_logs_integration_pipeline\` resource read and update operations.

## Who will it impact?

* [slack/#k9-ask-cloud-siem](https://dd.enterprise.slack.com/archives/C02PKN3LV96)

## Motivation

When SIEM is enabled, Datadog automatically injects OCSF \`schema-processor\` (with \`schema-category-mapper\` mappers) into integration pipelines. The provider was calling \`CheckForUnparsed\` on the full pipeline response, which fails on this structure. Since \`datadog_logs_integration_pipeline\` only manages \`is_enabled\` and never reads processor configuration, the check was unnecessary and fragile.

## Root cause

The failure chain when SIEM is enabled:

1. SIEM injects a \`schema-processor\` into the integration pipeline — an OCSF-specific processor type that didn't exist before.
2. The provider reads the full pipeline via \`GetLogsPipeline\`. The \`processors\` array is deserialized as \`[]LogsProcessor\`, a oneOf union over ~20 known processor types.
3. \`LogsProcessor.UnmarshalJSON\` tries every known type and counts matches. If \`match != 1\`, it sets \`LogsProcessor.UnparsedObject\` to the raw map and gives up.
4. \`schema-processor\` causes \`match = 0\`: in releases compiled before \`LogsSchemaProcessor\` was added to the \`LogsProcessor\` oneOf, the type simply wasn't tried. Even with a newer API client, \`LogsSchemaData\` can fail to parse if the \`extensions\` field returned by the API is not declared in the model, which sets \`LogsSchemaProcessor.UnparsedObject\`, driving \`match\` back to 0.
5. \`CheckForUnparsed(ddPipeline)\` walks the whole struct via reflection, finds \`LogsProcessor.UnparsedObject != nil\` (containing the full schema-processor block), and returns \`"object contains unparsed element: map[... type:schema-processor]"\`.

The custom pipeline resource (\`datadog_logs_custom_pipeline\`) was updated alongside the schema-processor API client changes and only checks processors it manages. The integration pipeline resource was blindly checking the entire API response including auto-injected OCSF processors it has no schema for.

## Testing Guidelines

No unit tests added — the resource only manages \`is_enabled\` and the removed code path was purely defensive validation that had no functional impact on state management.