### PR TITLE
[datadog_synthetics_test] Add always_execute field

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -1255,6 +1255,11 @@ func syntheticsTestAPIStep() *schema.Schema {
 					Type:        schema.TypeBool,
 					Optional:    true,
 				},
+				"always_execute": {
+					Description: "Determines whether or not to always execute this step even if the previous step failed or was skipped.",
+					Type:        schema.TypeBool,
+					Optional:    true,
+				},
 				"is_critical": {
 					Description: "Determines whether or not to consider the entire test as failed if this step fails. Can be used only if `allow_failure` is `true`.",
 					Type:        schema.TypeBool,
@@ -2835,6 +2840,11 @@ func updateSyntheticsAPITestLocalState(d *schema.ResourceData, syntheticsTest *d
 				localStep["allow_failure"] = step.SyntheticsAPITestStep.GetAllowFailure()
 				localStep["exit_if_succeed"] = step.SyntheticsAPITestStep.GetExitIfSucceed()
 				localStep["is_critical"] = step.SyntheticsAPITestStep.GetIsCritical()
+				if alwaysExecute, ok := step.SyntheticsAPITestStep.AdditionalProperties["always_execute"]; ok {
+					if v, ok := alwaysExecute.(bool); ok {
+						localStep["always_execute"] = v
+					}
+				}
 				localStep["extracted_values_from_script"] = step.SyntheticsAPITestStep.GetExtractedValuesFromScript()
 
 				if retry, ok := step.SyntheticsAPITestStep.GetRetryOk(); ok {
@@ -2857,6 +2867,7 @@ func updateSyntheticsAPITestLocalState(d *schema.ResourceData, syntheticsTest *d
 				localStep["name"] = step.SyntheticsAPISubtestStep.GetName()
 				localStep["subtype"] = step.SyntheticsAPISubtestStep.GetSubtype()
 				localStep["subtest_public_id"] = step.SyntheticsAPISubtestStep.GetSubtestPublicId()
+				localStep["always_execute"] = step.SyntheticsAPISubtestStep.GetAlwaysExecute()
 			}
 
 			localSteps[i] = localStep
@@ -3507,6 +3518,12 @@ func buildDatadogSyntheticsAPITest(d *schema.ResourceData) (*datadogV1.Synthetic
 				step.SyntheticsAPITestStep.SetAllowFailure(stepMap["allow_failure"].(bool))
 				step.SyntheticsAPITestStep.SetExitIfSucceed(stepMap["exit_if_succeed"].(bool))
 				step.SyntheticsAPITestStep.SetIsCritical(stepMap["is_critical"].(bool))
+				if alwaysExecute, ok := stepMap["always_execute"].(bool); ok {
+					if step.SyntheticsAPITestStep.AdditionalProperties == nil {
+						step.SyntheticsAPITestStep.AdditionalProperties = make(map[string]interface{})
+					}
+					step.SyntheticsAPITestStep.AdditionalProperties["always_execute"] = alwaysExecute
+				}
 				step.SyntheticsAPITestStep.SetExtractedValuesFromScript(stepMap["extracted_values_from_script"].(string))
 
 				optionsRetry := datadogV1.SyntheticsTestOptionsRetry{}
@@ -3539,6 +3556,9 @@ func buildDatadogSyntheticsAPITest(d *schema.ResourceData) (*datadogV1.Synthetic
 				step.SyntheticsAPISubtestStep.SetSubtype(datadogV1.SyntheticsAPISubtestStepSubtype(stepMap["subtype"].(string)))
 				if subtestPublicID, ok := stepMap["subtest_public_id"].(string); ok && subtestPublicID != "" {
 					step.SyntheticsAPISubtestStep.SetSubtestPublicId(subtestPublicID)
+				}
+				if alwaysExecute, ok := stepMap["always_execute"].(bool); ok {
+					step.SyntheticsAPISubtestStep.SetAlwaysExecute(alwaysExecute)
 				}
 			}
 

--- a/datadog/tests/resource_datadog_synthetics_test_test.go
+++ b/datadog/tests/resource_datadog_synthetics_test_test.go
@@ -6190,6 +6190,8 @@ func createSyntheticsMultistepAPITest(ctx context.Context, provider *schema.Prov
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.multi", "api_step.0.exit_if_succeed", "true"),
 			resource.TestCheckResourceAttr(
+				"datadog_synthetics_test.multi", "api_step.0.always_execute", "true"),
+			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.multi", "api_step.0.request_definition.#", "1"),
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.multi", "api_step.0.request_definition.0.method", "POST"),
@@ -6495,6 +6497,7 @@ resource "datadog_synthetics_test" "multi" {
   api_step {
     name = "First api step"
 	exit_if_succeed = true
+	always_execute = true
     request_definition {
       method           = "POST"
       url              = "https://www.datadoghq.com"
@@ -7057,6 +7060,8 @@ func createSyntheticsMultistepAPITestAllStepSubtypes(ctx context.Context, accPro
 				"datadog_synthetics_test.test_all_api_subtypes", "api_step.8.subtype", "playSubTest"),
 			resource.TestCheckResourceAttrSet(
 				"datadog_synthetics_test.test_all_api_subtypes", "api_step.8.subtest_public_id"),
+			resource.TestCheckResourceAttr(
+				"datadog_synthetics_test.test_all_api_subtypes", "api_step.8.always_execute", "true"),
 		),
 	}
 }
@@ -7278,6 +7283,7 @@ func createSyntheticsMultistepAPITestConfigAllStepSubtypes(testName string) stri
 				name              = "Subtest step"
 				subtype           = "playSubTest"
 				subtest_public_id = datadog_synthetics_test.single_api.id
+				always_execute    = true
 			}
 		}
 	`, testName)

--- a/docs/resources/synthetics_test.md
+++ b/docs/resources/synthetics_test.md
@@ -1141,6 +1141,7 @@ Required:
 Optional:
 
 - `allow_failure` (Boolean) Determines whether or not to continue with test if this step fails.
+- `always_execute` (Boolean) Determines whether or not to always execute this step even if the previous step failed or was skipped.
 - `assertion` (Block List) Assertions used for the test. Multiple `assertion` blocks are allowed with the structure below. (see [below for nested schema](#nestedblock--api_step--assertion))
 - `exit_if_succeed` (Boolean) Determines whether or not to exit the test if the step succeeds.
 - `extracted_value` (Block List) Values to parse and save as variables from the response. (see [below for nested schema](#nestedblock--api_step--extracted_value))


### PR DESCRIPTION
<!-- dd-meta {"pullId":"ceb2f9a2-b571-446c-a71a-06dce38c52b4","source":"chat","resourceId":"1c296ba3-0068-4774-a191-ad63a25edfbc","workflowId":"ee42392b-8604-4fac-b9d8-069e9386ca8f","codeChangeId":"ee42392b-8604-4fac-b9d8-069e9386ca8f","sourceType":"scheduled_task"} -->
## Description

This PR adds support for the `always_execute` field in Datadog Synthetics API tests, allowing users to specify whether a step should always execute even if the previous step failed or was skipped.

## Changes

- Added `always_execute` field to the API step schema definition
- Implemented read logic to retrieve `always_execute` from API test steps and subtest steps
- Implemented write logic to set `always_execute` when building Datadog API test configurations
- Added test coverage for the new field in both regular and subtest step scenarios

## How this fixes the issue

The `always_execute` field is a valid property on Datadog Synthetics API test steps that was previously not supported by the Terraform provider. This change enables users to configure this behavior through Terraform, ensuring the provider fully supports all available step configuration options.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/1c296ba3-0068-4774-a191-ad63a25edfbc)

Comment @datadog to request changes