### PR TITLE
[datadog_observability_pipelines] Mark use_legacy_search_syntax as Computed

### DIFF
--- a/datadog/fwprovider/resource_datadog_observability_pipeline.go
+++ b/datadog/fwprovider/resource_datadog_observability_pipeline.go
@@ -819,6 +819,7 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 						},
 						"use_legacy_search_syntax": schema.BoolAttribute{
 							Optional: true,
+							Computed: true,
 							Description: "Set to `true` to continue using the legacy search syntax while migrating filter queries. " +
 								"After migrating all queries to the new syntax, set to `false`. " +
 								"The legacy syntax is deprecated and will eventually be removed. " +


### PR DESCRIPTION
## Why

When the OPA public API starts defaulting `use_legacy_search_syntax=false` on newly created pipelines, Terraform users who don't explicitly set this field would see a perpetual plan diff — every `terraform plan` would show a non-empty change even after a successful `terraform apply`.

## What

Add `Computed: true` to the `use_legacy_search_syntax` schema attribute in the observability pipeline resource. This tells the Terraform plugin framework that the API may populate the field even when the user hasn't set it, so Terraform treats an API-returned value as authoritative instead of flagging it as drift.

## How to verify

- `go test ./datadog/fwprovider/... -run TestObservabilityPipelineSchema -v` passes
- After the companion dd-source PR ([OPA-5576](https://github.com/DataDog/dd-source/pulls)) lands, creating a pipeline without `use_legacy_search_syntax` and running `terraform plan` should show no diff

## Notes

- This is a non-breaking change: `Optional + Computed` is the standard Terraform pattern for API-defaulted fields
- Related: dd-source PR that adds the `false` default on the public API create path

[OPA-5576]: https://datadoghq.atlassian.net/browse/OPA-5576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ