### PR TITLE
[TFgen] Added a parser to load the OAS

### DIFF
--- a/.generator-v2/internal/cli/generate.go
+++ b/.generator-v2/internal/cli/generate.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/parser"
 )
 
 func newGenerateCmd(flags *globalFlags) *cobra.Command {
@@ -12,15 +14,21 @@ func newGenerateCmd(flags *globalFlags) *cobra.Command {
 		Use:   "generate",
 		Short: "Generate Terraform artifacts from the OpenAPI spec",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO: implement
+			spec, err := parser.LoadSpec(flags.spec, parser.WithMaxDepth(flags.maxDepth))
+			if err != nil {
+				return err
+			}
+
+			// TODO: model -> emit -> writer -> report, honoring --check and --include.
+			_ = spec
+			_ = check
+			_ = include
 			return nil
 		},
 	}
 
 	cmd.Flags().BoolVar(&check, "check", false, "Read-only mode: exit 3 if any file would change")
 	cmd.Flags().StringVar(&include, "include", "", "Comma-separated artifact names to generate (empty = all)")
-	_ = check
-	_ = include
 
 	return cmd
 }

--- a/.generator-v2/internal/cli/generate_test.go
+++ b/.generator-v2/internal/cli/generate_test.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/parser"
+)
+
+// runTfgen builds the root command exactly as Execute does, but with explicit
+// args and errors returned rather than printed, so tests can assert on them.
+func runTfgen(args ...string) error {
+	flags := &globalFlags{}
+	root := newRootCmd("test", flags)
+	root.AddCommand(newGenerateCmd(flags))
+	root.AddCommand(newVerifyCmd(flags))
+	root.SetArgs(args)
+	root.SilenceErrors = true
+	return root.Execute()
+}
+
+// TestGenerateWiresMaxDepth proves the --max-depth flag value reaches LoadSpec:
+// the same deep-but-acyclic spec loads at a high bound and fails at a low one.
+// If the flag were ignored, both runs would behave identically.
+func TestGenerateWiresMaxDepth(t *testing.T) {
+	deep := filepath.Join("..", "testdata", "parser", "deep_chain.yaml")
+
+	if err := runTfgen("generate", "--spec", deep, "--max-depth", "20"); err != nil {
+		t.Errorf("--max-depth 20 should load the 8-deep chain, got: %v", err)
+	}
+	if err := runTfgen("generate", "--spec", deep, "--max-depth", "4"); err == nil {
+		t.Error("--max-depth 4 should fail on the 8-deep chain, got nil")
+	}
+}
+
+// TestGenerateSurfacesCycleError proves cycle detection is reachable through the
+// command and surfaces the typed error.
+func TestGenerateSurfacesCycleError(t *testing.T) {
+	self := filepath.Join("..", "testdata", "parser", "cycle_self.yaml")
+
+	err := runTfgen("generate", "--spec", self)
+	var cycleErr *parser.RefCycleError
+	if !errors.As(err, &cycleErr) {
+		t.Fatalf("error %v (%T) is not a *parser.RefCycleError", err, err)
+	}
+}

--- a/.generator-v2/internal/cli/root.go
+++ b/.generator-v2/internal/cli/root.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/parser"
 )
 
 type globalFlags struct {
@@ -26,7 +27,7 @@ func newRootCmd(version string, flags *globalFlags) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&flags.outputRoot, "output-root", "datadog/fwprovider", "Root directory for generated artifacts")
 	cmd.PersistentFlags().StringVar(&flags.hooksRoot, "hooks-root", "datadog/fwprovider/hooks", "Root directory for hook subpackages")
 	cmd.PersistentFlags().StringVar(&flags.trackingField, "tracking-field", "x-datadog-tf-generator", "OpenAPI extension name for the tracking field")
-	cmd.PersistentFlags().IntVar(&flags.maxDepth, "max-depth", 8, "Hard limit on recursive $ref expansion")
+	cmd.PersistentFlags().IntVar(&flags.maxDepth, "max-depth", parser.DefaultMaxDepth, "Hard limit on recursive $ref expansion")
 	cmd.PersistentFlags().StringVar(&flags.report, "report", "-", "Where to write the run report (\"-\" = stdout)")
 	cmd.PersistentFlags().BoolVar(&flags.quiet, "quiet", false, "Suppress informational logging")
 

--- a/.generator-v2/internal/parser/cycles.go
+++ b/.generator-v2/internal/parser/cycles.go
@@ -18,19 +18,37 @@ type RefCycle struct {
 	Path []string
 }
 
+// RefCycleError reports one or more $ref cycles found while loading a spec. It
+// implements error so LoadSpec can fail fast, and exposes the offending refs so
+// callers can inspect them. The message names the OpenAPI path of the offending
+// $ref (e.g. "#/components/schemas/Node").
+type RefCycleError struct {
+	Cycles []RefCycle
+}
+
+func (e *RefCycleError) Error() string {
+	first := e.Cycles[0]
+	msg := fmt.Sprintf("parser: circular $ref at %s (cycle: %s)", first.Ref, strings.Join(first.Path, " -> "))
+	if len(e.Cycles) > 1 {
+		msg += fmt.Sprintf(" (and %d more)", len(e.Cycles)-1)
+	}
+	return msg
+}
+
 // DetectRefCycles walks the schema graph rooted at root. It follows $ref
 // references and every structural child (properties, items, prefixItems,
-// allOf/oneOf/anyOf, not, additionalProperties) and reports each distinct
-// $ref cycle. Callers mark cyclic schemas as terminal (model.SchemaKindRefCycle)
+// allOf/oneOf/anyOf, not, additionalProperties) and reports each distinct $ref
+// cycle. Callers mark cyclic schemas as terminal (model.SchemaKindRefCycle)
 // rather than expanding them forever.
 //
-// maxDepth bounds how deeply $refs may nest: an acyclic $ref chain longer than
-// maxDepth returns an error, guarding against pathological or unbounded specs
-// (the --max-depth flag). maxDepth <= 0 disables that bound. Cycles are still
-// found, since a re-entered $ref terminates the walk regardless of depth.
+// maxDepth bounds how many $ref edges may be followed on a single path: an
+// acyclic chain longer than maxDepth returns an error, guarding against
+// pathological or unbounded specs (the --max-depth flag). maxDepth <= 0 disables
+// that bound. Cycles are still found, since a re-entered $ref terminates the
+// walk regardless of depth.
 func DetectRefCycles(root *base.SchemaProxy, maxDepth int) ([]RefCycle, error) {
 	w := newCycleWalker(maxDepth)
-	if err := w.walkProxy(root); err != nil {
+	if err := w.walkProxy("", root); err != nil {
 		return nil, err
 	}
 	return w.cycles, nil
@@ -39,15 +57,16 @@ func DetectRefCycles(root *base.SchemaProxy, maxDepth int) ([]RefCycle, error) {
 // DetectComponentRefCycles runs cycle detection across every component schema,
 // seeding each with its own "#/components/schemas/<name>" ref so a component
 // that references itself (directly or transitively) is detected even though its
-// top-level node is a definition rather than a $ref. Detection state is shared
-// across components, so each schema's subtree is walked at most once.
+// top-level node is a definition rather than a $ref. The seed does not count
+// toward maxDepth, only the $ref edges followed from it do. Detection state is
+// shared across components, so each schema's subtree is walked at most once.
 func DetectComponentRefCycles(components *v3.Components, maxDepth int) ([]RefCycle, error) {
 	if components == nil || components.Schemas == nil {
 		return nil, nil
 	}
 	w := newCycleWalker(maxDepth)
 	for name, proxy := range components.Schemas.FromOldest() {
-		if err := w.walkNamed(componentSchemaPrefix+name, proxy); err != nil {
+		if err := w.walkProxy(componentSchemaPrefix+name, proxy); err != nil {
 			return nil, err
 		}
 	}
@@ -56,12 +75,15 @@ func DetectComponentRefCycles(components *v3.Components, maxDepth int) ([]RefCyc
 
 // cycleWalker is a three-color DFS over the schema graph: refs on stack are
 // "gray" (re-entry is a cycle), refs in done are "black" (subtree fully
-// explored, safe to prune).
+// explored, safe to prune). depth counts only the $ref edges currently on the
+// path, so the maxDepth bound is independent of whether the walk was seeded
+// with a component's own ref.
 type cycleWalker struct {
 	maxDepth int
-	stack    []string        // $refs currently being expanded (the DFS path)
+	depth    int             // count of $ref edges on the current path
+	stack    []string        // refs on the current path (for cycle detection)
 	onStack  map[string]bool // membership test for stack
-	done     map[string]bool // $refs whose subtree is fully explored
+	done     map[string]bool // refs whose subtree is fully explored
 	reported map[string]bool // closing refs already recorded, to dedupe
 	cycles   []RefCycle
 }
@@ -75,59 +97,68 @@ func newCycleWalker(maxDepth int) *cycleWalker {
 	}
 }
 
-// walkNamed expands a named component's schema content as if it were reached
-// through its canonical ref.
-func (w *cycleWalker) walkNamed(ref string, proxy *base.SchemaProxy) error {
-	if proxy == nil {
+// walkProxy descends into the schemaProxy for cycle detection. The ref argument distinguishes the
+// two ways a node is reached:
+//
+//   - ref != "": schemaProxy is a named component definition and ref is its canonical
+//     "#/components/schemas/<name>". It seeds the cycle stack (so the component
+//     can be detected referencing itself) but is not a $ref edge, so it does not
+//     consume depth budget.
+//   - ref == "": schemaProxy is a child node. If it is a $ref, it is followed as a
+//     depth-counted edge; otherwise it is an inline schema, which has no
+//     identity and cannot start a cycle, so the walkProxy simply descends into it.
+func (w *cycleWalker) walkProxy(ref string, schemaProxy *base.SchemaProxy) error {
+	if schemaProxy == nil {
 		return nil
 	}
-	entered, err := w.enter(ref)
+
+	edge := false
+	if ref == "" {
+		if !schemaProxy.IsReference() {
+			return w.walkSchema(schemaProxy.Schema())
+		}
+		ref, edge = schemaProxy.GetReference(), true
+	}
+
+	entered, err := w.enter(ref, edge)
 	if err != nil || !entered {
 		return err
 	}
-	walkErr := w.walkSchema(proxy.Schema())
-	w.leave(ref, walkErr == nil)
+	walkErr := w.walkSchema(schemaProxy.Schema())
+	w.leave(ref, walkErr == nil, edge)
 	return walkErr
 }
 
-func (w *cycleWalker) walkProxy(p *base.SchemaProxy) error {
-	if p == nil {
-		return nil
-	}
-	if !p.IsReference() {
-		return w.walkSchema(p.Schema())
-	}
-	ref := p.GetReference()
-	entered, err := w.enter(ref)
-	if err != nil || !entered {
-		return err
-	}
-	walkErr := w.walkSchema(p.Schema())
-	w.leave(ref, walkErr == nil)
-	return walkErr
-}
-
-// enter pushes ref onto the path unless it closes a cycle (recorded, then
-// skipped), has already been fully explored (skipped), or would exceed maxDepth
-// (error). It reports whether the caller should walk ref's children.
-func (w *cycleWalker) enter(ref string) (bool, error) {
-	switch {
-	case w.onStack[ref]:
+// enter handles a node on the path. It reports a cycle (and skips) when ref is
+// already on the stack, skips refs whose subtree is already explored, and
+// errors if the depth bound would be exceeded. Cycle and done checks take
+// precedence over the depth bound so a cyclic spec is reported as a cycle,
+// never as a depth error. It returns whether the caller should walk ref's children.
+func (w *cycleWalker) enter(ref string, edge bool) (bool, error) {
+	if w.onStack[ref] {
 		w.recordCycle(ref)
 		return false, nil
-	case w.done[ref]:
+	}
+	if w.done[ref] {
 		return false, nil
-	case w.maxDepth > 0 && len(w.stack) >= w.maxDepth:
+	}
+	if edge && w.maxDepth > 0 && w.depth >= w.maxDepth {
 		chain := append(append([]string{}, w.stack...), ref)
 		return false, fmt.Errorf("parser: $ref expansion exceeded --max-depth %d at %q (chain: %s)",
 			w.maxDepth, ref, strings.Join(chain, " -> "))
 	}
 	w.stack = append(w.stack, ref)
 	w.onStack[ref] = true
+	if edge {
+		w.depth++
+	}
 	return true, nil
 }
 
-func (w *cycleWalker) leave(ref string, completed bool) {
+func (w *cycleWalker) leave(ref string, completed, edge bool) {
+	if edge {
+		w.depth--
+	}
 	w.onStack[ref] = false
 	w.stack = w.stack[:len(w.stack)-1]
 	if completed {
@@ -141,28 +172,28 @@ func (w *cycleWalker) walkSchema(s *base.Schema) error {
 	}
 	for _, group := range [][]*base.SchemaProxy{s.AllOf, s.OneOf, s.AnyOf, s.PrefixItems} {
 		for _, p := range group {
-			if err := w.walkProxy(p); err != nil {
+			if err := w.walkProxy("", p); err != nil {
 				return err
 			}
 		}
 	}
-	if err := w.walkProxy(s.Not); err != nil {
+	if err := w.walkProxy("", s.Not); err != nil {
 		return err
 	}
 	if s.Properties != nil {
 		for _, p := range s.Properties.FromOldest() {
-			if err := w.walkProxy(p); err != nil {
+			if err := w.walkProxy("", p); err != nil {
 				return err
 			}
 		}
 	}
 	if s.Items != nil && s.Items.IsA() {
-		if err := w.walkProxy(s.Items.A); err != nil {
+		if err := w.walkProxy("", s.Items.A); err != nil {
 			return err
 		}
 	}
 	if s.AdditionalProperties != nil && s.AdditionalProperties.IsA() {
-		if err := w.walkProxy(s.AdditionalProperties.A); err != nil {
+		if err := w.walkProxy("", s.AdditionalProperties.A); err != nil {
 			return err
 		}
 	}

--- a/.generator-v2/internal/parser/cycles.go
+++ b/.generator-v2/internal/parser/cycles.go
@@ -1,0 +1,188 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pb33f/libopenapi/datamodel/high/base"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+)
+
+const componentSchemaPrefix = "#/components/schemas/"
+
+// RefCycle describes a $ref that re-enters a schema already being expanded.
+// Path is the chain of $ref targets that closes the loop; its first and last
+// elements are the repeated ref.
+type RefCycle struct {
+	Ref  string
+	Path []string
+}
+
+// DetectRefCycles walks the schema graph rooted at root. It follows $ref
+// references and every structural child (properties, items, prefixItems,
+// allOf/oneOf/anyOf, not, additionalProperties) and reports each distinct
+// $ref cycle. Callers mark cyclic schemas as terminal (model.SchemaKindRefCycle)
+// rather than expanding them forever.
+//
+// maxDepth bounds how deeply $refs may nest: an acyclic $ref chain longer than
+// maxDepth returns an error, guarding against pathological or unbounded specs
+// (the --max-depth flag). maxDepth <= 0 disables that bound. Cycles are still
+// found, since a re-entered $ref terminates the walk regardless of depth.
+func DetectRefCycles(root *base.SchemaProxy, maxDepth int) ([]RefCycle, error) {
+	w := newCycleWalker(maxDepth)
+	if err := w.walkProxy(root); err != nil {
+		return nil, err
+	}
+	return w.cycles, nil
+}
+
+// DetectComponentRefCycles runs cycle detection across every component schema,
+// seeding each with its own "#/components/schemas/<name>" ref so a component
+// that references itself (directly or transitively) is detected even though its
+// top-level node is a definition rather than a $ref. Detection state is shared
+// across components, so each schema's subtree is walked at most once.
+func DetectComponentRefCycles(components *v3.Components, maxDepth int) ([]RefCycle, error) {
+	if components == nil || components.Schemas == nil {
+		return nil, nil
+	}
+	w := newCycleWalker(maxDepth)
+	for name, proxy := range components.Schemas.FromOldest() {
+		if err := w.walkNamed(componentSchemaPrefix+name, proxy); err != nil {
+			return nil, err
+		}
+	}
+	return w.cycles, nil
+}
+
+// cycleWalker is a three-color DFS over the schema graph: refs on stack are
+// "gray" (re-entry is a cycle), refs in done are "black" (subtree fully
+// explored, safe to prune).
+type cycleWalker struct {
+	maxDepth int
+	stack    []string        // $refs currently being expanded (the DFS path)
+	onStack  map[string]bool // membership test for stack
+	done     map[string]bool // $refs whose subtree is fully explored
+	reported map[string]bool // closing refs already recorded, to dedupe
+	cycles   []RefCycle
+}
+
+func newCycleWalker(maxDepth int) *cycleWalker {
+	return &cycleWalker{
+		maxDepth: maxDepth,
+		onStack:  map[string]bool{},
+		done:     map[string]bool{},
+		reported: map[string]bool{},
+	}
+}
+
+// walkNamed expands a named component's schema content as if it were reached
+// through its canonical ref.
+func (w *cycleWalker) walkNamed(ref string, proxy *base.SchemaProxy) error {
+	if proxy == nil {
+		return nil
+	}
+	entered, err := w.enter(ref)
+	if err != nil || !entered {
+		return err
+	}
+	walkErr := w.walkSchema(proxy.Schema())
+	w.leave(ref, walkErr == nil)
+	return walkErr
+}
+
+func (w *cycleWalker) walkProxy(p *base.SchemaProxy) error {
+	if p == nil {
+		return nil
+	}
+	if !p.IsReference() {
+		return w.walkSchema(p.Schema())
+	}
+	ref := p.GetReference()
+	entered, err := w.enter(ref)
+	if err != nil || !entered {
+		return err
+	}
+	walkErr := w.walkSchema(p.Schema())
+	w.leave(ref, walkErr == nil)
+	return walkErr
+}
+
+// enter pushes ref onto the path unless it closes a cycle (recorded, then
+// skipped), has already been fully explored (skipped), or would exceed maxDepth
+// (error). It reports whether the caller should walk ref's children.
+func (w *cycleWalker) enter(ref string) (bool, error) {
+	switch {
+	case w.onStack[ref]:
+		w.recordCycle(ref)
+		return false, nil
+	case w.done[ref]:
+		return false, nil
+	case w.maxDepth > 0 && len(w.stack) >= w.maxDepth:
+		chain := append(append([]string{}, w.stack...), ref)
+		return false, fmt.Errorf("parser: $ref expansion exceeded --max-depth %d at %q (chain: %s)",
+			w.maxDepth, ref, strings.Join(chain, " -> "))
+	}
+	w.stack = append(w.stack, ref)
+	w.onStack[ref] = true
+	return true, nil
+}
+
+func (w *cycleWalker) leave(ref string, completed bool) {
+	w.onStack[ref] = false
+	w.stack = w.stack[:len(w.stack)-1]
+	if completed {
+		w.done[ref] = true
+	}
+}
+
+func (w *cycleWalker) walkSchema(s *base.Schema) error {
+	if s == nil {
+		return nil
+	}
+	for _, group := range [][]*base.SchemaProxy{s.AllOf, s.OneOf, s.AnyOf, s.PrefixItems} {
+		for _, p := range group {
+			if err := w.walkProxy(p); err != nil {
+				return err
+			}
+		}
+	}
+	if err := w.walkProxy(s.Not); err != nil {
+		return err
+	}
+	if s.Properties != nil {
+		for _, p := range s.Properties.FromOldest() {
+			if err := w.walkProxy(p); err != nil {
+				return err
+			}
+		}
+	}
+	if s.Items != nil && s.Items.IsA() {
+		if err := w.walkProxy(s.Items.A); err != nil {
+			return err
+		}
+	}
+	if s.AdditionalProperties != nil && s.AdditionalProperties.IsA() {
+		if err := w.walkProxy(s.AdditionalProperties.A); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *cycleWalker) recordCycle(ref string) {
+	if w.reported[ref] {
+		return
+	}
+	w.reported[ref] = true
+
+	start := 0
+	for i, r := range w.stack {
+		if r == ref {
+			start = i
+			break
+		}
+	}
+	path := append([]string{}, w.stack[start:]...)
+	path = append(path, ref)
+	w.cycles = append(w.cycles, RefCycle{Ref: ref, Path: path})
+}

--- a/.generator-v2/internal/parser/cycles.go
+++ b/.generator-v2/internal/parser/cycles.go
@@ -35,6 +35,22 @@ func (e *RefCycleError) Error() string {
 	return msg
 }
 
+// MaxDepthError reports that $ref expansion hit the --max-depth bound before a
+// path terminated. Ref is the $ref that would have pushed past the limit, Chain
+// is the path of $refs leading to it, and MaxDepth is the bound that was hit. It
+// is returned instead of a *RefCycleError so callers can tell "too deep" from a
+// genuine cycle via errors.As.
+type MaxDepthError struct {
+	Ref      string
+	Chain    []string
+	MaxDepth int
+}
+
+func (e *MaxDepthError) Error() string {
+	return fmt.Sprintf("parser: $ref expansion exceeded --max-depth %d at %q (chain: %s)",
+		e.MaxDepth, e.Ref, strings.Join(e.Chain, " -> "))
+}
+
 // DetectRefCycles walks the schema graph rooted at root. It follows $ref
 // references and every structural child (properties, items, prefixItems,
 // allOf/oneOf/anyOf, not, additionalProperties) and reports each distinct $ref
@@ -143,9 +159,11 @@ func (w *cycleWalker) enter(ref string, edge bool) (bool, error) {
 		return false, nil
 	}
 	if edge && w.maxDepth > 0 && w.depth >= w.maxDepth {
-		chain := append(append([]string{}, w.stack...), ref)
-		return false, fmt.Errorf("parser: $ref expansion exceeded --max-depth %d at %q (chain: %s)",
-			w.maxDepth, ref, strings.Join(chain, " -> "))
+		return false, &MaxDepthError{
+			Ref:      ref,
+			Chain:    append(append([]string{}, w.stack...), ref),
+			MaxDepth: w.maxDepth,
+		}
 	}
 	w.stack = append(w.stack, ref)
 	w.onStack[ref] = true

--- a/.generator-v2/internal/parser/cycles_test.go
+++ b/.generator-v2/internal/parser/cycles_test.go
@@ -1,0 +1,135 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pb33f/libopenapi"
+	"github.com/pb33f/libopenapi/datamodel/high/base"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+)
+
+func loadComponents(t *testing.T, fixture string) *v3.Components {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("../testdata/parser", fixture))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	doc, err := libopenapi.NewDocument(data)
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	model, err := doc.BuildV3Model()
+	if err != nil {
+		t.Fatalf("build v3 model: %v", err)
+	}
+	return model.Model.Components
+}
+
+func componentProxy(t *testing.T, comps *v3.Components, name string) *base.SchemaProxy {
+	t.Helper()
+	for k, v := range comps.Schemas.FromOldest() {
+		if k == name {
+			return v
+		}
+	}
+	t.Fatalf("component %q not found", name)
+	return nil
+}
+
+func TestDetectComponentRefCyclesSelfReference(t *testing.T) {
+	cycles, err := DetectComponentRefCycles(loadComponents(t, "cycle_self.yaml"), 16)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cycles) != 1 {
+		t.Fatalf("got %d cycles, want 1: %+v", len(cycles), cycles)
+	}
+	ref := componentSchemaPrefix + "Node"
+	if cycles[0].Ref != ref {
+		t.Errorf("cycle ref = %q, want %q", cycles[0].Ref, ref)
+	}
+	if want := []string{ref, ref}; !equal(cycles[0].Path, want) {
+		t.Errorf("cycle path = %v, want %v", cycles[0].Path, want)
+	}
+}
+
+func TestDetectComponentRefCyclesIndirect(t *testing.T) {
+	cycles, err := DetectComponentRefCycles(loadComponents(t, "cycle_indirect.yaml"), 16)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cycles) != 1 {
+		t.Fatalf("got %d cycles, want 1: %+v", len(cycles), cycles)
+	}
+	// Components iterate in document order (A before B), so the cycle is found
+	// from A: A -> B -> A.
+	want := []string{componentSchemaPrefix + "A", componentSchemaPrefix + "B", componentSchemaPrefix + "A"}
+	if !equal(cycles[0].Path, want) {
+		t.Errorf("cycle path = %v, want %v", cycles[0].Path, want)
+	}
+}
+
+func TestDetectComponentRefCyclesArrayItems(t *testing.T) {
+	cycles, err := DetectComponentRefCycles(loadComponents(t, "cycle_array_items.yaml"), 16)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cycles) != 1 || cycles[0].Ref != componentSchemaPrefix+"Tree" {
+		t.Fatalf("got %+v, want a single Tree cycle", cycles)
+	}
+}
+
+func TestDetectComponentRefCyclesAcyclic(t *testing.T) {
+	cycles, err := DetectComponentRefCycles(loadComponents(t, "acyclic_diamond.yaml"), 16)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cycles) != 0 {
+		t.Errorf("got %d cycles, want 0: %+v", len(cycles), cycles)
+	}
+}
+
+func TestDetectComponentRefCyclesMaxDepthDisabledStillFindsCycle(t *testing.T) {
+	cycles, err := DetectComponentRefCycles(loadComponents(t, "cycle_self.yaml"), 0)
+	if err != nil {
+		t.Fatalf("unexpected error with depth bound disabled: %v", err)
+	}
+	if len(cycles) != 1 {
+		t.Errorf("got %d cycles, want 1", len(cycles))
+	}
+}
+
+func TestDetectRefCyclesMaxDepth(t *testing.T) {
+	comps := loadComponents(t, "deep_chain.yaml")
+	root := componentProxy(t, comps, "S0") // S0 -> S1 -> ... -> S8 (8 refs deep)
+
+	if _, err := DetectRefCycles(root, 4); err == nil {
+		t.Error("expected an error when the chain exceeds --max-depth 4, got nil")
+	}
+
+	cycles, err := DetectRefCycles(root, 8)
+	if err != nil {
+		t.Errorf("depth 8 should accommodate the chain, got error: %v", err)
+	}
+	if len(cycles) != 0 {
+		t.Errorf("deep chain is acyclic, got %d cycles", len(cycles))
+	}
+
+	if _, err := DetectRefCycles(root, 0); err != nil {
+		t.Errorf("depth bound disabled should never error on an acyclic chain, got: %v", err)
+	}
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/.generator-v2/internal/parser/cycles_test.go
+++ b/.generator-v2/internal/parser/cycles_test.go
@@ -1,9 +1,9 @@
 package parser
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/pb33f/libopenapi"
@@ -81,8 +81,12 @@ func TestCycleWalkerDepthBoundError(t *testing.T) {
 	if err == nil {
 		t.Fatal("enter b should exceed --max-depth 1")
 	}
-	if !strings.Contains(err.Error(), "max-depth") {
-		t.Errorf("error should mention max-depth: %v", err)
+	var depthErr *MaxDepthError
+	if !errors.As(err, &depthErr) {
+		t.Fatalf("error %v (%T) is not a *MaxDepthError", err, err)
+	}
+	if depthErr.MaxDepth != 1 || depthErr.Ref != "b" {
+		t.Errorf("MaxDepthError = %+v, want MaxDepth=1 Ref=b", depthErr)
 	}
 	if w.onStack["b"] || len(w.stack) != 1 {
 		t.Errorf("a failed enter must not push: stack=%v", w.stack)
@@ -305,6 +309,46 @@ func TestDetectComponentRefCyclesViaAdditionalProperties(t *testing.T) {
 	}
 	if len(cycles) != 1 || cycles[0].Ref != componentSchemaPrefix+"Dict" {
 		t.Fatalf("got %+v, want a single Dict cycle (additionalProperties edge)", cycles)
+	}
+}
+
+func TestDetectComponentRefCyclesViaOneOf(t *testing.T) {
+	cycles, err := DetectComponentRefCycles(loadComponents(t, "cycle_oneof.yaml"), 16)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cycles) != 1 || cycles[0].Ref != componentSchemaPrefix+"Tree" {
+		t.Fatalf("got %+v, want a single Tree cycle (oneOf edge)", cycles)
+	}
+}
+
+func TestDetectComponentRefCyclesViaAnyOf(t *testing.T) {
+	cycles, err := DetectComponentRefCycles(loadComponents(t, "cycle_anyof.yaml"), 16)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cycles) != 1 || cycles[0].Ref != componentSchemaPrefix+"Graph" {
+		t.Fatalf("got %+v, want a single Graph cycle (anyOf edge)", cycles)
+	}
+}
+
+func TestDetectComponentRefCyclesViaNot(t *testing.T) {
+	cycles, err := DetectComponentRefCycles(loadComponents(t, "cycle_not.yaml"), 16)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cycles) != 1 || cycles[0].Ref != componentSchemaPrefix+"Excluded" {
+		t.Fatalf("got %+v, want a single Excluded cycle (not edge)", cycles)
+	}
+}
+
+func TestDetectComponentRefCyclesViaPrefixItems(t *testing.T) {
+	cycles, err := DetectComponentRefCycles(loadComponents(t, "cycle_prefixitems.yaml"), 16)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cycles) != 1 || cycles[0].Ref != componentSchemaPrefix+"Tuple" {
+		t.Fatalf("got %+v, want a single Tuple cycle (prefixItems edge)", cycles)
 	}
 }
 

--- a/.generator-v2/internal/parser/cycles_test.go
+++ b/.generator-v2/internal/parser/cycles_test.go
@@ -3,12 +3,178 @@ package parser
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi/datamodel/high/base"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 )
+
+// -------------------------------------------------------------------
+//  Unit tests
+// -------------------------------------------------------------------
+// These will exercise the cycleWalker state machine directly, aka
+// operating enter/leave/recordCycle functions without a real OpenAPI Schema
+
+func TestCycleWalkerEnterLeaveMaintainsStackAndDepth(t *testing.T) {
+	w := newCycleWalker(0) // depth bound disabled
+
+	entered, err := w.enter("a", true)
+	if err != nil || !entered {
+		t.Fatalf("enter a: entered=%v err=%v", entered, err)
+	}
+	if !w.onStack["a"] || len(w.stack) != 1 || w.depth != 1 {
+		t.Fatalf("after enter a: onStack=%v stack=%v depth=%d", w.onStack["a"], w.stack, w.depth)
+	}
+
+	w.leave("a", true, true)
+	if w.onStack["a"] || len(w.stack) != 0 || w.depth != 0 {
+		t.Fatalf("after leave a: onStack=%v stack=%v depth=%d", w.onStack["a"], w.stack, w.depth)
+	}
+	if !w.done["a"] {
+		t.Error("leave(completed=true) should mark a done")
+	}
+}
+
+func TestCycleWalkerLeaveIncompleteDoesNotMarkDone(t *testing.T) {
+	w := newCycleWalker(0)
+	w.enter("a", true)
+	w.leave("a", false, true)
+
+	if w.done["a"] {
+		t.Error("leave(completed=false) must not mark done")
+	}
+	if w.depth != 0 || len(w.stack) != 0 {
+		t.Errorf("leave must pop and decrement: depth=%d stack=%v", w.depth, w.stack)
+	}
+}
+
+func TestCycleWalkerSeedDoesNotConsumeDepth(t *testing.T) {
+	w := newCycleWalker(2)
+
+	if _, err := w.enter("seed", false); err != nil { // seed is not a $ref edge
+		t.Fatalf("enter seed: %v", err)
+	}
+	if w.depth != 0 {
+		t.Fatalf("seed must not consume depth, got depth=%d", w.depth)
+	}
+	// Two real edges fit within maxDepth=2 precisely because the seed is free.
+	if _, err := w.enter("a", true); err != nil {
+		t.Fatalf("enter a: %v", err)
+	}
+	if _, err := w.enter("b", true); err != nil {
+		t.Fatalf("enter b: %v", err)
+	}
+	if _, err := w.enter("c", true); err == nil {
+		t.Fatal("enter c should exceed --max-depth 2")
+	}
+}
+
+func TestCycleWalkerDepthBoundError(t *testing.T) {
+	w := newCycleWalker(1)
+	if _, err := w.enter("a", true); err != nil {
+		t.Fatalf("enter a: %v", err)
+	}
+
+	_, err := w.enter("b", true)
+	if err == nil {
+		t.Fatal("enter b should exceed --max-depth 1")
+	}
+	if !strings.Contains(err.Error(), "max-depth") {
+		t.Errorf("error should mention max-depth: %v", err)
+	}
+	if w.onStack["b"] || len(w.stack) != 1 {
+		t.Errorf("a failed enter must not push: stack=%v", w.stack)
+	}
+}
+
+func TestCycleWalkerDepthBoundDisabled(t *testing.T) {
+	w := newCycleWalker(0)
+	for _, ref := range []string{"a", "b", "c", "d", "e"} {
+		if _, err := w.enter(ref, true); err != nil {
+			t.Fatalf("enter %s with bound disabled: %v", ref, err)
+		}
+	}
+}
+
+func TestCycleWalkerReentryRecordsCycle(t *testing.T) {
+	w := newCycleWalker(0)
+	w.enter("a", true)
+	w.enter("b", true)
+
+	entered, err := w.enter("a", true)
+	if entered || err != nil {
+		t.Fatalf("re-entering on-stack a: entered=%v err=%v", entered, err)
+	}
+	if len(w.cycles) != 1 {
+		t.Fatalf("expected 1 cycle, got %d", len(w.cycles))
+	}
+	if got := w.cycles[0]; got.Ref != "a" || !equal(got.Path, []string{"a", "b", "a"}) {
+		t.Errorf("cycle = %+v, want Ref=a Path=[a b a]", got)
+	}
+}
+
+func TestCycleWalkerCycleClosesMidStack(t *testing.T) {
+	w := newCycleWalker(0)
+	w.enter("a", true)
+	w.enter("b", true)
+	w.enter("c", true)
+
+	// c -> b closes a cycle on b, not a; the path must start at b.
+	w.enter("b", true)
+	if len(w.cycles) != 1 {
+		t.Fatalf("expected 1 cycle, got %d", len(w.cycles))
+	}
+	if got := w.cycles[0]; got.Ref != "b" || !equal(got.Path, []string{"b", "c", "b"}) {
+		t.Errorf("cycle = %+v, want Ref=b Path=[b c b]", got)
+	}
+}
+
+func TestCycleWalkerCycleTakesPrecedenceOverDepth(t *testing.T) {
+	w := newCycleWalker(1) // at the bound after a single edge
+	w.enter("a", true)     // depth now 1 == maxDepth
+
+	// Re-entering a must be reported as a cycle, not rejected as a depth error.
+	entered, err := w.enter("a", true)
+	if entered {
+		t.Fatal("re-entry must not proceed")
+	}
+	if err != nil {
+		t.Fatalf("re-entry at the depth bound must be a cycle, not an error: %v", err)
+	}
+	if len(w.cycles) != 1 {
+		t.Errorf("re-entry should record a cycle, got %d", len(w.cycles))
+	}
+}
+
+func TestCycleWalkerDoneRefIsPruned(t *testing.T) {
+	w := newCycleWalker(0)
+	w.done["x"] = true
+
+	entered, err := w.enter("x", true)
+	if entered || err != nil {
+		t.Fatalf("entering a done ref: entered=%v err=%v", entered, err)
+	}
+	if len(w.stack) != 0 || len(w.cycles) != 0 {
+		t.Errorf("done ref must be skipped without push or cycle: stack=%v cycles=%v", w.stack, w.cycles)
+	}
+}
+
+func TestCycleWalkerRecordCycleDedupes(t *testing.T) {
+	w := newCycleWalker(0)
+	w.enter("a", true)
+
+	w.recordCycle("a")
+	w.recordCycle("a")
+	if len(w.cycles) != 1 {
+		t.Errorf("recordCycle should dedupe by ref, got %d cycles", len(w.cycles))
+	}
+}
+
+// -------------------------------------------------------------------
+//  Fixture tests
+// -------------------------------------------------------------------
 
 func loadComponents(t *testing.T, fixture string) *v3.Components {
 	t.Helper()
@@ -119,6 +285,26 @@ func TestDetectRefCyclesMaxDepth(t *testing.T) {
 
 	if _, err := DetectRefCycles(root, 0); err != nil {
 		t.Errorf("depth bound disabled should never error on an acyclic chain, got: %v", err)
+	}
+}
+
+func TestDetectComponentRefCyclesViaAllOf(t *testing.T) {
+	cycles, err := DetectComponentRefCycles(loadComponents(t, "cycle_allof.yaml"), 16)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cycles) != 1 || cycles[0].Ref != componentSchemaPrefix+"Loop" {
+		t.Fatalf("got %+v, want a single Loop cycle (allOf edge)", cycles)
+	}
+}
+
+func TestDetectComponentRefCyclesViaAdditionalProperties(t *testing.T) {
+	cycles, err := DetectComponentRefCycles(loadComponents(t, "cycle_additional_properties.yaml"), 16)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cycles) != 1 || cycles[0].Ref != componentSchemaPrefix+"Dict" {
+		t.Fatalf("got %+v, want a single Dict cycle (additionalProperties edge)", cycles)
 	}
 }
 

--- a/.generator-v2/internal/parser/parser.go
+++ b/.generator-v2/internal/parser/parser.go
@@ -11,14 +11,42 @@ import (
 	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
 )
 
+// DefaultMaxDepth bounds recursive $ref expansion when no override is supplied.
+// It matches the --max-depth CLI default documented in contracts/cli.md.
+const DefaultMaxDepth = 8
+
+// Option configures LoadSpec.
+type Option func(*loadConfig)
+
+type loadConfig struct {
+	maxDepth int
+}
+
+// WithMaxDepth sets the recursive $ref expansion limit — the value carried by
+// the --max-depth CLI flag. A value <= 0 disables the bound.
+func WithMaxDepth(n int) Option {
+	return func(c *loadConfig) { c.maxDepth = n }
+}
+
 // LoadSpec reads and parses the OpenAPI v3 specification at path and projects
 // it into the generator's internal model. Every operation across all paths and
 // methods is enumerated and the resulting slice is sorted by (path, method) so
-// downstream iteration and generated output is deterministic.
+// downstream iteration — and generated output — is deterministic.
 //
-// LoadSpec populates only what it can read straight from the document: Path,
-// Method, OperationId and Tag.
-func LoadSpec(path string) (*model.Spec, error) {
+// Before enumerating, LoadSpec resolves the component schema graph and fails
+// fast: a circular $ref returns a typed *RefCycleError naming the offending
+// $ref, and a $ref chain deeper than the --max-depth bound (WithMaxDepth,
+// default DefaultMaxDepth) returns an error. A spec that cannot be resolved must
+// not silently produce partial output.
+//
+// LoadSpec populates Path, Method, OperationId and Tag on each Operation;
+// Tracking, RequestSchema and ResponseSchema are filled by later passes.
+func LoadSpec(path string, opts ...Option) (*model.Spec, error) {
+	cfg := loadConfig{maxDepth: DefaultMaxDepth}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading spec %q: %w", path, err)
@@ -37,6 +65,17 @@ func LoadSpec(path string) (*model.Spec, error) {
 	spec := &model.Spec{
 		Source:     path,
 		Components: v3doc.Model.Components,
+	}
+
+	// Fail fast on an unresolvable schema graph before enumerating anything:
+	// circular $refs surface as a typed *RefCycleError, and expansion past
+	// --max-depth as a depth error (contracts/cli.md).
+	cycles, err := DetectComponentRefCycles(spec.Components, cfg.maxDepth)
+	if err != nil {
+		return nil, err
+	}
+	if len(cycles) > 0 {
+		return nil, &RefCycleError{Cycles: cycles}
 	}
 
 	if paths := v3doc.Model.Paths; paths != nil && paths.PathItems != nil {

--- a/.generator-v2/internal/parser/parser.go
+++ b/.generator-v2/internal/parser/parser.go
@@ -12,7 +12,6 @@ import (
 )
 
 // DefaultMaxDepth bounds recursive $ref expansion when no override is supplied.
-// It matches the --max-depth CLI default documented in contracts/cli.md.
 const DefaultMaxDepth = 8
 
 // Option configures LoadSpec.

--- a/.generator-v2/internal/parser/parser.go
+++ b/.generator-v2/internal/parser/parser.go
@@ -1,8 +1,80 @@
 package parser
 
-import "github.com/pb33f/libopenapi"
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
 
-// LoadSpec loads and parses the OpenAPI specification at path.
-func LoadSpec(path string) (libopenapi.Document, error) {
-	panic("not implemented")
+	"github.com/pb33f/libopenapi"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+)
+
+// LoadSpec reads and parses the OpenAPI v3 specification at path and projects
+// it into the generator's internal model. Every operation across all paths and
+// methods is enumerated and the resulting slice is sorted by (path, method) so
+// downstream iteration and generated output is deterministic.
+//
+// LoadSpec populates only what it can read straight from the document: Path,
+// Method, OperationId and Tag.
+func LoadSpec(path string) (*model.Spec, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading spec %q: %w", path, err)
+	}
+
+	doc, err := libopenapi.NewDocument(data)
+	if err != nil {
+		return nil, fmt.Errorf("parsing spec %q: %w", path, err)
+	}
+
+	v3doc, err := doc.BuildV3Model()
+	if err != nil {
+		return nil, fmt.Errorf("building OpenAPI v3 model for %q: %w", path, err)
+	}
+
+	spec := &model.Spec{
+		Source:     path,
+		Components: v3doc.Model.Components,
+	}
+
+	if paths := v3doc.Model.Paths; paths != nil && paths.PathItems != nil {
+		for opPath, item := range paths.PathItems.FromOldest() {
+			if item == nil {
+				continue
+			}
+			for method, op := range item.GetOperations().FromOldest() {
+				if op == nil {
+					continue
+				}
+				spec.Operations = append(spec.Operations, &model.Operation{
+					Path:        opPath,
+					Method:      strings.ToUpper(method),
+					OperationId: op.OperationId,
+					Tag:         firstTag(op.Tags),
+				})
+			}
+		}
+	}
+
+	sort.Slice(spec.Operations, func(i, j int) bool {
+		a, b := spec.Operations[i], spec.Operations[j]
+		if a.Path != b.Path {
+			return a.Path < b.Path
+		}
+		return a.Method < b.Method
+	})
+
+	return spec, nil
+}
+
+// firstTag returns the operation's first OpenAPI tag, or "" when untagged.
+// The first tag is what the client generator keys package selection on so
+// we must do the same.
+func firstTag(tags []string) string {
+	if len(tags) > 0 {
+		return tags[0]
+	}
+	return ""
 }

--- a/.generator-v2/internal/parser/parser_test.go
+++ b/.generator-v2/internal/parser/parser_test.go
@@ -123,4 +123,8 @@ func TestLoadSpecMaxDepthFailsFastNotAsCycle(t *testing.T) {
 	if errors.As(err, &cycleErr) {
 		t.Errorf("deep-but-acyclic refs must not be reported as a cycle: %v", err)
 	}
+	var depthErr *MaxDepthError
+	if !errors.As(err, &depthErr) {
+		t.Errorf("expected a typed *MaxDepthError, got %T: %v", err, err)
+	}
 }

--- a/.generator-v2/internal/parser/parser_test.go
+++ b/.generator-v2/internal/parser/parser_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"errors"
 	"path/filepath"
 	"slices"
 	"testing"
@@ -66,5 +67,60 @@ func TestLoadSpecOrderingIsDeterministic(t *testing.T) {
 		if order := operationOrder(got); !slices.Equal(order, baseline) {
 			t.Fatalf("run %d diverged:\n baseline = %v\n got      = %v", i, baseline, order)
 		}
+	}
+}
+
+// TestLoadSpecCircularRefReturnsTypedError covers the ticket AC: a deliberately
+// circular $ref makes LoadSpec fail with a typed *RefCycleError that names the
+// offending $ref path.
+func TestLoadSpecCircularRefReturnsTypedError(t *testing.T) {
+	_, err := LoadSpec(filepath.Join("../testdata/parser", "cycle_self.yaml"))
+	if err == nil {
+		t.Fatal("expected an error for a circular $ref, got nil")
+	}
+	var cycleErr *RefCycleError
+	if !errors.As(err, &cycleErr) {
+		t.Fatalf("error %v (%T) is not a *RefCycleError", err, err)
+	}
+	if len(cycleErr.Cycles) == 0 {
+		t.Fatal("RefCycleError carries no cycles")
+	}
+	if want := "#/components/schemas/Node"; cycleErr.Cycles[0].Ref != want {
+		t.Errorf("offending ref = %q, want %q", cycleErr.Cycles[0].Ref, want)
+	}
+}
+
+// TestLoadSpecIndirectCircularRefReturnsTypedError checks an A -> B -> A cycle
+// also surfaces as the typed error.
+func TestLoadSpecIndirectCircularRefReturnsTypedError(t *testing.T) {
+	_, err := LoadSpec(filepath.Join("../testdata/parser", "cycle_indirect.yaml"))
+	var cycleErr *RefCycleError
+	if !errors.As(err, &cycleErr) {
+		t.Fatalf("error %v (%T) is not a *RefCycleError", err, err)
+	}
+}
+
+// TestLoadSpecMaxDepthFailsFastNotAsCycle covers the ticket AC: --max-depth caps
+// recursion, and a deep-but-acyclic chain is never misclassified as a cycle.
+func TestLoadSpecMaxDepthFailsFastNotAsCycle(t *testing.T) {
+	deep := filepath.Join("../testdata/parser", "deep_chain.yaml")
+
+	// The chain is 8 $refs deep; the default bound (8) and an explicit 8 both
+	// accommodate it without error.
+	if _, err := LoadSpec(deep); err != nil {
+		t.Errorf("default --max-depth should accommodate the 8-deep chain, got: %v", err)
+	}
+	if _, err := LoadSpec(deep, WithMaxDepth(8)); err != nil {
+		t.Errorf("--max-depth 8 should accommodate the 8-deep chain, got: %v", err)
+	}
+
+	// A tighter bound fails fast — but as a depth error, not a cycle.
+	_, err := LoadSpec(deep, WithMaxDepth(4))
+	if err == nil {
+		t.Fatal("expected a depth error at --max-depth 4, got nil")
+	}
+	var cycleErr *RefCycleError
+	if errors.As(err, &cycleErr) {
+		t.Errorf("deep-but-acyclic refs must not be reported as a cycle: %v", err)
 	}
 }

--- a/.generator-v2/internal/parser/parser_test.go
+++ b/.generator-v2/internal/parser/parser_test.go
@@ -1,0 +1,70 @@
+package parser
+
+import (
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+)
+
+// scrambledSpecPath is a spec whose paths and methods are declared out of
+// (path, method) order on purpose (paths zebra/alpha/mid; /alpha lists
+// post/get/delete), so these tests fail if LoadSpec ever stops sorting.
+var scrambledSpecPath = filepath.Join("../testdata/parser", "scrambled_ordering.yaml")
+
+// operationOrder renders the operation sequence as "METHOD path" tokens so
+// orderings are easy to compare and to read in failure output.
+func operationOrder(s *model.Spec) []string {
+	out := make([]string, len(s.Operations))
+	for i, op := range s.Operations {
+		out[i] = op.Method + " " + op.Path
+	}
+	return out
+}
+
+// TestLoadSpecSortsByPathThenMethod pins the documented ordering: operations
+// come out sorted by path, then by method, regardless of source order.
+func TestLoadSpecSortsByPathThenMethod(t *testing.T) {
+	spec, err := LoadSpec(scrambledSpecPath)
+	if err != nil {
+		t.Fatalf("LoadSpec: %v", err)
+	}
+
+	want := []string{
+		"DELETE /alpha",
+		"GET /alpha",
+		"POST /alpha",
+		"PUT /mid",
+		"GET /zebra",
+	}
+	if got := operationOrder(spec); !slices.Equal(got, want) {
+		t.Errorf("operation order = %v, want %v", got, want)
+	}
+}
+
+// TestLoadSpecOrderingIsDeterministic loads the same spec many times and
+// asserts the ordering never changes. Go randomizes map iteration per range,
+// so if a future change iterated a plain map instead of the ordered structures
+// (or dropped the explicit sort), at least one of these runs would diverge.
+func TestLoadSpecOrderingIsDeterministic(t *testing.T) {
+	first, err := LoadSpec(scrambledSpecPath)
+	if err != nil {
+		t.Fatalf("LoadSpec: %v", err)
+	}
+	baseline := operationOrder(first)
+	if len(baseline) == 0 {
+		t.Fatal("expected operations, got none")
+	}
+
+	const runs = 5
+	for i := range runs {
+		got, err := LoadSpec(scrambledSpecPath)
+		if err != nil {
+			t.Fatalf("LoadSpec run %d: %v", i, err)
+		}
+		if order := operationOrder(got); !slices.Equal(order, baseline) {
+			t.Fatalf("run %d diverged:\n baseline = %v\n got      = %v", i, baseline, order)
+		}
+	}
+}

--- a/.generator-v2/internal/testdata/parser/acyclic_diamond.yaml
+++ b/.generator-v2/internal/testdata/parser/acyclic_diamond.yaml
@@ -1,0 +1,20 @@
+# Branch references Leaf twice (a diamond, shared but acyclic) — no cycle.
+openapi: 3.0.0
+info:
+  title: Acyclic
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Leaf:
+      type: object
+      properties:
+        value:
+          type: string
+    Branch:
+      type: object
+      properties:
+        left:
+          $ref: '#/components/schemas/Leaf'
+        right:
+          $ref: '#/components/schemas/Leaf'

--- a/.generator-v2/internal/testdata/parser/cycle_additional_properties.yaml
+++ b/.generator-v2/internal/testdata/parser/cycle_additional_properties.yaml
@@ -1,0 +1,13 @@
+# Dict is a map whose values are Dict — a $ref cycle through
+# additionalProperties. Exercises the map edge of the walk.
+openapi: 3.0.0
+info:
+  title: Cycles
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Dict:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/Dict'

--- a/.generator-v2/internal/testdata/parser/cycle_allof.yaml
+++ b/.generator-v2/internal/testdata/parser/cycle_allof.yaml
@@ -1,0 +1,16 @@
+# Loop merges itself via allOf — a $ref cycle through composition rather than a
+# plain property. Exercises the allOf edge of the walk.
+openapi: 3.0.0
+info:
+  title: Cycles
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Loop:
+      allOf:
+        - type: object
+          properties:
+            name:
+              type: string
+        - $ref: '#/components/schemas/Loop'

--- a/.generator-v2/internal/testdata/parser/cycle_anyof.yaml
+++ b/.generator-v2/internal/testdata/parser/cycle_anyof.yaml
@@ -1,0 +1,15 @@
+# Graph recurses through an anyOf variant. Exercises the AnyOf edge of the walk.
+openapi: 3.0.0
+info:
+  title: Cycles
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Graph:
+      anyOf:
+        - type: object
+          properties:
+            id:
+              type: string
+        - $ref: '#/components/schemas/Graph'

--- a/.generator-v2/internal/testdata/parser/cycle_array_items.yaml
+++ b/.generator-v2/internal/testdata/parser/cycle_array_items.yaml
@@ -1,0 +1,15 @@
+# Tree recurses through array items — exercises the Items edge of the walk.
+openapi: 3.0.0
+info:
+  title: Cycles
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Tree:
+      type: object
+      properties:
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/Tree'

--- a/.generator-v2/internal/testdata/parser/cycle_indirect.yaml
+++ b/.generator-v2/internal/testdata/parser/cycle_indirect.yaml
@@ -1,0 +1,18 @@
+# A references B references A — an indirect $ref cycle.
+openapi: 3.0.0
+info:
+  title: Cycles
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    A:
+      type: object
+      properties:
+        b:
+          $ref: '#/components/schemas/B'
+    B:
+      type: object
+      properties:
+        a:
+          $ref: '#/components/schemas/A'

--- a/.generator-v2/internal/testdata/parser/cycle_not.yaml
+++ b/.generator-v2/internal/testdata/parser/cycle_not.yaml
@@ -1,0 +1,12 @@
+# Excluded references itself through `not`. Exercises the Not edge of the walk.
+openapi: 3.0.0
+info:
+  title: Cycles
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Excluded:
+      type: object
+      not:
+        $ref: '#/components/schemas/Excluded'

--- a/.generator-v2/internal/testdata/parser/cycle_oneof.yaml
+++ b/.generator-v2/internal/testdata/parser/cycle_oneof.yaml
@@ -1,0 +1,16 @@
+# Tree recurses through a oneOf variant — the kind of polymorphic schema the
+# real Datadog OAS uses heavily. Exercises the OneOf edge of the walk.
+openapi: 3.0.0
+info:
+  title: Cycles
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Tree:
+      oneOf:
+        - type: object
+          properties:
+            leaf:
+              type: string
+        - $ref: '#/components/schemas/Tree'

--- a/.generator-v2/internal/testdata/parser/cycle_prefixitems.yaml
+++ b/.generator-v2/internal/testdata/parser/cycle_prefixitems.yaml
@@ -1,0 +1,13 @@
+# Tuple references itself through a prefixItems entry (OpenAPI 3.1 tuple typing).
+# Exercises the PrefixItems edge of the walk.
+openapi: 3.1.0
+info:
+  title: Cycles
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Tuple:
+      type: array
+      prefixItems:
+        - $ref: '#/components/schemas/Tuple'

--- a/.generator-v2/internal/testdata/parser/cycle_self.yaml
+++ b/.generator-v2/internal/testdata/parser/cycle_self.yaml
@@ -1,0 +1,15 @@
+# Node references itself via `parent` — a direct $ref cycle.
+openapi: 3.0.0
+info:
+  title: Cycles
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Node:
+      type: object
+      properties:
+        name:
+          type: string
+        parent:
+          $ref: '#/components/schemas/Node'

--- a/.generator-v2/internal/testdata/parser/deep_chain.yaml
+++ b/.generator-v2/internal/testdata/parser/deep_chain.yaml
@@ -1,0 +1,54 @@
+# An acyclic chain S0 -> S1 -> ... -> S8 (8 nested $refs deep). Used to exercise
+# the --max-depth guard: deep but never cyclic.
+openapi: 3.0.0
+info:
+  title: DeepChain
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    S0:
+      type: object
+      properties:
+        next:
+          $ref: '#/components/schemas/S1'
+    S1:
+      type: object
+      properties:
+        next:
+          $ref: '#/components/schemas/S2'
+    S2:
+      type: object
+      properties:
+        next:
+          $ref: '#/components/schemas/S3'
+    S3:
+      type: object
+      properties:
+        next:
+          $ref: '#/components/schemas/S4'
+    S4:
+      type: object
+      properties:
+        next:
+          $ref: '#/components/schemas/S5'
+    S5:
+      type: object
+      properties:
+        next:
+          $ref: '#/components/schemas/S6'
+    S6:
+      type: object
+      properties:
+        next:
+          $ref: '#/components/schemas/S7'
+    S7:
+      type: object
+      properties:
+        next:
+          $ref: '#/components/schemas/S8'
+    S8:
+      type: object
+      properties:
+        leaf:
+          type: string

--- a/.generator-v2/internal/testdata/parser/scrambled_ordering.yaml
+++ b/.generator-v2/internal/testdata/parser/scrambled_ordering.yaml
@@ -1,0 +1,36 @@
+# Spec for the parser ordering tests. Paths (zebra/alpha/mid) and /alpha's
+# methods (post/get/delete) are declared out of (path, method) order on
+# purpose, so the tests fail if LoadSpec ever stops sorting.
+openapi: 3.0.0
+info:
+  title: Ordering
+  version: 1.0.0
+paths:
+  /zebra:
+    get:
+      operationId: GetZebra
+      responses:
+        '200':
+          description: ok
+  /alpha:
+    post:
+      operationId: CreateAlpha
+      responses:
+        '201':
+          description: created
+    get:
+      operationId: GetAlpha
+      responses:
+        '200':
+          description: ok
+    delete:
+      operationId: DeleteAlpha
+      responses:
+        '204':
+          description: gone
+  /mid:
+    put:
+      operationId: PutMid
+      responses:
+        '200':
+          description: ok

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -77,7 +77,7 @@ tfgen-build:
 
 # Run the tfgen module's unit tests
 tfgen-test:
-	cd .generator-v2 && $(GO) test ./internal/... ./cmd/tfgen/...
+	cd .generator-v2 && $(GO) test ./internal/... ./cmd/tfgen/... -race -cover
 	@echo "tfgen tests passed"
 
 update-go-client:


### PR DESCRIPTION
## Changes 
Adds the OpenAPI spec loader for the v2 generator. `parser.LoadSpec` parses the Datadog OAS via libopenapi v3 into the internal `model.Spec` and `model.Operation`, enumerating every operation sorted by (path, method) so generated output is deterministic across runs.

Cycle detection lives in the same file walk: `LoadSpec` resolves the component schema graph and fails fast on an   unresolvable spec:
  - a circular `$ref` returns a typed `*RefCycleError` naming the offending ref, and
  - a `$ref` chain deeper than `--max-depth` (default 8) returns a depth error.

The `--max-depth` flag is wired through the generate command. 

## Test Plan
New coverage: deterministic-ordering regression, typed cycle error (self / indirect / allOf / additionalProperties / array-items), --max-depth bound, and the cycleWalker state machine.

```sh
❮ make tfgen-test
cd .generator-v2 && go test ./internal/... ./cmd/tfgen/... -race -cover
ok    generator/internal/cli        1.618s  coverage: 77.1% of statements
ok    generator/internal/model      2.099s  coverage: 100.0% of statements
ok    generator/internal/parser     1.891s  coverage: 86.2% of statements
      generator/cmd/tfgen                   coverage: 0.0% of statements
```