### PR TITLE
[SYNTH-26401] migrate CODEOWNERS to synthetics-orchestrating-managing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,7 +31,7 @@ datadog/*datadog_security_monitoring*       @DataDog/k9-cloud-siem
 datadog/*datadog_security_notification_rule* @DataDog/k9-shared-capabilities
 datadog/*datadog_service_definition*       @DataDog/service-catalog
 datadog/*datadog_service_level_objective*  @DataDog/slo-app
-datadog/*datadog_synthetics*               @DataDog/synthetics-managing
+datadog/*datadog_synthetics*               @DataDog/synthetics-orchestrating-managing
 datadog/*datadog_timeboard*                @DataDog/dashboards-backend
 datadog/*datadog_permissions*              @DataDog/team-aaa
 datadog/*datadog_user*                     @DataDog/team-aaa
@@ -90,7 +90,7 @@ datadog/**/*datadog_sensitive_data_scanner*      @DataDog/sensitive-data-scanner
 datadog/**/*datadog_service_account*             @DataDog/team-aaa
 datadog/**/*datadog_software_catalog*            @DataDog/service-catalog
 datadog/**/*datadog_spans_metric*                @DataDog/apm-trace-intake
-datadog/**/*datadog_synthetics*                  @DataDog/synthetics-managing
+datadog/**/*datadog_synthetics*                  @DataDog/synthetics-orchestrating-managing
 datadog/**/*datadog_team*                        @DataDog/aaa-omg
 datadog/**/*datadog_user*                        @DataDog/team-aaa
 datadog/**/*datadog_webhook*                     @DataDog/collaboration-integrations


### PR DESCRIPTION
What does this change do, and why?
--------------------- 
Updates `.github/CODEOWNERS` to replace references to the now-merged `synthetics-orchestrating` and `synthetics-managing` GitHub teams with the consolidated `synthetics-orchestrating-managing` team. This keeps review routing and ownership aligned with the new team structure.

What is the impact of this change?
---------------------
- Reviews on paths previously owned by `synthetics-orchestrating` or
   `synthetics-managing` are now auto-requested from
   `synthetics-orchestrating-managing`.
- Existing open PRs will not be retroactively re-assigned; only new
   pushes pick up the new owner.

Jira ticket / Incident number
----------------
https://datadoghq.atlassian.net/browse/SYNTH-26401