### PR TITLE
fwprovider: Fix mislabeled error wrappers in Create/Update handlers

### DIFF
--- a/datadog/fwprovider/resource_datadog_appsec_waf_custom_rule.go
+++ b/datadog/fwprovider/resource_datadog_appsec_waf_custom_rule.go
@@ -274,7 +274,7 @@ func (r *appsecWafCustomRuleResource) Create(ctx context.Context, request resour
 		return nil
 	})
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving AppsecWafCustomRule"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating AppsecWafCustomRule"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {
@@ -319,7 +319,7 @@ func (r *appsecWafCustomRuleResource) Update(ctx context.Context, request resour
 		return nil
 	})
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving AppsecWafCustomRule"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating AppsecWafCustomRule"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {

--- a/datadog/fwprovider/resource_datadog_appsec_waf_exclusion_filter.go
+++ b/datadog/fwprovider/resource_datadog_appsec_waf_exclusion_filter.go
@@ -214,7 +214,7 @@ func (r *appsecWafExclusionFilterResource) Create(ctx context.Context, request r
 		return nil
 	})
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving AppsecWafExclusionFilter"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating AppsecWafExclusionFilter"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {
@@ -259,7 +259,7 @@ func (r *appsecWafExclusionFilterResource) Update(ctx context.Context, request r
 		return nil
 	})
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving AppsecWafExclusionFilter"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating AppsecWafExclusionFilter"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {

--- a/datadog/fwprovider/resource_datadog_custom_allocation_rule.go
+++ b/datadog/fwprovider/resource_datadog_custom_allocation_rule.go
@@ -494,7 +494,7 @@ func (r *datadogCustomAllocationRuleResource) Create(ctx context.Context, reques
 
 	resp, _, err := r.Api.CreateCustomAllocationRule(r.Auth, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving DatadogCustomAllocationRule"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating DatadogCustomAllocationRule"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {
@@ -538,7 +538,7 @@ func (r *datadogCustomAllocationRuleResource) Update(ctx context.Context, reques
 
 	resp, _, err := r.Api.UpdateCustomAllocationRule(r.Auth, id, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving DatadogCustomAllocationRule"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating DatadogCustomAllocationRule"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {

--- a/datadog/fwprovider/resource_datadog_datastore.go
+++ b/datadog/fwprovider/resource_datadog_datastore.go
@@ -197,7 +197,7 @@ func (r *datastoreResource) Update(ctx context.Context, request resource.UpdateR
 
 	resp, _, err := r.Api.UpdateDatastore(r.Auth, id, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving Datastore"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating Datastore"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {

--- a/datadog/fwprovider/resource_datadog_downtime_schedule.go
+++ b/datadog/fwprovider/resource_datadog_downtime_schedule.go
@@ -229,7 +229,7 @@ func (r *DowntimeScheduleResource) Create(ctx context.Context, request resource.
 
 	resp, _, err := r.Api.CreateDowntime(r.Auth, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving DowntimeSchedule"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating DowntimeSchedule"))
 		return
 	}
 	r.updateState(ctx, &state, &resp)
@@ -255,7 +255,7 @@ func (r *DowntimeScheduleResource) Update(ctx context.Context, request resource.
 
 	resp, _, err := r.Api.UpdateDowntime(r.Auth, id, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving DowntimeSchedule"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating DowntimeSchedule"))
 		return
 	}
 	r.updateState(ctx, &state, &resp)

--- a/datadog/fwprovider/resource_datadog_gcp_uc_config.go
+++ b/datadog/fwprovider/resource_datadog_gcp_uc_config.go
@@ -175,7 +175,7 @@ func (r *gcpUcConfigResource) Create(ctx context.Context, request resource.Creat
 
 	resp, _, err := r.Api.CreateCostGCPUsageCostConfig(r.Auth, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving GcpUcConfig"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating GcpUcConfig"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {

--- a/datadog/fwprovider/resource_datadog_integration_cloudflare_account.go
+++ b/datadog/fwprovider/resource_datadog_integration_cloudflare_account.go
@@ -125,7 +125,7 @@ func (r *integrationCloudflareAccountResource) Create(ctx context.Context, reque
 
 	resp, _, err := r.Api.CreateCloudflareAccount(r.Auth, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving IntegrationCloudflareAccount"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating IntegrationCloudflareAccount"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {
@@ -155,7 +155,7 @@ func (r *integrationCloudflareAccountResource) Update(ctx context.Context, reque
 
 	resp, _, err := r.Api.UpdateCloudflareAccount(r.Auth, id, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving IntegrationCloudflareAccount"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating IntegrationCloudflareAccount"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {

--- a/datadog/fwprovider/resource_datadog_integration_confluent_account.go
+++ b/datadog/fwprovider/resource_datadog_integration_confluent_account.go
@@ -117,7 +117,7 @@ func (r *integrationConfluentAccountResource) Create(ctx context.Context, reques
 
 	resp, _, err := r.Api.CreateConfluentAccount(r.Auth, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving IntegrationConfluentAccount"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating IntegrationConfluentAccount"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {
@@ -147,7 +147,7 @@ func (r *integrationConfluentAccountResource) Update(ctx context.Context, reques
 
 	resp, _, err := r.Api.UpdateConfluentAccount(r.Auth, id, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving IntegrationConfluentAccount"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating IntegrationConfluentAccount"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {

--- a/datadog/fwprovider/resource_datadog_integration_confluent_resource.go
+++ b/datadog/fwprovider/resource_datadog_integration_confluent_resource.go
@@ -150,7 +150,7 @@ func (r *integrationConfluentResourceResource) Create(ctx context.Context, reque
 
 	resp, _, err := r.Api.CreateConfluentResource(r.Auth, accountId, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving IntegrationConfluentResource"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating IntegrationConfluentResource"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {
@@ -184,7 +184,7 @@ func (r *integrationConfluentResourceResource) Update(ctx context.Context, reque
 
 	resp, _, err := r.Api.UpdateConfluentResource(r.Auth, accountID, resourceID, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving IntegrationConfluentResource"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating IntegrationConfluentResource"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {

--- a/datadog/fwprovider/resource_datadog_integration_fastly_account.go
+++ b/datadog/fwprovider/resource_datadog_integration_fastly_account.go
@@ -134,7 +134,7 @@ func (r *integrationFastlyAccountResource) Create(ctx context.Context, request r
 
 	resp, _, err := r.Api.CreateFastlyAccount(r.Auth, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving IntegrationFastlyAccount"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating IntegrationFastlyAccount"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {
@@ -170,7 +170,7 @@ func (r *integrationFastlyAccountResource) Update(ctx context.Context, request r
 
 	resp, _, err := r.Api.UpdateFastlyAccount(r.Auth, id, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving IntegrationFastlyAccount"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating IntegrationFastlyAccount"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {

--- a/datadog/fwprovider/resource_datadog_integration_fastly_service.go
+++ b/datadog/fwprovider/resource_datadog_integration_fastly_service.go
@@ -140,7 +140,7 @@ func (r *integrationFastlyServiceResource) Create(ctx context.Context, request r
 
 	resp, _, err := r.Api.CreateFastlyService(r.Auth, accountId, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving IntegrationFastlyService"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating IntegrationFastlyService"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {
@@ -174,7 +174,7 @@ func (r *integrationFastlyServiceResource) Update(ctx context.Context, request r
 
 	resp, _, err := r.Api.UpdateFastlyService(r.Auth, accountID, serviceID, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving IntegrationFastlyService"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating IntegrationFastlyService"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {

--- a/datadog/fwprovider/resource_datadog_monitor.go
+++ b/datadog/fwprovider/resource_datadog_monitor.go
@@ -927,7 +927,7 @@ func (r *monitorResource) Create(ctx context.Context, request resource.CreateReq
 
 	resp, _, err := r.Api.CreateMonitor(r.Auth, *monitorBody)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving Monitor"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating Monitor"))
 		return
 	}
 	r.updateState(ctx, &state, &resp)
@@ -955,7 +955,7 @@ func (r *monitorResource) Update(ctx context.Context, request resource.UpdateReq
 
 	resp, _, err := r.Api.UpdateMonitor(r.Auth, *id, *updateRequestBody)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving Monitor"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating Monitor"))
 		return
 	}
 	r.updateState(ctx, &state, &resp)

--- a/datadog/fwprovider/resource_datadog_on_call_team_routing_rules.go
+++ b/datadog/fwprovider/resource_datadog_on_call_team_routing_rules.go
@@ -334,7 +334,7 @@ func (r *onCallTeamRoutingRulesResource) Update(ctx context.Context, request res
 		Include: &include,
 	})
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating OnCallTeamRoutingRules"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating OnCallTeamRoutingRules"))
 		return
 	}
 

--- a/datadog/fwprovider/resource_datadog_openapi_api.go
+++ b/datadog/fwprovider/resource_datadog_openapi_api.go
@@ -115,7 +115,7 @@ func (r *openapiApiResource) Create(ctx context.Context, request resource.Create
 	params := datadogV2.NewCreateOpenAPIOptionalParameters().WithOpenapiSpecFile(bodyReader)
 	resp, _, err := r.Api.CreateOpenAPI(r.Auth, *params)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving OpenapiApi"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating OpenapiApi"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {
@@ -147,7 +147,7 @@ func (r *openapiApiResource) Update(ctx context.Context, request resource.Update
 
 	resp, _, err := r.Api.UpdateOpenAPI(r.Auth, uuid, *params)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving OpenapiApi"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating OpenapiApi"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {

--- a/datadog/fwprovider/resource_datadog_restriction_policy.go
+++ b/datadog/fwprovider/resource_datadog_restriction_policy.go
@@ -136,7 +136,7 @@ func (r *RestrictionPolicyResource) Create(ctx context.Context, request resource
 
 	resp, _, err := r.API.UpdateRestrictionPolicy(r.Auth, resourceId, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving RestrictionPolicy"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating RestrictionPolicy"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {
@@ -165,7 +165,7 @@ func (r *RestrictionPolicyResource) Update(ctx context.Context, request resource
 
 	resp, _, err := r.API.UpdateRestrictionPolicy(r.Auth, resourceId, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving RestrictionPolicy"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating RestrictionPolicy"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {

--- a/datadog/fwprovider/resource_datadog_rum_application.go
+++ b/datadog/fwprovider/resource_datadog_rum_application.go
@@ -145,7 +145,7 @@ func (r *rumApplicationResource) Create(ctx context.Context, request resource.Cr
 
 	resp, _, err := r.Api.CreateRUMApplication(r.Auth, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving RumApplication"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating RumApplication"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {

--- a/datadog/fwprovider/resource_datadog_rum_metric.go
+++ b/datadog/fwprovider/resource_datadog_rum_metric.go
@@ -207,7 +207,7 @@ func (r *rumMetricResource) Create(ctx context.Context, request resource.CreateR
 
 	resp, _, err := r.Api.CreateRumMetric(r.Auth, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving RumMetric"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating RumMetric"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {
@@ -237,7 +237,7 @@ func (r *rumMetricResource) Update(ctx context.Context, request resource.UpdateR
 
 	resp, _, err := r.Api.UpdateRumMetric(r.Auth, id, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving RumMetric"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating RumMetric"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {

--- a/datadog/fwprovider/resource_datadog_rum_retention_filter.go
+++ b/datadog/fwprovider/resource_datadog_rum_retention_filter.go
@@ -147,7 +147,7 @@ func (r *rumRetentionFilterResource) Create(ctx context.Context, request resourc
 
 	resp, _, err := r.Api.CreateRetentionFilter(r.Auth, appId, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving RumRetentionFilter"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating RumRetentionFilter"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {
@@ -175,7 +175,7 @@ func (r *rumRetentionFilterResource) Update(ctx context.Context, request resourc
 
 	resp, _, err := r.Api.UpdateRetentionFilter(r.Auth, state.ApplicationID.ValueString(), state.ID.ValueString(), *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving RumRetentionFilter"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating RumRetentionFilter"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {

--- a/datadog/fwprovider/resource_datadog_synthetics_global_variable.go
+++ b/datadog/fwprovider/resource_datadog_synthetics_global_variable.go
@@ -347,7 +347,7 @@ func (r *syntheticsGlobalVariableResource) Create(ctx context.Context, request r
 
 	resp, _, err := r.Api.CreateGlobalVariable(r.Auth, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving SyntheticsGlobalVariable"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating SyntheticsGlobalVariable"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {
@@ -383,7 +383,7 @@ func (r *syntheticsGlobalVariableResource) Update(ctx context.Context, request r
 
 	resp, _, err := r.Api.EditGlobalVariable(r.Auth, id, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving SyntheticsGlobalVariable"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating SyntheticsGlobalVariable"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {

--- a/datadog/fwprovider/resource_datadog_team.go
+++ b/datadog/fwprovider/resource_datadog_team.go
@@ -127,7 +127,7 @@ func (r *teamResource) Create(ctx context.Context, request resource.CreateReques
 
 	resp, _, err := r.Api.CreateTeam(r.Auth, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving Team"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating Team"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {
@@ -157,7 +157,7 @@ func (r *teamResource) Update(ctx context.Context, request resource.UpdateReques
 
 	resp, _, err := r.Api.UpdateTeam(r.Auth, id, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving Team"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating Team"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {

--- a/datadog/fwprovider/resource_datadog_team_hierarchy_links.go
+++ b/datadog/fwprovider/resource_datadog_team_hierarchy_links.go
@@ -127,7 +127,7 @@ func (r *teamHierarchyLinksResource) Create(ctx context.Context, request resourc
 
 	resp, _, err := r.Api.AddTeamHierarchyLink(r.Auth, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving TeamHierarchyLinks"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating TeamHierarchyLinks"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {

--- a/datadog/fwprovider/resource_datadog_team_link.go
+++ b/datadog/fwprovider/resource_datadog_team_link.go
@@ -134,7 +134,7 @@ func (r *teamLinkResource) Create(ctx context.Context, request resource.CreateRe
 
 	resp, _, err := r.Api.CreateTeamLink(r.Auth, teamId, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving TeamLink"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating TeamLink"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {
@@ -166,7 +166,7 @@ func (r *teamLinkResource) Update(ctx context.Context, request resource.UpdateRe
 
 	resp, _, err := r.Api.UpdateTeamLink(r.Auth, teamId, id, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving TeamLink"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating TeamLink"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {

--- a/datadog/fwprovider/resource_datadog_team_membership.go
+++ b/datadog/fwprovider/resource_datadog_team_membership.go
@@ -165,7 +165,7 @@ func (r *teamMembershipResource) Create(ctx context.Context, request resource.Cr
 
 	resp, _, err := r.Api.CreateTeamMembership(r.Auth, teamId, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving TeamMembership"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating TeamMembership"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {
@@ -196,7 +196,7 @@ func (r *teamMembershipResource) Update(ctx context.Context, request resource.Up
 
 	resp, _, err := r.Api.UpdateTeamMembership(r.Auth, teamId, userId, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving TeamMembership"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating TeamMembership"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {

--- a/datadog/fwprovider/resource_datadog_user_role.go
+++ b/datadog/fwprovider/resource_datadog_user_role.go
@@ -136,7 +136,7 @@ func (r *userRoleResource) Create(ctx context.Context, request resource.CreateRe
 	roleId := state.RoleId.ValueString()
 	resp, _, err := r.Api.AddUserToRole(r.Auth, roleId, *body)
 	if err != nil {
-		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error retrieving UserRole"))
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating UserRole"))
 		return
 	}
 	if err := utils.CheckForUnparsed(resp); err != nil {


### PR DESCRIPTION
## What this PR does

Sweeps `datadog/fwprovider/` and fixes 42 mislabeled error wrappers across 24 resources. The plugin-framework resources call `utils.FrameworkErrorDiag(err, "error <verb> X")` to wrap API client errors in their CRUD handlers. Many `Create`/`Update` functions were labelled **"error retrieving X"** — copy-pasted from `Read` — even though they wrap `CreateX` / `UpdateX` / similar write API calls. One `Update` in `resource_datadog_on_call_team_routing_rules.go` was labelled **"error creating"**.

Read handlers are left alone — `"error retrieving"` is correct there.

## Why this matters

The wrapper string is the only context surfaced to the user before the upstream HTTP body, so the mislabel makes diagnosing failures materially harder: a POST that 400s on validation surfaces as "error retrieving …", which sends users down a long diagnostic detour looking for a GET path that does not exist.

### Concrete example

A POST to `CreateDowntime` failing on validation produces this in the Terraform output today:

```
Error: error retrieving DowntimeSchedule
  with datadog_downtime_schedule.dynamodb_provisioned_rollout_<table>,
  on datadog_downtime_schedule_generated.tf line 3, in resource "datadog_downtime_schedule" "dynamodb_provisioned_rollout_<table>":
   3: resource "datadog_downtime_schedule" "dynamodb_provisioned_rollout_<table>" {

400 Bad Request: {"errors":["Scheduled downtime start cannot be in the past"]}
```

The 400 body is unambiguously a write-time validation, but the wrapper says "retrieving". After this patch:

```
Error: error creating DowntimeSchedule
...
```

…which immediately points at the actual code path.

## What I checked

- Sweep methodology: for every receiver method named `Create` / `Update` / `Delete` in `datadog/fwprovider/resource_*.go`, find any `"error <verb> X"` literal inside its body whose `<verb>` doesn't match the handler kind, then verify it wraps an API write call (`CreateXxx`, `UpdateXxx`, `EditXxx`, `SetXxx`, `AddXxx`, etc.) immediately above. All 42 fixes match this pattern.
- Files touched (each fix replaces only the wrapper string; no behaviour change):

  ```
  resource_datadog_appsec_waf_custom_rule.go         (2)
  resource_datadog_appsec_waf_exclusion_filter.go    (2)
  resource_datadog_custom_allocation_rule.go         (2)
  resource_datadog_datastore.go                      (1)
  resource_datadog_downtime_schedule.go              (2)
  resource_datadog_gcp_uc_config.go                  (1)
  resource_datadog_integration_cloudflare_account.go (2)
  resource_datadog_integration_confluent_account.go  (2)
  resource_datadog_integration_confluent_resource.go (2)
  resource_datadog_integration_fastly_account.go     (2)
  resource_datadog_integration_fastly_service.go     (2)
  resource_datadog_monitor.go                        (2)
  resource_datadog_on_call_team_routing_rules.go     (1)
  resource_datadog_openapi_api.go                    (2)
  resource_datadog_restriction_policy.go             (2)
  resource_datadog_rum_application.go                (1)
  resource_datadog_rum_metric.go                     (2)
  resource_datadog_rum_retention_filter.go           (2)
  resource_datadog_synthetics_global_variable.go     (2)
  resource_datadog_team.go                           (2)
  resource_datadog_team_hierarchy_links.go           (1)
  resource_datadog_team_link.go                      (2)
  resource_datadog_team_membership.go                (2)
  resource_datadog_user_role.go                      (1)
  ```
- `go build ./...` clean.
- `gofmt -l datadog/fwprovider/` clean.

## Out of scope

- SDKv2 resources under `datadog/` — not swept.
- Datasources (`datasource_*.go`) — most use `"error retrieving"` legitimately; no obvious miswiring found in a spot check.
- No CHANGELOG entry added — error-message wording-only change, happy to add one if maintainers prefer.
