### PR TITLE
fix(dashboard_v2): always emit widget_layout x/y, even when zero (#3750)

### DIFF
--- a/datadog/dashboardmapping/engine.go
+++ b/datadog/dashboardmapping/engine.go
@@ -1703,21 +1703,23 @@ func buildWidgetEngineJSONFromMap(widget map[string]interface{}) map[string]inte
 
 		widgetJSON := map[string]interface{}{"definition": defJSON}
 
-		// Include widget_layout if present
+		// Include widget_layout if present.
+		//
+		// x, y, width, height are always emitted — even when zero — so the
+		// Datadog API receives an explicit `x`/`y` field on every widget.
+		// Stripping zero-valued x/y produced 400 responses of the form
+		// "MSL widget out of grid. 'x' is a required property" for any
+		// widget at the dashboard origin (or row/column 0). See #3750.
 		if layoutList, ok := widget["widget_layout"].([]interface{}); ok && len(layoutList) > 0 {
 			if layoutMap, ok := layoutList[0].(map[string]interface{}); ok {
 				layout := map[string]interface{}{}
 				for _, key := range []string{"x", "y", "width", "height"} {
-					if v := getIntFromMap(layoutMap, key); v != 0 {
-						layout[key] = v
-					}
+					layout[key] = getIntFromMap(layoutMap, key)
 				}
 				if getBoolFromMap(layoutMap, "is_column_break") {
 					layout["is_column_break"] = true
 				}
-				if len(layout) > 0 {
-					widgetJSON["layout"] = layout
-				}
+				widgetJSON["layout"] = layout
 			}
 		}
 

--- a/datadog/dashboardmapping/engine_widget_layout_test.go
+++ b/datadog/dashboardmapping/engine_widget_layout_test.go
@@ -1,0 +1,51 @@
+package dashboardmapping
+
+import "testing"
+
+// TestBuildWidgetEngineJSONFromMap_LayoutZeroValuesPreserved verifies that
+// widget_layout x/y are emitted in the API JSON even when the user-supplied
+// values are zero. Stripping zero-valued x/y previously produced 400 errors
+// of the form "MSL widget out of grid. 'x' is a required property" for any
+// widget anchored at the dashboard origin (or row/column 0). See #3750.
+func TestBuildWidgetEngineJSONFromMap_LayoutZeroValuesPreserved(t *testing.T) {
+	cases := []struct {
+		name   string
+		layout map[string]interface{}
+		wantX  int
+		wantY  int
+	}{
+		{"origin", map[string]interface{}{"x": 0, "y": 0, "width": 4, "height": 5}, 0, 0},
+		{"left edge", map[string]interface{}{"x": 0, "y": 5, "width": 4, "height": 5}, 0, 5},
+		{"top edge", map[string]interface{}{"x": 4, "y": 0, "width": 4, "height": 5}, 4, 0},
+		{"interior", map[string]interface{}{"x": 4, "y": 5, "width": 4, "height": 5}, 4, 5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			widget := map[string]interface{}{
+				"note_definition": []interface{}{
+					map[string]interface{}{"content": "x"},
+				},
+				"widget_layout": []interface{}{tc.layout},
+			}
+			out := buildWidgetEngineJSONFromMap(widget)
+			if out == nil {
+				t.Fatalf("buildWidgetEngineJSONFromMap returned nil")
+			}
+			layoutOut, ok := out["layout"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("expected layout map in widget JSON, got: %#v", out["layout"])
+			}
+			for _, key := range []string{"x", "y", "width", "height"} {
+				if _, ok := layoutOut[key]; !ok {
+					t.Errorf("layout missing %q (full layout: %#v)", key, layoutOut)
+				}
+			}
+			if got := layoutOut["x"]; got != tc.wantX {
+				t.Errorf("x = %v, want %v", got, tc.wantX)
+			}
+			if got := layoutOut["y"]; got != tc.wantY {
+				t.Errorf("y = %v, want %v", got, tc.wantY)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #3750. `datadog_dashboard_v2` was stripping `x=0` and `y=0` from the `widget_layout` payload, so the Datadog API rejected any dashboard whose layout placed a widget at the origin (or row/column 0) with:

```
400 Bad Request: Invalid widget at position N of type <type>.
Error: MSL widget out of grid. 'x' is a required property
```

The same `buildWidgetEngineJSONFromMap` is used recursively for sub-widgets inside `group_definition`, so the bug also blocks sub-widgets nested at `(0, 0)` within a group.

## Change

`datadog/dashboardmapping/engine.go`: drop the `if v != 0` guard around `x`/`y`/`width`/`height` so they are always emitted in the layout JSON. `width`/`height` are required by the schema and must always be present anyway; for `x`/`y`, zero is a legitimate position that needs to round-trip. `is_column_break` stays conditional (still optional/bool).

```diff
-           for _, key := range []string{"x", "y", "width", "height"} {
-               if v := getIntFromMap(layoutMap, key); v != 0 {
-                   layout[key] = v
-               }
-           }
-           if getBoolFromMap(layoutMap, "is_column_break") {
-               layout["is_column_break"] = true
-           }
-           if len(layout) > 0 {
-               widgetJSON["layout"] = layout
-           }
+           for _, key := range []string{"x", "y", "width", "height"} {
+               layout[key] = getIntFromMap(layoutMap, key)
+           }
+           if getBoolFromMap(layoutMap, "is_column_break") {
+               layout["is_column_break"] = true
+           }
+           widgetJSON["layout"] = layout
```

## Test

Adds `engine_widget_layout_test.go` covering the four corner cases (origin, left-edge, top-edge, interior). Without the fix, the `origin` / `left edge` / `top edge` cases produced a layout missing the offending coordinate; after the fix all four explicit fields are present.

```
$ go test -run TestBuildWidgetEngineJSONFromMap_LayoutZeroValuesPreserved -v ./datadog/dashboardmapping/...
=== RUN   TestBuildWidgetEngineJSONFromMap_LayoutZeroValuesPreserved
=== RUN   TestBuildWidgetEngineJSONFromMap_LayoutZeroValuesPreserved/origin
=== RUN   TestBuildWidgetEngineJSONFromMap_LayoutZeroValuesPreserved/left_edge
=== RUN   TestBuildWidgetEngineJSONFromMap_LayoutZeroValuesPreserved/top_edge
=== RUN   TestBuildWidgetEngineJSONFromMap_LayoutZeroValuesPreserved/interior
--- PASS: TestBuildWidgetEngineJSONFromMap_LayoutZeroValuesPreserved (0.00s)
PASS
```

Full package test suite still passes (`go test ./datadog/dashboardmapping/... → 24 passed`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./datadog/dashboardmapping/...`
- [ ] CI on this PR
- [ ] Verified on a real `apply` against a dashboard with a widget at `(0, 0)` (manual step for the maintainer reviewing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)