### PR TITLE
Fix integration skip regex escaping

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Build skip list for flaky tests
         id: skip-list
         run: |
-          SKIP_REGEX=$(python3 scripts/build_skip_regex.py)
+          SKIP_REGEX=$(python3 scripts/build_skip_regex.py --escape-for-make)
           if [ -n "$SKIP_REGEX" ]; then
             echo "test_args=-skip '${SKIP_REGEX}'" >> "$GITHUB_OUTPUT"
             echo "Skipping flaky tests: ${SKIP_REGEX}"


### PR DESCRIPTION
## Summary
Integration tests jobs are failing on master [currently](https://github.com/DataDog/terraform-provider-datadog/actions/runs/26261538718/job/77295845742). This fixes the execution by:
- Using `--escape-for-make` when building the flaky-test skip regex for scheduled/master integration tests.
- Preventing GNU Make from consuming `$` regex anchors and producing an unterminated quoted `-skip` argument.

## Testing
- `TESTARGS="-skip '$(python3 scripts/build_skip_regex.py --escape-for-make)'" make -n testacc`

## Changelog
- No changelog; CI-only change.