### PR TITLE
[datadog_dashboard_v2] Preserve zero layout coordinates

### DIFF
--- a/datadog/dashboardmapping/engine.go
+++ b/datadog/dashboardmapping/engine.go
@@ -1838,6 +1838,7 @@ func buildWidgetEngineJSONFromMap(widget map[string]interface{}) map[string]inte
 		if layoutList, ok := widget["widget_layout"].([]interface{}); ok && len(layoutList) > 0 {
 			if layoutMap, ok := layoutList[0].(map[string]interface{}); ok {
 				layout := map[string]interface{}{}
+				// Zero is a valid x/y coordinate, unlike width and height.
 				for _, key := range []string{"x", "y"} {
 					if _, ok := layoutMap[key]; ok {
 						layout[key] = getIntFromMap(layoutMap, key)

--- a/datadog/dashboardmapping/engine.go
+++ b/datadog/dashboardmapping/engine.go
@@ -1838,7 +1838,12 @@ func buildWidgetEngineJSONFromMap(widget map[string]interface{}) map[string]inte
 		if layoutList, ok := widget["widget_layout"].([]interface{}); ok && len(layoutList) > 0 {
 			if layoutMap, ok := layoutList[0].(map[string]interface{}); ok {
 				layout := map[string]interface{}{}
-				for _, key := range []string{"x", "y", "width", "height"} {
+				for _, key := range []string{"x", "y"} {
+					if _, ok := layoutMap[key]; ok {
+						layout[key] = getIntFromMap(layoutMap, key)
+					}
+				}
+				for _, key := range []string{"width", "height"} {
 					if v := getIntFromMap(layoutMap, key); v != 0 {
 						layout[key] = v
 					}

--- a/datadog/dashboardmapping/engine_layout_test.go
+++ b/datadog/dashboardmapping/engine_layout_test.go
@@ -1,0 +1,48 @@
+package dashboardmapping
+
+import "testing"
+
+func TestBuildWidgetEngineJSONFromMap_PreservesZeroLayoutCoordinatesForNestedGroupWidget(t *testing.T) {
+	widget := map[string]interface{}{
+		"group_definition": []interface{}{
+			map[string]interface{}{
+				"layout_type": "ordered",
+				"widget": []interface{}{
+					map[string]interface{}{
+						"query_value_definition": []interface{}{
+							map[string]interface{}{
+								"title": "CPU",
+							},
+						},
+						"widget_layout": []interface{}{
+							map[string]interface{}{
+								"x":      0,
+								"y":      0,
+								"width":  4,
+								"height": 2,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := BuildWidgetEngineJSONFromMap(widget)
+	groupDefinition := result["definition"].(map[string]interface{})
+	nestedWidgets := groupDefinition["widgets"].([]interface{})
+	nestedWidget := nestedWidgets[0].(map[string]interface{})
+	layout := nestedWidget["layout"].(map[string]interface{})
+
+	for _, key := range []string{"x", "y", "width", "height"} {
+		if _, ok := layout[key]; !ok {
+			t.Fatalf("expected layout to include %q, got: %#v", key, layout)
+		}
+	}
+	if layout["x"] != 0 {
+		t.Fatalf("expected x=0, got %#v", layout["x"])
+	}
+	if layout["y"] != 0 {
+		t.Fatalf("expected y=0, got %#v", layout["y"])
+	}
+}


### PR DESCRIPTION
## Summary

Fixes [WEBPS-7682](https://datadoghq.atlassian.net/browse/WEBPS-7682) by preserving explicit zero-valued `x` and `y` coordinates when `datadog_dashboard_v2` serializes `widget_layout` blocks to Dashboard API JSON.

The v2 dashboard mapping code previously copied layout integer fields only when `getIntFromMap(...) != 0`. That treated valid coordinates like `x = 0` and `y = 0` as empty values and omitted them from the outgoing `layout` object. For fixed-layout dashboards, especially nested widgets inside a group widget, the Dashboard API then rejected the payload with:

```text
Invalid widget at position 0 of type group. Error: MSL widget out of grid. Invalid layout in inner widget at position 0 of type query_value. Error: 'x' is a required property
```

This keeps the existing nonzero behavior for `width` and `height`, but changes `x` and `y` to serialize based on map presence instead of nonzero value, since `0` is a valid coordinate.

## Testing

Unit test:

```text
TEST=./datadog/dashboardmapping TESTARGS='-run TestBuildWidgetEngineJSONFromMap_PreservesZeroLayoutCoordinatesForNestedGroupWidget' make test
```

Result:

```text
PASS datadog/dashboardmapping.TestBuildWidgetEngineJSONFromMap_PreservesZeroLayoutCoordinatesForNestedGroupWidget
PASS datadog/dashboardmapping
DONE 1 tests in 0.400s
```

Build:

```text
make build
```

Result: passed, rebuilding the local provider binary at `/Users/briany.lee/go/bin/terraform-provider-datadog`.

Manual staging repro against `ddog` staging:

1. Built the provider locally with this branch.
2. Used a Terraform CLI dev override pointing `DataDog/datadog` at `/Users/briany.lee/go/bin`.
3. Applied this minimal `datadog_dashboard_v2` config:

```hcl
terraform {
  required_providers {
    datadog = {
      source = "DataDog/datadog"
    }
  }
}

provider "datadog" {
  api_url = "https://api.datad0g.com"
}

resource "datadog_dashboard_v2" "webps_7682_repro" {
  title       = "WEBPS-7682 repro"
  layout_type = "ordered"
  reflow_type = "fixed"

  widget {
    group_definition {
      layout_type = "ordered"
      title       = "Group"

      widget {
        query_value_definition {
          title = "CPU"

          request {
            q          = "avg:system.cpu.user{*}"
            aggregator = "avg"
          }
        }

        widget_layout {
          x      = 0
          y      = 0
          width  = 4
          height = 2
        }
      }
    }

    widget_layout {
      x      = 1
      y      = 1
      width  = 10
      height = 6
    }
  }
}
```

Before this fix, the same config failed against staging with the original ticket shape:

```text
Invalid widget at position 0 of type group. Error: MSL widget out of grid. Invalid layout in inner widget at position 0 of type query_value. Error: 'x' is a required property
```

After this fix, the same config applied successfully and created dashboard `vtv-9xa-zi9`.

Cleanup:

```text
TF_CLI_CONFIG_FILE=terraformrc terraform destroy
```

Result: dashboard `vtv-9xa-zi9` was destroyed successfully.


[WEBPS-7682]: https://datadoghq.atlassian.net/browse/WEBPS-7682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ