### PR TITLE
[datadog_cost_budget] Add validation for parent/child tag filter pairing

### DIFF
--- a/datadog/fwprovider/data_source_datadog_cost_budget.go
+++ b/datadog/fwprovider/data_source_datadog_cost_budget.go
@@ -187,5 +187,5 @@ func setDataSourceModelFromBudgetWithEntries(ctx context.Context, model *costBud
 
 	// Populate both schemas for backward compatibility
 	model.Entries, _ = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: budgetEntryAttrTypes()}, entries)
-	model.BudgetLine, _ = types.SetValueFrom(ctx, types.ObjectType{AttrTypes: budgetLineAttrTypes()}, convertFlatEntriesToBudgetLine(ctx, entries))
+	model.BudgetLine, _ = types.SetValueFrom(ctx, types.ObjectType{AttrTypes: budgetLineAttrTypes()}, convertFlatEntriesToBudgetLine(ctx, entries, nil))
 }

--- a/datadog/fwprovider/resource_datadog_cost_budget.go
+++ b/datadog/fwprovider/resource_datadog_cost_budget.go
@@ -307,6 +307,39 @@ func (r *costBudgetResource) ModifyPlan(ctx context.Context, req resource.Modify
 		return
 	}
 
+	// Validate parent_tag_filters/child_tag_filters pairing in budget_line
+	if hasBudgetLine {
+		var budgetLines []budgetLine
+		plan.BudgetLine.ElementsAs(ctx, &budgetLines, false)
+		for _, line := range budgetLines {
+			hasParent := !line.ParentTagFilters.IsNull() && !line.ParentTagFilters.IsUnknown() && len(line.ParentTagFilters.Elements()) > 0
+			hasChild := !line.ChildTagFilters.IsNull() && !line.ChildTagFilters.IsUnknown() && len(line.ChildTagFilters.Elements()) > 0
+			hasTags := !line.TagFilters.IsNull() && !line.TagFilters.IsUnknown() && len(line.TagFilters.Elements()) > 0
+
+			if hasParent && !hasChild {
+				resp.Diagnostics.AddError(
+					"Invalid budget_line Configuration",
+					"'parent_tag_filters' must be used together with 'child_tag_filters'. For non-hierarchical budgets, use 'tag_filters' instead.",
+				)
+				return
+			}
+			if hasChild && !hasParent {
+				resp.Diagnostics.AddError(
+					"Invalid budget_line Configuration",
+					"'child_tag_filters' must be used together with 'parent_tag_filters'. For non-hierarchical budgets, use 'tag_filters' instead.",
+				)
+				return
+			}
+			if hasTags && (hasParent || hasChild) {
+				resp.Diagnostics.AddError(
+					"Conflicting budget_line Configuration",
+					"'tag_filters' cannot be used together with 'parent_tag_filters'/'child_tag_filters'. Use either 'tag_filters' for non-hierarchical budgets or 'parent_tag_filters'/'child_tag_filters' for hierarchical budgets.",
+				)
+				return
+			}
+		}
+	}
+
 	// Skip validation if required fields are unknown
 	if plan.MetricsQuery.IsUnknown() || plan.StartMonth.IsUnknown() || plan.EndMonth.IsUnknown() {
 		return
@@ -459,8 +492,49 @@ func convertBudgetLineToFlatEntries(ctx context.Context, budgetLines []budgetLin
 	return flatEntries
 }
 
-// convertFlatEntriesToBudgetLine converts flat API entries to budget_line (grouped schema)
-func convertFlatEntriesToBudgetLine(ctx context.Context, flatEntries []budgetEntry) []budgetLine {
+// tagLayout describes which filter fields were used for a given tag combination
+type tagLayout struct {
+	tagFilters       []tagFilter
+	parentTagFilters []tagFilter
+	childTagFilters  []tagFilter
+}
+
+// buildTagLayoutMap builds a map from tag signature to the original field assignment
+// from the user's configured budget lines
+func buildTagLayoutMap(ctx context.Context, originalLines []budgetLine) map[string]*tagLayout {
+	layouts := make(map[string]*tagLayout)
+	for _, line := range originalLines {
+		var allTags []tagFilter
+
+		var tf, ptf, ctf []tagFilter
+		if !line.TagFilters.IsNull() && !line.TagFilters.IsUnknown() {
+			line.TagFilters.ElementsAs(ctx, &tf, false)
+			allTags = append(allTags, tf...)
+		}
+		if !line.ParentTagFilters.IsNull() && !line.ParentTagFilters.IsUnknown() {
+			line.ParentTagFilters.ElementsAs(ctx, &ptf, false)
+			allTags = append(allTags, ptf...)
+		}
+		if !line.ChildTagFilters.IsNull() && !line.ChildTagFilters.IsUnknown() {
+			line.ChildTagFilters.ElementsAs(ctx, &ctf, false)
+			allTags = append(allTags, ctf...)
+		}
+
+		key := tagSignature(allTags)
+		layouts[key] = &tagLayout{
+			tagFilters:       tf,
+			parentTagFilters: ptf,
+			childTagFilters:  ctf,
+		}
+	}
+	return layouts
+}
+
+// convertFlatEntriesToBudgetLine converts flat API entries to budget_line (grouped schema).
+// originalLines provides the user's configured budget lines so that the correct filter
+// field assignment (tag_filters vs parent_tag_filters/child_tag_filters) is preserved
+// on read-back from the API.
+func convertFlatEntriesToBudgetLine(ctx context.Context, flatEntries []budgetEntry, originalLines []budgetLine) []budgetLine {
 	type tagGroup struct {
 		tags   []tagFilter
 		months map[string]float64
@@ -481,24 +555,45 @@ func convertFlatEntriesToBudgetLine(ctx context.Context, flatEntries []budgetEnt
 		groups[key].months[strconv.FormatInt(entry.Month.ValueInt64(), 10)] = entry.Amount.ValueFloat64()
 	}
 
+	// Build layout map from original budget lines to preserve field assignment
+	layoutMap := buildTagLayoutMap(ctx, originalLines)
+
 	budgetLines := make([]budgetLine, 0, len(groups))
 	tagObjType := types.ObjectType{AttrTypes: tagFilterAttrTypes()}
 
-	for _, group := range groups {
+	for key, group := range groups {
 		amountsMap, _ := types.MapValueFrom(ctx, types.Float64Type, group.months)
 		line := budgetLine{Amounts: amountsMap}
 
-		if len(group.tags) == 2 {
-			line.ParentTagFilters, _ = types.ListValueFrom(ctx, tagObjType, []tagFilter{group.tags[0]})
-			line.ChildTagFilters, _ = types.ListValueFrom(ctx, tagObjType, []tagFilter{group.tags[1]})
-			line.TagFilters = types.ListNull(tagObjType)
-		} else {
-			line.ParentTagFilters = types.ListNull(tagObjType)
-			line.ChildTagFilters = types.ListNull(tagObjType)
-			if len(group.tags) > 0 {
-				line.TagFilters, _ = types.ListValueFrom(ctx, tagObjType, group.tags)
+		if layout, ok := layoutMap[key]; ok {
+			// Preserve the original field assignment from the user's config
+			if len(layout.parentTagFilters) > 0 || len(layout.childTagFilters) > 0 {
+				line.ParentTagFilters, _ = types.ListValueFrom(ctx, tagObjType, layout.parentTagFilters)
+				line.ChildTagFilters, _ = types.ListValueFrom(ctx, tagObjType, layout.childTagFilters)
+				line.TagFilters = types.ListNull(tagObjType)
+			} else if len(layout.tagFilters) > 0 {
+				line.TagFilters, _ = types.ListValueFrom(ctx, tagObjType, layout.tagFilters)
+				line.ParentTagFilters = types.ListNull(tagObjType)
+				line.ChildTagFilters = types.ListNull(tagObjType)
 			} else {
 				line.TagFilters = types.ListNull(tagObjType)
+				line.ParentTagFilters = types.ListNull(tagObjType)
+				line.ChildTagFilters = types.ListNull(tagObjType)
+			}
+		} else {
+			// Fallback for tag groups not in the original config (e.g., import)
+			if len(group.tags) == 2 {
+				line.ParentTagFilters, _ = types.ListValueFrom(ctx, tagObjType, []tagFilter{group.tags[0]})
+				line.ChildTagFilters, _ = types.ListValueFrom(ctx, tagObjType, []tagFilter{group.tags[1]})
+				line.TagFilters = types.ListNull(tagObjType)
+			} else {
+				line.ParentTagFilters = types.ListNull(tagObjType)
+				line.ChildTagFilters = types.ListNull(tagObjType)
+				if len(group.tags) > 0 {
+					line.TagFilters, _ = types.ListValueFrom(ctx, tagObjType, group.tags)
+				} else {
+					line.TagFilters = types.ListNull(tagObjType)
+				}
 			}
 		}
 
@@ -611,7 +706,11 @@ func setModelFromBudgetWithEntries(ctx context.Context, model *costBudgetModel, 
 	usingBudgetLine := !model.BudgetLine.IsNull() && !model.BudgetLine.IsUnknown()
 
 	if usingBudgetLine {
-		model.BudgetLine, _ = types.SetValueFrom(ctx, types.ObjectType{AttrTypes: budgetLineAttrTypes()}, convertFlatEntriesToBudgetLine(ctx, entries))
+		// Extract original budget lines to preserve filter field assignment on read-back
+		var originalLines []budgetLine
+		model.BudgetLine.ElementsAs(ctx, &originalLines, false)
+
+		model.BudgetLine, _ = types.SetValueFrom(ctx, types.ObjectType{AttrTypes: budgetLineAttrTypes()}, convertFlatEntriesToBudgetLine(ctx, entries, originalLines))
 		model.Entries = types.ListNull(types.ObjectType{AttrTypes: budgetEntryAttrTypes()})
 	} else {
 		model.Entries, _ = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: budgetEntryAttrTypes()}, entries)

--- a/datadog/fwprovider/resource_datadog_cost_budget.go
+++ b/datadog/fwprovider/resource_datadog_cost_budget.go
@@ -310,7 +310,10 @@ func (r *costBudgetResource) ModifyPlan(ctx context.Context, req resource.Modify
 	// Validate parent_tag_filters/child_tag_filters pairing in budget_line
 	if hasBudgetLine {
 		var budgetLines []budgetLine
-		plan.BudgetLine.ElementsAs(ctx, &budgetLines, false)
+		if diags := plan.BudgetLine.ElementsAs(ctx, &budgetLines, false); diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return
+		}
 		for _, line := range budgetLines {
 			hasParent := !line.ParentTagFilters.IsNull() && !line.ParentTagFilters.IsUnknown() && len(line.ParentTagFilters.Elements()) > 0
 			hasChild := !line.ChildTagFilters.IsNull() && !line.ChildTagFilters.IsUnknown() && len(line.ChildTagFilters.Elements()) > 0
@@ -604,7 +607,8 @@ func convertFlatEntriesToBudgetLine(ctx context.Context, flatEntries []budgetEnt
 	return budgetLines
 }
 
-// tagSignature creates a unique identifier for grouping entries by tag combination
+// tagSignature creates a unique identifier for grouping entries by tag combination.
+// Parts are sorted so the signature is stable regardless of tag ordering.
 func tagSignature(tags []tagFilter) string {
 	if len(tags) == 0 {
 		return ""
@@ -613,6 +617,7 @@ func tagSignature(tags []tagFilter) string {
 	for _, t := range tags {
 		parts = append(parts, t.TagKey.ValueString()+"="+t.TagValue.ValueString())
 	}
+	sort.Strings(parts)
 	return strings.Join(parts, ",")
 }
 

--- a/datadog/fwprovider/resource_datadog_cost_budget.go
+++ b/datadog/fwprovider/resource_datadog_cost_budget.go
@@ -567,15 +567,16 @@ func convertFlatEntriesToBudgetLine(ctx context.Context, flatEntries []budgetEnt
 
 		if layout, ok := layoutMap[key]; ok {
 			// Preserve the original field assignment from the user's config
-			if len(layout.parentTagFilters) > 0 || len(layout.childTagFilters) > 0 {
+			switch {
+			case len(layout.parentTagFilters) > 0 || len(layout.childTagFilters) > 0:
 				line.ParentTagFilters, _ = types.ListValueFrom(ctx, tagObjType, layout.parentTagFilters)
 				line.ChildTagFilters, _ = types.ListValueFrom(ctx, tagObjType, layout.childTagFilters)
 				line.TagFilters = types.ListNull(tagObjType)
-			} else if len(layout.tagFilters) > 0 {
+			case len(layout.tagFilters) > 0:
 				line.TagFilters, _ = types.ListValueFrom(ctx, tagObjType, layout.tagFilters)
 				line.ParentTagFilters = types.ListNull(tagObjType)
 				line.ChildTagFilters = types.ListNull(tagObjType)
-			} else {
+			default:
 				line.TagFilters = types.ListNull(tagObjType)
 				line.ParentTagFilters = types.ListNull(tagObjType)
 				line.ChildTagFilters = types.ListNull(tagObjType)

--- a/datadog/tests/resource_datadog_cost_budget_test.go
+++ b/datadog/tests/resource_datadog_cost_budget_test.go
@@ -766,6 +766,35 @@ resource "datadog_cost_budget" "foo" {
 }`,
 			expectError: `child_tag_filters.*must be used together with.*parent_tag_filters`,
 		},
+		// Validate tag_filters cannot be mixed with parent_tag_filters/child_tag_filters
+		{
+			name: "TagFiltersWithParentChild",
+			config: `
+resource "datadog_cost_budget" "foo" {
+  name = "test-tag-filters-conflict"
+  metrics_query = "sum:aws.cost.amortized{*} by {account,region}"
+  start_month = 202601
+  end_month = 202601
+  budget_line {
+    amounts = {
+      "202601" = 1000
+    }
+    tag_filters {
+      tag_key = "region"
+      tag_value = "us-east-1"
+    }
+    parent_tag_filters {
+      tag_key = "account"
+      tag_value = "production"
+    }
+    child_tag_filters {
+      tag_key = "team"
+      tag_value = "backend"
+    }
+  }
+}`,
+			expectError: `tag_filters.*cannot be used together with`,
+		},
 		// Validate all tag combinations have entries for all months
 		{
 			name: "MissingMonths",

--- a/datadog/tests/resource_datadog_cost_budget_test.go
+++ b/datadog/tests/resource_datadog_cost_budget_test.go
@@ -724,6 +724,48 @@ resource "datadog_cost_budget" "foo" {
 }`,
 			expectError: `Either 'entries' or 'budget_line' must be specified`,
 		},
+		// Validate parent_tag_filters requires child_tag_filters
+		{
+			name: "ParentTagWithoutChild",
+			config: `
+resource "datadog_cost_budget" "foo" {
+  name = "test-parent-without-child"
+  metrics_query = "sum:aws.cost.amortized{*} by {account}"
+  start_month = 202601
+  end_month = 202601
+  budget_line {
+    amounts = {
+      "202601" = 1000
+    }
+    parent_tag_filters {
+      tag_key = "account"
+      tag_value = "production"
+    }
+  }
+}`,
+			expectError: `parent_tag_filters.*must be used together with.*child_tag_filters`,
+		},
+		// Validate child_tag_filters requires parent_tag_filters
+		{
+			name: "ChildTagWithoutParent",
+			config: `
+resource "datadog_cost_budget" "foo" {
+  name = "test-child-without-parent"
+  metrics_query = "sum:aws.cost.amortized{*} by {account}"
+  start_month = 202601
+  end_month = 202601
+  budget_line {
+    amounts = {
+      "202601" = 1000
+    }
+    child_tag_filters {
+      tag_key = "account"
+      tag_value = "production"
+    }
+  }
+}`,
+			expectError: `child_tag_filters.*must be used together with.*parent_tag_filters`,
+		},
 		// Validate all tag combinations have entries for all months
 		{
 			name: "MissingMonths",


### PR DESCRIPTION
## Context

Using `parent_tag_filters` or `child_tag_filters` alone in a `budget_line` block caused a destroy+create loop on every apply, because the read-back logic would map the tags to the wrong field and produce a state hash mismatch.

## Summary

- Fix the read-back logic: instead of guessing which field to assign tags to based on count, the provider now consults the prior state to preserve the user's original field assignment (`tag_filters` vs `parent_tag_filters`/`child_tag_filters`) when reading back from the API
- Add plan-time validation to catch `parent_tag_filters`/`child_tag_filters` used without each other, with a clear error guiding users to `tag_filters` instead
- Add test cases for the new validation

## Breaking Change

Configs that use `parent_tag_filters` or `child_tag_filters` alone (without the other) will now fail at `terraform plan` instead of silently entering a destroy+create loop. These configs were never functional, so this is intentional -- but it is a behaviour change worth noting for anyone upgrading.

Jira: https://datadoghq.atlassian.net/browse/CCT-1427

## Test plan

- [x] Validation test: `parent_tag_filters` without `child_tag_filters` rejected at plan time
- [x] Validation test: `child_tag_filters` without `parent_tag_filters` rejected at plan time
- [x] Validation test: `tag_filters` used alongside `parent_tag_filters`/`child_tag_filters` rejected at plan time
- [x] Existing hierarchical budget tests still pass
- [x] Existing `tag_filters` budget tests still pass

All 22 tests passed locally in replay mode (`RECORD=false`).