### PR TITLE
Add CODEOWNERS entry for datadog_org_group resources

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -119,6 +119,9 @@ examples/resources/datadog_org_group*            @DataDog/org-management
 # Doc templates (override the auto-generated docs)
 templates/resources/org_group*.md.tmpl           @DataDog/org-management
 
+# Test cassettes (recorded HTTP traffic for replay)
+datadog/tests/cassettes/TestAccDatadogOrgGroup*  @DataDog/org-management
+
 # Team-specific
 docs/resources/observability_pipeline.md         @DataDog/observability-pipelines
 scripts/*cloud-cost-import-existing-resources*   @DataDog/cloud-cost-management

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -62,6 +62,7 @@ datadog/**/*datadog_incident*                    @DataDog/incident-app
 datadog/**/*datadog_ip_allowlist*                @DataDog/team-aaa
 datadog/**/*datadog_openapi*                     @DataDog/service-catalog
 datadog/**/*datadog_org_connection*              @DataDog/aaa-granular-access
+datadog/**/*datadog_org_group*                   @DataDog/org-management
 datadog/**/*datadog_reference_table*             @DataDog/redapl-experiences
 datadog/**/*datadog_action_connection*           @DataDog/action-platform
 datadog/**/*datadog_agentless*                   @DataDog/k9-agentless

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -113,14 +113,10 @@ datadog/**/*observability_pipeline*              @DataDog/observability-pipeline
 datadog/**/*datadog_secure_embed_dashboard*      @DataDog/api-reliability @DataDog/reporting-and-sharing
 
 # Examples (HCL snippets embedded in rendered docs)
-examples/data-sources/datadog_org_group*         @DataDog/org-management
-examples/resources/datadog_org_group*            @DataDog/org-management
+examples/**/datadog_org_group*/**                @DataDog/org-management
 
 # Doc templates (override the auto-generated docs)
-templates/resources/org_group*.md.tmpl           @DataDog/org-management
-
-# Test cassettes (recorded HTTP traffic for replay)
-datadog/tests/cassettes/TestAccDatadogOrgGroup*  @DataDog/org-management
+templates/**/org_group*.md.tmpl                  @DataDog/org-management
 
 # Team-specific
 docs/resources/observability_pipeline.md         @DataDog/observability-pipelines

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -112,6 +112,13 @@ datadog/**/*datadog_deployment_gate*             @DataDog/ci-app-backend
 datadog/**/*observability_pipeline*              @DataDog/observability-pipelines
 datadog/**/*datadog_secure_embed_dashboard*      @DataDog/api-reliability @DataDog/reporting-and-sharing
 
+# Examples (HCL snippets embedded in rendered docs)
+examples/data-sources/datadog_org_group*         @DataDog/org-management
+examples/resources/datadog_org_group*            @DataDog/org-management
+
+# Doc templates (override the auto-generated docs)
+templates/resources/org_group*.md.tmpl           @DataDog/org-management
+
 # Team-specific
 docs/resources/observability_pipeline.md         @DataDog/observability-pipelines
 scripts/*cloud-cost-import-existing-resources*   @DataDog/cloud-cost-management


### PR DESCRIPTION
## Summary

Claims the `datadog_org_group` resources, data sources, examples, and doc templates (added in #3686) for `@DataDog/org-management`. Also introduces two new generic sections — `# Examples` and `# Doc templates` — since neither had any per-feature ownership structure before.

## Changes to `.github/CODEOWNERS`

```diff
+ datadog/**/*datadog_org_group*              @DataDog/org-management

+ # Examples (HCL snippets embedded in rendered docs)
+ examples/**/datadog_org_group*/**           @DataDog/org-management

+ # Doc templates (override the auto-generated docs)
+ templates/**/org_group*.md.tmpl             @DataDog/org-management
```

## Ownership scope

| Path pattern | Owner | Source |
| --- | --- | --- |
| `datadog/fwprovider/*org_group*.go` (8 files) | `@DataDog/org-management` | Plugin Framework section |
| `datadog/tests/*org_group*_test.go` (8 files) | `@DataDog/org-management` | Plugin Framework section |
| `examples/{resources,data-sources}/datadog_org_group*/**` (12 dirs) | `@DataDog/org-management` | **new Examples section** |
| `templates/resources/org_group*.md.tmpl` (3 files) | `@DataDog/org-management` | **new Doc templates section** |
| `docs/{resources,data-sources}/org_group*.md` (8 files) | `@DataDog/api-reliability` `@DataDog/documentation` | inherited from `/docs/` rule |
| `datadog/tests/cassettes/...` (16 files) | *(unowned)* | inherited from line-8 exemption |
| Shared infra (`framework_provider.go`, `api_instances_helper.go`, test infra, `go.{mod,sum}`) | `@DataDog/api-reliability` | inherited from default `*` rule |

## Notes

- **Cassettes intentionally left unowned.** The existing line-8 exemption (`datadog/tests/cassettes/`) keeps cassette approval open to any reviewer with write access — this PR does not deviate from that.
- **Docs intentionally not claimed.** Per existing precedent, `/docs/` belongs to `@DataDog/api-reliability` and `@DataDog/documentation`. Org-management is not a docs owner.
- **`**` globs used for examples/templates** so future reorganizations (e.g. nested example dirs or templates moving under data-sources) don't silently lose ownership.
- The two new sections are **generic** — future teams can drop their own `<resource>*` lines into them rather than scattering team-specific entries across the file.

## Test plan

- [x] `datadog/**/*datadog_org_group*` glob expands to the 16 source + test files added by #3686
- [x] `examples/**/datadog_org_group*/**` covers all 12 example directories
- [x] `templates/**/org_group*.md.tmpl` covers all 3 doc templates
- [x] Cassettes remain unowned (verified — pattern does not match `TestAccDatadogOrgGroup*` since CODEOWNERS is case-sensitive and the names use no underscores)