### PR TITLE
[TFgen] Added a report structure

### DIFF
--- a/.generator-v2/go.mod
+++ b/.generator-v2/go.mod
@@ -5,6 +5,7 @@ go 1.25.8
 toolchain go1.26.1
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/pb33f/libopenapi v0.37.2
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2

--- a/.generator-v2/go.sum
+++ b/.generator-v2/go.sum
@@ -7,6 +7,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/pb33f/jsonpath v0.8.2 h1:Ou4C7zjYClBm97dfZjDCjdZGusJoynv/vrtiEKNfj2Y=

--- a/.generator-v2/internal/cli/generate.go
+++ b/.generator-v2/internal/cli/generate.go
@@ -25,13 +25,11 @@ func newGenerateCmd(flags *globalFlags) *cobra.Command {
 				return err
 			}
 			runReport := model.RunReport{
-				RunId: uuid.NewString(), 		// v4 uuid
-				GeneratorVersion: cmd.Version,	// Version stamped by main.go
-				SpecHash: spec.Hash,
-				StartedAt: time.Now(),
+				RunId:            uuid.NewString(),   // v4 uuid
+				GeneratorVersion: cmd.Root().Version, // Version stamped by main.go
+				SpecHash:         spec.Hash,
+				StartedAt:        time.Now(),
 			}
-
-
 
 			// TODO: model -> emit -> writer -> report, honoring --check and --include.
 			_ = spec

--- a/.generator-v2/internal/cli/generate.go
+++ b/.generator-v2/internal/cli/generate.go
@@ -1,8 +1,12 @@
 package cli
 
 import (
+	"time"
+
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
 	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/parser"
 )
 
@@ -20,11 +24,21 @@ func newGenerateCmd(flags *globalFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			runReport := model.RunReport{
+				RunId: uuid.NewString(), 		// v4 uuid
+				GeneratorVersion: cmd.Version,	// Version stamped by main.go
+				SpecHash: spec.Hash,
+				StartedAt: time.Now(),
+			}
+
+
 
 			// TODO: model -> emit -> writer -> report, honoring --check and --include.
 			_ = spec
 			_ = check
 			_ = include
+
+			runReport.FinishedAt = time.Now()
 			return nil
 		},
 	}

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -66,6 +66,8 @@ type Spec struct {
 	Operations []*Operation
 	// Components is the shared component set, retained for lazy $ref resolution.
 	Components *v3.Components
+	// Hash is the lowercase hex SHA-256 of the spec source
+	Hash string
 }
 
 // Operation is a single OpenAPI operation, tagged with whether it is in scope

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -9,6 +9,8 @@
 package model
 
 import (
+	"time"
+
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 )
 
@@ -204,4 +206,90 @@ type Mapper struct {
 	SdkPath string
 	// GoType is the Go type used at this mapping site, e.g. types.String.
 	GoType string
+}
+
+// ----------------------------------------------------------------------------
+// Run-report types
+//
+// Field names and JSON tags mirror contracts/run-report.schema.json so
+// report.WriteJSON can marshal a RunReport straight to the structured output
+// CI gates on.
+// ----------------------------------------------------------------------------
+
+// ArtifactStatus is the terminal state of an artifact in a generate run.
+type ArtifactStatus string
+
+const (
+	ArtifactStatusCreated   ArtifactStatus = "created"
+	ArtifactStatusUpdated   ArtifactStatus = "updated"
+	ArtifactStatusUnchanged ArtifactStatus = "unchanged"
+	ArtifactStatusSkipped   ArtifactStatus = "skipped"
+	ArtifactStatusFailed    ArtifactStatus = "failed"
+)
+
+// DiagnosticSeverity classifies a Diagnostic.
+type DiagnosticSeverity string
+
+const (
+	SeverityError   DiagnosticSeverity = "error"
+	SeverityWarning DiagnosticSeverity = "warning"
+	SeverityInfo    DiagnosticSeverity = "info"
+)
+
+// SkipReason explains why an operation produced no artifact.
+type SkipReason string
+
+const (
+	SkipReasonTrackingFieldAbsent SkipReason = "tracking_field_absent"
+	SkipReasonTrackingFieldSkip   SkipReason = "tracking_field_skip_true"
+)
+
+// RunReport is the structured output of a tfgen generate run.
+type RunReport struct {
+	RunId             string                `json:"run_id"`
+	GeneratorVersion  string                `json:"generator_version"`
+	SpecHash          string                `json:"spec_hash"`
+	StartedAt         time.Time             `json:"started_at"`
+	FinishedAt        time.Time             `json:"finished_at"`
+	Artifacts         []ArtifactReportEntry `json:"artifacts"`
+	SkippedOperations []SkippedOperation    `json:"skipped_operations,omitempty"`
+	Summary           *RunSummary           `json:"summary,omitempty"`
+}
+
+// RunSummary holds convenience counts for CI assertions, one per ArtifactStatus.
+type RunSummary struct {
+	Created   int `json:"created"`
+	Updated   int `json:"updated"`
+	Unchanged int `json:"unchanged"`
+	Skipped   int `json:"skipped"`
+	Failed    int `json:"failed"`
+}
+
+// ArtifactReportEntry is the per-artifact section of a RunReport.
+type ArtifactReportEntry struct {
+	Name        string         `json:"name"`
+	Kind        ArtifactKind   `json:"kind"`
+	Status      ArtifactStatus `json:"status"`
+	Path        string         `json:"path"`
+	Diagnostics []Diagnostic   `json:"diagnostics,omitempty"`
+	// OrphanedHooks lists hook functions declared but no longer referenced.
+	OrphanedHooks []string `json:"orphaned_hooks,omitempty"`
+}
+
+// Diagnostic is a single error/warning/info collected during generation.
+type Diagnostic struct {
+	Severity DiagnosticSeverity `json:"severity"`
+	Message  string             `json:"message"`
+	// Location is an optional source-side anchor,
+	// e.g. spec:components.schemas.Pet.properties.tags.
+	Location string `json:"location,omitempty"`
+}
+
+// SkippedOperation records an operation that produced no artifact, listed for
+// visibility rather than as a failure.
+type SkippedOperation struct {
+	OperationId string     `json:"operation_id"`
+	Path        string     `json:"path"`
+	Method      string     `json:"method"`
+	Reason      SkipReason `json:"reason"`
 }

--- a/.generator-v2/internal/parser/parser.go
+++ b/.generator-v2/internal/parser/parser.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"sort"
@@ -77,6 +79,7 @@ func LoadSpec(path string, opts ...Option) (*model.Spec, error) {
 	spec := &model.Spec{
 		Source:     path,
 		Components: v3doc.Model.Components,
+		Hash: specHash(data),
 	}
 
 	// Fail fast on an unresolvable schema graph before enumerating anything:
@@ -138,4 +141,9 @@ func firstTag(tags []string) string {
 		return tags[0]
 	}
 	return ""
+}
+
+func specHash(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
 }

--- a/.generator-v2/internal/parser/parser.go
+++ b/.generator-v2/internal/parser/parser.go
@@ -79,7 +79,7 @@ func LoadSpec(path string, opts ...Option) (*model.Spec, error) {
 	spec := &model.Spec{
 		Source:     path,
 		Components: v3doc.Model.Components,
-		Hash: specHash(data),
+		Hash:       specHash(data),
 	}
 
 	// Fail fast on an unresolvable schema graph before enumerating anything:

--- a/.generator-v2/internal/report/report.go
+++ b/.generator-v2/internal/report/report.go
@@ -15,7 +15,7 @@ import (
 //
 // The summary block is derived from the artifact statuses rather than trusted
 // from the caller, so its counts always agree with the artifacts array. CI
-// will eventually gates on these counts, so they must not drift.
+// will eventually gate on these counts, so they must not drift.
 // The caller's report is not mutated.
 //
 // Output is deterministic: field order is fixed and a RunReport carries no maps,

--- a/.generator-v2/internal/report/report.go
+++ b/.generator-v2/internal/report/report.go
@@ -1,0 +1,59 @@
+// Package report serializes a model.RunReport into the structured JSON consumed
+// by CI (to gate regeneration drift), by maintainers (to audit per-artifact
+// status), and by downstream tooling.
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+)
+
+// WriteJSON encodes report as indented JSON to writer.
+//
+// The summary block is derived from the artifact statuses rather than trusted
+// from the caller, so its counts always agree with the artifacts array. CI
+// will eventually gates on these counts, so they must not drift.
+// The caller's report is not mutated.
+//
+// Output is deterministic: field order is fixed and a RunReport carries no maps,
+// so identical reports serialize to identical bytes.
+func WriteJSON(writer io.Writer, report *model.RunReport) error {
+	if report == nil {
+		return fmt.Errorf("report: nil RunReport")
+	}
+
+	out := *report // shallow copy: set Summary for output without touching the caller's report
+	out.Summary = summarize(report.Artifacts)
+
+	enc := json.NewEncoder(writer)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(&out); err != nil {
+		return fmt.Errorf("report: encoding run report: %w", err)
+	}
+	return nil
+}
+
+// summarize tallies artifact entries by status into the convenience counts. The
+// five buckets correspond one-to-one to the ArtifactStatus values.
+func summarize(entries []model.ArtifactReportEntry) *model.RunSummary {
+	s := &model.RunSummary{}
+	for _, e := range entries {
+		switch e.Status {
+		case model.ArtifactStatusCreated:
+			s.Created++
+		case model.ArtifactStatusUpdated:
+			s.Updated++
+		case model.ArtifactStatusUnchanged:
+			s.Unchanged++
+		case model.ArtifactStatusSkipped:
+			s.Skipped++
+		case model.ArtifactStatusFailed:
+			s.Failed++
+		}
+	}
+	return s
+}

--- a/.generator-v2/internal/report/report_test.go
+++ b/.generator-v2/internal/report/report_test.go
@@ -1,0 +1,202 @@
+package report
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+)
+
+func fixedTime() time.Time { return time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC) }
+
+// sampleReport has one artifact in each ArtifactStatus, plus a diagnostic and a
+// skipped operation, so every summary bucket and every nested shape is covered.
+func sampleReport() *model.RunReport {
+	ts := fixedTime()
+	return &model.RunReport{
+		RunId:            "11111111-1111-1111-1111-111111111111",
+		GeneratorVersion: "v1.2.3",
+		SpecHash:         "abc123",
+		StartedAt:        ts,
+		FinishedAt:       ts,
+		Artifacts: []model.ArtifactReportEntry{
+			{Name: "pet", Kind: model.ArtifactKindDataSource, Status: model.ArtifactStatusCreated, Path: "datadog/fwprovider/data_source_datadog_pet.go"},
+			{Name: "team", Kind: model.ArtifactKindDataSource, Status: model.ArtifactStatusUnchanged, Path: "p2"},
+			{Name: "monitor", Kind: model.ArtifactKindResource, Status: model.ArtifactStatusUpdated, Path: "p3"},
+			{Name: "slo", Kind: model.ArtifactKindResource, Status: model.ArtifactStatusSkipped, Path: "p4"},
+			{
+				Name: "incident_type", Kind: model.ArtifactKindResource, Status: model.ArtifactStatusFailed, Path: "p5",
+				Diagnostics: []model.Diagnostic{{Severity: model.SeverityError, Message: "boom", Location: "spec:x"}},
+			},
+		},
+		SkippedOperations: []model.SkippedOperation{
+			{OperationId: "ListThings", Path: "/things", Method: "GET", Reason: model.SkipReasonTrackingFieldAbsent},
+		},
+	}
+}
+
+func writeToMap(t *testing.T, r *model.RunReport) map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, r); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
+	}
+	return m
+}
+
+func TestWriteJSONHasRequiredTopLevelFields(t *testing.T) {
+	m := writeToMap(t, sampleReport())
+
+	// Required  fields
+	for _, k := range []string{"run_id", "generator_version", "spec_hash", "started_at", "finished_at", "artifacts", "summary"} {
+		if _, ok := m[k]; !ok {
+			t.Errorf("missing required key %q", k)
+		}
+	}
+
+	for key, want := range map[string]any{
+		"run_id":            "11111111-1111-1111-1111-111111111111",
+		"generator_version": "v1.2.3",
+		"spec_hash":         "abc123",
+		"started_at":        "2026-06-03T12:00:00Z",
+		"finished_at":       "2026-06-03T12:00:00Z",
+	} {
+		if m[key] != want {
+			t.Errorf("%s = %v, want %v", key, m[key], want)
+		}
+	}
+}
+
+func TestWriteJSONSummaryCounts(t *testing.T) {
+	m := writeToMap(t, sampleReport())
+
+	sum, ok := m["summary"].(map[string]any)
+	if !ok {
+		t.Fatalf("summary missing or wrong type: %T", m["summary"])
+	}
+	want := map[string]float64{"created": 1, "updated": 1, "unchanged": 1, "skipped": 1, "failed": 1}
+	for k, v := range want {
+		got, ok := sum[k].(float64)
+		if !ok || got != v {
+			t.Errorf("summary[%q] = %v, want %v", k, sum[k], v)
+		}
+	}
+}
+
+// TestWriteJSONDerivesSummary proves the writer computes the summary from the
+// artifacts (ignoring a stale caller value) and does not mutate the caller's report.
+func TestWriteJSONDerivesSummary(t *testing.T) {
+	r := sampleReport()
+	r.Summary = &model.RunSummary{Created: 99} // deliberately wrong
+
+	sum := writeToMap(t, r)["summary"].(map[string]any)
+	if sum["created"].(float64) != 1 {
+		t.Errorf("writer should derive summary from artifacts, got created=%v", sum["created"])
+	}
+	if r.Summary == nil || r.Summary.Created != 99 {
+		t.Errorf("WriteJSON must not mutate the caller's report, Summary=%+v", r.Summary)
+	}
+}
+
+func TestWriteJSONArtifactAndSkippedShape(t *testing.T) {
+	m := writeToMap(t, sampleReport())
+
+	arts, ok := m["artifacts"].([]any)
+	if !ok || len(arts) != 5 {
+		t.Fatalf("artifacts = %v, want 5 entries", m["artifacts"])
+	}
+
+	first := arts[0].(map[string]any)
+	for _, k := range []string{"name", "kind", "status", "path"} {
+		if _, ok := first[k]; !ok {
+			t.Errorf("artifact entry missing required key %q", k)
+		}
+	}
+	if first["kind"] != "data_source" || first["status"] != "created" {
+		t.Errorf("artifact[0] kind/status = %v/%v, want data_source/created", first["kind"], first["status"])
+	}
+
+	// The failed artifact carries a diagnostic with severity + message + location.
+	diags := arts[4].(map[string]any)["diagnostics"].([]any)
+	d := diags[0].(map[string]any)
+	if d["severity"] != "error" || d["message"] != "boom" || d["location"] != "spec:x" {
+		t.Errorf("diagnostic = %v", d)
+	}
+
+	skipped, ok := m["skipped_operations"].([]any)
+	if !ok || len(skipped) != 1 {
+		t.Fatalf("skipped_operations = %v, want 1 entry", m["skipped_operations"])
+	}
+	so := skipped[0].(map[string]any)
+	for _, k := range []string{"operation_id", "path", "method", "reason"} {
+		if _, ok := so[k]; !ok {
+			t.Errorf("skipped operation missing required key %q", k)
+		}
+	}
+	if so["reason"] != "tracking_field_absent" || so["method"] != "GET" {
+		t.Errorf("skipped operation = %v", so)
+	}
+}
+
+func TestWriteJSONOmitsEmptyOptionalFields(t *testing.T) {
+	ts := fixedTime()
+	r := &model.RunReport{
+		RunId: "x", GeneratorVersion: "v", SpecHash: "h", StartedAt: ts, FinishedAt: ts,
+		Artifacts: []model.ArtifactReportEntry{
+			{Name: "a", Kind: model.ArtifactKindDataSource, Status: model.ArtifactStatusUnchanged, Path: "p"},
+		},
+	}
+	m := writeToMap(t, r)
+
+	if _, ok := m["skipped_operations"]; ok {
+		t.Error("skipped_operations should be omitted when empty")
+	}
+	art := m["artifacts"].([]any)[0].(map[string]any)
+	if _, ok := art["diagnostics"]; ok {
+		t.Error("diagnostics should be omitted when empty")
+	}
+	if _, ok := art["orphaned_hooks"]; ok {
+		t.Error("orphaned_hooks should be omitted when empty")
+	}
+	if _, ok := m["summary"]; !ok {
+		t.Error("summary should always be present, even with no skipped/failed artifacts")
+	}
+}
+
+func TestWriteJSONDeterministic(t *testing.T) {
+	r := sampleReport()
+	var a, b bytes.Buffer
+	if err := WriteJSON(&a, r); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	if err := WriteJSON(&b, r); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	if a.String() != b.String() {
+		t.Errorf("non-deterministic output:\n--- run 1 ---\n%s\n--- run 2 ---\n%s", a.String(), b.String())
+	}
+}
+
+func TestWriteJSONNilReport(t *testing.T) {
+	if err := WriteJSON(io.Discard, nil); err == nil {
+		t.Error("expected an error for a nil report")
+	}
+}
+
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) { return 0, errors.New("write failed") }
+
+func TestWriteJSONPropagatesWriterError(t *testing.T) {
+	if err := WriteJSON(errWriter{}, sampleReport()); err == nil {
+		t.Error("expected WriteJSON to propagate the writer error")
+	}
+}


### PR DESCRIPTION
## Summary

Adds the run-report layer for the tfgen generator (FR-014). report.WriteJSON serializes a model.RunReport to JSON matching contracts/run-report.schema.json, deriving the per-status summary from the artifacts so the counts CI gates on can't drift from the artifact list. The report types (RunReport, ArtifactReportEntry, Diagnostic, SkippedOperation, RunSummary + status/severity/reason enums) live in internal/model.

The generate command now initializes a report with the fields it can populate up front — a fresh v4 run ID (google/uuid), the build-stamped generator version (main.Version), the spec SHA-256 (specHash in the parser), and start/finish timestamps. Per-artifact entries are filled in by the generation pipeline in a later change.

## Test Plan

New report_test.go covers required fields, derived summary counts, nested artifact/skipped/diagnostic shape, omitempty behavior, determinism, and the nil/writer-error paths.
