### PR TITLE
[datadog_service_account_application_key] Fix scoped key example

### DIFF
--- a/docs/resources/service_account_application_key.md
+++ b/docs/resources/service_account_application_key.md
@@ -13,8 +13,7 @@ Provides a Datadog `service_account_application_key` resource. This can be used 
 ## Example Usage
 
 ```terraform
-# Source the permissions for scoped keys
-data "datadog_permissions" "dd_perms" {}
+# See the permissions available for scoped keys at https://docs.datadoghq.com/account_management/rbac/permissions/#permissions-list
 
 # Create an unrestricted Service Account Application Key
 # This key inherits all permissions of the service account that owns the key
@@ -29,8 +28,8 @@ resource "datadog_service_account_application_key" "monitor_management_key" {
   service_account_id = "00000000-0000-1234-0000-000000000000"
   name               = "Monitor Management Service Account Key"
   scopes = [
-    data.datadog_permissions.dd_perms.permissions.monitors_read,
-    data.datadog_permissions.dd_perms.permissions.monitors_write
+    "monitors_read",
+    "monitors_write"
   ]
 }
 ```

--- a/examples/resources/datadog_service_account_application_key/resource.tf
+++ b/examples/resources/datadog_service_account_application_key/resource.tf
@@ -1,5 +1,4 @@
-# Source the permissions for scoped keys
-data "datadog_permissions" "dd_perms" {}
+# See the permissions available for scoped keys at https://docs.datadoghq.com/account_management/rbac/permissions/#permissions-list
 
 # Create an unrestricted Service Account Application Key
 # This key inherits all permissions of the service account that owns the key
@@ -14,7 +13,7 @@ resource "datadog_service_account_application_key" "monitor_management_key" {
   service_account_id = "00000000-0000-1234-0000-000000000000"
   name               = "Monitor Management Service Account Key"
   scopes = [
-    data.datadog_permissions.dd_perms.permissions.monitors_read,
-    data.datadog_permissions.dd_perms.permissions.monitors_write
+    "monitors_read",
+    "monitors_write"
   ]
 }


### PR DESCRIPTION
## What

This updates the `datadog_service_account_application_key` scoped key example.

- Remove the example that passes permission IDs returned by `data.datadog_permissions` into `scopes`
- Use Datadog authorization scope names directly, which is what the API accepts
- Regenerate `docs/resources/service_account_application_key.md` from the updated example

## Why

As described in #3819, the current example suggests passing permission IDs into application key `scopes`. Datadog rejects that request with `Invalid scopes`.

The provider implementation and acceptance tests already use scope names directly, so this change aligns the documentation example with the provider behavior and Datadog API expectations.

## References

- Fixes #3819
- Requested labels: `changelog/documentation`, `resource/datadog_service_account_application_key`

## Tests

- PASS: `make fmtcheck`
- PASS: `make docs`
- PASS: `make check-docs`
- PASS: `make test TEST="./datadog ./datadog/dashboardmapping ./datadog/fwprovider ./datadog/fwprovider/observability_pipeline ./datadog/internal/customtypes ./datadog/internal/fwutils ./datadog/internal/planmodifiers ./datadog/internal/utils ./datadog/internal/validators ./version"`
- NOTE: full `make test` was attempted, but `datadog/tests` includes acceptance tests and failed because `DD_TEST_CLIENT_API_KEY` is not set in this local environment.