### PR TITLE
Enforce [datadog_*] PR title prefix and explain CHANGELOG impact

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -29,8 +29,12 @@ jobs:
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
         with:
           script: |
-            const re = new RegExp('\\[\\w+\\] \\w+');
+            const re = /^\[datadog_\w+\] .+/;
             const title = context.payload.pull_request.title;
             if (!re.test(title)) {
-              core.setFailed("Invalid title format: use '[resource_name] Description'");
+              core.setFailed(
+                "Invalid PR title format. Expected: '[datadog_<resource_or_datasource>] <Description>'.\n" +
+                "PR titles are used to generate CHANGELOG entries, so the bracketed tag must name the main affected resource or datasource (e.g. '[datadog_monitor]', '[datadog_logs_index]').\n" +
+                "If this change does not need to be included in the changelog, add the 'changelog/no-changelog' label to skip this check."
+              );
             }


### PR DESCRIPTION
## Summary

The previous regex in `.github/workflows/changelog.yaml` accepted any bracketed tag, so titles like `[fix] ...` or non-resource tags slipped through and produced noisy CHANGELOG entries (PR titles feed directly into auto-generated release notes via `.github/release.yml`).

This PR:

- Tightens the regex to require the `[datadog_<resource>]` convention already used across the repo.
- Rewrites the failure message to (a) explain the CHANGELOG implication so authors understand why the format matters and (b) point them at the `changelog/no-changelog` label as an escape hatch when a PR genuinely shouldn't appear in the changelog.
