### PR TITLE
[TFgen] Phase 1 Setup CLI

### DIFF
--- a/.generator-v2/internal/cli/root.go
+++ b/.generator-v2/internal/cli/root.go
@@ -16,9 +16,9 @@ type globalFlags struct {
 
 func newRootCmd(version string, flags *globalFlags) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "tfgen",
-		Short:   "Datadog Terraform Provider Generator",
-		Version: version,
+		Use:          "tfgen",
+		Short:        "Datadog Terraform Provider Generator",
+		Version:      version,
 		SilenceUsage: true,
 	}
 

--- a/.generator-v2/internal/testdata/fixtures/README.md
+++ b/.generator-v2/internal/testdata/fixtures/README.md
@@ -1,0 +1,32 @@
+# Fixture Catalogue
+
+Curated test inputs for the `tfgen` end-to-end suite. Each fixture is a self-contained directory holding everything needed to drive the generator and assert on its output: an OpenAPI input spec and the expected golden code the generator should produce from it.
+
+The E2E suite runs `tfgen` against a fixture's `openapi.yaml` and compares the result against the committed `out/` directory. Each fixture therefore exercises one specific generator capability end to end.
+
+## Layout
+
+Each fixture is a directory under this one:
+
+```
+<fixture_name>/
+├── openapi.yaml         # Input spec with x-datadog-tf-generator annotations
+├── out/                 # Expected golden output (committed)
+│   └── *.go
+└── README.md            # (optional) what this fixture exercises
+```
+
+- **`openapi.yaml`** — the OpenAPI spec the generator reads. The resources and data sources to generate are marked with the `x-datadog-tf-generator` extension.
+- **`out/`** — the golden output: the `.go` files the generator is expected to emit. These are committed and diffed against on every run. When generator behavior changes intentionally, regenerate this directory and review the diff by hand.
+- **`README.md`** *(optional)* — a short note describing the capability the fixture targets (e.g. a particular schema shape, a hook, or an error path).
+
+## Naming
+
+Name each fixture after the artifact it generates so the catalogue reads as a list of capabilities:
+
+- `data_source_<name>` — a generated data source (e.g. `data_source_pet`).
+- `resource_<name>` — a generated resource.
+- Append a distinguishing suffix when a fixture targets a variant or edge case (e.g. `data_source_team_with_hooks`, `broken_hook_signature`).
+
+> [!NOTE]
+> This catalogue is currently empty. Fixtures are added in later phases as the corresponding generator capabilities land.

--- a/.github/workflows/tfgen.yml
+++ b/.github/workflows/tfgen.yml
@@ -5,11 +5,11 @@ permissions:
 
 on:
   pull_request:
-    branches:
-      - master
     paths:
       - ".generator-v2/internal/**"
       - ".generator-v2/cmd/tfgen/**"
+      - ".generator-v2/go.mod"
+      - ".generator-v2/go.sum"
       - ".github/workflows/tfgen.yml"
 
 concurrency:

--- a/.github/workflows/tfgen.yml
+++ b/.github/workflows/tfgen.yml
@@ -1,0 +1,42 @@
+name: Generator Checks
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - ".generator-v2/internal/**"
+      - ".generator-v2/cmd/tfgen/**"
+      - ".github/workflows/tfgen.yml"
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}-tfgen
+  cancel-in-progress: true
+
+jobs:
+  build-and-vet:
+    name: build and vet
+    runs-on: ubuntu-latest
+    if: github.event.action != 'closed' && github.event.pull_request.merged != true
+    defaults:
+      run:
+        working-directory: .generator-v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+
+      - name: Install Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
+        with:
+          go-version-file: .generator-v2/go.mod
+          cache: true
+          cache-dependency-path: .generator-v2/go.sum
+
+      - name: go build
+        run: go build ./cmd/tfgen/...
+
+      - name: go vet
+        run: go vet ./cmd/tfgen/...

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,6 +6,7 @@ DIR=~/.terraform.d/plugins
 ZORKIAN_VERSION?=master
 API_CLIENT_VERSION?=master
 LOCAL_PACKAGE="github.com/terraform-providers/terraform-provider-datadog"
+GO?=go
 
 default: build
 
@@ -68,6 +69,16 @@ test-compile: get-test-deps
 		exit 1; \
 	fi
 	gotestsum --format testname -- -c $(TEST) $(TESTARGS)
+	
+# Build the tfgen binary into bin/tfgen (generator lives in its own module under .generator-v2)
+tfgen-build:
+	cd .generator-v2 && $(GO) build -o $(CURDIR)/bin/tfgen ./cmd/tfgen
+	@echo "Built tfgen -> bin/tfgen"
+
+# Run the tfgen module's unit tests
+tfgen-test:
+	cd .generator-v2 && $(GO) test ./internal/... ./cmd/tfgen/...
+	@echo "tfgen tests passed"
 
 update-go-client:
 	echo "Updating the Zorkian client to ${ZORKIAN_VERSION} and the API Client to ${API_CLIENT_VERSION}"
@@ -103,4 +114,4 @@ check-docs: docs
 		echo "Success: No generated documentation changes detected"; \
 	fi
 
-.PHONY: build check-docs docs test testall testacc cassettes vet fmt fmtcheck errcheck lint lint-new lint-fix test-compile get-test-deps license-check sweep
+.PHONY: build check-docs docs test testall testacc tfgen-build tfgen-test cassettes vet fmt fmtcheck errcheck lint lint-new lint-fix test-compile get-test-deps license-check sweep


### PR DESCRIPTION
 [APIR-2491](https://datadoghq.atlassian.net/browse/APIR-2491)
 ## What this does

  Phase 1 scaffolding for the new generator (tfgen): build, CI, and test-fixture
  plumbing so later phases have a consistent place to land. No generator logic
  yet. Targets the `generator-v2` branch, which already has the stubs and deps.

  ## Changes

  - CI workflow (`.github/workflows/tfgen.yml`): runs `go build` and `go vet`
    against the generator on any PR that touches `.generator-v2/internal/**`,
    `.generator-v2/cmd/tfgen/**`, or the workflow file. Build and vet only for
    now. Unit tests, e2e, coverage, and the `generate --check` / `verify --strict`
    gates come in later phases.

  - Make targets: `make tfgen-build` builds the binary to `bin/tfgen`,
    `make tfgen-test` runs `go test ./internal/... ./cmd/tfgen/...`. Both run
    inside the `.generator-v2` module and honor a `GO=` override.

  - Fixture catalogue (`.generator-v2/internal/testdata/fixtures/README.md`):
    documents the per-fixture layout (input `openapi.yaml`, committed golden
    `out/`, optional README) so e2e fixtures get added consistently. No fixtures
    included here.

  ## Testing

  - `make tfgen-build` produces `bin/tfgen`.
  - `make tfgen-test` exits 0 (no test files yet).
  - Workflow runs build + vet clean.

[APIR-2491]: https://datadoghq.atlassian.net/browse/APIR-2491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ