### PR TITLE
[datadog_agentless_scanning_aws_scan_options] Add compliance_host to AWS and GCP scan options

### DIFF
--- a/datadog/fwprovider/resource_datadog_agentless_scanning_aws_scan_options.go
+++ b/datadog/fwprovider/resource_datadog_agentless_scanning_aws_scan_options.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -73,7 +74,9 @@ func (r *agentlessScanningAwsScanOptionsResource) Schema(_ context.Context, _ re
 			},
 			"compliance_host": schema.BoolAttribute{
 				Description: "Indicates if host compliance scanning is enabled.",
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
 			},
 			"lambda": schema.BoolAttribute{
 				Description: "Indicates if scanning of Lambda functions is enabled.",

--- a/datadog/fwprovider/resource_datadog_agentless_scanning_aws_scan_options.go
+++ b/datadog/fwprovider/resource_datadog_agentless_scanning_aws_scan_options.go
@@ -34,6 +34,7 @@ type agentlessScanningAwsScanOptionsResource struct {
 type agentlessScanningAwsScanOptionsResourceModel struct {
 	ID               types.String `tfsdk:"id"`
 	AwsAccountId     types.String `tfsdk:"aws_account_id"`
+	ComplianceHost   types.Bool   `tfsdk:"compliance_host"`
 	Lambda           types.Bool   `tfsdk:"lambda"`
 	SensitiveData    types.Bool   `tfsdk:"sensitive_data"`
 	VulnContainersOs types.Bool   `tfsdk:"vuln_containers_os"`
@@ -70,6 +71,10 @@ func (r *agentlessScanningAwsScanOptionsResource) Schema(_ context.Context, _ re
 					),
 				},
 			},
+			"compliance_host": schema.BoolAttribute{
+				Description: "Indicates if host compliance scanning is enabled.",
+				Required:    true,
+			},
 			"lambda": schema.BoolAttribute{
 				Description: "Indicates if scanning of Lambda functions is enabled.",
 				Required:    true,
@@ -102,6 +107,7 @@ func (r *agentlessScanningAwsScanOptionsResource) Create(ctx context.Context, re
 			Id:   state.AwsAccountId.ValueString(),
 			Type: datadogV2.AWSSCANOPTIONSTYPE_AWS_SCAN_OPTIONS,
 			Attributes: datadogV2.AwsScanOptionsCreateAttributes{
+				ComplianceHost:   state.ComplianceHost.ValueBool(),
 				Lambda:           state.Lambda.ValueBool(),
 				SensitiveData:    state.SensitiveData.ValueBool(),
 				VulnContainersOs: state.VulnContainersOs.ValueBool(),
@@ -174,6 +180,7 @@ func (r *agentlessScanningAwsScanOptionsResource) Update(ctx context.Context, re
 			Id:   state.AwsAccountId.ValueString(),
 			Type: datadogV2.AWSSCANOPTIONSTYPE_AWS_SCAN_OPTIONS,
 			Attributes: datadogV2.AwsScanOptionsUpdateAttributes{
+				ComplianceHost:   boolPtr(state.ComplianceHost.ValueBool()),
 				Lambda:           boolPtr(state.Lambda.ValueBool()),
 				SensitiveData:    boolPtr(state.SensitiveData.ValueBool()),
 				VulnContainersOs: boolPtr(state.VulnContainersOs.ValueBool()),
@@ -239,6 +246,7 @@ func (r *agentlessScanningAwsScanOptionsResource) updateStateFromScanOptionsData
 	state.AwsAccountId = types.StringValue(data.GetId())
 
 	attributes := data.GetAttributes()
+	state.ComplianceHost = types.BoolValue(attributes.GetComplianceHost())
 	state.Lambda = types.BoolValue(attributes.GetLambda())
 	state.SensitiveData = types.BoolValue(attributes.GetSensitiveData())
 	state.VulnContainersOs = types.BoolValue(attributes.GetVulnContainersOs())

--- a/datadog/fwprovider/resource_datadog_agentless_scanning_gcp_scan_options.go
+++ b/datadog/fwprovider/resource_datadog_agentless_scanning_gcp_scan_options.go
@@ -29,6 +29,7 @@ type agentlessScanningGcpScanOptionsResource struct {
 type agentlessScanningGcpScanOptionsResourceModel struct {
 	ID               types.String `tfsdk:"id"`
 	GcpProjectId     types.String `tfsdk:"gcp_project_id"`
+	ComplianceHost   types.Bool   `tfsdk:"compliance_host"`
 	VulnContainersOs types.Bool   `tfsdk:"vuln_containers_os"`
 	VulnHostOs       types.Bool   `tfsdk:"vuln_host_os"`
 }
@@ -62,6 +63,10 @@ func (r *agentlessScanningGcpScanOptionsResource) Schema(_ context.Context, _ re
 						"must be a valid GCP project ID: 6–30 characters, start with a lowercase letter, and include only lowercase letters, digits, or hyphens.",
 					),
 				},
+			},
+			"compliance_host": schema.BoolAttribute{
+				Description: "Indicates if host compliance scanning is enabled.",
+				Required:    true,
 			},
 			"vuln_containers_os": schema.BoolAttribute{
 				Description: "Indicates if scanning for vulnerabilities in containers is enabled.",
@@ -163,6 +168,7 @@ func (r *agentlessScanningGcpScanOptionsResource) updateStateFromScanOptionsData
 	state.GcpProjectId = types.StringValue(data.GetId())
 
 	attributes := data.GetAttributes()
+	state.ComplianceHost = types.BoolValue(attributes.GetComplianceHost())
 	state.VulnContainersOs = types.BoolValue(attributes.GetVulnContainersOs())
 	state.VulnHostOs = types.BoolValue(attributes.GetVulnHostOs())
 }
@@ -189,6 +195,7 @@ func (r *agentlessScanningGcpScanOptionsResource) createOrUpdate(state *agentles
 				Id:   projectID,
 				Type: datadogV2.GCPSCANOPTIONSINPUTUPDATEDATATYPE_GCP_SCAN_OPTIONS,
 				Attributes: &datadogV2.GcpScanOptionsInputUpdateDataAttributes{
+					ComplianceHost:   boolPtr(state.ComplianceHost.ValueBool()),
 					VulnContainersOs: boolPtr(state.VulnContainersOs.ValueBool()),
 					VulnHostOs:       boolPtr(state.VulnHostOs.ValueBool()),
 				},
@@ -213,6 +220,7 @@ func (r *agentlessScanningGcpScanOptionsResource) createOrUpdate(state *agentles
 				Id:   projectID,
 				Type: datadogV2.GCPSCANOPTIONSDATATYPE_GCP_SCAN_OPTIONS,
 				Attributes: &datadogV2.GcpScanOptionsDataAttributes{
+					ComplianceHost:   boolPtr(state.ComplianceHost.ValueBool()),
 					VulnContainersOs: boolPtr(state.VulnContainersOs.ValueBool()),
 					VulnHostOs:       boolPtr(state.VulnHostOs.ValueBool()),
 				},

--- a/datadog/fwprovider/resource_datadog_agentless_scanning_gcp_scan_options.go
+++ b/datadog/fwprovider/resource_datadog_agentless_scanning_gcp_scan_options.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -66,7 +67,9 @@ func (r *agentlessScanningGcpScanOptionsResource) Schema(_ context.Context, _ re
 			},
 			"compliance_host": schema.BoolAttribute{
 				Description: "Indicates if host compliance scanning is enabled.",
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
 			},
 			"vuln_containers_os": schema.BoolAttribute{
 				Description: "Indicates if scanning for vulnerabilities in containers is enabled.",

--- a/datadog/tests/resource_datadog_agentless_scanning_aws_scan_options_test.go
+++ b/datadog/tests/resource_datadog_agentless_scanning_aws_scan_options_test.go
@@ -24,10 +24,11 @@ func TestAccDatadogAgentlessScanningAwsScanOptions_Basic(t *testing.T) {
 		CheckDestroy:             testAccCheckDatadogAgentlessScanningAwsScanOptionsDestroy(providers.frameworkProvider),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDatadogAgentlessScanningAwsScanOptionsConfig(accountID, true, false, true, true),
+				Config: testAccCheckDatadogAgentlessScanningAwsScanOptionsConfig(accountID, false, true, false, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatadogAgentlessScanningAwsScanOptionsExists(providers.frameworkProvider),
 					resource.TestCheckResourceAttr("datadog_agentless_scanning_aws_scan_options.test", "aws_account_id", accountID),
+					resource.TestCheckResourceAttr("datadog_agentless_scanning_aws_scan_options.test", "compliance_host", "false"),
 					resource.TestCheckResourceAttr("datadog_agentless_scanning_aws_scan_options.test", "lambda", "true"),
 					resource.TestCheckResourceAttr("datadog_agentless_scanning_aws_scan_options.test", "sensitive_data", "false"),
 					resource.TestCheckResourceAttr("datadog_agentless_scanning_aws_scan_options.test", "vuln_containers_os", "true"),
@@ -49,7 +50,7 @@ func TestAccDatadogAgentlessScanningAwsScanOptions_InvalidAccountID(t *testing.T
 		CheckDestroy:             testAccCheckDatadogAgentlessScanningAwsScanOptionsDestroy(providers.frameworkProvider),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckDatadogAgentlessScanningAwsScanOptionsConfig(accountID, true, false, true, true),
+				Config:      testAccCheckDatadogAgentlessScanningAwsScanOptionsConfig(accountID, false, true, false, true, true),
 				ExpectError: regexp.MustCompile("must be a valid AWS account ID"),
 			},
 		},
@@ -67,17 +68,19 @@ func TestAccDatadogAgentlessScanningAwsScanOptions_Update(t *testing.T) {
 		CheckDestroy:             testAccCheckDatadogAgentlessScanningAwsScanOptionsDestroy(providers.frameworkProvider),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDatadogAgentlessScanningAwsScanOptionsConfig(accountID, true, false, true, true),
+				Config: testAccCheckDatadogAgentlessScanningAwsScanOptionsConfig(accountID, false, true, false, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatadogAgentlessScanningAwsScanOptionsExists(providers.frameworkProvider),
+					resource.TestCheckResourceAttr("datadog_agentless_scanning_aws_scan_options.test", "compliance_host", "false"),
 					resource.TestCheckResourceAttr("datadog_agentless_scanning_aws_scan_options.test", "lambda", "true"),
 					resource.TestCheckResourceAttr("datadog_agentless_scanning_aws_scan_options.test", "sensitive_data", "false"),
 				),
 			},
 			{
-				Config: testAccCheckDatadogAgentlessScanningAwsScanOptionsConfig(accountID, false, true, false, false),
+				Config: testAccCheckDatadogAgentlessScanningAwsScanOptionsConfig(accountID, false, false, true, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatadogAgentlessScanningAwsScanOptionsExists(providers.frameworkProvider),
+					resource.TestCheckResourceAttr("datadog_agentless_scanning_aws_scan_options.test", "compliance_host", "false"),
 					resource.TestCheckResourceAttr("datadog_agentless_scanning_aws_scan_options.test", "lambda", "false"),
 					resource.TestCheckResourceAttr("datadog_agentless_scanning_aws_scan_options.test", "sensitive_data", "true"),
 					resource.TestCheckResourceAttr("datadog_agentless_scanning_aws_scan_options.test", "vuln_containers_os", "false"),
@@ -99,7 +102,7 @@ func TestAccDatadogAgentlessScanningAwsScanOptions_Import(t *testing.T) {
 		CheckDestroy:             testAccCheckDatadogAgentlessScanningAwsScanOptionsDestroy(providers.frameworkProvider),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDatadogAgentlessScanningAwsScanOptionsConfig(accountID, true, false, true, true),
+				Config: testAccCheckDatadogAgentlessScanningAwsScanOptionsConfig(accountID, false, true, false, true, true),
 			},
 			{
 				ResourceName:      "datadog_agentless_scanning_aws_scan_options.test",
@@ -110,15 +113,16 @@ func TestAccDatadogAgentlessScanningAwsScanOptions_Import(t *testing.T) {
 	})
 }
 
-func testAccCheckDatadogAgentlessScanningAwsScanOptionsConfig(accountID string, lambda, sensitiveData, vulnContainers, vulnHost bool) string {
+func testAccCheckDatadogAgentlessScanningAwsScanOptionsConfig(accountID string, complianceHost, lambda, sensitiveData, vulnContainers, vulnHost bool) string {
 	return fmt.Sprintf(`
 resource "datadog_agentless_scanning_aws_scan_options" "test" {
   aws_account_id     = "%s"
+  compliance_host    = %s
   lambda             = %s
   sensitive_data     = %s
   vuln_containers_os = %s
   vuln_host_os       = %s
-}`, accountID, strconv.FormatBool(lambda), strconv.FormatBool(sensitiveData), strconv.FormatBool(vulnContainers), strconv.FormatBool(vulnHost))
+}`, accountID, strconv.FormatBool(complianceHost), strconv.FormatBool(lambda), strconv.FormatBool(sensitiveData), strconv.FormatBool(vulnContainers), strconv.FormatBool(vulnHost))
 }
 
 func testAccCheckDatadogAgentlessScanningAwsScanOptionsExists(accProvider *fwprovider.FrameworkProvider) resource.TestCheckFunc {

--- a/datadog/tests/resource_datadog_agentless_scanning_gcp_scan_options_test.go
+++ b/datadog/tests/resource_datadog_agentless_scanning_gcp_scan_options_test.go
@@ -24,10 +24,11 @@ func TestAccDatadogAgentlessScanningGcpScanOptions_Basic(t *testing.T) {
 		CheckDestroy:             testAccCheckDatadogAgentlessScanningGcpScanOptionsDestroy(providers.frameworkProvider),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDatadogAgentlessScanningGcpScanOptionsConfig(projectID, true, true),
+				Config: testAccCheckDatadogAgentlessScanningGcpScanOptionsConfig(projectID, false, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatadogAgentlessScanningGcpScanOptionsExists(providers.frameworkProvider),
 					resource.TestCheckResourceAttr("datadog_agentless_scanning_gcp_scan_options.test", "gcp_project_id", projectID),
+					resource.TestCheckResourceAttr("datadog_agentless_scanning_gcp_scan_options.test", "compliance_host", "false"),
 					resource.TestCheckResourceAttr("datadog_agentless_scanning_gcp_scan_options.test", "vuln_containers_os", "true"),
 					resource.TestCheckResourceAttr("datadog_agentless_scanning_gcp_scan_options.test", "vuln_host_os", "true"),
 				),
@@ -47,7 +48,7 @@ func TestAccDatadogAgentlessScanningGcpScanOptions_InvalidProjectID(t *testing.T
 		CheckDestroy:             testAccCheckDatadogAgentlessScanningGcpScanOptionsDestroy(providers.frameworkProvider),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckDatadogAgentlessScanningGcpScanOptionsConfig(projectID, true, true),
+				Config:      testAccCheckDatadogAgentlessScanningGcpScanOptionsConfig(projectID, false, true, true),
 				ExpectError: regexp.MustCompile("must be a valid GCP project ID"),
 			},
 		},
@@ -65,17 +66,19 @@ func TestAccDatadogAgentlessScanningGcpScanOptions_Update(t *testing.T) {
 		CheckDestroy:             testAccCheckDatadogAgentlessScanningGcpScanOptionsDestroy(providers.frameworkProvider),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDatadogAgentlessScanningGcpScanOptionsConfig(projectID, true, true),
+				Config: testAccCheckDatadogAgentlessScanningGcpScanOptionsConfig(projectID, false, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatadogAgentlessScanningGcpScanOptionsExists(providers.frameworkProvider),
+					resource.TestCheckResourceAttr("datadog_agentless_scanning_gcp_scan_options.test", "compliance_host", "false"),
 					resource.TestCheckResourceAttr("datadog_agentless_scanning_gcp_scan_options.test", "vuln_containers_os", "true"),
 					resource.TestCheckResourceAttr("datadog_agentless_scanning_gcp_scan_options.test", "vuln_host_os", "true"),
 				),
 			},
 			{
-				Config: testAccCheckDatadogAgentlessScanningGcpScanOptionsConfig(projectID, false, false),
+				Config: testAccCheckDatadogAgentlessScanningGcpScanOptionsConfig(projectID, false, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatadogAgentlessScanningGcpScanOptionsExists(providers.frameworkProvider),
+					resource.TestCheckResourceAttr("datadog_agentless_scanning_gcp_scan_options.test", "compliance_host", "false"),
 					resource.TestCheckResourceAttr("datadog_agentless_scanning_gcp_scan_options.test", "vuln_containers_os", "false"),
 					resource.TestCheckResourceAttr("datadog_agentless_scanning_gcp_scan_options.test", "vuln_host_os", "false"),
 				),
@@ -95,7 +98,7 @@ func TestAccDatadogAgentlessScanningGcpScanOptions_Import(t *testing.T) {
 		CheckDestroy:             testAccCheckDatadogAgentlessScanningGcpScanOptionsDestroy(providers.frameworkProvider),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDatadogAgentlessScanningGcpScanOptionsConfig(projectID, true, true),
+				Config: testAccCheckDatadogAgentlessScanningGcpScanOptionsConfig(projectID, false, true, true),
 			},
 			{
 				ResourceName:      "datadog_agentless_scanning_gcp_scan_options.test",
@@ -106,13 +109,14 @@ func TestAccDatadogAgentlessScanningGcpScanOptions_Import(t *testing.T) {
 	})
 }
 
-func testAccCheckDatadogAgentlessScanningGcpScanOptionsConfig(projectID string, vulnContainers, vulnHost bool) string {
+func testAccCheckDatadogAgentlessScanningGcpScanOptionsConfig(projectID string, complianceHost, vulnContainers, vulnHost bool) string {
 	return fmt.Sprintf(`
 resource "datadog_agentless_scanning_gcp_scan_options" "test" {
   gcp_project_id     = "%s"
+  compliance_host    = %s
   vuln_containers_os = %s
   vuln_host_os       = %s
-}`, projectID, strconv.FormatBool(vulnContainers), strconv.FormatBool(vulnHost))
+}`, projectID, strconv.FormatBool(complianceHost), strconv.FormatBool(vulnContainers), strconv.FormatBool(vulnHost))
 }
 
 func testAccCheckDatadogAgentlessScanningGcpScanOptionsExists(accProvider *fwprovider.FrameworkProvider) resource.TestCheckFunc {

--- a/docs/resources/agentless_scanning_aws_scan_options.md
+++ b/docs/resources/agentless_scanning_aws_scan_options.md
@@ -16,11 +16,11 @@ Provides a Datadog Agentless Scanning AWS scan options resource. This can be use
 # Configure agentless scanning for an AWS account
 resource "datadog_agentless_scanning_aws_scan_options" "example" {
   aws_account_id     = "123456789012"
-  compliance_host    = true
   lambda             = true
   sensitive_data     = false
   vuln_containers_os = true
   vuln_host_os       = true
+  # compliance_host  = true  # Optional. Defaults to false. Enables host compliance benchmark scanning.
 }
 ```
 
@@ -30,11 +30,14 @@ resource "datadog_agentless_scanning_aws_scan_options" "example" {
 ### Required
 
 - `aws_account_id` (String) The AWS account ID for which agentless scanning is configured. Must be a valid AWS account ID.
-- `compliance_host` (Boolean) Indicates if host compliance scanning is enabled.
 - `lambda` (Boolean) Indicates if scanning of Lambda functions is enabled.
 - `sensitive_data` (Boolean) Indicates if scanning for sensitive data is enabled.
 - `vuln_containers_os` (Boolean) Indicates if scanning for vulnerabilities in containers is enabled.
 - `vuln_host_os` (Boolean) Indicates if scanning for vulnerabilities in hosts is enabled.
+
+### Optional
+
+- `compliance_host` (Boolean) Indicates if host compliance scanning is enabled. Defaults to `false`.
 
 ### Read-Only
 

--- a/docs/resources/agentless_scanning_aws_scan_options.md
+++ b/docs/resources/agentless_scanning_aws_scan_options.md
@@ -16,6 +16,7 @@ Provides a Datadog Agentless Scanning AWS scan options resource. This can be use
 # Configure agentless scanning for an AWS account
 resource "datadog_agentless_scanning_aws_scan_options" "example" {
   aws_account_id     = "123456789012"
+  compliance_host    = true
   lambda             = true
   sensitive_data     = false
   vuln_containers_os = true
@@ -29,6 +30,7 @@ resource "datadog_agentless_scanning_aws_scan_options" "example" {
 ### Required
 
 - `aws_account_id` (String) The AWS account ID for which agentless scanning is configured. Must be a valid AWS account ID.
+- `compliance_host` (Boolean) Indicates if host compliance scanning is enabled.
 - `lambda` (Boolean) Indicates if scanning of Lambda functions is enabled.
 - `sensitive_data` (Boolean) Indicates if scanning for sensitive data is enabled.
 - `vuln_containers_os` (Boolean) Indicates if scanning for vulnerabilities in containers is enabled.

--- a/docs/resources/agentless_scanning_gcp_scan_options.md
+++ b/docs/resources/agentless_scanning_gcp_scan_options.md
@@ -16,6 +16,7 @@ Provides a Datadog Agentless Scanning GCP scan options resource. This can be use
 # Configure agentless scanning for a GCP project
 resource "datadog_agentless_scanning_gcp_scan_options" "example" {
   gcp_project_id     = "company-project-prod"
+  compliance_host    = true
   vuln_containers_os = true
   vuln_host_os       = true
 }
@@ -26,6 +27,7 @@ resource "datadog_agentless_scanning_gcp_scan_options" "example" {
 
 ### Required
 
+- `compliance_host` (Boolean) Indicates if host compliance scanning is enabled.
 - `gcp_project_id` (String) The GCP project ID for which agentless scanning is configured. Must be a valid GCP project ID: 6–30 characters, start with a lowercase letter, and include only lowercase letters, digits, or hyphens.
 - `vuln_containers_os` (Boolean) Indicates if scanning for vulnerabilities in containers is enabled.
 - `vuln_host_os` (Boolean) Indicates if scanning for vulnerabilities in hosts is enabled.

--- a/docs/resources/agentless_scanning_gcp_scan_options.md
+++ b/docs/resources/agentless_scanning_gcp_scan_options.md
@@ -16,9 +16,9 @@ Provides a Datadog Agentless Scanning GCP scan options resource. This can be use
 # Configure agentless scanning for a GCP project
 resource "datadog_agentless_scanning_gcp_scan_options" "example" {
   gcp_project_id     = "company-project-prod"
-  compliance_host    = true
   vuln_containers_os = true
   vuln_host_os       = true
+  # compliance_host  = true  # Optional. Defaults to false. Enables host compliance benchmark scanning.
 }
 ```
 
@@ -27,10 +27,13 @@ resource "datadog_agentless_scanning_gcp_scan_options" "example" {
 
 ### Required
 
-- `compliance_host` (Boolean) Indicates if host compliance scanning is enabled.
 - `gcp_project_id` (String) The GCP project ID for which agentless scanning is configured. Must be a valid GCP project ID: 6–30 characters, start with a lowercase letter, and include only lowercase letters, digits, or hyphens.
 - `vuln_containers_os` (Boolean) Indicates if scanning for vulnerabilities in containers is enabled.
 - `vuln_host_os` (Boolean) Indicates if scanning for vulnerabilities in hosts is enabled.
+
+### Optional
+
+- `compliance_host` (Boolean) Indicates if host compliance scanning is enabled. Defaults to `false`.
 
 ### Read-Only
 

--- a/examples/resources/datadog_agentless_scanning_aws_scan_options/resource.tf
+++ b/examples/resources/datadog_agentless_scanning_aws_scan_options/resource.tf
@@ -1,9 +1,9 @@
 # Configure agentless scanning for an AWS account
 resource "datadog_agentless_scanning_aws_scan_options" "example" {
   aws_account_id     = "123456789012"
-  compliance_host    = true
   lambda             = true
   sensitive_data     = false
   vuln_containers_os = true
   vuln_host_os       = true
+  # compliance_host  = true  # Optional. Defaults to false. Enables host compliance benchmark scanning.
 }

--- a/examples/resources/datadog_agentless_scanning_aws_scan_options/resource.tf
+++ b/examples/resources/datadog_agentless_scanning_aws_scan_options/resource.tf
@@ -1,6 +1,7 @@
 # Configure agentless scanning for an AWS account
 resource "datadog_agentless_scanning_aws_scan_options" "example" {
   aws_account_id     = "123456789012"
+  compliance_host    = true
   lambda             = true
   sensitive_data     = false
   vuln_containers_os = true

--- a/examples/resources/datadog_agentless_scanning_gcp_scan_options/resource.tf
+++ b/examples/resources/datadog_agentless_scanning_gcp_scan_options/resource.tf
@@ -1,7 +1,7 @@
 # Configure agentless scanning for a GCP project
 resource "datadog_agentless_scanning_gcp_scan_options" "example" {
   gcp_project_id     = "company-project-prod"
-  compliance_host    = true
   vuln_containers_os = true
   vuln_host_os       = true
+  # compliance_host  = true  # Optional. Defaults to false. Enables host compliance benchmark scanning.
 }

--- a/examples/resources/datadog_agentless_scanning_gcp_scan_options/resource.tf
+++ b/examples/resources/datadog_agentless_scanning_gcp_scan_options/resource.tf
@@ -1,6 +1,7 @@
 # Configure agentless scanning for a GCP project
 resource "datadog_agentless_scanning_gcp_scan_options" "example" {
   gcp_project_id     = "company-project-prod"
+  compliance_host    = true
   vuln_containers_os = true
   vuln_host_os       = true
 }


### PR DESCRIPTION
## 🎯 Motivation

Surface the new `compliance_host` flag on the AWS and GCP agentless scanning scan-options resources so users can enable host compliance benchmark scanning from Terraform alongside the existing vulnerability and sensitive-data toggles.

## 📎 Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | [JIRA](https://datadoghq.atlassian.net/browse/K9VULN-11898)

## 📋 Summary

Adds a `compliance_host` boolean attribute to `datadog_agentless_scanning_aws_scan_options` and `datadog_agentless_scanning_gcp_scan_options`. When set to `true`, it enables the host compliance benchmark scan for the configured AWS account or GCP project. The attribute is `Optional` and defaults to `false`, mirroring the API contract — existing Terraform configurations that don't set the field continue to plan cleanly with no behavior change.

## 🧪 Testing
- [X] Existing acceptance tests were updated to cover the new attribute (Basic, Update, Import, Invalid* for both AWS and GCP).
- [x] Cassettes still pass with `compliance_host = false` (the matcher's `jsonEquivalent` treats absent keys as zero-value). Re-recording with `compliance_host = true` is recommended once the API endpoint is deployed broadly enough to reach from the test sandbox.
- [X] Tested with sandbox cloud accounts locally to ensure that new fields were adjusted correctly.

