### PR TITLE
[misc] (CI) Change CI to allow the misc prefix in PR title

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,4 +1,4 @@
-name: "Ensure labels"
+name: "Ensure labels and PR title"
 
 permissions:
   contents: read
@@ -29,7 +29,7 @@ jobs:
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
         with:
           script: |
-            const re = /^\[datadog_\w+\] .+/;
+            const re = /^\[(datadog_\w+\)|(misc`)] .+/;
             const title = context.payload.pull_request.title;
             if (!re.test(title)) {
               core.setFailed(


### PR DESCRIPTION
## Motivation
Repo maintainers could not create PR that were unrelated to resources.

## Changes
Change the ensure label CI job to allow the misc prefix 