### PR TITLE
[datadog_security_monitoring_rule] Fix anomaly_detection_options Computed drift

### DIFF
--- a/datadog/fwprovider/resource_datadog_security_monitoring_rule.go
+++ b/datadog/fwprovider/resource_datadog_security_monitoring_rule.go
@@ -1300,7 +1300,7 @@ func extractTfOptions(ctx context.Context, options datadogV2.SecurityMonitoringR
 	if impossibleTravelOptions, ok := options.GetImpossibleTravelOptionsOk(); ok {
 		tfOptions.ImpossibleTravelOptions = []impossibleTravelOptionsModel{extractImpossibleTravelOptions(impossibleTravelOptions)}
 	}
-	if anomalyDetectionOptions, ok := options.GetAnomalyDetectionOptionsOk(); ok {
+	if anomalyDetectionOptions, ok := options.GetAnomalyDetectionOptionsOk(); ok && len(priorOption.AnomalyDetectionOptions) > 0 {
 		tfOptions.AnomalyDetectionOptions = []anomalyDetectionOptionsModel{extractAnomalyDetectionOptions(anomalyDetectionOptions)}
 	}
 	if thirdPartyOptions, ok := options.GetThirdPartyRuleOptionsOk(); ok {


### PR DESCRIPTION
## Summary

- **Root cause**: `detection_method = "anomaly_detection"` causes the Datadog API to always populate `anomaly_detection_options` with server-side defaults, even when omitted from config. The extractor unconditionally stored these in state, causing a plan/state block count mismatch (0 in plan, 1 in state). OpenTofu enforces this at apply time; Terraform shows perpetual drift.
- **Fix**: Only populate `anomaly_detection_options` in state when the prior state already contained them — i.e. the user explicitly declared the block. No schema changes, no type changes, one-line condition.

## Test plan

- [x] `make fmtcheck` passes
- [x] `make vet` passes
- [x] `make docs && make check-docs` — no docs changes needed
- [x] `TestAccDatadogSecurityMonitoringRule_AnomalyDetectionRule` passes with `RECORD=false`
- [x] `TestAccDatadogSecurityMonitoringRule_AnomalyDetectionRuleInstantaneousBaseline` passes with `RECORD=false`

🤖 Generated with [Claude Code](https://claude.ai/code)