### PR TITLE
Emit the PR URL as a GHA annotation when preparing release

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -97,3 +97,5 @@ jobs:
               repo: context.repo.repo,
               labels: ["changelog/no-changelog"],
             });
+
+            core.notice(pr.html_url, { title: 'Release PR created' });


### PR DESCRIPTION
Makes it less clicks to find the PR.