### PR TITLE
[datadog_synthetics_private_location] Preserve config across Update for imported resources

### DIFF
--- a/datadog/fwprovider/resource_datadog_synthetics_private_location.go
+++ b/datadog/fwprovider/resource_datadog_synthetics_private_location.go
@@ -239,6 +239,39 @@ func (r *syntheticsPrivateLocationResource) Update(ctx context.Context, request 
 	}
 	r.updateState(ctx, &state, &resp)
 
+	// Preserve `config` across Update.
+	//
+	// The Datadog Synthetics API only emits the private-location `config`
+	// payload from the Create endpoint — Read and Update responses do not
+	// include it. `updateState` therefore leaves `state.Config` untouched.
+	//
+	// For Create-then-Update flows the `UseStateForUnknown` plan modifier
+	// carries the prior known value into the planned state, so this is a
+	// no-op. For Import-then-Update flows the prior `state.Config` is null
+	// (ImportStatePassthroughID only writes `id`, and Read can't recover
+	// `config`), the plan modifier has nothing to carry forward, and the
+	// post-apply consistency check fails with:
+	//
+	//   Provider returned invalid result object after apply ... unknown value
+	//   for datadog_synthetics_private_location.<name>.config
+	//
+	// Fall back to the prior state's `Config` (if known), otherwise a known
+	// empty string, so post-apply consistency holds. Real config data is
+	// never lost: it's only knowable at Create time, and Create populates it
+	// directly.
+	if state.Config.IsNull() || state.Config.IsUnknown() {
+		var prior syntheticsPrivateLocationModel
+		response.Diagnostics.Append(request.State.Get(ctx, &prior)...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+		if !prior.Config.IsNull() && !prior.Config.IsUnknown() {
+			state.Config = prior.Config
+		} else {
+			state.Config = types.StringValue("")
+		}
+	}
+
 	// Save data into Terraform state
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }

--- a/datadog/tests/resource_datadog_synthetics_private_location_test.go
+++ b/datadog/tests/resource_datadog_synthetics_private_location_test.go
@@ -83,6 +83,61 @@ func TestAccDatadogSyntheticsPrivateLocation_Updated(t *testing.T) {
 	})
 }
 
+// TestAccDatadogSyntheticsPrivateLocation_ImportThenUpdate exercises the
+// Import-then-Update flow that previously failed with:
+//
+//	Provider returned invalid result object after apply ... unknown value
+//	for datadog_synthetics_private_location.<name>.config
+//
+// The Datadog API only emits the private-location `config` payload on Create
+// (Read and Update responses don't include it). Before the fix, an imported
+// resource started with `state.Config = null`, the `UseStateForUnknown` plan
+// modifier had no known prior value to carry forward, and the Update handler
+// left `state.Config` unknown — tripping the post-apply consistency check.
+//
+// Steps:
+//  1. Create the resource via config so it exists in DD.
+//  2. ImportState with `ImportStatePersist: true` so the test's working
+//     state is replaced by an imported state where `config` is null
+//     (matching what `terraform import` produces in real use).
+//  3. Apply an Update on top of that imported state — should succeed.
+func TestAccDatadogSyntheticsPrivateLocation_ImportThenUpdate(t *testing.T) {
+	cleanupSyntheticsTests(t)
+	t.Parallel()
+	if !isReplaying() {
+		log.Println("Skipping private locations tests in non replaying mode")
+		return
+	}
+	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
+	privateLocationName := uniqueEntityName(ctx, t)
+	frameworkProvider := providers.frameworkProvider
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: accProviders,
+		CheckDestroy:             testSyntheticsPrivateLocationIsDestroyed(frameworkProvider),
+		Steps: []resource.TestStep{
+			// 1. Create
+			{
+				Config: createSyntheticsPrivateLocationConfig(privateLocationName),
+			},
+			// 2. Re-import. ImportStatePersist replaces working state with
+			//    the imported state, where `config` is null (Read API does
+			//    not return it).
+			{
+				Config:                  createSyntheticsPrivateLocationConfig(privateLocationName),
+				ResourceName:            "datadog_synthetics_private_location.foo",
+				ImportState:             true,
+				ImportStatePersist:      true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"config", "api_key"},
+			},
+			// 3. Update on top of imported state — previously failed.
+			updateSyntheticsPrivateLocationStep(ctx, frameworkProvider, t),
+		},
+	})
+}
+
 func createSyntheticsPrivateLocationStep(ctx context.Context, accProvider *fwprovider.FrameworkProvider, t *testing.T) resource.TestStep {
 	privateLocationName := uniqueEntityName(ctx, t)
 	return resource.TestStep{


### PR DESCRIPTION
Fixes #3747.

## Summary

The Datadog Synthetics API only emits the private-location `config` payload from the **Create** endpoint. Read and Update responses do not include it. The framework `Update` handler called `updateState` (which does not touch `state.Config`) and saved state, leaving `state.Config` unknown post-apply. Terraform core's consistency check then aborts with:

```
Error: Provider returned invalid result object after apply

After the apply operation, the provider still indicated an unknown value for
datadog_synthetics_private_location.<name>.config. All values must be known
after apply, so this is always a bug in the provider...
```

For Create-then-Update flows the bug is masked by the `UseStateForUnknown` plan modifier carrying the prior known config into the planned state. **For Import-then-Update flows** `state.Config` is null after import (`ImportStatePassthroughID` only writes `id`, and Read can't recover config), the plan modifier has nothing to carry forward, and the bug fires on the first Update.

## Fix

In `Update`, after `r.updateState(ctx, &state, &resp)`: if `state.Config` is null or unknown, fall back to the prior state's `Config`; if even that is null/unknown, fall back to a known empty string. Real `config` data is never lost — it's only knowable at Create time and is set directly there.

The check uses `IsNull() || IsUnknown()`, which is consistent with existing patterns in `datadog/fwprovider/resource_datadog_spans_metric.go`, `resource_datadog_compliance_resource_evaluation_filter.go`, and `resource_datadog_app_builder_app.go`.

## Test

Adds `TestAccDatadogSyntheticsPrivateLocation_ImportThenUpdate` exercising the Import-then-Update flow. It uses `ImportStatePersist: true` (already in use in `resource_datadog_security_monitoring_default_rule_test.go`) so the test's working state is replaced by the imported state — matching what real-world `terraform import` produces — before the subsequent Update step.

**Cassette recording note:** the new test fails at `Failed to initialize cassette recorder for "TestAccDatadogSyntheticsPrivateLocation_ImportThenUpdate": requested cassette not found` until a cassette is recorded against a sandbox org. Existing `_Basic`, `_Updated`, and `_importBasic` tests still pass in replay mode (`RECORD=false`):

```
PASS datadog/tests.TestAccDatadogSyntheticsPrivateLocation_Basic   (2.34s)
PASS datadog/tests.TestAccDatadogSyntheticsPrivateLocation_Updated (3.81s)
```

I don't have a sandbox DD org to record against, so I'm hoping a maintainer with access can re-run with `RECORD=true` during review. Happy to add additional checks if useful.

## Quality gates

- [x] `make fmtcheck` passes
- [x] `make vet` passes
- [x] `make lint-new` passes (0 issues, mirrors CI's `--new-from-rev=origin/master`)
- [x] `make docs && make check-docs` passes (no schema changes)
- [x] `go build ./...` passes
- [x] Existing acceptance tests pass in replay mode
- [x] `make errcheck` — 8 failures, all pre-existing in unrelated files (`resource_datadog_service_level_objective.go`, `resource_datadog_synthetics_test_.go`); none in changed files

## Systemic note

#3747 includes a section flagging the same root-cause pattern in #2508 (`datadog_integration_gcp_sts.delegate_account_email`, open since 2024, still affected on master) and other framework resources with `UseStateForUnknown()` on Create-only Computed values (`datadog_api_key.key`, `datadog_application_key.key`, `datadog_service_account_application_key.key`).

This PR is intentionally scoped to `synthetics_private_location.config` only. Each of the other candidates likely needs its own targeted analysis (e.g., for `delegate_account_email`, re-fetching via `MakeGCPSTSDelegate` in Update may be more idiomatic than preserving from state). I'm happy to follow up with separate PRs for the others if that's useful, but felt mixing them into one PR would muddy review.

## Out of scope

`Create` (lines 193–205 on master) contains six `fmt.Println` debug statements that print on every successful Create and look like leftovers from #2881's framework migration. Flagged in #3747 as a candidate for separate cleanup.
