### PR TITLE
Fix APM resource stats query construction

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -8231,7 +8231,12 @@ func buildDatadogMetricQuery(data map[string]interface{}) *datadogV1.FormulaAndF
 func buildDatadogFormulaAndFunctionAPMResourceStatsQuery(data map[string]interface{}) *datadogV1.FormulaAndFunctionQueryDefinition {
 	dataSource := datadogV1.FormulaAndFunctionApmResourceStatsDataSource(data["data_source"].(string))
 	stat := datadogV1.FormulaAndFunctionApmResourceStatName(data["stat"].(string))
-	apmResourceStatsQuery := datadogV1.NewFormulaAndFunctionApmResourceStatsQueryDefinition(dataSource, data["env"].(string), data["name"].(string), data["service"].(string), stat)
+	apmResourceStatsQuery := datadogV1.NewFormulaAndFunctionApmResourceStatsQueryDefinitionWithDefaults()
+	apmResourceStatsQuery.SetDataSource(dataSource)
+	apmResourceStatsQuery.SetEnv(data["env"].(string))
+	apmResourceStatsQuery.SetName(data["name"].(string))
+	apmResourceStatsQuery.SetService(data["service"].(string))
+	apmResourceStatsQuery.SetStat(stat)
 
 	// cross_org_uuids
 	if cross_org_uuids, ok := data["cross_org_uuids"].([]interface{}); ok && len(cross_org_uuids) == 1 {


### PR DESCRIPTION
## What

Updates dashboard APM resource stats query construction to use the generated `WithDefaults` constructor and setters instead of the strict positional constructor.

## Why

DataDog/datadog-api-spec#5400 marks `operation_name` and `group_by` as required for APM resource stats queries. The generated Go client's strict constructor therefore gains two required positional args, which breaks the Terraform provider build at `resource_datadog_dashboard.go`.

Using `NewFormulaAndFunctionApmResourceStatsQueryDefinitionWithDefaults()` keeps this provider compatible with both the current Go client and the generated client from the API spec change while preserving existing Terraform behavior.

## Verification

- `go test ./datadog -run TestAccDatadogDashboard -count=0`

Related: DataDog/datadog-api-spec#5400
