### PR TITLE
[TFgen] Implement tracking-field decoder + duplicate artifact name detection

### DIFF
--- a/.generator-v2/go.mod
+++ b/.generator-v2/go.mod
@@ -6,7 +6,9 @@ toolchain go1.26.1
 
 require (
 	github.com/pb33f/libopenapi v0.37.2
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2
+	go.yaml.in/yaml/v4 v4.0.0-rc.4
 )
 
 require (
@@ -16,6 +18,6 @@ require (
 	github.com/pb33f/jsonpath v0.8.2 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
 	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 )

--- a/.generator-v2/go.sum
+++ b/.generator-v2/go.sum
@@ -5,6 +5,8 @@ github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/pb33f/jsonpath v0.8.2 h1:Ou4C7zjYClBm97dfZjDCjdZGusJoynv/vrtiEKNfj2Y=
@@ -16,6 +18,8 @@ github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
@@ -27,6 +31,8 @@ go.yaml.in/yaml/v4 v4.0.0-rc.4 h1:UP4+v6fFrBIb1l934bDl//mmnoIZEDK0idg1+AIvX5U=
 go.yaml.in/yaml/v4 v4.0.0-rc.4/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/.generator-v2/internal/cli/generate.go
+++ b/.generator-v2/internal/cli/generate.go
@@ -14,7 +14,9 @@ func newGenerateCmd(flags *globalFlags) *cobra.Command {
 		Use:   "generate",
 		Short: "Generate Terraform artifacts from the OpenAPI spec",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			spec, err := parser.LoadSpec(flags.spec, parser.WithMaxDepth(flags.maxDepth))
+			spec, err := parser.LoadSpec(flags.spec,
+				parser.WithMaxDepth(flags.maxDepth),
+				parser.WithTrackingFieldName(flags.trackingField))
 			if err != nil {
 				return err
 			}

--- a/.generator-v2/internal/contracts/contracts.go
+++ b/.generator-v2/internal/contracts/contracts.go
@@ -1,0 +1,20 @@
+// Package contracts holds the machine-readable contracts the generator
+// validates against. The files are embedded so the tfgen binary is
+// self-contained and never depends on its working directory at runtime.
+//
+// New contracts (e.g. a CLI-flag doc or a run-report schema) are added here as
+// another //go:embed directive plus an exported var.
+package contracts
+
+import _ "embed"
+
+// TrackingFieldSchema is the embedded JSON Schema (draft 2020-12) for the
+// x-datadog-tf-generator OpenAPI vendor extension. parser.DecodeTracking
+// compiles it once and validates every extension against it.
+//
+//go:embed tracking-field.schema.json
+var TrackingFieldSchema []byte
+
+// TrackingFieldSchemaID is the schema's canonical $id — the URL it is
+// registered and compiled under by the validator.
+const TrackingFieldSchemaID = "https://datadog.github.io/terraform-provider-datadog/contracts/tracking-field.schema.json"

--- a/.generator-v2/internal/contracts/contracts.go
+++ b/.generator-v2/internal/contracts/contracts.go
@@ -14,7 +14,3 @@ import _ "embed"
 //
 //go:embed tracking-field.schema.json
 var TrackingFieldSchema []byte
-
-// TrackingFieldSchemaID is the schema's canonical $id — the URL it is
-// registered and compiled under by the validator.
-const TrackingFieldSchemaID = "https://datadog.github.io/terraform-provider-datadog/contracts/tracking-field.schema.json"

--- a/.generator-v2/internal/contracts/tracking-field.schema.json
+++ b/.generator-v2/internal/contracts/tracking-field.schema.json
@@ -17,7 +17,7 @@
         "pattern": "^[a-z][a-z0-9_]*$",
         "minLength": 1,
         "maxLength": 64,
-        "description": "Terraform-facing artifact name without the 'datadog_' prefix. Must be lowercase snake_case. Must be unique across the entire spec."
+        "description": "Terraform-facing artifact name without the 'datadog_' prefix. Must be lowercase snake_case. Must be unique per artifact_kind — resources and data sources are separate Terraform namespaces, so a resource and a data source may share a name."
       },
       "group": {
         "type": "object",

--- a/.generator-v2/internal/contracts/tracking-field.schema.json
+++ b/.generator-v2/internal/contracts/tracking-field.schema.json
@@ -1,0 +1,72 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://datadog.github.io/terraform-provider-datadog/contracts/tracking-field.schema.json",
+    "title": "x-datadog-tf-generator",
+    "description": "OpenAPI 3.0 vendor extension that opts an operation in to Datadog Terraform provider generation.",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["artifact_kind", "artifact_name"],
+    "properties": {
+      "artifact_kind": {
+        "type": "string",
+        "enum": ["resource", "data_source"],
+        "description": "Whether this operation should be exposed as a Terraform resource (with full CRUD lifecycle) or a Terraform data source (read-only)."
+      },
+      "artifact_name": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9_]*$",
+        "minLength": 1,
+        "maxLength": 64,
+        "description": "Terraform-facing artifact name without the 'datadog_' prefix. Must be lowercase snake_case. Must be unique across the entire spec."
+      },
+      "group": {
+        "type": "object",
+        "description": "Declares which OpenAPI operations form the C/R/U/D quadruple. May reference operations by their operationId.",
+        "additionalProperties": false,
+        "properties": {
+          "create": { "type": "string", "description": "operationId of the Create endpoint." },
+          "read":   { "type": "string", "description": "operationId of the Read endpoint." },
+          "update": { "type": "string", "description": "operationId of the Update endpoint. May be omitted; the generator will then mark all attributes ForceNew per the missing-CRUD edge case in the spec." },
+          "delete": { "type": "string", "description": "operationId of the Delete endpoint." }
+        },
+        "required": ["read"]
+      },
+      "id_strategy": {
+        "type": "string",
+        "enum": ["data.id", "data.attributes.id", "data.attributes.uuid", "header.location"],
+        "default": "data.id",
+        "description": "How to derive the Terraform resource ID from the API response on Create/Read."
+      },
+      "sensitive": {
+        "type": "boolean",
+        "default": false,
+        "description": "When attached to a Schema Object, marks the attribute as Terraform-sensitive (suppressed in plan output)."
+      },
+      "skip": {
+        "type": "boolean",
+        "default": false,
+        "description": "Explicitly disable generation for this operation while keeping the annotation in place. Equivalent to removing the extension, but documented in-spec so reviewers see the choice."
+      }
+    },
+    "examples": [
+      {
+        "artifact_kind": "data_source",
+        "artifact_name": "team",
+        "group":{
+          "read": "GetTeam"
+        }
+      },
+      {
+        "artifact_kind": "resource",
+        "artifact_name": "incident_type",
+        "group": {
+          "create": "CreateIncidentType",
+          "read": "GetIncidentType",
+          "update": "UpdateIncidentType",
+          "delete": "DeleteIncidentType"
+        },
+        "id_strategy": "data.id"
+      }
+    ]
+  }
+  

--- a/.generator-v2/internal/model/tracking.go
+++ b/.generator-v2/internal/model/tracking.go
@@ -11,7 +11,8 @@ type TrackingFieldMetadata struct {
 	// Required.
 	ArtifactKind ArtifactKind `json:"artifact_kind"`
 	// ArtifactName is the Terraform-facing name without the datadog_ prefix,
-	// lowercase snake_case, unique across the spec. Required.
+	// lowercase snake_case, unique per artifact_kind (resources and data
+	// sources are separate Terraform namespaces). Required.
 	ArtifactName string `json:"artifact_name"`
 	// Group declares which operations form the C/R/U/D quadruple. Required for
 	// resources; for data sources only Read is meaningful.

--- a/.generator-v2/internal/parser/duplicates.go
+++ b/.generator-v2/internal/parser/duplicates.go
@@ -17,16 +17,19 @@ type OperationLocation struct {
 }
 
 // ArtifactNameCollision records every operation that declared a given
-// artifact_name, when more than one did.
+// (kind, artifact_name) pair, when more than one did. Uniqueness is scoped per
+// kind: Terraform resources and data sources occupy separate namespaces, so a
+// datadog_team resource and a datadog_team data source may coexist.
 type ArtifactNameCollision struct {
+	Kind    model.ArtifactKind
 	Name    string
 	Sources []OperationLocation
 }
 
-// DuplicateArtifactNameError aggregates every artifact_name collision found
-// across the spec into a single error, naming all source locations for each.
-// Collisions are sorted by name and their sources by (path, method), so the
-// message is deterministic regardless of input order.
+// DuplicateArtifactNameError aggregates every (kind, artifact_name) collision
+// found across the spec into a single error, naming all source locations for
+// each. Collisions are sorted by (name, kind) and their sources by
+// (path, method), so the message is deterministic regardless of input order.
 type DuplicateArtifactNameError struct {
 	Collisions []ArtifactNameCollision
 }
@@ -35,7 +38,7 @@ func (e *DuplicateArtifactNameError) Error() string {
 	var b strings.Builder
 	b.WriteString("parser: duplicate artifact_name across operations:")
 	for _, c := range e.Collisions {
-		fmt.Fprintf(&b, "\n  %q declared by:", c.Name)
+		fmt.Fprintf(&b, "\n  %s %q declared by:", c.Kind, c.Name)
 		for _, s := range c.Sources {
 			fmt.Fprintf(&b, "\n    - %s %s (operationId %q)", s.Method, s.Path, s.OperationId)
 		}
@@ -43,18 +46,28 @@ func (e *DuplicateArtifactNameError) Error() string {
 	return b.String()
 }
 
-// CheckDuplicateArtifactNames reports every artifact_name claimed by more than
-// one operation. Operations without tracking metadata are ignored (they
-// generate no artifact and so cannot collide). It returns a single aggregated
-// *DuplicateArtifactNameError naming every collision and all of its sources, or
-// nil when all names are unique.
+// CheckDuplicateArtifactNames reports every (kind, artifact_name) pair claimed
+// by more than one operation. Uniqueness is scoped per kind — Terraform
+// resources and data sources are separate namespaces, so the same name under
+// different kinds is allowed. Operations without tracking metadata are ignored
+// (they generate no artifact and so cannot collide). It returns a single
+// aggregated *DuplicateArtifactNameError naming every collision and all of its
+// sources, or nil when every name is unique within its kind.
 func CheckDuplicateArtifactNames(spec *model.Spec) error {
-	byName := make(map[string][]OperationLocation)
+	// Key on (kind, name) rather than name alone. Keying on the kind value
+	// itself — not an `== "resource"` special case — keeps this correct if new
+	// artifact kinds are ever introduced.
+	type artifactKey struct {
+		Kind model.ArtifactKind
+		Name string
+	}
+	byKey := make(map[artifactKey][]OperationLocation)
 	for _, op := range spec.Operations {
 		if op == nil || op.Tracking == nil {
 			continue
 		}
-		byName[op.Tracking.ArtifactName] = append(byName[op.Tracking.ArtifactName], OperationLocation{
+		key := artifactKey{Kind: op.Tracking.ArtifactKind, Name: op.Tracking.ArtifactName}
+		byKey[key] = append(byKey[key], OperationLocation{
 			Path:        op.Path,
 			Method:      op.Method,
 			OperationId: op.OperationId,
@@ -62,7 +75,7 @@ func CheckDuplicateArtifactNames(spec *model.Spec) error {
 	}
 
 	var collisions []ArtifactNameCollision
-	for name, locs := range byName {
+	for key, locs := range byKey {
 		if len(locs) < 2 {
 			continue
 		}
@@ -72,11 +85,16 @@ func CheckDuplicateArtifactNames(spec *model.Spec) error {
 			}
 			return locs[i].Method < locs[j].Method
 		})
-		collisions = append(collisions, ArtifactNameCollision{Name: name, Sources: locs})
+		collisions = append(collisions, ArtifactNameCollision{Kind: key.Kind, Name: key.Name, Sources: locs})
 	}
 	if len(collisions) == 0 {
 		return nil
 	}
-	sort.Slice(collisions, func(i, j int) bool { return collisions[i].Name < collisions[j].Name })
+	sort.Slice(collisions, func(i, j int) bool {
+		if collisions[i].Name != collisions[j].Name {
+			return collisions[i].Name < collisions[j].Name
+		}
+		return collisions[i].Kind < collisions[j].Kind
+	})
 	return &DuplicateArtifactNameError{Collisions: collisions}
 }

--- a/.generator-v2/internal/parser/duplicates.go
+++ b/.generator-v2/internal/parser/duplicates.go
@@ -1,0 +1,82 @@
+package parser
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+)
+
+// OperationLocation identifies one operation participating in an artifact_name
+// collision.
+type OperationLocation struct {
+	Path        string
+	Method      string
+	OperationId string
+}
+
+// ArtifactNameCollision records every operation that declared a given
+// artifact_name, when more than one did.
+type ArtifactNameCollision struct {
+	Name    string
+	Sources []OperationLocation
+}
+
+// DuplicateArtifactNameError aggregates every artifact_name collision found
+// across the spec into a single error, naming all source locations for each.
+// Collisions are sorted by name and their sources by (path, method), so the
+// message is deterministic regardless of input order.
+type DuplicateArtifactNameError struct {
+	Collisions []ArtifactNameCollision
+}
+
+func (e *DuplicateArtifactNameError) Error() string {
+	var b strings.Builder
+	b.WriteString("parser: duplicate artifact_name across operations:")
+	for _, c := range e.Collisions {
+		fmt.Fprintf(&b, "\n  %q declared by:", c.Name)
+		for _, s := range c.Sources {
+			fmt.Fprintf(&b, "\n    - %s %s (operationId %q)", s.Method, s.Path, s.OperationId)
+		}
+	}
+	return b.String()
+}
+
+// CheckDuplicateArtifactNames reports every artifact_name claimed by more than
+// one operation. Operations without tracking metadata are ignored (they
+// generate no artifact and so cannot collide). It returns a single aggregated
+// *DuplicateArtifactNameError naming every collision and all of its sources, or
+// nil when all names are unique.
+func CheckDuplicateArtifactNames(spec *model.Spec) error {
+	byName := make(map[string][]OperationLocation)
+	for _, op := range spec.Operations {
+		if op == nil || op.Tracking == nil {
+			continue
+		}
+		byName[op.Tracking.ArtifactName] = append(byName[op.Tracking.ArtifactName], OperationLocation{
+			Path:        op.Path,
+			Method:      op.Method,
+			OperationId: op.OperationId,
+		})
+	}
+
+	var collisions []ArtifactNameCollision
+	for name, locs := range byName {
+		if len(locs) < 2 {
+			continue
+		}
+		sort.Slice(locs, func(i, j int) bool {
+			if locs[i].Path != locs[j].Path {
+				return locs[i].Path < locs[j].Path
+			}
+			return locs[i].Method < locs[j].Method
+		})
+		collisions = append(collisions, ArtifactNameCollision{Name: name, Sources: locs})
+	}
+	if len(collisions) == 0 {
+		return nil
+	}
+	sort.Slice(collisions, func(i, j int) bool { return collisions[i].Name < collisions[j].Name })
+	return &DuplicateArtifactNameError{Collisions: collisions}
+}

--- a/.generator-v2/internal/parser/duplicates_test.go
+++ b/.generator-v2/internal/parser/duplicates_test.go
@@ -22,6 +22,13 @@ func trackedOp(path, method, operationId, artifactName string) *model.Operation 
 	}
 }
 
+// kindedOp is trackedOp with an explicit artifact kind, for cross-kind tests.
+func kindedOp(path, method, operationId, artifactName string, kind model.ArtifactKind) *model.Operation {
+	op := trackedOp(path, method, operationId, artifactName)
+	op.Tracking.ArtifactKind = kind
+	return op
+}
+
 func TestCheckDuplicateArtifactNamesUnique(t *testing.T) {
 	spec := &model.Spec{Operations: []*model.Operation{
 		trackedOp("/a", "GET", "GetA", "alpha"),
@@ -132,4 +139,41 @@ func TestCheckDuplicateArtifactNamesDeterministic(t *testing.T) {
 	if errA.Error() != errB.Error() {
 		t.Errorf("non-deterministic output:\nA:\n%s\nB:\n%s", errA.Error(), errB.Error())
 	}
+}
+
+// TestCheckDuplicateArtifactNamesIsPerKind pins Finding #1: artifact_name
+// uniqueness is scoped per artifact_kind. Terraform keeps resources and data
+// sources in separate namespaces, so a resource and a data source may share a
+// name; two artifacts of the SAME kind sharing a name is still a collision.
+//
+// NOTE: encodes the desired post-fix behavior — the "across kinds" case is red
+// against name-only keying until uniqueness keys on (kind, name).
+func TestCheckDuplicateArtifactNamesIsPerKind(t *testing.T) {
+	t.Run("same name across kinds is allowed", func(t *testing.T) {
+		spec := &model.Spec{Operations: []*model.Operation{
+			kindedOp("/teams", "POST", "CreateTeam", "team", model.ArtifactKindResource),
+			kindedOp("/teams/{id}", "GET", "GetTeam", "team", model.ArtifactKindDataSource),
+		}}
+		if err := CheckDuplicateArtifactNames(spec); err != nil {
+			t.Fatalf("a resource and a data source named %q must be allowed, got: %v", "team", err)
+		}
+	})
+
+	t.Run("same name same kind collides", func(t *testing.T) {
+		spec := &model.Spec{Operations: []*model.Operation{
+			kindedOp("/teams", "GET", "ListTeams", "team", model.ArtifactKindDataSource),
+			kindedOp("/teams/{id}", "GET", "GetTeam", "team", model.ArtifactKindDataSource),
+		}}
+		err := CheckDuplicateArtifactNames(spec)
+		var dup *DuplicateArtifactNameError
+		if !errors.As(err, &dup) {
+			t.Fatalf("two data_sources named %q must collide, got: %v", "team", err)
+		}
+		// The message must disambiguate by kind — not just say "team".
+		for _, want := range []string{"ListTeams", "GetTeam", string(model.ArtifactKindDataSource)} {
+			if !strings.Contains(dup.Error(), want) {
+				t.Errorf("collision message missing %q:\n%s", want, dup.Error())
+			}
+		}
+	})
 }

--- a/.generator-v2/internal/parser/duplicates_test.go
+++ b/.generator-v2/internal/parser/duplicates_test.go
@@ -68,8 +68,9 @@ func TestCheckDuplicateArtifactNamesSingleCollision(t *testing.T) {
 	if len(dup.Collisions[0].Sources) != 2 {
 		t.Fatalf("got %d sources, want 2", len(dup.Collisions[0].Sources))
 	}
+	// message names the kind, the name, and both source operations.
 	msg := dup.Error()
-	for _, want := range []string{"team", "ListTeams", "GetTeam", "/teams", "/teams/{id}"} {
+	for _, want := range []string{string(model.ArtifactKindResource), "team", "ListTeams", "GetTeam", "/teams", "/teams/{id}"} {
 		if !strings.Contains(msg, want) {
 			t.Errorf("error message missing %q:\n%s", want, msg)
 		}
@@ -144,33 +145,14 @@ func TestCheckDuplicateArtifactNamesDeterministic(t *testing.T) {
 // TestCheckDuplicateArtifactNamesIsPerKind pins Finding #1: artifact_name
 // uniqueness is scoped per artifact_kind. Terraform keeps resources and data
 // sources in separate namespaces, so a resource and a data source may share a
-// name; two artifacts of the SAME kind sharing a name is still a collision.
+// name without colliding. (The same-kind collision — including the kind in the
+// message — is covered by TestCheckDuplicateArtifactNamesSingleCollision.)
 func TestCheckDuplicateArtifactNamesIsPerKind(t *testing.T) {
-	t.Run("same name across kinds is allowed", func(t *testing.T) {
-		spec := &model.Spec{Operations: []*model.Operation{
-			kindedOp("/teams", "POST", "CreateTeam", "team", model.ArtifactKindResource),
-			kindedOp("/teams/{id}", "GET", "GetTeam", "team", model.ArtifactKindDataSource),
-		}}
-		if err := CheckDuplicateArtifactNames(spec); err != nil {
-			t.Fatalf("a resource and a data source named %q must be allowed, got: %v", "team", err)
-		}
-	})
-
-	t.Run("same name same kind collides", func(t *testing.T) {
-		spec := &model.Spec{Operations: []*model.Operation{
-			kindedOp("/teams", "GET", "ListTeams", "team", model.ArtifactKindDataSource),
-			kindedOp("/teams/{id}", "GET", "GetTeam", "team", model.ArtifactKindDataSource),
-		}}
-		err := CheckDuplicateArtifactNames(spec)
-		var dup *DuplicateArtifactNameError
-		if !errors.As(err, &dup) {
-			t.Fatalf("two data_sources named %q must collide, got: %v", "team", err)
-		}
-		// The message must disambiguate by kind — not just say "team".
-		for _, want := range []string{"ListTeams", "GetTeam", string(model.ArtifactKindDataSource)} {
-			if !strings.Contains(dup.Error(), want) {
-				t.Errorf("collision message missing %q:\n%s", want, dup.Error())
-			}
-		}
-	})
+	spec := &model.Spec{Operations: []*model.Operation{
+		kindedOp("/teams", "POST", "CreateTeam", "team", model.ArtifactKindResource),
+		kindedOp("/teams/{id}", "GET", "GetTeam", "team", model.ArtifactKindDataSource),
+	}}
+	if err := CheckDuplicateArtifactNames(spec); err != nil {
+		t.Fatalf("a resource and a data source named %q must be allowed, got: %v", "team", err)
+	}
 }

--- a/.generator-v2/internal/parser/duplicates_test.go
+++ b/.generator-v2/internal/parser/duplicates_test.go
@@ -1,0 +1,135 @@
+package parser
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+)
+
+// trackedOp builds a model.Operation carrying tracking metadata for the given
+// artifact name. The kind is irrelevant to duplicate detection.
+func trackedOp(path, method, operationId, artifactName string) *model.Operation {
+	return &model.Operation{
+		Path:        path,
+		Method:      method,
+		OperationId: operationId,
+		Tracking: &model.TrackingFieldMetadata{
+			ArtifactKind: model.ArtifactKindResource,
+			ArtifactName: artifactName,
+		},
+	}
+}
+
+func TestCheckDuplicateArtifactNamesUnique(t *testing.T) {
+	spec := &model.Spec{Operations: []*model.Operation{
+		trackedOp("/a", "GET", "GetA", "alpha"),
+		trackedOp("/b", "GET", "GetB", "beta"),
+		trackedOp("/c", "GET", "GetC", "gamma"),
+	}}
+	if err := CheckDuplicateArtifactNames(spec); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestCheckDuplicateArtifactNamesIgnoresUntracked(t *testing.T) {
+	spec := &model.Spec{Operations: []*model.Operation{
+		trackedOp("/a", "GET", "GetA", "alpha"),
+		{Path: "/health", Method: "GET", OperationId: "GetHealth"}, // Tracking nil
+		nil, // defensive: nil entries are skipped
+		trackedOp("/b", "GET", "GetB", "beta"),
+	}}
+	if err := CheckDuplicateArtifactNames(spec); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestCheckDuplicateArtifactNamesSingleCollision(t *testing.T) {
+	spec := &model.Spec{Operations: []*model.Operation{
+		trackedOp("/teams", "GET", "ListTeams", "team"),
+		trackedOp("/teams/{id}", "GET", "GetTeam", "team"),
+	}}
+	err := CheckDuplicateArtifactNames(spec)
+	var dup *DuplicateArtifactNameError
+	if !errors.As(err, &dup) {
+		t.Fatalf("error %v (%T) is not a *DuplicateArtifactNameError", err, err)
+	}
+	if len(dup.Collisions) != 1 {
+		t.Fatalf("got %d collisions, want 1", len(dup.Collisions))
+	}
+	if len(dup.Collisions[0].Sources) != 2 {
+		t.Fatalf("got %d sources, want 2", len(dup.Collisions[0].Sources))
+	}
+	msg := dup.Error()
+	for _, want := range []string{"team", "ListTeams", "GetTeam", "/teams", "/teams/{id}"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+func TestCheckDuplicateArtifactNamesListsAllSources(t *testing.T) {
+	spec := &model.Spec{Operations: []*model.Operation{
+		trackedOp("/teams", "GET", "ListTeams", "team"),
+		trackedOp("/teams/{id}", "GET", "GetTeam", "team"),
+		trackedOp("/teams/search", "POST", "SearchTeams", "team"),
+	}}
+	err := CheckDuplicateArtifactNames(spec)
+	var dup *DuplicateArtifactNameError
+	if !errors.As(err, &dup) {
+		t.Fatalf("error %v (%T) is not a *DuplicateArtifactNameError", err, err)
+	}
+	if n := len(dup.Collisions[0].Sources); n != 3 {
+		t.Fatalf("got %d sources, want all 3 listed", n)
+	}
+	for _, want := range []string{"ListTeams", "GetTeam", "SearchTeams"} {
+		if !strings.Contains(dup.Error(), want) {
+			t.Errorf("error message missing source %q", want)
+		}
+	}
+}
+
+func TestCheckDuplicateArtifactNamesMultipleCollisionsSortedByName(t *testing.T) {
+	spec := &model.Spec{Operations: []*model.Operation{
+		trackedOp("/z", "GET", "GetZ1", "zeta"),
+		trackedOp("/z2", "GET", "GetZ2", "zeta"),
+		trackedOp("/a", "GET", "GetA1", "alpha"),
+		trackedOp("/a2", "GET", "GetA2", "alpha"),
+	}}
+	err := CheckDuplicateArtifactNames(spec)
+	var dup *DuplicateArtifactNameError
+	if !errors.As(err, &dup) {
+		t.Fatalf("error %v (%T) is not a *DuplicateArtifactNameError", err, err)
+	}
+	if len(dup.Collisions) != 2 {
+		t.Fatalf("got %d collisions, want 2", len(dup.Collisions))
+	}
+	if dup.Collisions[0].Name != "alpha" || dup.Collisions[1].Name != "zeta" {
+		t.Errorf("collisions not sorted by name: %q then %q", dup.Collisions[0].Name, dup.Collisions[1].Name)
+	}
+}
+
+func TestCheckDuplicateArtifactNamesDeterministic(t *testing.T) {
+	// Same collisions, different declaration orders, must yield identical output.
+	build := func(ops ...*model.Operation) *model.Spec { return &model.Spec{Operations: ops} }
+	a := build(
+		trackedOp("/teams", "GET", "ListTeams", "team"),
+		trackedOp("/teams/{id}", "GET", "GetTeam", "team"),
+		trackedOp("/users", "GET", "ListUsers", "user"),
+		trackedOp("/users/{id}", "GET", "GetUser", "user"),
+	)
+	b := build(
+		trackedOp("/users/{id}", "GET", "GetUser", "user"),
+		trackedOp("/teams/{id}", "GET", "GetTeam", "team"),
+		trackedOp("/users", "GET", "ListUsers", "user"),
+		trackedOp("/teams", "GET", "ListTeams", "team"),
+	)
+	errA, errB := CheckDuplicateArtifactNames(a), CheckDuplicateArtifactNames(b)
+	if errA == nil || errB == nil {
+		t.Fatal("expected duplicate errors from both specs")
+	}
+	if errA.Error() != errB.Error() {
+		t.Errorf("non-deterministic output:\nA:\n%s\nB:\n%s", errA.Error(), errB.Error())
+	}
+}

--- a/.generator-v2/internal/parser/duplicates_test.go
+++ b/.generator-v2/internal/parser/duplicates_test.go
@@ -145,9 +145,6 @@ func TestCheckDuplicateArtifactNamesDeterministic(t *testing.T) {
 // uniqueness is scoped per artifact_kind. Terraform keeps resources and data
 // sources in separate namespaces, so a resource and a data source may share a
 // name; two artifacts of the SAME kind sharing a name is still a collision.
-//
-// NOTE: encodes the desired post-fix behavior — the "across kinds" case is red
-// against name-only keying until uniqueness keys on (kind, name).
 func TestCheckDuplicateArtifactNamesIsPerKind(t *testing.T) {
 	t.Run("same name across kinds is allowed", func(t *testing.T) {
 		spec := &model.Spec{Operations: []*model.Operation{

--- a/.generator-v2/internal/parser/parser.go
+++ b/.generator-v2/internal/parser/parser.go
@@ -18,13 +18,26 @@ const DefaultMaxDepth = 8
 type Option func(*loadConfig)
 
 type loadConfig struct {
-	maxDepth int
+	maxDepth          int
+	trackingFieldName string
 }
 
 // WithMaxDepth sets the recursive $ref expansion limit — the value carried by
 // the --max-depth CLI flag. A value <= 0 disables the bound.
 func WithMaxDepth(n int) Option {
 	return func(c *loadConfig) { c.maxDepth = n }
+}
+
+// WithTrackingFieldName overrides the OpenAPI extension key LoadSpec decodes
+// tracking metadata from — the value carried by the --tracking-field flag. An
+// empty name keeps the default (DefaultTrackingFieldName); the override is
+// reserved for generator-internal fixture tests.
+func WithTrackingFieldName(name string) Option {
+	return func(c *loadConfig) {
+		if name != "" {
+			c.trackingFieldName = name
+		}
+	}
 }
 
 // LoadSpec reads and parses the OpenAPI v3 specification at path and projects
@@ -41,7 +54,7 @@ func WithMaxDepth(n int) Option {
 // LoadSpec populates Path, Method, OperationId and Tag on each Operation;
 // Tracking, RequestSchema and ResponseSchema are filled by later passes.
 func LoadSpec(path string, opts ...Option) (*model.Spec, error) {
-	cfg := loadConfig{maxDepth: DefaultMaxDepth}
+	cfg := loadConfig{maxDepth: DefaultMaxDepth, trackingFieldName: DefaultTrackingFieldName}
 	for _, opt := range opts {
 		opt(&cfg)
 	}
@@ -86,11 +99,17 @@ func LoadSpec(path string, opts ...Option) (*model.Spec, error) {
 				if op == nil {
 					continue
 				}
+				upperMethod := strings.ToUpper(method)
+				tracking, err := DecodeTracking(op, opPath, upperMethod, cfg.trackingFieldName)
+				if err != nil {
+					return nil, err
+				}
 				spec.Operations = append(spec.Operations, &model.Operation{
 					Path:        opPath,
-					Method:      strings.ToUpper(method),
+					Method:      upperMethod,
 					OperationId: op.OperationId,
 					Tag:         firstTag(op.Tags),
+					Tracking:    tracking,
 				})
 			}
 		}
@@ -103,6 +122,10 @@ func LoadSpec(path string, opts ...Option) (*model.Spec, error) {
 		}
 		return a.Method < b.Method
 	})
+
+	if err := CheckDuplicateArtifactNames(spec); err != nil {
+		return nil, err
+	}
 
 	return spec, nil
 }

--- a/.generator-v2/internal/parser/parser_test.go
+++ b/.generator-v2/internal/parser/parser_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
@@ -126,5 +127,62 @@ func TestLoadSpecMaxDepthFailsFastNotAsCycle(t *testing.T) {
 	var depthErr *MaxDepthError
 	if !errors.As(err, &depthErr) {
 		t.Errorf("expected a typed *MaxDepthError, got %T: %v", err, err)
+	}
+}
+
+// TestLoadSpecPopulatesTracking checks the end-to-end wiring: flagged
+// operations get decoded tracking metadata, unflagged ones stay nil.
+func TestLoadSpecPopulatesTracking(t *testing.T) {
+	spec, err := LoadSpec(filepath.Join("../testdata/parser", "tracking_valid.yaml"))
+	if err != nil {
+		t.Fatalf("LoadSpec: %v", err)
+	}
+	byID := make(map[string]*model.Operation, len(spec.Operations))
+	for _, op := range spec.Operations {
+		byID[op.OperationId] = op
+	}
+
+	if res := byID["CreateIncidentType"]; res == nil || res.Tracking == nil {
+		t.Fatalf("CreateIncidentType tracking not populated: %+v", res)
+	} else if res.Tracking.ArtifactKind != model.ArtifactKindResource || res.Tracking.ArtifactName != "incident_type" {
+		t.Errorf("resource tracking = %+v", res.Tracking)
+	}
+
+	if ds := byID["GetTeam"]; ds == nil || ds.Tracking == nil || ds.Tracking.ArtifactKind != model.ArtifactKindDataSource {
+		t.Fatalf("GetTeam tracking = %+v", ds)
+	}
+
+	if h := byID["GetHealth"]; h == nil || h.Tracking != nil {
+		t.Errorf("unflagged GetHealth should have nil tracking, got %+v", h)
+	}
+}
+
+// TestLoadSpecDuplicateArtifactNamesReturnsTypedError covers the AC: two
+// operations resolving to the same artifact_name fail with the aggregated typed
+// error naming both source locations.
+func TestLoadSpecDuplicateArtifactNamesReturnsTypedError(t *testing.T) {
+	_, err := LoadSpec(filepath.Join("../testdata/parser", "tracking_duplicate.yaml"))
+	var dup *DuplicateArtifactNameError
+	if !errors.As(err, &dup) {
+		t.Fatalf("error %v (%T) is not a *DuplicateArtifactNameError", err, err)
+	}
+	for _, want := range []string{"ListTeams", "GetTeam"} {
+		if !strings.Contains(dup.Error(), want) {
+			t.Errorf("duplicate error missing source %q:\n%s", want, dup.Error())
+		}
+	}
+}
+
+// TestLoadSpecMalformedTrackingReturnsTypedError covers the AC: a malformed
+// extension fails with a typed error carrying the real OpenAPI path threaded
+// through a genuine libopenapi parse.
+func TestLoadSpecMalformedTrackingReturnsTypedError(t *testing.T) {
+	_, err := LoadSpec(filepath.Join("../testdata/parser", "tracking_malformed.yaml"))
+	var te *TrackingError
+	if !errors.As(err, &te) {
+		t.Fatalf("error %v (%T) is not a *TrackingError", err, err)
+	}
+	if te.Path != "/widgets" {
+		t.Errorf("TrackingError.Path = %q, want %q", te.Path, "/widgets")
 	}
 }

--- a/.generator-v2/internal/parser/parser_test.go
+++ b/.generator-v2/internal/parser/parser_test.go
@@ -189,10 +189,7 @@ func TestLoadSpecMalformedTrackingReturnsTypedError(t *testing.T) {
 
 // TestLoadSpecAllowsSameNameAcrossKinds is the LoadSpec-level counterpart to
 // Finding #1: a spec with a resource and a data source sharing one artifact_name
-// must load without a duplicate error, and both must decode with their kinds.
-//
-// NOTE: encodes the desired post-fix behavior — red until uniqueness keys on
-// (kind, name).
+// loads without a duplicate error, and both decode with their kinds.
 func TestLoadSpecAllowsSameNameAcrossKinds(t *testing.T) {
 	spec, err := LoadSpec(filepath.Join("../testdata/parser", "tracking_cross_kind_names.yaml"))
 	if err != nil {

--- a/.generator-v2/internal/parser/parser_test.go
+++ b/.generator-v2/internal/parser/parser_test.go
@@ -186,3 +186,26 @@ func TestLoadSpecMalformedTrackingReturnsTypedError(t *testing.T) {
 		t.Errorf("TrackingError.Path = %q, want %q", te.Path, "/widgets")
 	}
 }
+
+// TestLoadSpecAllowsSameNameAcrossKinds is the LoadSpec-level counterpart to
+// Finding #1: a spec with a resource and a data source sharing one artifact_name
+// must load without a duplicate error, and both must decode with their kinds.
+//
+// NOTE: encodes the desired post-fix behavior — red until uniqueness keys on
+// (kind, name).
+func TestLoadSpecAllowsSameNameAcrossKinds(t *testing.T) {
+	spec, err := LoadSpec(filepath.Join("../testdata/parser", "tracking_cross_kind_names.yaml"))
+	if err != nil {
+		t.Fatalf("a resource and data source sharing a name must load without error, got: %v", err)
+	}
+	byID := make(map[string]*model.Operation, len(spec.Operations))
+	for _, op := range spec.Operations {
+		byID[op.OperationId] = op
+	}
+	if r := byID["CreateTeam"]; r == nil || r.Tracking == nil || r.Tracking.ArtifactKind != model.ArtifactKindResource {
+		t.Errorf("CreateTeam resource tracking = %+v", r)
+	}
+	if d := byID["GetTeam"]; d == nil || d.Tracking == nil || d.Tracking.ArtifactKind != model.ArtifactKindDataSource {
+		t.Errorf("GetTeam data_source tracking = %+v", d)
+	}
+}

--- a/.generator-v2/internal/parser/tracking.go
+++ b/.generator-v2/internal/parser/tracking.go
@@ -17,8 +17,9 @@ import (
 // decodes by default. It can be overridden via WithTrackingFieldName (the
 // --tracking-field flag), which is reserved for generator-internal fixture
 // tests.
-
-// TODO: will have to be changed later once global cli flags are wired. Default value should be set there.
+//
+// TODO: once the global CLI flags are wired, the default should be set there
+// (on the --tracking-field flag) rather than here.
 const DefaultTrackingFieldName = "x-datadog-tf-generator"
 
 // compiledSchema compiles the embedded tracking-field schema exactly once for
@@ -31,11 +32,21 @@ var compiledSchema = sync.OnceValues(func() (*jsonschema.Schema, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parser: parsing embedded tracking-field schema: %w", err)
 	}
+	// Register and compile under the schema's own $id, so the JSON file is the
+	// single source of truth for that identifier.
+	obj, ok := doc.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("parser: embedded tracking-field schema is not a JSON object")
+	}
+	id, ok := obj["$id"].(string)
+	if !ok || id == "" {
+		return nil, fmt.Errorf("parser: embedded tracking-field schema has no $id")
+	}
 	c := jsonschema.NewCompiler()
-	if err := c.AddResource(contracts.TrackingFieldSchemaID, doc); err != nil {
+	if err := c.AddResource(id, doc); err != nil {
 		return nil, fmt.Errorf("parser: registering tracking-field schema: %w", err)
 	}
-	sch, err := c.Compile(contracts.TrackingFieldSchemaID)
+	sch, err := c.Compile(id)
 	if err != nil {
 		return nil, fmt.Errorf("parser: compiling tracking-field schema: %w", err)
 	}

--- a/.generator-v2/internal/parser/tracking.go
+++ b/.generator-v2/internal/parser/tracking.go
@@ -1,0 +1,118 @@
+package parser
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/contracts"
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+)
+
+// DefaultTrackingFieldName is the OpenAPI vendor-extension key the generator
+// decodes by default. It can be overridden via WithTrackingFieldName (the
+// --tracking-field flag), which is reserved for generator-internal fixture
+// tests.
+
+// TODO: will have to be changed later once global cli flags are wired. Default value should be set there.
+const DefaultTrackingFieldName = "x-datadog-tf-generator"
+
+// compiledSchema compiles the embedded tracking-field schema exactly once for
+// the life of the process. Compilation reads only the embedded bytes, so a
+// failure indicates a bug in the committed contract rather than anything
+// attributable to the spec under test. Compiled schemas are safe for
+// concurrent Validate calls.
+var compiledSchema = sync.OnceValues(func() (*jsonschema.Schema, error) {
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(contracts.TrackingFieldSchema))
+	if err != nil {
+		return nil, fmt.Errorf("parser: parsing embedded tracking-field schema: %w", err)
+	}
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource(contracts.TrackingFieldSchemaID, doc); err != nil {
+		return nil, fmt.Errorf("parser: registering tracking-field schema: %w", err)
+	}
+	sch, err := c.Compile(contracts.TrackingFieldSchemaID)
+	if err != nil {
+		return nil, fmt.Errorf("parser: compiling tracking-field schema: %w", err)
+	}
+	return sch, nil
+})
+
+// TrackingError reports a malformed tracking-field extension. It names the
+// OpenAPI location (method + path + operationId) so the spec author can find
+// the offending operation, and wraps the underlying validation or decode
+// failure for errors.As / Unwrap.
+type TrackingError struct {
+	Path        string
+	Method      string
+	OperationId string
+	Cause       error
+}
+
+func (e *TrackingError) Error() string {
+	return fmt.Sprintf("parser: invalid tracking-field extension on %s %s (operationId %q): %v",
+		e.Method, e.Path, e.OperationId, e.Cause)
+}
+
+func (e *TrackingError) Unwrap() error { return e.Cause }
+
+// DecodeTracking decodes and validates the tracking-field extension (named by
+// extensionName) on op. It returns (nil, nil) when op is out of scope: it
+// carries no extensions, the extension is absent, or the extension sets
+// skip:true (a documented opt-out equivalent to removing the annotation). A
+// malformed extension yields a *TrackingError naming the OpenAPI location at
+// path/method.
+//
+// op alone does not know its own OpenAPI path, so path and method are supplied
+// by the caller (LoadSpec) for the error message.
+func DecodeTracking(op *v3.Operation, path, method, extensionName string) (*model.TrackingFieldMetadata, error) {
+	if op == nil || op.Extensions == nil {
+		return nil, nil
+	}
+	node := op.Extensions.GetOrZero(extensionName)
+	if node == nil {
+		return nil, nil // absent → out of scope
+	}
+
+	wrap := func(cause error) error {
+		return &TrackingError{Path: path, Method: method, OperationId: op.OperationId, Cause: cause}
+	}
+
+	// Decode once into a generic value to validate against the JSON schema —
+	// the single source of truth for the extension's shape.
+	var raw any
+	if err := node.Decode(&raw); err != nil {
+		return nil, wrap(fmt.Errorf("decoding extension node: %w", err))
+	}
+	sch, err := compiledSchema()
+	if err != nil {
+		return nil, err // committed-contract bug, not author-attributable
+	}
+	if err := sch.Validate(raw); err != nil {
+		return nil, wrap(err)
+	}
+
+	// Shape is valid: project onto the typed metadata. The model carries JSON
+	// tags (the snake_case keys, and how it later round-trips into the run
+	// report), so bridge YAML→JSON rather than decoding the node directly —
+	// go.yaml.in/yaml honors yaml tags, which the model does not declare.
+	jsonBytes, err := json.Marshal(raw)
+	if err != nil {
+		return nil, wrap(fmt.Errorf("re-encoding extension: %w", err))
+	}
+	var meta model.TrackingFieldMetadata
+	if err := json.Unmarshal(jsonBytes, &meta); err != nil {
+		return nil, wrap(fmt.Errorf("decoding extension into metadata: %w", err))
+	}
+	if meta.Skip {
+		return nil, nil
+	}
+	if meta.IdStrategy == "" {
+		meta.IdStrategy = model.IdStrategyDataID // schema default "data.id"
+	}
+	return &meta, nil
+}

--- a/.generator-v2/internal/parser/tracking.go
+++ b/.generator-v2/internal/parser/tracking.go
@@ -82,12 +82,25 @@ func DecodeTracking(op *v3.Operation, path, method, extensionName string) (*mode
 		return &TrackingError{Path: path, Method: method, OperationId: op.OperationId, Cause: cause}
 	}
 
-	// Decode once into a generic value to validate against the JSON schema —
-	// the single source of truth for the extension's shape.
+	// Decode once into a generic value. It must stay `any`: the validator works
+	// on JSON-native values (map[string]any/…), not Go structs, and the model
+	// declares no yaml tags — so decoding straight into the struct would both
+	// fail validation and silently drop the snake_case keys.
 	var raw any
 	if err := node.Decode(&raw); err != nil {
 		return nil, wrap(fmt.Errorf("decoding extension node: %w", err))
 	}
+
+	// Honor an explicit skip:true before validating: it is a documented opt-out
+	// equivalent to removing the extension, so a skipped operation is out of
+	// scope and must not surface shape errors. Only a real boolean true counts;
+	// any other value falls through to validation (a non-bool skip is invalid).
+	if m, ok := raw.(map[string]any); ok {
+		if skip, _ := m["skip"].(bool); skip {
+			return nil, nil
+		}
+	}
+
 	sch, err := compiledSchema()
 	if err != nil {
 		return nil, err // committed-contract bug, not author-attributable
@@ -107,9 +120,6 @@ func DecodeTracking(op *v3.Operation, path, method, extensionName string) (*mode
 	var meta model.TrackingFieldMetadata
 	if err := json.Unmarshal(jsonBytes, &meta); err != nil {
 		return nil, wrap(fmt.Errorf("decoding extension into metadata: %w", err))
-	}
-	if meta.Skip {
-		return nil, nil
 	}
 	if meta.IdStrategy == "" {
 		meta.IdStrategy = model.IdStrategyDataID // schema default "data.id"

--- a/.generator-v2/internal/parser/tracking_test.go
+++ b/.generator-v2/internal/parser/tracking_test.go
@@ -1,0 +1,209 @@
+package parser
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/pb33f/libopenapi/orderedmap"
+	yaml "go.yaml.in/yaml/v4"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+)
+
+const (
+	trackPath   = "/api/v2/things"
+	trackMethod = "POST"
+)
+
+// opWithExt builds a *v3.Operation carrying a single vendor extension under
+// key, whose value is the YAML mapping in body — mirroring how libopenapi
+// stores an extension (the mapping node, i.e. the parsed document's Content[0]).
+func opWithExt(t *testing.T, operationId, key, body string) *v3.Operation {
+	t.Helper()
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(body), &doc); err != nil {
+		t.Fatalf("unmarshal extension body: %v", err)
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		t.Fatalf("expected a YAML document node with content, got kind %d", doc.Kind)
+	}
+	ext := orderedmap.ToOrderedMap(map[string]*yaml.Node{key: doc.Content[0]})
+	return &v3.Operation{OperationId: operationId, Extensions: ext}
+}
+
+func TestDecodeTrackingOutOfScopeReturnsNil(t *testing.T) {
+	t.Run("nil operation", func(t *testing.T) {
+		got, err := DecodeTracking(nil, trackPath, trackMethod, DefaultTrackingFieldName)
+		if got != nil || err != nil {
+			t.Fatalf("got (%v, %v), want (nil, nil)", got, err)
+		}
+	})
+	t.Run("no extensions", func(t *testing.T) {
+		got, err := DecodeTracking(&v3.Operation{OperationId: "Op"}, trackPath, trackMethod, DefaultTrackingFieldName)
+		if got != nil || err != nil {
+			t.Fatalf("got (%v, %v), want (nil, nil)", got, err)
+		}
+	})
+	t.Run("different extension key present", func(t *testing.T) {
+		op := opWithExt(t, "Op", "x-some-other-extension", "foo: bar\n")
+		got, err := DecodeTracking(op, trackPath, trackMethod, DefaultTrackingFieldName)
+		if got != nil || err != nil {
+			t.Fatalf("got (%v, %v), want (nil, nil)", got, err)
+		}
+	})
+	t.Run("skip true", func(t *testing.T) {
+		op := opWithExt(t, "Op", DefaultTrackingFieldName,
+			"artifact_kind: resource\nartifact_name: thing\ngroup:\n  read: GetThing\nskip: true\n")
+		got, err := DecodeTracking(op, trackPath, trackMethod, DefaultTrackingFieldName)
+		if got != nil || err != nil {
+			t.Fatalf("got (%v, %v), want (nil, nil)", got, err)
+		}
+	})
+}
+
+func TestDecodeTrackingValidResource(t *testing.T) {
+	op := opWithExt(t, "CreateIncidentType", DefaultTrackingFieldName, `
+artifact_kind: resource
+artifact_name: incident_type
+group:
+  create: CreateIncidentType
+  read: GetIncidentType
+  update: UpdateIncidentType
+  delete: DeleteIncidentType
+id_strategy: data.attributes.id
+`)
+	got, err := DecodeTracking(op, trackPath, trackMethod, DefaultTrackingFieldName)
+	if err != nil {
+		t.Fatalf("DecodeTracking: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected metadata, got nil")
+	}
+	if got.ArtifactKind != model.ArtifactKindResource {
+		t.Errorf("ArtifactKind = %q, want %q", got.ArtifactKind, model.ArtifactKindResource)
+	}
+	if got.ArtifactName != "incident_type" {
+		t.Errorf("ArtifactName = %q, want %q", got.ArtifactName, "incident_type")
+	}
+	if got.IdStrategy != model.IdStrategyDataAttributesID {
+		t.Errorf("IdStrategy = %q, want %q", got.IdStrategy, model.IdStrategyDataAttributesID)
+	}
+	if got.Group == nil || got.Group.Create != "CreateIncidentType" || got.Group.Delete != "DeleteIncidentType" {
+		t.Errorf("Group = %+v, want full CRUD", got.Group)
+	}
+}
+
+func TestDecodeTrackingValidDataSource(t *testing.T) {
+	op := opWithExt(t, "GetTeam", DefaultTrackingFieldName, `
+artifact_kind: data_source
+artifact_name: team
+group:
+  read: GetTeam
+`)
+	got, err := DecodeTracking(op, trackPath, trackMethod, DefaultTrackingFieldName)
+	if err != nil {
+		t.Fatalf("DecodeTracking: %v", err)
+	}
+	if got == nil || got.ArtifactKind != model.ArtifactKindDataSource {
+		t.Fatalf("got %+v, want data_source kind", got)
+	}
+	if got.Group == nil || got.Group.Read != "GetTeam" {
+		t.Errorf("Group = %+v, want Read=GetTeam", got.Group)
+	}
+}
+
+func TestDecodeTrackingDefaultsIdStrategy(t *testing.T) {
+	op := opWithExt(t, "GetTeam", DefaultTrackingFieldName, `
+artifact_kind: data_source
+artifact_name: team
+group:
+  read: GetTeam
+`)
+	got, err := DecodeTracking(op, trackPath, trackMethod, DefaultTrackingFieldName)
+	if err != nil {
+		t.Fatalf("DecodeTracking: %v", err)
+	}
+	if got.IdStrategy != model.IdStrategyDataID {
+		t.Errorf("IdStrategy = %q, want applied default %q", got.IdStrategy, model.IdStrategyDataID)
+	}
+}
+
+// TestDecodeTrackingSensitiveAccepted proves additionalProperties:false does
+// not reject the declared optional sensitive property.
+func TestDecodeTrackingSensitiveAccepted(t *testing.T) {
+	op := opWithExt(t, "GetSecret", DefaultTrackingFieldName, `
+artifact_kind: data_source
+artifact_name: secret
+group:
+  read: GetSecret
+sensitive: true
+`)
+	got, err := DecodeTracking(op, trackPath, trackMethod, DefaultTrackingFieldName)
+	if err != nil {
+		t.Fatalf("DecodeTracking: %v", err)
+	}
+	if got == nil || !got.Sensitive {
+		t.Fatalf("got %+v, want Sensitive=true", got)
+	}
+}
+
+func TestDecodeTrackingMalformedReturnsTrackingError(t *testing.T) {
+	cases := map[string]string{
+		"missing artifact_name": "artifact_kind: resource\n",
+		"missing artifact_kind": "artifact_name: thing\n",
+		"unknown artifact_kind": "artifact_kind: widget\nartifact_name: thing\n",
+		"unknown property":      "artifact_kind: resource\nartifact_name: thing\nbogus: 1\n",
+		"bad name pattern":      "artifact_kind: resource\nartifact_name: NotSnake\n",
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			op := opWithExt(t, "Op", DefaultTrackingFieldName, body)
+			got, err := DecodeTracking(op, trackPath, trackMethod, DefaultTrackingFieldName)
+			if got != nil {
+				t.Errorf("expected nil metadata on error, got %+v", got)
+			}
+			var te *TrackingError
+			if !errors.As(err, &te) {
+				t.Fatalf("error %v (%T) is not a *TrackingError", err, err)
+			}
+		})
+	}
+}
+
+func TestDecodeTrackingErrorNamesOpenAPILocation(t *testing.T) {
+	op := opWithExt(t, "CreateWidget", DefaultTrackingFieldName, "artifact_kind: widget\nartifact_name: widget\n")
+	_, err := DecodeTracking(op, "/api/v2/widgets", "POST", DefaultTrackingFieldName)
+	var te *TrackingError
+	if !errors.As(err, &te) {
+		t.Fatalf("error %v (%T) is not a *TrackingError", err, err)
+	}
+	if te.Path != "/api/v2/widgets" || te.Method != "POST" || te.OperationId != "CreateWidget" {
+		t.Errorf("location = %s %s (%s), want POST /api/v2/widgets (CreateWidget)", te.Method, te.Path, te.OperationId)
+	}
+	if !strings.Contains(te.Error(), "/api/v2/widgets") {
+		t.Errorf("error message %q does not contain the OpenAPI path", te.Error())
+	}
+}
+
+// TestDecodeTrackingHonorsCustomExtensionName covers the --tracking-field
+// override path (reserved for generator-internal fixture tests).
+func TestDecodeTrackingHonorsCustomExtensionName(t *testing.T) {
+	const custom = "x-tfgen-fixture"
+	op := opWithExt(t, "GetTeam", custom, "artifact_kind: data_source\nartifact_name: team\ngroup:\n  read: GetTeam\n")
+
+	got, err := DecodeTracking(op, trackPath, trackMethod, custom)
+	if err != nil {
+		t.Fatalf("DecodeTracking(custom): %v", err)
+	}
+	if got == nil || got.ArtifactName != "team" {
+		t.Fatalf("got %+v, want artifact_name team", got)
+	}
+
+	// The same op under the default name resolves to out-of-scope.
+	got, err = DecodeTracking(op, trackPath, trackMethod, DefaultTrackingFieldName)
+	if got != nil || err != nil {
+		t.Fatalf("got (%v, %v), want (nil, nil) under non-matching name", got, err)
+	}
+}

--- a/.generator-v2/internal/parser/tracking_test.go
+++ b/.generator-v2/internal/parser/tracking_test.go
@@ -61,6 +61,16 @@ func TestDecodeTrackingOutOfScopeReturnsNil(t *testing.T) {
 			t.Fatalf("got (%v, %v), want (nil, nil)", got, err)
 		}
 	})
+	// skip:true must short-circuit BEFORE validation — a skipped operation is
+	// out of scope, so even an otherwise-malformed extension produces no error.
+	t.Run("skip true bypasses validation", func(t *testing.T) {
+		op := opWithExt(t, "Op", DefaultTrackingFieldName,
+			"artifact_kind: widget\nbogus: 1\nskip: true\n") // bad kind, unknown prop, missing name
+		got, err := DecodeTracking(op, trackPath, trackMethod, DefaultTrackingFieldName)
+		if got != nil || err != nil {
+			t.Fatalf("got (%v, %v), want (nil, nil) — skip must bypass validation", got, err)
+		}
+	})
 }
 
 func TestDecodeTrackingValidResource(t *testing.T) {
@@ -114,39 +124,79 @@ group:
 	}
 }
 
-func TestDecodeTrackingDefaultsIdStrategy(t *testing.T) {
-	op := opWithExt(t, "GetTeam", DefaultTrackingFieldName, `
-artifact_kind: data_source
-artifact_name: team
-group:
-  read: GetTeam
-`)
-	got, err := DecodeTracking(op, trackPath, trackMethod, DefaultTrackingFieldName)
-	if err != nil {
-		t.Fatalf("DecodeTracking: %v", err)
-	}
-	if got.IdStrategy != model.IdStrategyDataID {
-		t.Errorf("IdStrategy = %q, want applied default %q", got.IdStrategy, model.IdStrategyDataID)
-	}
-}
+// TestDecodeTrackingOptionalFields covers each non-required field both present
+// and omitted. The required pair (artifact_kind + artifact_name) alone is a
+// schema-valid extension, so it is the base every case builds on.
+func TestDecodeTrackingOptionalFields(t *testing.T) {
+	const required = "artifact_kind: data_source\nartifact_name: team\n"
 
-// TestDecodeTrackingSensitiveAccepted proves additionalProperties:false does
-// not reject the declared optional sensitive property.
-func TestDecodeTrackingSensitiveAccepted(t *testing.T) {
-	op := opWithExt(t, "GetSecret", DefaultTrackingFieldName, `
-artifact_kind: data_source
-artifact_name: secret
-group:
-  read: GetSecret
-sensitive: true
-`)
-	got, err := DecodeTracking(op, trackPath, trackMethod, DefaultTrackingFieldName)
-	if err != nil {
-		t.Fatalf("DecodeTracking: %v", err)
+	decode := func(t *testing.T, body string) *model.TrackingFieldMetadata {
+		t.Helper()
+		op := opWithExt(t, "Op", DefaultTrackingFieldName, body)
+		got, err := DecodeTracking(op, trackPath, trackMethod, DefaultTrackingFieldName)
+		if err != nil {
+			t.Fatalf("DecodeTracking: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected metadata, got nil")
+		}
+		return got
 	}
-	if got == nil || !got.Sensitive {
-		t.Fatalf("got %+v, want Sensitive=true", got)
-	}
+
+	// All four optional fields omitted: group nil, id_strategy defaulted,
+	// sensitive/skip false. Also confirms a groupless extension is schema-valid.
+	t.Run("all omitted", func(t *testing.T) {
+		got := decode(t, required)
+		if got.Group != nil {
+			t.Errorf("Group = %+v, want nil when omitted", got.Group)
+		}
+		if got.IdStrategy != model.IdStrategyDataID {
+			t.Errorf("IdStrategy = %q, want default %q", got.IdStrategy, model.IdStrategyDataID)
+		}
+		if got.Sensitive {
+			t.Error("Sensitive = true, want false when omitted")
+		}
+		if got.Skip {
+			t.Error("Skip = true, want false when omitted")
+		}
+	})
+
+	t.Run("group present", func(t *testing.T) {
+		got := decode(t, required+"group:\n  create: C\n  read: R\n  update: U\n  delete: D\n")
+		if got.Group == nil {
+			t.Fatal("Group = nil, want populated")
+		}
+		if got.Group.Create != "C" || got.Group.Read != "R" || got.Group.Update != "U" || got.Group.Delete != "D" {
+			t.Errorf("Group = %+v, want C/R/U/D", got.Group)
+		}
+	})
+
+	t.Run("id_strategy present", func(t *testing.T) {
+		got := decode(t, required+"id_strategy: data.attributes.uuid\n")
+		if got.IdStrategy != model.IdStrategyDataAttributesUID {
+			t.Errorf("IdStrategy = %q, want %q", got.IdStrategy, model.IdStrategyDataAttributesUID)
+		}
+	})
+
+	// sensitive present also proves additionalProperties:false does not reject
+	// the declared optional property.
+	t.Run("sensitive present", func(t *testing.T) {
+		got := decode(t, required+"sensitive: true\n")
+		if !got.Sensitive {
+			t.Error("Sensitive = false, want true")
+		}
+	})
+
+	// skip:true is the one optional field whose presence changes control flow —
+	// it short-circuits to (nil, nil) before validation (covered in
+	// TestDecodeTrackingOutOfScopeReturnsNil). An explicit skip:false decodes
+	// normally.
+	t.Run("skip false present", func(t *testing.T) {
+		got := decode(t, required+"skip: false\n")
+		if got.Skip {
+			t.Error("Skip = true, want false")
+		}
+	})
 }
 
 func TestDecodeTrackingMalformedReturnsTrackingError(t *testing.T) {

--- a/.generator-v2/internal/parser/tracking_test.go
+++ b/.generator-v2/internal/parser/tracking_test.go
@@ -53,16 +53,9 @@ func TestDecodeTrackingOutOfScopeReturnsNil(t *testing.T) {
 			t.Fatalf("got (%v, %v), want (nil, nil)", got, err)
 		}
 	})
-	t.Run("skip true", func(t *testing.T) {
-		op := opWithExt(t, "Op", DefaultTrackingFieldName,
-			"artifact_kind: resource\nartifact_name: thing\ngroup:\n  read: GetThing\nskip: true\n")
-		got, err := DecodeTracking(op, trackPath, trackMethod, DefaultTrackingFieldName)
-		if got != nil || err != nil {
-			t.Fatalf("got (%v, %v), want (nil, nil)", got, err)
-		}
-	})
-	// skip:true must short-circuit BEFORE validation — a skipped operation is
-	// out of scope, so even an otherwise-malformed extension produces no error.
+	// skip:true short-circuits BEFORE validation — a skipped operation is out of
+	// scope, so even an otherwise-malformed extension produces no error (which
+	// also subsumes a well-formed annotation carrying skip:true).
 	t.Run("skip true bypasses validation", func(t *testing.T) {
 		op := opWithExt(t, "Op", DefaultTrackingFieldName,
 			"artifact_kind: widget\nbogus: 1\nskip: true\n") // bad kind, unknown prop, missing name

--- a/.generator-v2/internal/testdata/parser/tracking_cross_kind_names.yaml
+++ b/.generator-v2/internal/testdata/parser/tracking_cross_kind_names.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.0
+info:
+  title: tracking cross-kind names fixture
+  version: 1.0.0
+# A resource and a data source share the artifact_name "team". They live in
+# separate Terraform namespaces (datadog_team resource vs datadog_team data
+# source), so this must NOT be reported as a duplicate.
+paths:
+  /teams:
+    post:
+      operationId: CreateTeam
+      x-datadog-tf-generator:
+        artifact_kind: resource
+        artifact_name: team
+        group:
+          create: CreateTeam
+          read: GetTeam
+      responses:
+        '201':
+          description: created
+  /teams/{id}:
+    get:
+      operationId: GetTeam
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      x-datadog-tf-generator:
+        artifact_kind: data_source
+        artifact_name: team
+        group:
+          read: GetTeam
+      responses:
+        '200':
+          description: ok

--- a/.generator-v2/internal/testdata/parser/tracking_duplicate.yaml
+++ b/.generator-v2/internal/testdata/parser/tracking_duplicate.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: tracking duplicate fixture
+  version: 1.0.0
+paths:
+  /teams:
+    get:
+      operationId: ListTeams
+      x-datadog-tf-generator:
+        artifact_kind: data_source
+        artifact_name: team
+        group:
+          read: ListTeams
+      responses:
+        '200':
+          description: ok
+  /teams/{id}:
+    get:
+      operationId: GetTeam
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      x-datadog-tf-generator:
+        artifact_kind: data_source
+        artifact_name: team
+        group:
+          read: GetTeam
+      responses:
+        '200':
+          description: ok

--- a/.generator-v2/internal/testdata/parser/tracking_malformed.yaml
+++ b/.generator-v2/internal/testdata/parser/tracking_malformed.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.0
+info:
+  title: tracking malformed fixture
+  version: 1.0.0
+paths:
+  /widgets:
+    post:
+      operationId: CreateWidget
+      x-datadog-tf-generator:
+        artifact_kind: widget
+        artifact_name: widget
+      responses:
+        '201':
+          description: created

--- a/.generator-v2/internal/testdata/parser/tracking_valid.yaml
+++ b/.generator-v2/internal/testdata/parser/tracking_valid.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.0
+info:
+  title: tracking valid fixture
+  version: 1.0.0
+paths:
+  /incident_types:
+    post:
+      operationId: CreateIncidentType
+      x-datadog-tf-generator:
+        artifact_kind: resource
+        artifact_name: incident_type
+        group:
+          create: CreateIncidentType
+          read: GetIncidentType
+          update: UpdateIncidentType
+          delete: DeleteIncidentType
+      responses:
+        '201':
+          description: created
+  /teams/{id}:
+    get:
+      operationId: GetTeam
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      x-datadog-tf-generator:
+        artifact_kind: data_source
+        artifact_name: team
+        group:
+          read: GetTeam
+      responses:
+        '200':
+          description: ok
+  /health:
+    get:
+      operationId: GetHealth
+      responses:
+        '200':
+          description: ok


### PR DESCRIPTION
## Changes

Decodes the `x-datadog-tf-generator` vendor extension into typed metadata on
`model.Operation.Tracking` during `LoadSpec`, and enforces global uniqueness of the resulting
`artifact_name`. Both run inside a single `LoadSpec` call, which now returns a fully-populated
`*model.Spec` or an actionable error.

- **`parser.DecodeTracking(op, path, method, extensionName) (*model.TrackingFieldMetadata, error)`** — parses the extension into a typed `*model.TrackingFieldMetadata` (`artifact_kind`,
`artifact_name`, `group`, `id_strategy`, `sensitive`, `skip`) for downstream codegen,
applying the `id_strategy` default (`data.id`). Before populating the struct it validates the
raw value at runtime against the committed JSON Schema
(`internal/contracts/tracking-field.schema.json`, embedded via a new `contracts` package), so
callers only ever get well-formed metadata back. Returns `(nil, nil)` when the operation is
out of scope (no extension, or `skip: true`), and a typed `*TrackingError` naming the OpenAPI
location (method + path + operationId) when the extension is malformed (unknown
`artifact_kind`, missing required field, unknown property, bad name pattern, …).
- **`parser.CheckDuplicateArtifactNames(spec)`** — walks every `Operation.Tracking` and fails
with a single aggregated `*DuplicateArtifactNameError` listing each `artifact_name` collision
and **all** of its source locations, sorted by name then (path, method) for deterministic
output.
- **Pipeline wiring** — decode happens per-operation in the enumeration loop (storing the
metadata on `Operation.Tracking`, fail-fast on a malformed extension); the duplicate check
runs after the deterministic sort.
- **`--tracking-field`** **seam** — adds a `WithTrackingFieldName` `LoadSpec` option and threads
`flags.trackingField` through the `generate` command, mirroring the existing `--max-depth`
wiring.
- **New dependency** — `github.com/santhosh-tekuri/jsonschema/v6` (a JSON-Schema validator,
_not_ a second OAS parser).

> Note: the model carries `json:` tags, so once the value is validated `DecodeTracking`
> bridges YAML→JSON (`json.Marshal`/`Unmarshal`) to fill the typed struct, rather than decoding
> the `yaml.Node` directly.

## Test Plan

New coverage — **decode (asserts the returned metadata):** valid resource / valid data source
(kind, name, group, id_strategy populated), absent extension, `skip:true`, missing required
fields, unknown `artifact_kind`, unknown property (`additionalProperties:false`), bad
`artifact_name` pattern, applied `id_strategy` default, error-carries-OpenAPI-path, custom
extension name. **Duplicates:** none / single collision / all-sources-listed /
multiple-collisions-sorted / ignores-untracked / deterministic-across-input-order. **LoadSpec**
**wiring fixtures:** tracking populated (resource + data source + unflagged op), duplicate →
typed error naming both ops, malformed → typed error carrying the real OpenAPI path.

```sh
❯ make tfgen-test
cd .generator-v2 && go test ./internal/... ./cmd/tfgen/...
ok    generator/internal/cli        0.505s
?     generator/internal/contracts  [no test files]
ok    generator/internal/model      0.495s
ok    generator/internal/parser     0.561s
      generator/cmd/tfgen           [no test files]
tfgen tests passed
```

## Follow-ups / action items

- [ ] **Remove the parser-side default extension name once the global CLI flags are wired into**
**the cobra root (APIR-2923).** `DefaultTrackingFieldName` and the empty-name fallback are a
temporary stopgap so `LoadSpec` is usable standalone — the real default
(`x-datadog-tf-generator`) already lives on the `--tracking-field` flag in `root.go`. Once the
wiring guarantees the name is always supplied, delete:
    - the `DefaultTrackingFieldName` const — `internal/parser/tracking.go`
    - the `if name != ""` fallback in `WithTrackingFieldName` **and** the `trackingFieldName: DefaultTrackingFieldName` seed in `LoadSpec` — `internal/parser/parser.go`

    …so the extension name has a single source of truth (the CLI flag), instead of a default
defined in two places.

-  [ ] **Update OAS extension contract**

> ⚠️ **Note:** artifact-name uniqueness is enforced **per `artifact_kind`**, not globally — a
  `resource` and a `data_source` may share a name (matches Terraform's separate namespaces).
  This intentionally refines the literal AC; the schema is updated to match, but the ticket AC +
  APIR-2492 discovery doc still say "globally unique" and need an owner's confirmation.

