### PR TITLE
[CI] Change runner for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   create_release:
     name: Create release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16-core-latest
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
     steps:
       - name: Get GitHub App token


### PR DESCRIPTION
### Motivation
Our github runners are crashing during the release job. We are forcing the runner to be one of the larger ones.

### Changes
Changed the "runs-on" tags in the release workflow