### PR TITLE
[datadog_team_notification_rule] Fix slack.channel docs

### DIFF
--- a/datadog/fwprovider/resource_datadog_team_notification_rule.go
+++ b/datadog/fwprovider/resource_datadog_team_notification_rule.go
@@ -112,7 +112,7 @@ func (r *teamNotificationRuleResource) Schema(_ context.Context, _ resource.Sche
 				Attributes: map[string]schema.Attribute{
 					"channel": schema.StringAttribute{
 						Optional:    true,
-						Description: "Slack channel name for notifications, without a leading '#'",
+						Description: "Slack channel name for notifications, without a leading '#'.",
 					},
 					"workspace": schema.StringAttribute{
 						Optional:    true,

--- a/datadog/fwprovider/resource_datadog_team_notification_rule.go
+++ b/datadog/fwprovider/resource_datadog_team_notification_rule.go
@@ -112,7 +112,7 @@ func (r *teamNotificationRuleResource) Schema(_ context.Context, _ resource.Sche
 				Attributes: map[string]schema.Attribute{
 					"channel": schema.StringAttribute{
 						Optional:    true,
-						Description: "Slack channel name for notifications (for example, #alerts or #team-notifications).",
+						Description: "Slack channel name for notifications, without a leading '#'",
 					},
 					"workspace": schema.StringAttribute{
 						Optional:    true,

--- a/docs/resources/team_notification_rule.md
+++ b/docs/resources/team_notification_rule.md
@@ -33,7 +33,7 @@ resource "datadog_team_notification_rule" "foo" {
     service_name = "my-service"
   }
   slack {
-    channel   = "#test-channel"
+    channel   = "test-channel"
     workspace = "Datadog"
   }
 }
@@ -86,7 +86,7 @@ Optional:
 
 Optional:
 
-- `channel` (String) Slack channel name for notifications (for example, #alerts or #team-notifications).
+- `channel` (String) Slack channel name for notifications, without a leading '#'
 - `workspace` (String) Slack workspace name where the channel is located.
 
 ## Import

--- a/docs/resources/team_notification_rule.md
+++ b/docs/resources/team_notification_rule.md
@@ -86,7 +86,7 @@ Optional:
 
 Optional:
 
-- `channel` (String) Slack channel name for notifications, without a leading '#'. 
+- `channel` (String) Slack channel name for notifications, without a leading '#'.
 - `workspace` (String) Slack workspace name where the channel is located.
 
 ## Import

--- a/docs/resources/team_notification_rule.md
+++ b/docs/resources/team_notification_rule.md
@@ -86,7 +86,7 @@ Optional:
 
 Optional:
 
-- `channel` (String) Slack channel name for notifications, without a leading '#'
+- `channel` (String) Slack channel name for notifications, without a leading '#'. 
 - `workspace` (String) Slack workspace name where the channel is located.
 
 ## Import

--- a/examples/resources/datadog_team_notification_rule/resource.tf
+++ b/examples/resources/datadog_team_notification_rule/resource.tf
@@ -18,7 +18,7 @@ resource "datadog_team_notification_rule" "foo" {
     service_name = "my-service"
   }
   slack {
-    channel   = "#test-channel"
+    channel   = "test-channel"
     workspace = "Datadog"
   }
 }


### PR DESCRIPTION
# Summary
Fixes https://github.com/DataDog/terraform-provider-datadog/issues/3883

In the `slack.channel` example in the resource `datadog_team_notification_rule` docs, the user is instructed to configure Slack channel names as `#channel_name`, but DataDog prepends the channel name with `#`, resulting in invalid channel name `##channel_name`

I updated the docs to reflect this behaviour and the example to drop the leading `#` from the Slack channel name.
This broke alerts on our account, removing the leading `#` from the channel name when using this resource fixed them.