### PR TITLE
[TFgen] (flags) Relocated CLI flags to be in the appropriate command.

### DIFF
--- a/.generator-v2/internal/cli/generate.go
+++ b/.generator-v2/internal/cli/generate.go
@@ -13,14 +13,20 @@ import (
 func newGenerateCmd(flags *globalFlags) *cobra.Command {
 	var check bool
 	var include string
+	var spec          string
+	var outputRoot    string
+	var hooksRoot     string
+	var trackingField string
+	var maxDepth      int
+	var report        string
 
 	cmd := &cobra.Command{
 		Use:   "generate",
 		Short: "Generate Terraform artifacts from the OpenAPI spec",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			spec, err := parser.LoadSpec(flags.spec,
-				parser.WithMaxDepth(flags.maxDepth),
-				parser.WithTrackingFieldName(flags.trackingField))
+			spec, err := parser.LoadSpec(spec,
+				parser.WithMaxDepth(maxDepth),
+				parser.WithTrackingFieldName(trackingField))
 			if err != nil {
 				return err
 			}
@@ -41,8 +47,14 @@ func newGenerateCmd(flags *globalFlags) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&check, "check", false, "Read-only mode: exit 3 if any file would change")
-	cmd.Flags().StringVar(&include, "include", "", "Comma-separated artifact names to generate (empty = all)")
+	cmd.PersistentFlags().BoolVar(&check, "check", false, "Read-only mode: exit 3 if any file would change")
+	cmd.PersistentFlags().IntVar(&maxDepth, "max-depth", parser.DefaultMaxDepth, "Hard limit on recursive $ref expansion")
+	cmd.PersistentFlags().StringVar(&spec, "spec", ".generator/V2/openapi.yaml", "OpenAPI spec to read")
+	cmd.PersistentFlags().StringVar(&include, "include", "", "Comma-separated artifact names to generate (empty = all)")
+	cmd.PersistentFlags().StringVar(&outputRoot, "output-root", "datadog/fwprovider", "Root directory for generated artifacts")
+	cmd.PersistentFlags().StringVar(&hooksRoot, "hooks-root", "datadog/fwprovider/hooks", "Root directory for hook subpackages")
+	cmd.PersistentFlags().StringVar(&trackingField, "tracking-field", "x-datadog-tf-generator", "OpenAPI extension name for the tracking field")
+	cmd.PersistentFlags().StringVar(&report, "report", "-", "Where to write the run report (\"-\" = stdout)")
 
 	return cmd
 }

--- a/.generator-v2/internal/cli/root.go
+++ b/.generator-v2/internal/cli/root.go
@@ -2,17 +2,10 @@ package cli
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/parser"
 )
 
 type globalFlags struct {
-	spec          string
-	outputRoot    string
-	hooksRoot     string
-	trackingField string
-	maxDepth      int
-	report        string
+
 	quiet         bool
 }
 
@@ -24,12 +17,7 @@ func newRootCmd(version string, flags *globalFlags) *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	cmd.PersistentFlags().StringVar(&flags.spec, "spec", ".generator/V2/openapi.yaml", "OpenAPI spec to read")
-	cmd.PersistentFlags().StringVar(&flags.outputRoot, "output-root", "datadog/fwprovider", "Root directory for generated artifacts")
-	cmd.PersistentFlags().StringVar(&flags.hooksRoot, "hooks-root", "datadog/fwprovider/hooks", "Root directory for hook subpackages")
-	cmd.PersistentFlags().StringVar(&flags.trackingField, "tracking-field", "x-datadog-tf-generator", "OpenAPI extension name for the tracking field")
-	cmd.PersistentFlags().IntVar(&flags.maxDepth, "max-depth", parser.DefaultMaxDepth, "Hard limit on recursive $ref expansion")
-	cmd.PersistentFlags().StringVar(&flags.report, "report", "-", "Where to write the run report (\"-\" = stdout)")
+
 	cmd.PersistentFlags().BoolVar(&flags.quiet, "quiet", false, "Suppress informational logging")
 
 	return cmd


### PR DESCRIPTION
### Motivation

Flags like `--spec`, `--output-root`, `--hooks-root`, `--tracking-field`, `--max-depth`, and `--report` only make sense for the generate subcommand. 
Keeping them on the root command made the CLI surface misleading and coupled unrelated concerns.

### Changes

Moved those flags from globalFlags / root command PersistentFlags down to local variables and PersistentFlags on the generate command.
Only `--quiet` (which applies globally) remains on the root.