### PR TITLE
[datadog_security_monitoring_rule] Fix anomaly detection rule condition field to handle dynamic API default

### DIFF
--- a/datadog/fwprovider/resource_datadog_security_monitoring_rule.go
+++ b/datadog/fwprovider/resource_datadog_security_monitoring_rule.go
@@ -296,10 +296,10 @@ func (r *securityMonitoringRuleResource) Schema(_ context.Context, _ resource.Sc
 							Description: "Name of the case.",
 						},
 						"condition": schema.StringAttribute{
-							Optional:    true,
-							Computed:    true,
-							Default:     stringdefault.StaticString(""),
-							Description: "A rule case contains logical operations (`>`,`>=`, `&&`, `||`) to determine if a signal should be generated based on the event counts in the previously defined queries.",
+							Optional:      true,
+							Computed:      true,
+							PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+							Description:   "A rule case contains logical operations (`>`,`>=`, `&&`, `||`) to determine if a signal should be generated based on the event counts in the previously defined queries.",
 						},
 						"notifications": schema.ListAttribute{
 							Optional:    true,

--- a/docs/resources/security_monitoring_rule.md
+++ b/docs/resources/security_monitoring_rule.md
@@ -101,7 +101,7 @@ Required:
 Optional:
 
 - `action` (Block List) Action to perform when the case trigger (see [below for nested schema](#nestedblock--case--action))
-- `condition` (String) A rule case contains logical operations (`>`,`>=`, `&&`, `||`) to determine if a signal should be generated based on the event counts in the previously defined queries. Defaults to `""`.
+- `condition` (String) A rule case contains logical operations (`>`,`>=`, `&&`, `||`) to determine if a signal should be generated based on the event counts in the previously defined queries.
 - `name` (String) Name of the case. Defaults to `""`.
 - `notifications` (List of String) Notification targets for each rule case.
 


### PR DESCRIPTION
## Summary

- Replaces `Default: stringdefault.StaticString("")` on the `condition` field in `case` blocks with `PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}`
- The Datadog API returns a non-empty default condition for some rule types when `condition` is not explicitly set. The old static default of `""` would cause a provider inconsistency error after apply since the planned value would differ from the API response.
- `UseStateForUnknown` preserves backward compatibility for existing resources (the prior state value is kept in plan) while allowing new resources to accept whatever value the API generates.

## Test plan
- [x] Acceptance tests pass
- [x] Verify anomaly detection rule create without explicit `condition` does not produce "provider produced inconsistent result" error
- [x] Verify normal threshold rules with explicit `condition` are unaffected
- [x] Verify existing resources with `condition = ""` in state continue to work without drift
