### PR TITLE
fix[datadog_metric_active_tags_and_aggregations]: protect against incorrect empty results

### DIFF
--- a/datadog/fwprovider/data_source_datadog_metric_active_tags_and_aggregations.go
+++ b/datadog/fwprovider/data_source_datadog_metric_active_tags_and_aggregations.go
@@ -93,18 +93,17 @@ func (d *datadogMetricActiveTagsAndAggregationsDataSource) Read(ctx context.Cont
 	if !state.Window.IsNull() {
 		params = *params.WithWindowSeconds(state.Window.ValueInt64())
 	}
-	ddResp, _, err := d.Api.ListActiveMetricConfigurations(d.Auth, state.Metric.String(), params)
+	ddResp, _, err := d.Api.ListActiveMetricConfigurations(d.Auth, state.Metric.ValueString(), params)
 	if err != nil {
 		resp.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error listing active metric tags and aggregations"))
 		return
 	}
 
 	data := ddResp.GetData()
-	id := data.Id
 	tags := data.Attributes.GetActiveTags()
 	aggregations := data.Attributes.GetActiveAggregations()
 
-	d.updateState(ctx, &state, *id, tags, aggregations)
+	d.updateState(ctx, &state, state.Metric.ValueString(), tags, aggregations)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 

--- a/datadog/tests/cassettes/TestAccDatadogMetricActiveTagsAndAggregationsDatasource.yaml
+++ b/datadog/tests/cassettes/TestAccDatadogMetricActiveTagsAndAggregationsDatasource.yaml
@@ -17,7 +17,7 @@ interactions:
         headers:
             Accept:
                 - application/json
-        url: https://api.datadoghq.com/api/v2/metrics/%22foo.bar%22/active-configurations
+        url: https://api.datadoghq.com/api/v2/metrics/foo.bar/active-configurations
         method: GET
       response:
         proto: HTTP/1.1
@@ -29,7 +29,7 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"data":{"type":"actively_queried_configurations","id":"\"foo.bar\"","attributes":{"active_tags":["environment","version"],"active_aggregations":[{"space":"avg","time":"sum"}]}}}
+            {"data":{"type":"actively_queried_configurations","id":"foo.bar","attributes":{"active_tags":["environment","version"],"active_aggregations":[{"space":"avg","time":"sum"}]}}}
         headers:
             Content-Type:
                 - application/json
@@ -52,7 +52,7 @@ interactions:
         headers:
             Accept:
                 - application/json
-        url: https://api.datadoghq.com/api/v2/metrics/%22foo.bar%22/active-configurations
+        url: https://api.datadoghq.com/api/v2/metrics/foo.bar/active-configurations
         method: GET
       response:
         proto: HTTP/1.1
@@ -64,7 +64,7 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"data":{"type":"actively_queried_configurations","id":"\"foo.bar\"","attributes":{"active_tags":["environment","version"],"active_aggregations":[{"space":"avg","time":"sum"}]}}}
+            {"data":{"type":"actively_queried_configurations","id":"foo.bar","attributes":{"active_tags":["environment","version"],"active_aggregations":[{"space":"avg","time":"sum"}]}}}
         headers:
             Content-Type:
                 - application/json
@@ -87,7 +87,7 @@ interactions:
         headers:
             Accept:
                 - application/json
-        url: https://api.datadoghq.com/api/v2/metrics/%22foo.bar%22/active-configurations
+        url: https://api.datadoghq.com/api/v2/metrics/foo.bar/active-configurations
         method: GET
       response:
         proto: HTTP/1.1
@@ -99,7 +99,7 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"data":{"type":"actively_queried_configurations","id":"\"foo.bar\"","attributes":{"active_tags":["environment","version"],"active_aggregations":[{"space":"avg","time":"sum"}]}}}
+            {"data":{"type":"actively_queried_configurations","id":"foo.bar","attributes":{"active_tags":["environment","version"],"active_aggregations":[{"space":"avg","time":"sum"}]}}}
         headers:
             Content-Type:
                 - application/json


### PR DESCRIPTION
Fixes https://github.com/DataDog/terraform-provider-datadog/issues/3791 to ensure `datadog_metric_active_tags_and_aggregations` does not incorrectly return empty results.

The Read function called ListActiveMetricConfigurations with state.Metric.String(). On a plugin-framework types.String, .String() returns the Go-fmt'd representation (fmt.Sprintf("%q", ...)), wrapping the value in literal double-quotes. A metric like foo.bar reached the API as "\"foo.bar\"", which the API treats as a non-existent metric and returns an empty body without erroring, so the data source silently returned empty active_tags and active_aggregations for every metric. The correct accessor is .ValueString(), used by every sibling metric data source in this package.

Also drop the dereference of data.Id (typed *string,omitempty in the SDK), which would panic on a response missing an id, and set the resource ID from state.Metric.ValueString() — the value the API returns today and the convention used elsewhere.

The existing cassette was recorded against the buggy path and encoded the quoted form in both the request URL and the response id field; updated to the unquoted form so the existing assertions catch a regression.