### PR TITLE
Run integration tests for PRs from forks

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -3,8 +3,11 @@ name: Run Integration Tests
 permissions:
   contents: read
 
+# pull_request_target so that PRs from forks can mint Datadog credentials via
+# OIDC. The credentialed job checks out the PR head and, for forks, runs in the
+# forks-prs environment.
 on: # yamllint disable-line rule:truthy
-  pull_request:
+  pull_request_target:
     types:
       - labeled
       - unlabeled
@@ -25,10 +28,25 @@ env:
 jobs:
   integration_tests:
     runs-on: ubuntu-latest
-    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci/integrations')) || github.event_name == 'schedule'
+    if: (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'ci/integrations')) || github.event_name == 'schedule'
+    # Fork PRs run untrusted code with live (short-lived, test-org) credentials,
+    # so they run in the forks-prs environment. The scheduled run on master uses
+    # no environment gate.
+    environment: ${{ github.event.pull_request.head.repo.fork && 'forks-prs' || '' }}
+    permissions:
+      contents: read
+      id-token: write # Required to mint Datadog credentials via dd-sts
     steps:
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        with:
+          # PR head for pull_request_target; the triggering ref for the schedule.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Mint Datadog credentials
+        id: dd-sts
+        uses: DataDog/dd-sts-action@7d2d231c02fd54a3da912e582ff87cb995d1fd30 # v1.0.4
+        with:
+          policy: terraform-provider-datadog
       - name: Install Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
@@ -48,8 +66,8 @@ jobs:
       - name: Sweep stale test resources
         run: make sweep
         env:
-          DD_TEST_CLIENT_API_KEY: ${{ secrets.DD_CLIENT_API_KEY }}
-          DD_TEST_CLIENT_APP_KEY: ${{ secrets.DD_CLIENT_APP_KEY }}
+          DD_TEST_CLIENT_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
+          DD_TEST_CLIENT_APP_KEY: ${{ steps.dd-sts.outputs.app_key }}
       - name: Build skip list for flaky tests
         id: skip-list
         run: |
@@ -65,8 +83,8 @@ jobs:
         env:
           RECORD: "none"
           CI: "true"
-          DD_TEST_CLIENT_API_KEY: ${{ secrets.DD_CLIENT_API_KEY }}
-          DD_TEST_CLIENT_APP_KEY: ${{ secrets.DD_CLIENT_APP_KEY }}
+          DD_TEST_CLIENT_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
+          DD_TEST_CLIENT_APP_KEY: ${{ steps.dd-sts.outputs.app_key }}
           DD_HTTP_CLIENT_RETRY_ENABLED: "true"
           TF_ACC_TERRAFORM_PATH: "/home/runner/.cache/terraform/terraform"
           TF_ACC_TEMP_DIR: "/tmp"

--- a/.github/workflows/test_pr_integration.yml
+++ b/.github/workflows/test_pr_integration.yml
@@ -33,9 +33,10 @@ jobs:
         id: changed
         run: |
           # pull_request_target checks out the base branch (trusted). Fetch the
-          # PR head and diff by filename only, so untrusted PR code is never
-          # executed in this credential-less job; the test selection scripts
-          # below run from the trusted base checkout.
+          # PR head so the diff and test-selection can see it. Untrusted PR code
+          # is never executed in this credential-less job: we diff by filename
+          # and the selection script only reads PR-head file *contents* (via
+          # git show) to find test function names — it never runs them.
           git fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/head"
           git diff --name-only "origin/${{ github.base_ref }}...${{ github.event.pull_request.head.sha }}" > /tmp/changed_files.txt
           echo "Changed files:"
@@ -43,7 +44,7 @@ jobs:
       - name: Select tests and build args
         id: build-args
         run: |
-          RUN_REGEX=$(python3 scripts/select_pr_tests.py --escape-for-make < /tmp/changed_files.txt)
+          RUN_REGEX=$(python3 scripts/select_pr_tests.py --escape-for-make --git-ref "${{ github.event.pull_request.head.sha }}" < /tmp/changed_files.txt)
 
           if [ -z "$RUN_REGEX" ]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test_pr_integration.yml
+++ b/.github/workflows/test_pr_integration.yml
@@ -3,8 +3,11 @@ name: PR Integration Tests
 permissions:
   contents: read
 
+# pull_request_target so that PRs from forks can mint Datadog credentials via
+# OIDC. The credentialed job checks out the PR head and, for forks, runs in the
+# forks-prs environment.
 on: # yamllint disable-line rule:truthy
-  pull_request:
+  pull_request_target:
     branches: [master, v3]
     types: [opened, synchronize, reopened]
 
@@ -22,14 +25,19 @@ jobs:
       test_args: ${{ steps.build-args.outputs.test_args }}
       should_run: ${{ steps.build-args.outputs.should_run }}
     steps:
-      - name: Checkout code
+      - name: Checkout base
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
           fetch-depth: 0
       - name: Get changed files
         id: changed
         run: |
-          git diff --name-only origin/${{ github.base_ref }}...HEAD > /tmp/changed_files.txt
+          # pull_request_target checks out the base branch (trusted). Fetch the
+          # PR head and diff by filename only, so untrusted PR code is never
+          # executed in this credential-less job; the test selection scripts
+          # below run from the trusted base checkout.
+          git fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/head"
+          git diff --name-only "origin/${{ github.base_ref }}...${{ github.event.pull_request.head.sha }}" > /tmp/changed_files.txt
           echo "Changed files:"
           cat /tmp/changed_files.txt
       - name: Select tests and build args
@@ -59,9 +67,23 @@ jobs:
     needs: determine-tests
     if: needs.determine-tests.outputs.should_run == 'true'
     runs-on: ubuntu-latest
+    # Fork PRs run untrusted code with live (short-lived, test-org) credentials,
+    # so they run in the forks-prs environment. Same-repo PRs run without an
+    # environment gate.
+    environment: ${{ github.event.pull_request.head.repo.fork && 'forks-prs' || '' }}
+    permissions:
+      contents: read
+      id-token: write # Required to mint Datadog credentials via dd-sts
     steps:
-      - name: Checkout code
+      - name: Checkout PR code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Mint Datadog credentials
+        id: dd-sts
+        uses: DataDog/dd-sts-action@7d2d231c02fd54a3da912e582ff87cb995d1fd30 # v1.0.4
+        with:
+          policy: terraform-provider-datadog
       - name: Install Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
@@ -81,15 +103,15 @@ jobs:
       - name: Sweep stale test resources
         run: make sweep
         env:
-          DD_TEST_CLIENT_API_KEY: ${{ secrets.DD_CLIENT_API_KEY }}
-          DD_TEST_CLIENT_APP_KEY: ${{ secrets.DD_CLIENT_APP_KEY }}
+          DD_TEST_CLIENT_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
+          DD_TEST_CLIENT_APP_KEY: ${{ steps.dd-sts.outputs.app_key }}
       - name: Run selected integration tests
         run: make testacc
         env:
           RECORD: "none"
           CI: "true"
-          DD_TEST_CLIENT_API_KEY: ${{ secrets.DD_CLIENT_API_KEY }}
-          DD_TEST_CLIENT_APP_KEY: ${{ secrets.DD_CLIENT_APP_KEY }}
+          DD_TEST_CLIENT_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
+          DD_TEST_CLIENT_APP_KEY: ${{ steps.dd-sts.outputs.app_key }}
           DD_HTTP_CLIENT_RETRY_ENABLED: "true"
           TF_ACC_TERRAFORM_PATH: "/home/runner/.cache/terraform/terraform"
           TF_ACC_TEMP_DIR: "/tmp"

--- a/.github/workflows/test_pr_integration.yml
+++ b/.github/workflows/test_pr_integration.yml
@@ -89,16 +89,13 @@ jobs:
         with:
           go-version: "1.23"
           cache: true
-      - uses: actions/cache@f4b3439a656ba812b8cb417d2d49f9c810103092
-        with:
-          path: ~/.cache/terraform
-          key: terraform-${{ env.TERRAFORM_VERSION }}
+      # No GHA cache: the Terraform binary is small (~30MB, a few seconds to
+      # download) and a shared cache would let untrusted fork PR code poison a
+      # binary that a later trusted, credentialed run could restore and execute.
       - name: Install terraform
         run: |
           mkdir -p ~/.cache/terraform
-          if [ ! -f ~/.cache/terraform/terraform-${{ env.TERRAFORM_VERSION }} ]; then
-            wget https://releases.hashicorp.com/terraform/${{ env.TERRAFORM_VERSION }}/terraform_${{ env.TERRAFORM_VERSION }}_linux_amd64.zip -O ~/.cache/terraform/terraform-${{ env.TERRAFORM_VERSION }}
-          fi
+          wget https://releases.hashicorp.com/terraform/${{ env.TERRAFORM_VERSION }}/terraform_${{ env.TERRAFORM_VERSION }}_linux_amd64.zip -O ~/.cache/terraform/terraform-${{ env.TERRAFORM_VERSION }}
           unzip -o -d ~/.cache/terraform ~/.cache/terraform/terraform-${{ env.TERRAFORM_VERSION }}
       - name: Sweep stale test resources
         run: make sweep

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -7,6 +7,11 @@ Usage:
     git diff --name-only origin/master...HEAD | python3 scripts/select_pr_tests.py
     echo "datadog/resource_datadog_monitor.go" | python3 scripts/select_pr_tests.py
 
+    # Read test-file contents from a git ref instead of the working tree. Used
+    # by the pull_request_target workflow, which checks out the trusted base but
+    # needs the PR head's version of the tests to discover newly added ones:
+    git diff ... | python3 scripts/select_pr_tests.py --git-ref <pr-head-sha>
+
 Exit behavior:
     - Outputs pipe-separated test function regex to stdout
     - Empty output means no relevant tests found (caller should skip tests)
@@ -14,8 +19,9 @@ Exit behavior:
 
 import os
 import re
+import subprocess
 import sys
-from typing import List
+from typing import List, Optional
 
 _RESOURCE_PATH_RE = re.compile(
     r"^datadog/(?:fwprovider/)?(resource_datadog_|data_source_datadog_)(.+)\.go$"
@@ -24,18 +30,84 @@ _TEST_PATH_RE = re.compile(r"^datadog/tests/.*_test\.go$")
 _FUNC_RE = re.compile(r"^func (Test[A-Za-z0-9_]+)\(", re.MULTILINE)
 
 
+def _git_list_test_files(repo_root: str, ref: str) -> List[str]:
+    """List datadog/tests/*_test.go paths present at the given ref."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", repo_root, "ls-tree", "-r", "--name-only", ref, "datadog/tests"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    except (subprocess.CalledProcessError, OSError):
+        return []
+    return [p for p in out.splitlines() if p.endswith("_test.go")]
+
+
+def _git_read(repo_root: str, ref: str, relpath: str) -> Optional[str]:
+    """Return the contents of relpath at the given ref, or None if absent.
+
+    Only reads blob text (never executes it), so it is safe to point at an
+    untrusted PR head.
+    """
+    try:
+        return subprocess.run(
+            ["git", "-C", repo_root, "show", f"{ref}:{relpath}"],
+            check=True,
+            capture_output=True,
+        ).stdout.decode("utf-8", errors="replace")
+    except (subprocess.CalledProcessError, OSError):
+        return None
+
+
+def _fs_list_test_files(repo_root: str) -> List[str]:
+    """List datadog/tests/*_test.go paths in the working tree."""
+    tests_dir = os.path.join(repo_root, "datadog", "tests")
+    try:
+        return [
+            os.path.join("datadog", "tests", fname)
+            for fname in os.listdir(tests_dir)
+            if fname.endswith("_test.go")
+        ]
+    except FileNotFoundError:
+        return []
+
+
+def _fs_read(repo_root: str, relpath: str) -> Optional[str]:
+    """Return the contents of relpath from the working tree, or None if absent."""
+    try:
+        with open(os.path.join(repo_root, relpath)) as fh:
+            return fh.read()
+    except OSError:
+        return None
+
+
 def select_pr_tests(
     changed_files: List[str],
     repo_root: str,
     *,
     escape_for_make: bool = False,
+    git_ref: Optional[str] = None,
 ) -> str:
     if not changed_files:
         return ""
 
-    tests_dir = os.path.join(repo_root, "datadog", "tests")
+    # Resolve test files and their contents either from a git ref (the PR head,
+    # so newly added tests are visible) or from the working tree (local use).
+    if git_ref:
+        def list_test_files() -> List[str]:
+            return _git_list_test_files(repo_root, git_ref)
 
-    # Phase 1: Categorize changed files
+        def read_content(relpath: str) -> Optional[str]:
+            return _git_read(repo_root, git_ref, relpath)
+    else:
+        def list_test_files() -> List[str]:
+            return _fs_list_test_files(repo_root)
+
+        def read_content(relpath: str) -> Optional[str]:
+            return _fs_read(repo_root, relpath)
+
+    # Phase 1: Categorize changed files (repo-relative paths throughout)
     resource_types: set[str] = set()
     direct_test_files: set[str] = set()
 
@@ -45,7 +117,7 @@ def select_pr_tests(
             continue
 
         if _TEST_PATH_RE.match(f):
-            direct_test_files.add(os.path.join(repo_root, f))
+            direct_test_files.add(f)
             continue
 
         m = _RESOURCE_PATH_RE.match(f)
@@ -60,27 +132,19 @@ def select_pr_tests(
     matched_test_files: set[str] = set()
 
     if resource_types:
-        try:
-            test_files = [
-                os.path.join(tests_dir, fname)
-                for fname in os.listdir(tests_dir)
-                if fname.endswith("_test.go")
-            ]
-        except FileNotFoundError:
-            test_files = []
-
-        for rtype in resource_types:
-            pattern = re.compile(
+        patterns = [
+            re.compile(
                 rf'(?:resource|data)\s+"{re.escape(rtype)}"'
                 rf'|"{re.escape(rtype)}\.'
             )
-            for tf in test_files:
-                try:
-                    with open(tf) as fh:
-                        if pattern.search(fh.read()):
-                            matched_test_files.add(tf)
-                except OSError:
-                    continue
+            for rtype in resource_types
+        ]
+        for tf in list_test_files():
+            content = read_content(tf)
+            if content is None:
+                continue
+            if any(p.search(content) for p in patterns):
+                matched_test_files.add(tf)
 
     # Phase 3: Combine
     all_test_files = matched_test_files | direct_test_files
@@ -90,12 +154,11 @@ def select_pr_tests(
     # Phase 4: Extract test function names
     test_funcs: set[str] = set()
     for tf in all_test_files:
-        try:
-            with open(tf) as fh:
-                for m in _FUNC_RE.finditer(fh.read()):
-                    test_funcs.add(m.group(1))
-        except OSError:
+        content = read_content(tf)
+        if content is None:
             continue
+        for m in _FUNC_RE.finditer(content):
+            test_funcs.add(m.group(1))
 
     if not test_funcs:
         return ""
@@ -107,12 +170,20 @@ def select_pr_tests(
 def main() -> None:
     escape = "--escape-for-make" in sys.argv
 
+    git_ref = None
+    if "--git-ref" in sys.argv:
+        idx = sys.argv.index("--git-ref")
+        if idx + 1 < len(sys.argv):
+            git_ref = sys.argv[idx + 1]
+
     repo_root = os.path.join(os.path.dirname(__file__), "..")
     repo_root = os.path.abspath(repo_root)
 
     changed_files = [line for line in sys.stdin.read().splitlines() if line.strip()]
 
-    result = select_pr_tests(changed_files, repo_root, escape_for_make=escape)
+    result = select_pr_tests(
+        changed_files, repo_root, escape_for_make=escape, git_ref=git_ref
+    )
     if result:
         print(result)
 

--- a/scripts/test_select_pr_tests.py
+++ b/scripts/test_select_pr_tests.py
@@ -2,6 +2,7 @@
 """Unit tests for select_pr_tests.py."""
 
 import os
+import subprocess
 import tempfile
 import textwrap
 import unittest
@@ -173,6 +174,51 @@ class TestSelectPrTests(unittest.TestCase):
             escape_for_make=True,
         )
         self.assertEqual(result, "^TestA$$")
+
+    def test_git_ref_discovers_newly_added_test_file(self):
+        # A new test file added by a PR is absent from the (trusted base)
+        # working tree but present at the PR head ref. Filesystem mode misses
+        # it; --git-ref mode reads it from the committed blob and finds it.
+        def git(*args):
+            subprocess.run(
+                ["git", "-C", self.tmpdir, *args],
+                check=True,
+                capture_output=True,
+            )
+
+        git("init", "-q")
+        git("config", "user.email", "test@example.com")
+        git("config", "user.name", "test")
+        self._write_file(
+            "datadog/tests/resource_datadog_new_test.go",
+            '''\
+            package test
+
+            func TestAccNewResource(t *testing.T) {
+                resource "datadog_new" "x" {}
+            }
+            ''',
+        )
+        git("add", "-A")
+        git("commit", "-q", "-m", "add new test")
+        head = subprocess.run(
+            ["git", "-C", self.tmpdir, "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+        # Simulate the base checkout that lacks the new file.
+        os.remove(
+            os.path.join(self.tmpdir, "datadog/tests/resource_datadog_new_test.go")
+        )
+
+        changed = ["datadog/tests/resource_datadog_new_test.go"]
+        self.assertEqual(select_pr_tests(changed, self.tmpdir), "")
+        self.assertEqual(
+            select_pr_tests(changed, self.tmpdir, git_ref=head),
+            "^TestAccNewResource$",
+        )
 
     def test_no_matching_tests(self):
         # Resource changed but no test file references it


### PR DESCRIPTION
## What

The integration-test workflows now mint short-lived Datadog credentials at job time over GitHub OIDC (via `DataDog/dd-sts-action`) instead of reading long-lived API/APP keys from repository secrets. PR runs use `pull_request_target`, and PRs from forks run in a protected `forks-prs` environment.

## Why

PRs opened from forks don't have access to repository secrets, so the integration test jobs could not authenticate and had to be skipped and merged manually. This lets fork PRs run integration tests while removing long-lived credentials from the repository.

## Changes

- `pull_request` → `pull_request_target` on both integration-test workflows.
- Credentials are minted per run via `DataDog/dd-sts-action` (short-lived, test-org scoped); `DD_TEST_CLIENT_*` now come from the action outputs and the static secret references are removed.
- `id-token: write` is granted only on the credentialed jobs (the unprivileged jobs cannot mint tokens).
- Fork PRs run in the `forks-prs` environment; same-repo PRs and the scheduled run are unaffected.
- The PR test-selection job no longer executes untrusted PR code: it checks out the trusted base, fetches the PR head, and diffs by filename only.

## Required to land / follow-ups

- Depends on the server-side OIDC trust configuration being deployed first.
- Requires a `forks-prs` environment configured in repository settings.
- The static `DD_CLIENT_API_KEY` / `DD_CLIENT_APP_KEY` secrets can be removed once this is validated.

## Security note

`pull_request_target` runs the base branch's workflow definition but the credentialed job checks out and runs the PR's code. Fork PRs run in the protected `forks-prs` environment, and minted credentials are short-lived and scoped to a dedicated test org.
