### PR TITLE
Add mergegate check to require all files have a codeowner

### DIFF
--- a/.repository.datadog.yaml
+++ b/.repository.datadog.yaml
@@ -1,0 +1,4 @@
+schema-version: v1
+kind: mergegate
+rules:
+  - require: all-files-are-owned


### PR DESCRIPTION
Note that the codeowner *can* be nobody, so long as it is explicitly so (e.g. as we have for generated cassettes in this project).