### PR TITLE
[datadog_on_call_team_routing_rules] Add customizable_content to send_slack_message

### DIFF
--- a/datadog/fwprovider/resource_datadog_on_call_team_routing_rules.go
+++ b/datadog/fwprovider/resource_datadog_on_call_team_routing_rules.go
@@ -52,8 +52,14 @@ type teamRuleActionModel struct {
 }
 
 type slackMessageModel struct {
-	Workspace types.String `tfsdk:"workspace"`
-	Channel   types.String `tfsdk:"channel"`
+	Workspace           types.String                   `tfsdk:"workspace"`
+	Channel             types.String                   `tfsdk:"channel"`
+	CustomizableContent *slackCustomizableContentModel `tfsdk:"customizable_content"`
+}
+
+type slackCustomizableContentModel struct {
+	IncludeDescription types.Bool `tfsdk:"include_description"`
+	IncludeSource      types.Bool `tfsdk:"include_source"`
 }
 
 type teamsMessageModel struct {
@@ -219,6 +225,21 @@ func (r *onCallTeamRoutingRulesResource) Schema(_ context.Context, _ resource.Sc
 											"workspace": schema.StringAttribute{
 												Optional:    true,
 												Description: "Slack workspace ID.",
+											},
+										},
+										Blocks: map[string]schema.Block{
+											"customizable_content": schema.SingleNestedBlock{
+												Description: "Controls what alert context is included in the Slack message. If omitted, the API default (title only) is used.",
+												Attributes: map[string]schema.Attribute{
+													"include_description": schema.BoolAttribute{
+														Optional:    true,
+														Description: "Whether to include the alert description in the Slack message.",
+													},
+													"include_source": schema.BoolAttribute{
+														Optional:    true,
+														Description: "Whether to include the alert source in the Slack message.",
+													},
+												},
 											},
 										},
 									},
@@ -452,12 +473,30 @@ func (r *onCallTeamRoutingRulesResource) stateFromResponse(resp *datadogV2.TeamR
 		stateActions := []*teamRuleActionModel{}
 		for _, action := range attributes.Actions {
 			if action.SendSlackMessageAction != nil {
-				stateActions = append(stateActions, &teamRuleActionModel{
-					Slack: &slackMessageModel{
-						Workspace: types.StringValue(action.SendSlackMessageAction.Workspace),
-						Channel:   types.StringValue(action.SendSlackMessageAction.Channel),
-					},
-				})
+				slack := &slackMessageModel{
+					Workspace: types.StringValue(action.SendSlackMessageAction.Workspace),
+					Channel:   types.StringValue(action.SendSlackMessageAction.Channel),
+				}
+				// customizable_content is not yet a typed field on SendSlackMessageAction
+				// in datadog-api-client-go; round-trip it via AdditionalProperties. When
+				// the API spec adds this field and the client is regenerated, swap to
+				// the typed accessors.
+				if raw, ok := action.SendSlackMessageAction.AdditionalProperties["customizable_content"]; ok {
+					if cc, ok := raw.(map[string]interface{}); ok {
+						ccModel := &slackCustomizableContentModel{
+							IncludeDescription: types.BoolNull(),
+							IncludeSource:      types.BoolNull(),
+						}
+						if v, ok := cc["include_description"].(bool); ok {
+							ccModel.IncludeDescription = types.BoolValue(v)
+						}
+						if v, ok := cc["include_source"].(bool); ok {
+							ccModel.IncludeSource = types.BoolValue(v)
+						}
+						slack.CustomizableContent = ccModel
+					}
+				}
+				stateActions = append(stateActions, &teamRuleActionModel{Slack: slack})
 			} else if action.SendTeamsMessageAction != nil {
 				stateActions = append(stateActions, &teamRuleActionModel{
 					Teams: &teamsMessageModel{
@@ -541,6 +580,22 @@ func (r *onCallTeamRoutingRulesResource) teamRoutingRulesRequestFromModel(state 
 				action.SendSlackMessageAction.Type = datadogV2.SENDSLACKMESSAGEACTIONTYPE_SEND_SLACK_MESSAGE
 				action.SendSlackMessageAction.Channel = plannedAction.Slack.Channel.ValueString()
 				action.SendSlackMessageAction.Workspace = plannedAction.Slack.Workspace.ValueString()
+				// customizable_content is not yet a typed field on SendSlackMessageAction
+				// in datadog-api-client-go; serialize via AdditionalProperties (works because
+				// the SDK's MarshalJSON folds AdditionalProperties into the output). Migrate
+				// to typed accessors once the client is regenerated.
+				if plannedAction.Slack.CustomizableContent != nil {
+					cc := map[string]interface{}{}
+					if !plannedAction.Slack.CustomizableContent.IncludeDescription.IsNull() {
+						cc["include_description"] = plannedAction.Slack.CustomizableContent.IncludeDescription.ValueBool()
+					}
+					if !plannedAction.Slack.CustomizableContent.IncludeSource.IsNull() {
+						cc["include_source"] = plannedAction.Slack.CustomizableContent.IncludeSource.ValueBool()
+					}
+					action.SendSlackMessageAction.AdditionalProperties = map[string]interface{}{
+						"customizable_content": cc,
+					}
+				}
 			}
 			if plannedAction.Workflow != nil {
 				action.TriggerWorkflowAutomationAction = datadogV2.NewTriggerWorkflowAutomationActionWithDefaults()

--- a/docs/resources/on_call_team_routing_rules.md
+++ b/docs/resources/on_call_team_routing_rules.md
@@ -21,6 +21,10 @@ resource "datadog_on_call_team_routing_rules" "team_rules_test" {
       send_slack_message {
         workspace = "workspace"
         channel   = "channel"
+        customizable_content {
+          include_description = true
+          include_source      = true
+        }
       }
     }
     time_restrictions {
@@ -83,6 +87,18 @@ Required:
 
 - `channel` (String) Slack channel ID.
 - `workspace` (String) Slack workspace ID.
+
+Optional:
+
+- `customizable_content` (Block, Optional) Controls what alert context is included in the Slack message. If omitted, the API default (title only) is used. (see [below for nested schema](#nestedblock--rule--action--send_slack_message--customizable_content))
+
+<a id="nestedblock--rule--action--send_slack_message--customizable_content"></a>
+### Nested Schema for `rule.action.send_slack_message.customizable_content`
+
+Optional:
+
+- `include_description` (Boolean) Whether to include the alert description in the Slack message.
+- `include_source` (Boolean) Whether to include the alert source in the Slack message.
 
 
 <a id="nestedblock--rule--action--send_teams_message"></a>

--- a/examples/resources/datadog_on_call_team_routing_rules/resource.tf
+++ b/examples/resources/datadog_on_call_team_routing_rules/resource.tf
@@ -6,6 +6,10 @@ resource "datadog_on_call_team_routing_rules" "team_rules_test" {
       send_slack_message {
         workspace = "workspace"
         channel   = "channel"
+        customizable_content {
+          include_description = true
+          include_source      = true
+        }
       }
     }
     time_restrictions {


### PR DESCRIPTION
## Summary

Adds `customizable_content { include_description, include_source }` to the `send_slack_message` action on `datadog_on_call_team_routing_rules`.

Closes #3740.

## Background

The On-Call routing-rules API supports a `customizable_content` object on `send_slack_message` actions, controlling whether the alert description and source are rendered in the Slack message. The DD UI exposes this as the "Include description" / "Include source" checkboxes when editing a Slack action. The field is round-tripped through `GET/PUT /api/v2/on-call/teams/{team_id}/routing-rules`, but the provider has not yet exposed it — so applying the resource silently wipes whatever the user set in the UI.

## Changes

- `datadog/fwprovider/resource_datadog_on_call_team_routing_rules.go` — new `customizable_content` sub-block under `send_slack_message`, with `include_description` and `include_source` bool attributes; wired through `stateFromResponse` and `teamRoutingRulesRequestFromModel`.
- `examples/resources/datadog_on_call_team_routing_rules/resource.tf` — example updated to demonstrate the new field.
- `docs/resources/on_call_team_routing_rules.md` — manually updated (this doc is in the `generate-docs.sh` exclude list).

## Note on the API client

`customizable_content` is not yet a typed field on `datadogV2.SendSlackMessageAction` in `datadog-api-client-go`. As an interim measure, this change round-trips it via the SDK's `AdditionalProperties` map (the SDK's `MarshalJSON` folds `AdditionalProperties` into the wire payload, and unknown JSON keys land back in `AdditionalProperties` on read — verified end-to-end). The two relevant call sites have comments calling out that when the API spec is updated and the client is regenerated, the implementation should swap to the typed accessors.

If you'd prefer to land the spec/client regeneration first, I'm happy to revise.

## Testing

- `make fmtcheck` ✓
- `make docs && make check-docs` ✓ (the manually maintained `on_call_team_routing_rules.md` is excluded from regeneration; I updated it by hand)
- `go vet ./...` ✓
- `go build ./...` ✓
- Built provider binary + `terraform validate` on a scratch config that exercises both the new `customizable_content` block and a Slack action without it (backward compatibility) — both pass.

I did not add a new acceptance test step or record a cassette — that needs `DD_TEST_CLIENT_API_KEY` sandbox credentials, which I don't have. Happy to extend the existing `TestAccOnCallTeamRoutingRulesCreateAndUpdate` with a `customizable_content` config and re-record the cassette if a maintainer can hand off creds, or leave the test addition to you.

## Test plan

- [ ] Maintainer extends `TestAccOnCallTeamRoutingRulesCreateAndUpdate` with a step that sets `customizable_content` and re-records the cassette under sandbox.
- [ ] Maintainer verifies the round-trip in `RECORD=none` mode against a live test team to confirm the UI reflects `include_description` / `include_source` after apply.
