### PR TITLE
[CLOUDMAPS-2848] Add Cloudcraft widget support

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -2492,12 +2492,12 @@ func getCloudcraftDefinitionSchema() map[string]*schema.Schema {
 		"highlighted": {
 			Description: "Search query that visually highlights matching resources in the diagram.",
 			Type:        schema.TypeString,
-			Optional:    true,
+			Required:    true,
 		},
 		"show_empty_groups": {
-			Description: "Whether to show empty outline groups (VPCs, subnets, security groups, etc.).",
+			Description: "Whether to show empty outline groups in the diagram.",
 			Type:        schema.TypeBool,
-			Optional:    true,
+			Required:    true,
 		},
 		"title": {
 			Description: "The title of the widget.",
@@ -2547,14 +2547,10 @@ func buildDatadogCloudcraftDefinition(terraformDefinition map[string]interface{}
 	}
 	datadogDefinition.SetGroupBy(datadogGroupBy)
 	datadogDefinition.SetProjection(datadogV1.CloudcraftWidgetDefinitionProjection(terraformDefinition["projection"].(string)))
+	datadogDefinition.SetHighlighted(terraformDefinition["highlighted"].(string))
+	datadogDefinition.SetShowEmptyGroups(terraformDefinition["show_empty_groups"].(bool))
 
 	// Optional params
-	if v, ok := terraformDefinition["highlighted"].(string); ok && len(v) != 0 {
-		datadogDefinition.SetHighlighted(v)
-	}
-	if v, ok := terraformDefinition["show_empty_groups"].(bool); ok {
-		datadogDefinition.SetShowEmptyGroups(v)
-	}
 	if v, ok := terraformDefinition["title"].(string); ok && len(v) != 0 {
 		datadogDefinition.SetTitle(v)
 	}
@@ -2583,14 +2579,10 @@ func buildTerraformCloudcraftDefinition(datadogDefinition *datadogV1.CloudcraftW
 	terraformDefinition["overlay_filter"] = datadogDefinition.GetOverlayFilter()
 	terraformDefinition["group_by"] = datadogDefinition.GetGroupBy()
 	terraformDefinition["projection"] = string(datadogDefinition.GetProjection())
+	terraformDefinition["highlighted"] = datadogDefinition.GetHighlighted()
+	terraformDefinition["show_empty_groups"] = datadogDefinition.GetShowEmptyGroups()
 
 	// Optional params
-	if v, ok := datadogDefinition.GetHighlightedOk(); ok {
-		terraformDefinition["highlighted"] = *v
-	}
-	if v, ok := datadogDefinition.GetShowEmptyGroupsOk(); ok {
-		terraformDefinition["show_empty_groups"] = *v
-	}
 	if v, ok := datadogDefinition.GetTitleOk(); ok {
 		terraformDefinition["title"] = *v
 	}

--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -985,6 +985,15 @@ func getNonGroupWidgetSchema(isPowerpackSchema bool) map[string]*schema.Schema {
 				Schema: getChangeDefinitionSchema(),
 			},
 		},
+		"cloudcraft_definition": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "The definition for a Cloudcraft widget.",
+			Elem: &schema.Resource{
+				Schema: getCloudcraftDefinitionSchema(),
+			},
+		},
 		"check_status_definition": {
 			Type:        schema.TypeList,
 			Optional:    true,
@@ -1381,6 +1390,10 @@ func buildDatadogWidget(terraformWidget map[string]interface{}) (*datadogV1.Widg
 		if changeDefinition, ok := def[0].(map[string]interface{}); ok {
 			definition = datadogV1.ChangeWidgetDefinitionAsWidgetDefinition(buildDatadogChangeDefinition(changeDefinition))
 		}
+	} else if def, ok := terraformWidget["cloudcraft_definition"].([]interface{}); ok && len(def) > 0 {
+		if cloudcraftDefinition, ok := def[0].(map[string]interface{}); ok {
+			definition = datadogV1.CloudcraftWidgetDefinitionAsWidgetDefinition(buildDatadogCloudcraftDefinition(cloudcraftDefinition))
+		}
 	} else if def, ok := terraformWidget["check_status_definition"].([]interface{}); ok && len(def) > 0 {
 		if checkStatusDefinition, ok := def[0].(map[string]interface{}); ok {
 			definition = datadogV1.CheckStatusWidgetDefinitionAsWidgetDefinition(buildDatadogCheckStatusDefinition(checkStatusDefinition))
@@ -1673,6 +1686,9 @@ func buildTerraformWidget(datadogWidget *datadogV1.Widget) (map[string]interface
 	} else if widgetDefinition.ChangeWidgetDefinition != nil {
 		terraformDefinition := buildTerraformChangeDefinition(widgetDefinition.ChangeWidgetDefinition)
 		terraformWidget["change_definition"] = []map[string]interface{}{terraformDefinition}
+	} else if widgetDefinition.CloudcraftWidgetDefinition != nil {
+		terraformDefinition := buildTerraformCloudcraftDefinition(widgetDefinition.CloudcraftWidgetDefinition)
+		terraformWidget["cloudcraft_definition"] = []map[string]interface{}{terraformDefinition}
 	} else if widgetDefinition.CheckStatusWidgetDefinition != nil {
 		terraformDefinition := buildTerraformCheckStatusDefinition(widgetDefinition.CheckStatusWidgetDefinition)
 		terraformWidget["check_status_definition"] = []map[string]interface{}{terraformDefinition}
@@ -2431,6 +2447,144 @@ func buildTerraformChangeRequests(datadogChangeRequests *[]datadogV1.ChangeWidge
 		terraformRequests[i] = terraformRequest
 	}
 	return &terraformRequests
+}
+
+//
+// Cloudcraft Widget Definition helpers
+//
+
+func getCloudcraftDefinitionSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"query_string": {
+			Description: "The query string used to filter the resources displayed by the widget.",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"provider": {
+			Description:      "The cloud provider for the Cloudcraft widget.",
+			Type:             schema.TypeString,
+			Required:         true,
+			ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewCloudcraftWidgetDefinitionProviderFromValue),
+		},
+		"overlay": {
+			Description:      "The overlay applied to the Cloudcraft widget.",
+			Type:             schema.TypeString,
+			Required:         true,
+			ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewCloudcraftWidgetDefinitionOverlayFromValue),
+		},
+		"overlay_filter": {
+			Description: "The filter applied to the overlay.",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"group_by": {
+			Description: "The list of attributes used to group resources within the diagram.",
+			Type:        schema.TypeList,
+			Required:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+		},
+		"projection": {
+			Description:      "The projection used to render the Cloudcraft diagram.",
+			Type:             schema.TypeString,
+			Required:         true,
+			ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewCloudcraftWidgetDefinitionProjectionFromValue),
+		},
+		"title": {
+			Description: "The title of the widget.",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"title_size": {
+			Description: "The size of the widget's title (defaults to 16).",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"title_align": {
+			Description:      "The alignment of the widget's title.",
+			Type:             schema.TypeString,
+			ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewWidgetTextAlignFromValue),
+			Optional:         true,
+		},
+		"live_span": {
+			Description:      "The timeframe to use when displaying the widget.",
+			Type:             schema.TypeString,
+			ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewWidgetLiveSpanFromValue),
+			Optional:         true,
+		},
+		"custom_link": {
+			Description: "A nested block describing a custom link. Multiple `custom_link` blocks are allowed using the structure below.",
+			Type:        schema.TypeList,
+			Optional:    true,
+			Elem: &schema.Resource{
+				Schema: getWidgetCustomLinkSchema(),
+			},
+		},
+	}
+}
+
+func buildDatadogCloudcraftDefinition(terraformDefinition map[string]interface{}) *datadogV1.CloudcraftWidgetDefinition {
+	datadogDefinition := datadogV1.NewCloudcraftWidgetDefinitionWithDefaults()
+
+	// Required params
+	datadogDefinition.SetQueryString(terraformDefinition["query_string"].(string))
+	datadogDefinition.SetProvider(datadogV1.CloudcraftWidgetDefinitionProvider(terraformDefinition["provider"].(string)))
+	datadogDefinition.SetOverlay(datadogV1.CloudcraftWidgetDefinitionOverlay(terraformDefinition["overlay"].(string)))
+	datadogDefinition.SetOverlayFilter(terraformDefinition["overlay_filter"].(string))
+	terraformGroupBy := terraformDefinition["group_by"].([]interface{})
+	datadogGroupBy := make([]string, len(terraformGroupBy))
+	for i, g := range terraformGroupBy {
+		datadogGroupBy[i] = g.(string)
+	}
+	datadogDefinition.SetGroupBy(datadogGroupBy)
+	datadogDefinition.SetProjection(datadogV1.CloudcraftWidgetDefinitionProjection(terraformDefinition["projection"].(string)))
+
+	// Optional params
+	if v, ok := terraformDefinition["title"].(string); ok && len(v) != 0 {
+		datadogDefinition.SetTitle(v)
+	}
+	if v, ok := terraformDefinition["title_size"].(string); ok && len(v) != 0 {
+		datadogDefinition.SetTitleSize(v)
+	}
+	if v, ok := terraformDefinition["title_align"].(string); ok && len(v) != 0 {
+		datadogDefinition.SetTitleAlign(datadogV1.WidgetTextAlign(v))
+	}
+	if widgetTime := buildDatadogWidgetTime(terraformDefinition); widgetTime != nil {
+		datadogDefinition.Time = widgetTime
+	}
+	if v, ok := terraformDefinition["custom_link"].([]interface{}); ok && len(v) > 0 {
+		datadogDefinition.SetCustomLinks(*buildDatadogWidgetCustomLinks(&v))
+	}
+	return datadogDefinition
+}
+
+func buildTerraformCloudcraftDefinition(datadogDefinition *datadogV1.CloudcraftWidgetDefinition) map[string]interface{} {
+	terraformDefinition := map[string]interface{}{}
+
+	// Required params
+	terraformDefinition["query_string"] = datadogDefinition.GetQueryString()
+	terraformDefinition["provider"] = string(datadogDefinition.GetProvider())
+	terraformDefinition["overlay"] = string(datadogDefinition.GetOverlay())
+	terraformDefinition["overlay_filter"] = datadogDefinition.GetOverlayFilter()
+	terraformDefinition["group_by"] = datadogDefinition.GetGroupBy()
+	terraformDefinition["projection"] = string(datadogDefinition.GetProjection())
+
+	// Optional params
+	if v, ok := datadogDefinition.GetTitleOk(); ok {
+		terraformDefinition["title"] = *v
+	}
+	if v, ok := datadogDefinition.GetTitleSizeOk(); ok {
+		terraformDefinition["title_size"] = *v
+	}
+	if v, ok := datadogDefinition.GetTitleAlignOk(); ok {
+		terraformDefinition["title_align"] = *v
+	}
+	if v, ok := datadogDefinition.GetTimeOk(); ok {
+		buildTerraformWidgetTime(v, terraformDefinition)
+	}
+	if v, ok := datadogDefinition.GetCustomLinksOk(); ok {
+		terraformDefinition["custom_link"] = buildTerraformWidgetCustomLinks(v)
+	}
+	return terraformDefinition
 }
 
 //

--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -2489,6 +2489,16 @@ func getCloudcraftDefinitionSchema() map[string]*schema.Schema {
 			Required:         true,
 			ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewCloudcraftWidgetDefinitionProjectionFromValue),
 		},
+		"highlighted": {
+			Description: "Search query that visually highlights matching resources in the diagram.",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"show_empty_groups": {
+			Description: "Whether to show empty outline groups (VPCs, subnets, security groups, etc.).",
+			Type:        schema.TypeBool,
+			Optional:    true,
+		},
 		"title": {
 			Description: "The title of the widget.",
 			Type:        schema.TypeString,
@@ -2539,6 +2549,12 @@ func buildDatadogCloudcraftDefinition(terraformDefinition map[string]interface{}
 	datadogDefinition.SetProjection(datadogV1.CloudcraftWidgetDefinitionProjection(terraformDefinition["projection"].(string)))
 
 	// Optional params
+	if v, ok := terraformDefinition["highlighted"].(string); ok && len(v) != 0 {
+		datadogDefinition.SetHighlighted(v)
+	}
+	if v, ok := terraformDefinition["show_empty_groups"].(bool); ok {
+		datadogDefinition.SetShowEmptyGroups(v)
+	}
 	if v, ok := terraformDefinition["title"].(string); ok && len(v) != 0 {
 		datadogDefinition.SetTitle(v)
 	}
@@ -2569,6 +2585,12 @@ func buildTerraformCloudcraftDefinition(datadogDefinition *datadogV1.CloudcraftW
 	terraformDefinition["projection"] = string(datadogDefinition.GetProjection())
 
 	// Optional params
+	if v, ok := datadogDefinition.GetHighlightedOk(); ok {
+		terraformDefinition["highlighted"] = *v
+	}
+	if v, ok := datadogDefinition.GetShowEmptyGroupsOk(); ok {
+		terraformDefinition["show_empty_groups"] = *v
+	}
 	if v, ok := datadogDefinition.GetTitleOk(); ok {
 		terraformDefinition["title"] = *v
 	}

--- a/datadog/tests/resource_datadog_dashboard_cloudcraft_test.go
+++ b/datadog/tests/resource_datadog_dashboard_cloudcraft_test.go
@@ -1,0 +1,76 @@
+package test
+
+import "testing"
+
+const datadogDashboardCloudcraftConfig = `
+resource "datadog_dashboard" "cloudcraft_dashboard" {
+  title         = "{{uniq}}"
+  description   = "Created using the Datadog provider in Terraform"
+  layout_type   = "free"
+
+  widget {
+		cloudcraft_definition {
+			query_string   = "service:web-store"
+			provider       = "aws"
+			overlay        = "Observability"
+			overlay_filter = "env:prod"
+			group_by       = ["region", "service"]
+			projection     = "isometric"
+			title          = "env: prod, service: web-store"
+			title_size     = "16"
+			title_align    = "left"
+			live_span      = "1h"
+      		custom_link {
+				link  = "https://app.datadoghq.com/dashboard/lists"
+				label = "Test Custom Link label"
+			}
+			custom_link {
+				link           = "https://app.datadoghq.com/dashboard/lists"
+				is_hidden      = true
+				override_label = "logs"
+			}
+		}
+		widget_layout {
+			height = 43
+			width  = 32
+			x      = 5
+			y      = 5
+		}
+  }
+}
+`
+
+var datadogDashboardCloudcraftAsserts = []string{
+	"title = {{uniq}}",
+	"widget.0.widget_layout.0.width = 32",
+	"widget.0.cloudcraft_definition.0.title_align = left",
+	"description = Created using the Datadog provider in Terraform",
+	"widget.0.widget_layout.0.x = 5",
+	"widget.0.cloudcraft_definition.0.title_size = 16",
+	"layout_type = free",
+	"widget.0.cloudcraft_definition.0.query_string = service:web-store",
+	"widget.0.cloudcraft_definition.0.provider = aws",
+	"widget.0.cloudcraft_definition.0.overlay = Observability",
+	"widget.0.cloudcraft_definition.0.overlay_filter = env:prod",
+	"widget.0.cloudcraft_definition.0.projection = isometric",
+	"widget.0.cloudcraft_definition.0.live_span = 1h",
+	"widget.0.cloudcraft_definition.0.group_by.0 = region",
+	"widget.0.cloudcraft_definition.0.group_by.1 = service",
+	"widget.0.widget_layout.0.y = 5",
+	"widget.0.cloudcraft_definition.0.title = env: prod, service: web-store",
+	"widget.0.widget_layout.0.height = 43",
+	"widget.0.cloudcraft_definition.0.custom_link.# = 2",
+	"widget.0.cloudcraft_definition.0.custom_link.0.label = Test Custom Link label",
+	"widget.0.cloudcraft_definition.0.custom_link.0.link = https://app.datadoghq.com/dashboard/lists",
+	"widget.0.cloudcraft_definition.0.custom_link.1.override_label = logs",
+	"widget.0.cloudcraft_definition.0.custom_link.1.link = https://app.datadoghq.com/dashboard/lists",
+	"widget.0.cloudcraft_definition.0.custom_link.1.is_hidden = true",
+}
+
+func TestAccDatadogDashboardCloudcraft(t *testing.T) {
+	testAccDatadogDashboardWidgetUtil(t, datadogDashboardCloudcraftConfig, "datadog_dashboard.cloudcraft_dashboard", datadogDashboardCloudcraftAsserts)
+}
+
+func TestAccDatadogDashboardCloudcraft_import(t *testing.T) {
+	testAccDatadogDashboardWidgetUtilImport(t, datadogDashboardCloudcraftConfig, "datadog_dashboard.cloudcraft_dashboard")
+}


### PR DESCRIPTION
## Summary

Adds Cloudcraft widget support to datadog_dashboard, modeled after TopologyMap (#1557) and Geomap (#954).

Jira: [CLOUDMAPS-2848](https://datadoghq.atlassian.net/browse/CLOUDMAPS-2848)

## Implementation

- getCloudcraftDefinitionSchema with 6 required fields (query_string, provider, overlay, overlay_filter, group_by, projection) plus standard title/live_span/custom_link
- buildDatadogCloudcraftDefinition / buildTerraformCloudcraftDefinition converters
- Registered in getWidgetSchema, buildDatadogWidgetDefinition, and buildTerraformWidgetDefinition switches
- TestAccDatadogDashboardCloudcraft and import test

## DRAFT — cannot build until SDK regenerates

Build will fail locally until SDK types CloudcraftWidgetDefinition / Provider / Overlay / Projection are generated. Depends on:
1. datadog-api-spec PR with CloudcraftWidgetDefinition (CLOUDMAPS-2848)
2. datadog-api-client-go SDK regeneration
3. terraform-provider-datadog vendor version bump landing first

## Test plan

- [ ] SDK types generated and vendored before merge
- [ ] go build ./... passes
- [ ] gofmt clean
- [ ] Acceptance test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CLOUDMAPS-2848]: https://datadoghq.atlassian.net/browse/CLOUDMAPS-2848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ