### PR TITLE
[datadog_dashboard_v2] Drop unmapped API fields instead of failing

### DIFF
--- a/datadog/dashboardmapping/engine.go
+++ b/datadog/dashboardmapping/engine.go
@@ -342,6 +342,83 @@ func toStringSliceFromInterface(raw interface{}) []string {
 	return result
 }
 
+// pruneUnknownFields recursively removes keys from `state` that don't appear in `fields`.
+// SchemaOnly fields count as known. Container types (TypeBlock, TypeBlockList, TypeOneOf)
+// are recursed into.
+//
+// `extraKnown` declares additional accepted keys at this level — typically fields that
+// post-processing injects into a widget's defState (e.g. group.widget,
+// split_group.source_widget_definition). A nil children slice means "accept the key,
+// don't recurse"; non-nil means "accept and recurse against these fields".
+//
+// Returns dropped paths (rooted at `path`) for diagnostic surfacing.
+func pruneUnknownFields(state map[string]interface{}, fields []FieldSpec, extraKnown map[string][]FieldSpec, path string) []string {
+	known := make(map[string]*FieldSpec, len(fields))
+	for i := range fields {
+		known[fields[i].HCLKey] = &fields[i]
+	}
+	var dropped []string
+	for key, val := range state {
+		if extraKnown != nil {
+			if children, ok := extraKnown[key]; ok {
+				if children != nil {
+					dropped = append(dropped, recurseIntoBlock(val, children, path, key)...)
+				}
+				continue
+			}
+		}
+		f, ok := known[key]
+		if !ok {
+			dropped = append(dropped, joinPath(path, key))
+			delete(state, key)
+			continue
+		}
+		switch f.Type {
+		case TypeBlock, TypeBlockList:
+			dropped = append(dropped, recurseIntoBlock(val, f.Children, path, key)...)
+		case TypeOneOf:
+			variantFields := make([]FieldSpec, 0, len(f.Children))
+			for i := range f.Children {
+				c := f.Children[i]
+				variantFields = append(variantFields, FieldSpec{
+					HCLKey:   c.HCLKey,
+					Type:     TypeBlock,
+					Children: c.Children,
+				})
+			}
+			dropped = append(dropped, recurseIntoBlock(val, variantFields, path, key)...)
+		}
+	}
+	return dropped
+}
+
+// recurseIntoBlock walks the []interface{} of a block/blocklist value and prunes
+// each element's map against the supplied children spec.
+func recurseIntoBlock(val interface{}, children []FieldSpec, parentPath, key string) []string {
+	items, ok := val.([]interface{})
+	if !ok {
+		return nil
+	}
+	var dropped []string
+	for i, item := range items {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		dropped = append(dropped, pruneUnknownFields(
+			m, children, nil,
+			fmt.Sprintf("%s[%d]", joinPath(parentPath, key), i))...)
+	}
+	return dropped
+}
+
+func joinPath(parent, key string) string {
+	if parent == "" {
+		return key
+	}
+	return parent + "." + key
+}
+
 // ============================================================
 // Formula Request Config — unified formula/query request builder
 // ============================================================
@@ -532,10 +609,20 @@ func isFormulaCapableWidget(jsonType string) bool {
 // buildWidgetSortByJSON builds the JSON for a WidgetSortBy block (sort { count, order_by { ... } }).
 // Each order_by element is a discriminated union: formula_sort or group_sort.
 
-func flattenWidgetEngineJSON(widgetData map[string]interface{}) map[string]interface{} {
+// widgetExtraKnownFields lists fields that flattenWidgetPostProcess injects into a
+// widget's defState that are NOT declared in WidgetSpec.Fields. The pruner uses this
+// to avoid dropping legitimate post-processed keys. nil children means "accept the
+// key but don't recurse" — the inner contents have already been pruned at their own
+// flattenWidgetEngineJSON call.
+var widgetExtraKnownFields = map[string]map[string][]FieldSpec{
+	"group":       {"widget": nil},
+	"split_group": {"source_widget_definition": nil},
+}
+
+func flattenWidgetEngineJSON(widgetData map[string]interface{}) (map[string]interface{}, []string) {
 	def, ok := widgetData["definition"].(map[string]interface{})
 	if !ok {
-		return nil
+		return nil, nil
 	}
 	widgetType, _ := def["type"].(string)
 
@@ -550,13 +637,19 @@ func flattenWidgetEngineJSON(widgetData map[string]interface{}) map[string]inter
 
 		// Per-widget post-processing: formula/query blocks, type-specific fixups,
 		// and Batch C complex widget handling — all consolidated in one hook.
-		flattenWidgetPostProcess(spec, def, defState)
+		drops := flattenWidgetPostProcess(spec, def, defState)
+
+		// Generic guard: drop any key that isn't part of this widget's schema. Surfaces
+		// API responses that include fields not present in the OpenAPI spec / our schema
+		// (e.g. treemap requests that contain "style" the API returns but the spec omits).
+		drops = append(drops, pruneUnknownFields(defState, allFields,
+			widgetExtraKnownFields[spec.JSONType], spec.HCLKey)...)
 
 		return map[string]interface{}{
 			spec.HCLKey: []interface{}{defState},
-		}
+		}, drops
 	}
-	return nil
+	return nil, nil
 }
 
 // flattenFormulaQueryJSON converts a single query JSON object into the HCL query block state.
@@ -861,7 +954,12 @@ func flattenEventQueryJSON(q map[string]interface{}) map[string]interface{} {
 	return result
 }
 
-func flattenWidgetPostProcess(spec WidgetSpec, def map[string]interface{}, defState map[string]interface{}) {
+// flattenWidgetPostProcess applies per-widget-type post-processing to defState.
+// Returns dropped paths bubbled up from nested widget flattens (group children,
+// split_graph source widget). Drops from the parent widget itself are produced by
+// the caller's own pruneUnknownFields pass.
+func flattenWidgetPostProcess(spec WidgetSpec, def map[string]interface{}, defState map[string]interface{}) []string {
+	var nestedDrops []string
 	// ---- Formula/query request flattening ----
 	if isFormulaCapableWidget(spec.JSONType) {
 		if requests, ok := def["requests"].([]interface{}); ok {
@@ -923,9 +1021,12 @@ func flattenWidgetPostProcess(spec WidgetSpec, def map[string]interface{}, defSt
 	// ---- Split graph source widget + static_splits ----
 	if spec.JSONType == "split_group" {
 		if srcDef, ok := def["source_widget_definition"].(map[string]interface{}); ok {
-			flatSrc := flattenSplitGraphSourceWidgetJSON(srcDef)
+			flatSrc, srcDrops := flattenSplitGraphSourceWidgetJSON(srcDef)
 			if flatSrc != nil {
 				defState["source_widget_definition"] = []interface{}{flatSrc}
+			}
+			for _, p := range srcDrops {
+				nestedDrops = append(nestedDrops, joinPath(spec.HCLKey+".source_widget_definition[0]", p))
 			}
 		}
 		if splitConfigArr, ok := defState["split_config"].([]interface{}); ok && len(splitConfigArr) > 0 {
@@ -942,9 +1043,14 @@ func flattenWidgetPostProcess(spec WidgetSpec, def map[string]interface{}, defSt
 	// ---- Group nested widgets ----
 	if spec.JSONType == "group" {
 		if widgets, ok := def["widgets"].([]interface{}); ok {
-			defState["widget"] = flattenGroupWidgetsJSON(widgets)
+			flatWidgets, childDrops := flattenGroupWidgetsJSON(widgets)
+			defState["widget"] = flatWidgets
+			for _, p := range childDrops {
+				nestedDrops = append(nestedDrops, joinPath(spec.HCLKey+".widget", p))
+			}
 		}
 	}
+	return nestedDrops
 }
 
 func flattenQueryTableRequestJSON(req map[string]interface{}) map[string]interface{} {
@@ -1067,8 +1173,8 @@ func flattenSplitConfigStaticSplitsJSON(staticSplits []interface{}) []interface{
 }
 
 // flattenSplitGraphSourceWidgetJSON flattens the source_widget_definition JSON
-// for a split_graph widget response.
-func flattenSplitGraphSourceWidgetJSON(srcDef map[string]interface{}) map[string]interface{} {
+// for a split_graph widget response. Returns dropped paths from the inner widget.
+func flattenSplitGraphSourceWidgetJSON(srcDef map[string]interface{}) (map[string]interface{}, []string) {
 	widgetType, _ := srcDef["type"].(string)
 	for _, spec := range allWidgetSpecs {
 		if spec.JSONType != widgetType {
@@ -1079,25 +1185,31 @@ func flattenSplitGraphSourceWidgetJSON(srcDef map[string]interface{}) map[string
 		allFields = append(allFields, spec.Fields...)
 		defState := FlattenEngineJSON(allFields, srcDef)
 		// Apply the same per-widget post-processing as the main flatten engine
-		flattenWidgetPostProcess(spec, srcDef, defState)
+		drops := flattenWidgetPostProcess(spec, srcDef, defState)
+		drops = append(drops, pruneUnknownFields(defState, allFields,
+			widgetExtraKnownFields[spec.JSONType], spec.HCLKey)...)
 		return map[string]interface{}{
 			spec.HCLKey: []interface{}{defState},
-		}
+		}, drops
 	}
-	return nil
+	return nil, nil
 }
 
 // buildGroupWidgetsJSON builds the "widgets" array for a group widget.
 
-func flattenGroupWidgetsJSON(widgets []interface{}) []interface{} {
+func flattenGroupWidgetsJSON(widgets []interface{}) ([]interface{}, []string) {
 	result := make([]interface{}, len(widgets))
+	var drops []string
 	for i, w := range widgets {
 		widgetData, ok := w.(map[string]interface{})
 		if !ok {
 			result[i] = map[string]interface{}{}
 			continue
 		}
-		flattened := flattenWidgetEngineJSON(widgetData)
+		flattened, childDrops := flattenWidgetEngineJSON(widgetData)
+		for _, p := range childDrops {
+			drops = append(drops, fmt.Sprintf("[%d].%s", i, p))
+		}
 		if flattened == nil {
 			flattened = map[string]interface{}{}
 		}
@@ -1142,7 +1254,7 @@ func flattenGroupWidgetsJSON(widgets []interface{}) []interface{} {
 		}
 		result[i] = flattened
 	}
-	return result
+	return result, drops
 }
 
 // ============================================================
@@ -1238,8 +1350,9 @@ func FlattenTemplateVariablePresets(tvps []interface{}) []interface{} {
 
 // FlattenWidgetEngineJSON is the exported entry point for flattening a single widget's JSON map
 // into HCL state suitable for setting on a TypeList field in schema.ResourceData.
-// Returns nil if the widget type is not recognized.
-func FlattenWidgetEngineJSON(widgetData map[string]interface{}) map[string]interface{} {
+// Returns nil if the widget type is not recognized. The second return value is a list
+// of API JSON paths whose values were dropped because they have no matching schema field.
+func FlattenWidgetEngineJSON(widgetData map[string]interface{}) (map[string]interface{}, []string) {
 	return flattenWidgetEngineJSON(widgetData)
 }
 
@@ -2230,16 +2343,24 @@ func MarshalDashboardJSONFromMap(data map[string]interface{}, id string) (string
 // into a []interface{} suitable for d.Set("widget", ...).
 // It reuses the existing flattenWidgetEngineJSON function which already returns
 // map[string]interface{} compatible with SDKv2's d.Set().
-func FlattenWidgetsForSDKv2(apiWidgets []interface{}) []interface{} {
+//
+// The second return value lists API JSON paths whose values were dropped because
+// the schema has no matching field — surface these to the user via diagnostics so
+// silent data loss is observable.
+func FlattenWidgetsForSDKv2(apiWidgets []interface{}) ([]interface{}, []string) {
 	result := make([]interface{}, 0, len(apiWidgets))
-	for _, w := range apiWidgets {
+	var drops []string
+	for i, w := range apiWidgets {
 		widgetData, ok := w.(map[string]interface{})
 		if !ok {
 			continue
 		}
 
 		// Flatten the widget definition using the existing engine function.
-		flattened := FlattenWidgetEngineJSON(widgetData)
+		flattened, widgetDrops := FlattenWidgetEngineJSON(widgetData)
+		for _, p := range widgetDrops {
+			drops = append(drops, fmt.Sprintf("widget[%d].%s", i, p))
+		}
 		if flattened == nil {
 			flattened = map[string]interface{}{}
 		}
@@ -2287,7 +2408,7 @@ func FlattenWidgetsForSDKv2(apiWidgets []interface{}) []interface{} {
 
 		result = append(result, flattened)
 	}
-	return result
+	return result, drops
 }
 
 // ============================================================

--- a/datadog/dashboardmapping/engine_prune_test.go
+++ b/datadog/dashboardmapping/engine_prune_test.go
@@ -1,0 +1,181 @@
+package dashboardmapping
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TestPrune_TreemapStyleInGroup reproduces the bug where a treemap widget nested
+// inside a group has a "style" block in its request that the schema doesn't declare.
+// The prune pass should drop "style" and surface the path so the SDKv2 d.Set call
+// no longer fails with "Invalid address to set".
+func TestPrune_TreemapStyleInGroup(t *testing.T) {
+	apiWidgets := []interface{}{
+		map[string]interface{}{
+			"id": float64(6005583415655279),
+			"definition": map[string]interface{}{
+				"title":       "New group",
+				"type":        "group",
+				"layout_type": "ordered",
+				"widgets": []interface{}{
+					map[string]interface{}{
+						"id": float64(3095397288867546),
+						"definition": map[string]interface{}{
+							"type":  "treemap",
+							"title": "",
+							"requests": []interface{}{
+								map[string]interface{}{
+									"response_format": "scalar",
+									"queries": []interface{}{
+										map[string]interface{}{
+											"data_source": "metrics",
+											"name":        "query1",
+											"query":       "sum:system.mem.total{*} by {service}",
+											"aggregator":  "sum",
+										},
+									},
+									"style": map[string]interface{}{
+										"palette": "datadog16",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, drops := FlattenWidgetsForSDKv2(apiWidgets)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 flattened widget, got %d", len(result))
+	}
+
+	// Verify the path was dropped and surfaced.
+	wantPath := "widget[0].group_definition.widget.[0].treemap_definition.request[0].style"
+	found := false
+	for _, p := range drops {
+		if p == wantPath {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected dropped path %q in %v", wantPath, drops)
+	}
+
+	// Walk into the result and verify the offending key is gone.
+	groupWrapper := result[0].(map[string]interface{})
+	groupDef := groupWrapper["group_definition"].([]interface{})[0].(map[string]interface{})
+	nestedWidgets := groupDef["widget"].([]interface{})
+	treemapWrapper := nestedWidgets[0].(map[string]interface{})
+	treemapDef := treemapWrapper["treemap_definition"].([]interface{})[0].(map[string]interface{})
+	reqs := treemapDef["request"].([]interface{})
+	req0 := reqs[0].(map[string]interface{})
+	if _, hasStyle := req0["style"]; hasStyle {
+		t.Errorf("expected 'style' to be pruned from treemap request, but it is still present: %v", req0)
+	}
+	// Ensure legitimate keys survive.
+	if _, hasQuery := req0["query"]; !hasQuery {
+		t.Error("expected 'query' to remain after prune")
+	}
+}
+
+// TestPrune_KeepsKnownFields verifies that timeseries requests (which legitimately
+// have a 'style' block in their schema) are not affected by pruning.
+func TestPrune_KeepsKnownFields(t *testing.T) {
+	apiWidgets := []interface{}{
+		map[string]interface{}{
+			"definition": map[string]interface{}{
+				"type": "timeseries",
+				"requests": []interface{}{
+					map[string]interface{}{
+						"response_format": "timeseries",
+						"queries": []interface{}{
+							map[string]interface{}{
+								"data_source": "metrics",
+								"name":        "query1",
+								"query":       "avg:system.cpu.user{*}",
+							},
+						},
+						"style": map[string]interface{}{
+							"palette":    "dog_classic",
+							"line_type":  "solid",
+							"line_width": "normal",
+						},
+					},
+				},
+			},
+		},
+	}
+	_, drops := FlattenWidgetsForSDKv2(apiWidgets)
+	if len(drops) != 0 {
+		t.Errorf("expected no drops on a well-formed timeseries widget, got: %v", drops)
+	}
+}
+
+// TestPrune_DirectHelper exercises pruneUnknownFields against a synthetic state map.
+// FlattenEngineJSON itself filters API JSON to declared fields, so the pruner exists
+// to clean up keys that POST-PROCESSORS inject (the treemap.style case is the
+// motivating example). This test simulates that situation directly.
+func TestPrune_DirectHelper(t *testing.T) {
+	state := map[string]interface{}{
+		"title":            "ok",
+		"injected_unknown": "from a buggy post-processor",
+		"request": []interface{}{
+			map[string]interface{}{
+				"query":          []interface{}{},
+				"injected_style": map[string]interface{}{"palette": "x"},
+			},
+		},
+	}
+	fields := []FieldSpec{
+		{HCLKey: "title", Type: TypeString},
+		{HCLKey: "request", Type: TypeBlockList, Children: []FieldSpec{
+			{HCLKey: "query", Type: TypeBlockList},
+		}},
+	}
+	drops := pruneUnknownFields(state, fields, nil, "widget_def")
+
+	gotPaths := make([]string, len(drops))
+	copy(gotPaths, drops)
+	sort.Strings(gotPaths)
+	wantPaths := []string{
+		"widget_def.injected_unknown",
+		"widget_def.request[0].injected_style",
+	}
+	if !reflect.DeepEqual(gotPaths, wantPaths) {
+		t.Errorf("dropped paths mismatch.\n got: %v\nwant: %v", gotPaths, wantPaths)
+	}
+	if _, present := state["injected_unknown"]; present {
+		t.Error("expected injected_unknown to be removed from state")
+	}
+	req0 := state["request"].([]interface{})[0].(map[string]interface{})
+	if _, present := req0["injected_style"]; present {
+		t.Error("expected injected_style to be removed from nested state")
+	}
+	if _, present := req0["query"]; !present {
+		t.Error("expected legitimate 'query' to remain")
+	}
+}
+
+// TestPrune_RespectsExtraKnown verifies that fields listed in extraKnown are not dropped,
+// even though they don't appear in the FieldSpec list.
+func TestPrune_RespectsExtraKnown(t *testing.T) {
+	state := map[string]interface{}{
+		"title":  "ok",
+		"widget": []interface{}{map[string]interface{}{}}, // post-process injection on group
+	}
+	fields := []FieldSpec{
+		{HCLKey: "title", Type: TypeString},
+	}
+	extra := map[string][]FieldSpec{"widget": nil}
+	drops := pruneUnknownFields(state, fields, extra, "group_def")
+	if len(drops) != 0 {
+		t.Errorf("expected no drops, got %v", drops)
+	}
+	if _, present := state["widget"]; !present {
+		t.Error("expected 'widget' to be preserved via extraKnown")
+	}
+}

--- a/datadog/resource_datadog_dashboard_v2.go
+++ b/datadog/resource_datadog_dashboard_v2.go
@@ -283,9 +283,22 @@ func setDashboardStateSDKv2(d *schema.ResourceData, resp map[string]interface{})
 	var apiWidgets []interface{}
 	if v, ok := resp["widgets"].([]interface{}); ok {
 		apiWidgets = v
-		flatWidgets := dashboardmapping.FlattenWidgetsForSDKv2(v)
+		flatWidgets, dropped := dashboardmapping.FlattenWidgetsForSDKv2(v)
 		if err := d.Set("widget", flatWidgets); err != nil {
 			diags = append(diags, diag.FromErr(err)...)
+		}
+		if len(dropped) > 0 {
+			for _, p := range dropped {
+				log.Printf("[WARN] datadog_dashboard_v2 %s: dropped unmapped API field at %s", d.Id(), p)
+			}
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  fmt.Sprintf("Dashboard contains %d field(s) returned by the Datadog API with no schema mapping", len(dropped)),
+				Detail: fmt.Sprintf(
+					"The following paths were stripped from state because the schema does not declare them; their values will not be preserved on apply.\n  %s\nIf any of these are fields you need, file an issue against the provider.",
+					strings.Join(dropped, "\n  "),
+				),
+			})
 		}
 	}
 

--- a/datadog/resource_datadog_powerpack_v2.go
+++ b/datadog/resource_datadog_powerpack_v2.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
+	"strings"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -391,7 +393,8 @@ func setPowerpackState(d *schema.ResourceData, ppk *datadogV2.PowerpackResponse)
 	// Widgets — unmarshal each PowerpackInnerWidget to map, then flatten via engine
 	rawWidgets := attrs.GroupWidget.Definition.Widgets
 	flatWidgets := make([]interface{}, 0, len(rawWidgets))
-	for _, ppkWidget := range rawWidgets {
+	var allDropped []string
+	for i, ppkWidget := range rawWidgets {
 		widgetJSON, err := ppkWidget.MarshalJSON()
 		if err != nil {
 			continue
@@ -400,7 +403,10 @@ func setPowerpackState(d *schema.ResourceData, ppk *datadogV2.PowerpackResponse)
 		if err := json.Unmarshal(widgetJSON, &widgetData); err != nil {
 			continue
 		}
-		flattened := dashboardmapping.FlattenWidgetEngineJSON(widgetData)
+		flattened, dropped := dashboardmapping.FlattenWidgetEngineJSON(widgetData)
+		for _, p := range dropped {
+			allDropped = append(allDropped, fmt.Sprintf("widget[%d].%s", i, p))
+		}
 		if flattened == nil {
 			flattened = map[string]interface{}{}
 		}
@@ -425,6 +431,19 @@ func setPowerpackState(d *schema.ResourceData, ppk *datadogV2.PowerpackResponse)
 	}
 	if err := d.Set("widget", flatWidgets); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
+	}
+	if len(allDropped) > 0 {
+		for _, p := range allDropped {
+			log.Printf("[WARN] datadog_powerpack_v2 %s: dropped unmapped API field at %s", d.Id(), p)
+		}
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  fmt.Sprintf("Powerpack contains %d field(s) returned by the Datadog API with no schema mapping", len(allDropped)),
+			Detail: fmt.Sprintf(
+				"The following paths were stripped from state because the schema does not declare them; their values will not be preserved on apply.\n  %s\nIf any of these are fields you need, file an issue against the provider.",
+				strings.Join(allDropped, "\n  "),
+			),
+		})
 	}
 
 	return diags


### PR DESCRIPTION
## Summary

The v2 dashboard resource fails to import some dashboards with errors like:

```
Error: Invalid address to set: []string{"widget", "3", "group_definition", "0", "widget", "2", "treemap_definition", "0", "request", "0", "style"}
```

This happens when the Datadog API returns fields in the dashboard JSON that are not declared in the resource's SDKv2 schema. The motivating case: a treemap widget request contains a `style` block (`{"palette":"datadog16"}`), but `TreeMapWidgetRequest` in the OpenAPI spec doesn't define `style`. `flattenWidgetPostProcess` falls through to the default scalar formula request config (`scalarFormulaRequestConfig`), which reads any `style` it sees, producing a flattened-state path the schema does not know about. SDKv2's `d.Set` then rejects the unknown path.

## Approach

Rather than add a per-widget exception (e.g. a treemap-specific `FormulaRequestConfig`), this introduces a **generic schema-aware prune pass** at the flatten boundary:

- After `flattenWidgetPostProcess` runs, the flattened `defState` is walked against the widget's `FieldSpec` tree (`pruneUnknownFields`). Any key not declared — and not registered as a legitimate post-processor injection (`group.widget`, `split_group.source_widget_definition`) — is removed and its path recorded.
- `flattenWidgetEngineJSON`, `flattenWidgetPostProcess`, `flattenGroupWidgetsJSON`, `flattenSplitGraphSourceWidgetJSON`, `FlattenWidgetEngineJSON`, and `FlattenWidgetsForSDKv2` now thread a `[]string` of dropped paths upward.
- `resource_datadog_dashboard_v2` and `resource_datadog_powerpack_v2` capture the drops on Read: one `log.Printf("[WARN] ...")` per path, plus a single `diag.Warning` summary listing all dropped paths. Silent data loss becomes visible without spamming on every plan.

This catches the treemap case **and** any future spec drift uniformly — no per-widget code path needed.

## Tradeoffs

- **Silent drop on round-trip.** A user importing a dashboard with an unmapped field won't see it in state. The `diag.Warning` makes it visible at Read time, but warnings can be missed.
- The pruner only walks `TypeBlock` / `TypeBlockList` / `TypeOneOf` containers. Other container types (none today) would need branches.
- Unknown JSON keys returned by the API for fields not in any FieldSpec at all are already filtered earlier by `FlattenEngineJSON` (whitelist extraction). The pruner is the safety net for keys that **post-processors** introduce — that's where this class of bug lives.

## Test plan

- [x] `go build ./...`
- [x] `go test ./datadog/dashboardmapping/` (existing tests pass)
- [x] New unit tests in `datadog/dashboardmapping/engine_prune_test.go`:
  - `TestPrune_TreemapStyleInGroup` — reproduces the exact failure mode and asserts both the pruning and the surfaced path
  - `TestPrune_KeepsKnownFields` — regression check that timeseries widgets (which legitimately have a `style` block) are unaffected
  - `TestPrune_DirectHelper` — exercises `pruneUnknownFields` against synthetic state
  - `TestPrune_RespectsExtraKnown` — verifies `extraKnown` allowlist works
- [x] Acceptance test pass with `RECORD=none` for `TestAccDatadogDashboardV2_*`
- [x] Manual import of a real dashboard containing a treemap with `style`