### PR TITLE
Fix GPG secret injection in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
   create_release:
     name: Create release
     runs-on: ubuntu-16-core-latest
+    environment: Main Branch
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
     steps:
       - name: Get GitHub App token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
   create_release:
     name: Create release
     runs-on: ubuntu-16-core-latest
-    environment: Main Branch
+    environment: release
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
     steps:
       - name: Get GitHub App token


### PR DESCRIPTION
## Summary

- Adds `environment: release` to the `create_release` job in the release workflow.

## Root cause

`GPG_PRIVATE_KEY` is stored as an environment secret scoped to the **release** GitHub environment. GitHub only injects environment secrets when a job explicitly declares `environment: <name>`. Without it, the secret resolves to an empty string and `paultyng/ghaction-import-gpg` fails with _"GPG private key required"_.

The branch protection on the environment (`master` and `release/*`) was correctly configured — the job simply never opted into the environment, so the secret was never made available.

Observed failure: https://github.com/DataDog/terraform-provider-datadog/actions/runs/26875509318/job/79261950744

## Test plan
- [ ] Merge a `release/*` PR and verify the release workflow completes successfully through the **Import GPG key** step.