### PR TITLE
feat(auth): support TFE dynamic provider credentials via web identity token fallback

### DIFF
--- a/datadog/fwprovider/framework_provider.go
+++ b/datadog/fwprovider/framework_provider.go
@@ -587,15 +587,21 @@ func defaultConfigureFunc(p *FrameworkProvider, request *provider.ConfigureReque
 		)
 		switch cloudProviderType {
 		case "aws":
-			auth = context.WithValue(
-				auth,
-				datadog.ContextAWSVariables,
-				map[string]string{
-					datadog.AWSAccessKeyIdName:     awsAccessKeyId,
-					datadog.AWSSecretAccessKeyName: awsSecretAccessKey,
-					datadog.AWSSessionTokenName:    awsSessionToken,
-				},
-			)
+			// Only inject static credentials when they are actually present.
+			// When absent (e.g. TFE dynamic provider credentials / IRSA), omitting
+			// ContextAWSVariables lets AWSAuth.GetCredentials fall through to the
+			// AWS_WEB_IDENTITY_TOKEN_FILE + AWS_ROLE_ARN exchange path.
+			if awsAccessKeyId != "" {
+				auth = context.WithValue(
+					auth,
+					datadog.ContextAWSVariables,
+					map[string]string{
+						datadog.AWSAccessKeyIdName:     awsAccessKeyId,
+						datadog.AWSSecretAccessKeyName: awsSecretAccessKey,
+						datadog.AWSSessionTokenName:    awsSessionToken,
+					},
+				)
+			}
 		default:
 			diags.AddError("cloud_provider_type must be set to a valid value unless validate = false", "")
 			return diags

--- a/datadog/fwprovider/framework_provider.go
+++ b/datadog/fwprovider/framework_provider.go
@@ -219,6 +219,9 @@ type ProviderSchema struct {
 	AWSAccessKeyId                   types.String `tfsdk:"aws_access_key_id"`
 	AWSSecretAccessKey               types.String `tfsdk:"aws_secret_access_key"`
 	AWSSessionToken                  types.String `tfsdk:"aws_session_token"`
+	AWSWebIdentityTokenFile          types.String `tfsdk:"aws_web_identity_token_file"`
+	AWSRoleARN                       types.String `tfsdk:"aws_role_arn"`
+	AWSRoleSessionName               types.String `tfsdk:"aws_role_session_name"`
 	HttpClientRetryEnabled           types.String `tfsdk:"http_client_retry_enabled"`
 	HttpClientRetryTimeout           types.Int64  `tfsdk:"http_client_retry_timeout"`
 	HttpClientRetryBackoffMultiplier types.Int64  `tfsdk:"http_client_retry_backoff_multiplier"`
@@ -321,6 +324,18 @@ func (p *FrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
 				Optional:    true,
 				Sensitive:   true,
 				Description: "The AWS session token; used for cloud-provider-based authentication. This can also be set using the `AWS_SESSION_TOKEN` environment variable. Required when using `cloud_provider_type` set to `aws` and using temporary credentials.",
+			},
+			"aws_web_identity_token_file": schema.StringAttribute{
+				Optional:    true,
+				Description: "Path to the OIDC web identity token file; used for web identity token exchange (e.g. explicit IRSA configuration). This can also be set using the `AWS_WEB_IDENTITY_TOKEN_FILE` environment variable. Takes precedence over the environment variable when both are set.",
+			},
+			"aws_role_arn": schema.StringAttribute{
+				Optional:    true,
+				Description: "The ARN of the IAM role to assume via web identity token exchange. This can also be set using the `AWS_ROLE_ARN` environment variable. Takes precedence over the environment variable when both are set.",
+			},
+			"aws_role_session_name": schema.StringAttribute{
+				Optional:    true,
+				Description: "The session name to use when assuming the IAM role via web identity token exchange. Appears in CloudTrail and is useful for multi-workspace attribution. This can also be set using the `AWS_ROLE_SESSION_NAME` environment variable. Defaults to `datadog-api-client`.",
 			},
 			"http_client_retry_enabled": schema.StringAttribute{
 				Optional:    true,
@@ -440,6 +455,24 @@ func (p *FrameworkProvider) ConfigureConfigDefaults(ctx context.Context, config 
 			config.AWSSessionToken = types.StringValue(awsSessionToken)
 		}
 	}
+	if config.AWSWebIdentityTokenFile.IsNull() {
+		tokenFile, err := utils.GetMultiEnvVar(utils.AWSWebIdentityTokenFile)
+		if err == nil {
+			config.AWSWebIdentityTokenFile = types.StringValue(tokenFile)
+		}
+	}
+	if config.AWSRoleARN.IsNull() {
+		roleARN, err := utils.GetMultiEnvVar(utils.AWSRoleARN)
+		if err == nil {
+			config.AWSRoleARN = types.StringValue(roleARN)
+		}
+	}
+	if config.AWSRoleSessionName.IsNull() {
+		sessionName, err := utils.GetMultiEnvVar(utils.AWSRoleSessionName)
+		if err == nil {
+			config.AWSRoleSessionName = types.StringValue(sessionName)
+		}
+	}
 
 	if config.HttpClientRetryEnabled.IsNull() {
 		retryEnabled, err := utils.GetMultiEnvVar(utils.DDHTTPRetryEnabled)
@@ -548,6 +581,9 @@ func defaultConfigureFunc(p *FrameworkProvider, request *provider.ConfigureReque
 	awsAccessKeyId := config.AWSAccessKeyId.ValueString()
 	awsSecretAccessKey := config.AWSSecretAccessKey.ValueString()
 	awsSessionToken := config.AWSSessionToken.ValueString()
+	awsWebIdentityTokenFile := config.AWSWebIdentityTokenFile.ValueString()
+	awsRoleARN := config.AWSRoleARN.ValueString()
+	awsRoleSessionName := config.AWSRoleSessionName.ValueString()
 	bearerToken := config.BearerToken.ValueString()
 
 	if validate {
@@ -590,7 +626,7 @@ func defaultConfigureFunc(p *FrameworkProvider, request *provider.ConfigureReque
 			// Only inject static credentials when they are actually present.
 			// When absent (e.g. TFE dynamic provider credentials / IRSA), omitting
 			// ContextAWSVariables lets AWSAuth.GetCredentials fall through to the
-			// AWS_WEB_IDENTITY_TOKEN_FILE + AWS_ROLE_ARN exchange path.
+			// web identity or environment-variable paths.
 			if awsAccessKeyId != "" {
 				auth = context.WithValue(
 					auth,
@@ -599,6 +635,20 @@ func defaultConfigureFunc(p *FrameworkProvider, request *provider.ConfigureReque
 						datadog.AWSAccessKeyIdName:     awsAccessKeyId,
 						datadog.AWSSecretAccessKeyName: awsSecretAccessKey,
 						datadog.AWSSessionTokenName:    awsSessionToken,
+					},
+				)
+			} else if awsWebIdentityTokenFile != "" || awsRoleARN != "" {
+				if awsWebIdentityTokenFile == "" || awsRoleARN == "" {
+					diags.AddError("aws_web_identity_token_file and aws_role_arn must both be set when using web identity token exchange", "")
+					return diags
+				}
+				auth = context.WithValue(
+					auth,
+					datadog.ContextAWSWebIdentityVariables,
+					datadog.AWSWebIdentityVariables{
+						TokenFile:       awsWebIdentityTokenFile,
+						RoleARN:         awsRoleARN,
+						RoleSessionName: awsRoleSessionName,
 					},
 				)
 			}

--- a/datadog/internal/utils/utils.go
+++ b/datadog/internal/utils/utils.go
@@ -82,6 +82,15 @@ const AWSSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
 // AWSSessionToken name of env var for AWS Session Token
 const AWSSessionToken = "AWS_SESSION_TOKEN"
 
+// AWSWebIdentityTokenFile name of env var for the OIDC web identity token file path
+const AWSWebIdentityTokenFile = "AWS_WEB_IDENTITY_TOKEN_FILE"
+
+// AWSRoleARN name of env var for the IAM role ARN to assume via web identity
+const AWSRoleARN = "AWS_ROLE_ARN"
+
+// AWSRoleSessionName name of env var for the IAM role session name used during web identity token exchange
+const AWSRoleSessionName = "AWS_ROLE_SESSION_NAME"
+
 // BaseIPRangesSubdomain ip ranges subdomain
 const BaseIPRangesSubdomain = "ip-ranges"
 

--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -431,15 +431,21 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		)
 		switch cloudProviderType {
 		case "aws":
-			auth = context.WithValue(
-				auth,
-				datadog.ContextAWSVariables,
-				map[string]string{
-					datadog.AWSAccessKeyIdName:     awsAccessKeyId,
-					datadog.AWSSecretAccessKeyName: awsSecretAccessKey,
-					datadog.AWSSessionTokenName:    awsSessionToken,
-				},
-			)
+			// Only inject static credentials when they are actually present.
+			// When absent (e.g. TFE dynamic provider credentials / IRSA), omitting
+			// ContextAWSVariables lets AWSAuth.GetCredentials fall through to the
+			// AWS_WEB_IDENTITY_TOKEN_FILE + AWS_ROLE_ARN exchange path.
+			if awsAccessKeyId != "" {
+				auth = context.WithValue(
+					auth,
+					datadog.ContextAWSVariables,
+					map[string]string{
+						datadog.AWSAccessKeyIdName:     awsAccessKeyId,
+						datadog.AWSSecretAccessKeyName: awsSecretAccessKey,
+						datadog.AWSSessionTokenName:    awsSessionToken,
+					},
+				)
+			}
 		default:
 			return nil, diag.FromErr(errors.New("cloud_provider_type must be set to a valid value unless validate = false"))
 		}

--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -135,6 +135,21 @@ func Provider() *schema.Provider {
 				Sensitive:   true,
 				Description: "The AWS session token; used for cloud-provider-based authentication. This can also be set using the `AWS_SESSION_TOKEN` environment variable. Required when using `cloud_provider_type` set to `aws` and using temporary credentials.",
 			},
+			"aws_web_identity_token_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Path to the OIDC web identity token file; used for web identity token exchange (e.g. explicit IRSA configuration). This can also be set using the `AWS_WEB_IDENTITY_TOKEN_FILE` environment variable. Takes precedence over the environment variable when both are set.",
+			},
+			"aws_role_arn": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ARN of the IAM role to assume via web identity token exchange. This can also be set using the `AWS_ROLE_ARN` environment variable. Takes precedence over the environment variable when both are set.",
+			},
+			"aws_role_session_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The session name to use when assuming the IAM role via web identity token exchange. Appears in CloudTrail and is useful for multi-workspace attribution. This can also be set using the `AWS_ROLE_SESSION_NAME` environment variable. Defaults to `datadog-api-client`.",
+			},
 			"http_client_retry_enabled": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -377,6 +392,18 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	if awsSessionToken == "" {
 		awsSessionToken, _ = utils.GetMultiEnvVar(utils.AWSSessionToken)
 	}
+	awsWebIdentityTokenFile := d.Get("aws_web_identity_token_file").(string)
+	if awsWebIdentityTokenFile == "" {
+		awsWebIdentityTokenFile, _ = utils.GetMultiEnvVar(utils.AWSWebIdentityTokenFile)
+	}
+	awsRoleARN := d.Get("aws_role_arn").(string)
+	if awsRoleARN == "" {
+		awsRoleARN, _ = utils.GetMultiEnvVar(utils.AWSRoleARN)
+	}
+	awsRoleSessionName := d.Get("aws_role_session_name").(string)
+	if awsRoleSessionName == "" {
+		awsRoleSessionName, _ = utils.GetMultiEnvVar(utils.AWSRoleSessionName)
+	}
 
 	httpRetryEnabled := true
 	httpRetryEnabledStr := d.Get("http_client_retry_enabled").(string)
@@ -434,7 +461,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 			// Only inject static credentials when they are actually present.
 			// When absent (e.g. TFE dynamic provider credentials / IRSA), omitting
 			// ContextAWSVariables lets AWSAuth.GetCredentials fall through to the
-			// AWS_WEB_IDENTITY_TOKEN_FILE + AWS_ROLE_ARN exchange path.
+			// web identity or environment-variable paths.
 			if awsAccessKeyId != "" {
 				auth = context.WithValue(
 					auth,
@@ -443,6 +470,19 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 						datadog.AWSAccessKeyIdName:     awsAccessKeyId,
 						datadog.AWSSecretAccessKeyName: awsSecretAccessKey,
 						datadog.AWSSessionTokenName:    awsSessionToken,
+					},
+				)
+			} else if awsWebIdentityTokenFile != "" || awsRoleARN != "" {
+				if awsWebIdentityTokenFile == "" || awsRoleARN == "" {
+					return nil, diag.FromErr(errors.New("aws_web_identity_token_file and aws_role_arn must both be set when using web identity token exchange"))
+				}
+				auth = context.WithValue(
+					auth,
+					datadog.ContextAWSWebIdentityVariables,
+					datadog.AWSWebIdentityVariables{
+						TokenFile:       awsWebIdentityTokenFile,
+						RoleARN:         awsRoleARN,
+						RoleSessionName: awsRoleSessionName,
 					},
 				)
 			}

--- a/datadog/tests/framework_provider_test.go
+++ b/datadog/tests/framework_provider_test.go
@@ -444,6 +444,92 @@ func TestFrameworkProviderConfigure_CloudAuthWithOnlyAppKey(t *testing.T) {
 	}
 }
 
+// TestFrameworkProviderConfigure_CloudAuthWebIdentity verifies that when cloud_provider_type = "aws"
+// is configured without static AWS credentials, ContextAWSVariables is NOT injected into
+// the auth context — allowing AWSAuth.GetCredentials to fall through to the web identity
+// token exchange path (AWS_WEB_IDENTITY_TOKEN_FILE + AWS_ROLE_ARN).
+func TestFrameworkProviderConfigure_CloudAuthWebIdentity(t *testing.T) {
+	os.Unsetenv("DD_API_KEY")
+	os.Unsetenv("DD_APP_KEY")
+	os.Unsetenv("DATADOG_API_KEY")
+	os.Unsetenv("DATADOG_APP_KEY")
+	os.Unsetenv("AWS_ACCESS_KEY_ID")
+	os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+	os.Unsetenv("AWS_SESSION_TOKEN")
+
+	p := fwprovider.New().(*fwprovider.FrameworkProvider)
+	config := &fwprovider.ProviderSchema{
+		OrgUuid:                types.StringValue("test-org-uuid"),
+		CloudProviderType:      types.StringValue("aws"),
+		CloudProviderRegion:    types.StringValue("us-east-1"),
+		ApiUrl:                 types.StringValue("https://api.datad0g.com"),
+		Validate:               types.StringValue("false"),
+		HttpClientRetryEnabled: types.StringValue("false"),
+	}
+
+	request := &provider.ConfigureRequest{}
+	diags := p.ConfigureCallbackFunc(p, request, config)
+
+	if diags.HasError() {
+		t.Fatalf("framework provider configure should not error with cloud auth + no static creds, got: %v", diags)
+	}
+	if p.DatadogApiInstances == nil {
+		t.Fatal("DatadogApiInstances should be set")
+	}
+
+	if p.DatadogApiInstances.HttpClient.GetConfig().DelegatedTokenConfig == nil {
+		t.Error("DelegatedTokenConfig should be set when cloud_provider_type is configured")
+	}
+
+	// Key assertion: ContextAWSVariables must NOT be injected when no static creds are
+	// present, so GetCredentials can fall through to the web identity exchange path.
+	if p.Auth.Value(common.ContextAWSVariables) != nil {
+		t.Error("ContextAWSVariables should NOT be set in auth context when no static AWS credentials are configured")
+	}
+}
+
+// TestFrameworkProviderConfigure_CloudAuthWithStaticCreds verifies that when cloud_provider_type = "aws"
+// is configured WITH static AWS credentials, ContextAWSVariables IS injected so GetCredentials
+// uses them directly (i.e. the guard doesn't break the existing static-creds path).
+func TestFrameworkProviderConfigure_CloudAuthWithStaticCreds(t *testing.T) {
+	os.Unsetenv("DD_API_KEY")
+	os.Unsetenv("DD_APP_KEY")
+	os.Unsetenv("DATADOG_API_KEY")
+	os.Unsetenv("DATADOG_APP_KEY")
+
+	// ConfigureCallbackFunc is called directly in tests, bypassing ConfigureConfigDefaults
+	// where env var fallback happens — so creds must be set on the schema struct directly.
+	p := fwprovider.New().(*fwprovider.FrameworkProvider)
+	config := &fwprovider.ProviderSchema{
+		OrgUuid:                types.StringValue("test-org-uuid"),
+		CloudProviderType:      types.StringValue("aws"),
+		CloudProviderRegion:    types.StringValue("us-east-1"),
+		ApiUrl:                 types.StringValue("https://api.datad0g.com"),
+		Validate:               types.StringValue("false"),
+		HttpClientRetryEnabled: types.StringValue("false"),
+		AWSAccessKeyId:         types.StringValue("test-key-id"),
+		AWSSecretAccessKey:     types.StringValue("test-secret-key"),
+		AWSSessionToken:        types.StringValue("test-session-token"),
+	}
+
+	request := &provider.ConfigureRequest{}
+	diags := p.ConfigureCallbackFunc(p, request, config)
+
+	if diags.HasError() {
+		t.Fatalf("framework provider configure should not error with cloud auth + static creds, got: %v", diags)
+	}
+
+	// Static creds must be injected via ContextAWSVariables so GetCredentials uses them directly.
+	ctxCreds := p.Auth.Value(common.ContextAWSVariables)
+	if ctxCreds == nil {
+		t.Fatal("ContextAWSVariables should be set in auth context when static AWS credentials are configured")
+	}
+	credsMap := ctxCreds.(map[string]string)
+	if credsMap[common.AWSAccessKeyIdName] != "test-key-id" {
+		t.Errorf("expected AWS_ACCESS_KEY_ID = test-key-id, got %q", credsMap[common.AWSAccessKeyIdName])
+	}
+}
+
 // TestFrameworkProviderConfigure_BearerTokenOnly tests that Bearer auth works when only `bearer_token` is set.
 func TestFrameworkProviderConfigure_BearerTokenOnly(t *testing.T) {
 	os.Unsetenv("DD_API_KEY")

--- a/datadog/tests/provider_test.go
+++ b/datadog/tests/provider_test.go
@@ -1249,6 +1249,94 @@ func TestProviderConfigure_CloudAuthWithOnlyAppKey(t *testing.T) {
 	}
 }
 
+// TestProviderConfigure_CloudAuthWebIdentity verifies that when cloud_provider_type = "aws"
+// is configured without static AWS credentials, ContextAWSVariables is NOT injected into
+// the auth context — allowing AWSAuth.GetCredentials to fall through to the web identity
+// token exchange path (AWS_WEB_IDENTITY_TOKEN_FILE + AWS_ROLE_ARN).
+func TestProviderConfigure_CloudAuthWebIdentity(t *testing.T) {
+	os.Unsetenv("DD_API_KEY")
+	os.Unsetenv("DD_APP_KEY")
+	os.Unsetenv("DATADOG_API_KEY")
+	os.Unsetenv("DATADOG_APP_KEY")
+	os.Unsetenv("AWS_ACCESS_KEY_ID")
+	os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+	os.Unsetenv("AWS_SESSION_TOKEN")
+
+	d := schema.TestResourceDataRaw(t, datadog.Provider().Schema, map[string]interface{}{
+		"org_uuid":              "test-org-uuid",
+		"cloud_provider_type":   "aws",
+		"cloud_provider_region": "us-east-1",
+		"api_url":               "https://api.datad0g.com",
+		"validate":              false,
+	})
+
+	p := datadog.Provider()
+	result, diags := p.ConfigureContextFunc(context.Background(), d)
+
+	if diags.HasError() {
+		t.Fatalf("providerConfigure should not error with cloud auth + no static creds, got: %v", diags)
+	}
+	if result == nil {
+		t.Fatal("providerConfigure should return a result")
+	}
+
+	config := result.(*datadog.ProviderConfiguration)
+
+	if config.DatadogApiInstances.HttpClient.GetConfig().DelegatedTokenConfig == nil {
+		t.Error("DelegatedTokenConfig should be set when cloud_provider_type is configured")
+	}
+
+	// Key assertion: ContextAWSVariables must NOT be injected when no static creds are
+	// present, so GetCredentials can fall through to the web identity exchange path.
+	if config.Auth.Value(common.ContextAWSVariables) != nil {
+		t.Error("ContextAWSVariables should NOT be set in auth context when no static AWS credentials are configured")
+	}
+}
+
+// TestProviderConfigure_CloudAuthWithStaticCreds verifies that when cloud_provider_type = "aws"
+// is configured WITH static AWS credentials, ContextAWSVariables IS injected so GetCredentials
+// uses them directly (i.e. the guard doesn't break the existing static-creds path).
+func TestProviderConfigure_CloudAuthWithStaticCreds(t *testing.T) {
+	os.Unsetenv("DD_API_KEY")
+	os.Unsetenv("DD_APP_KEY")
+	os.Unsetenv("DATADOG_API_KEY")
+	os.Unsetenv("DATADOG_APP_KEY")
+	os.Setenv("AWS_ACCESS_KEY_ID", "test-key-id")
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret-key")
+	os.Setenv("AWS_SESSION_TOKEN", "test-session-token")
+	defer func() {
+		os.Unsetenv("AWS_ACCESS_KEY_ID")
+		os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+		os.Unsetenv("AWS_SESSION_TOKEN")
+	}()
+
+	d := schema.TestResourceDataRaw(t, datadog.Provider().Schema, map[string]interface{}{
+		"org_uuid":              "test-org-uuid",
+		"cloud_provider_type":   "aws",
+		"cloud_provider_region": "us-east-1",
+		"api_url":               "https://api.datad0g.com",
+		"validate":              false,
+	})
+
+	p := datadog.Provider()
+	result, diags := p.ConfigureContextFunc(context.Background(), d)
+
+	if diags.HasError() {
+		t.Fatalf("providerConfigure should not error with cloud auth + static creds, got: %v", diags)
+	}
+	config := result.(*datadog.ProviderConfiguration)
+
+	// Static creds must be injected via ContextAWSVariables so GetCredentials uses them directly.
+	ctxCreds := config.Auth.Value(common.ContextAWSVariables)
+	if ctxCreds == nil {
+		t.Fatal("ContextAWSVariables should be set in auth context when static AWS credentials are configured")
+	}
+	credsMap := ctxCreds.(map[string]string)
+	if credsMap[common.AWSAccessKeyIdName] != "test-key-id" {
+		t.Errorf("expected AWS_ACCESS_KEY_ID = test-key-id, got %q", credsMap[common.AWSAccessKeyIdName])
+	}
+}
+
 // TestProviderConfigure_BearerTokenOnly tests that Bearer auth works when only `bearer_token` is set.
 func TestProviderConfigure_BearerTokenOnly(t *testing.T) {
 	os.Unsetenv("DD_API_KEY")

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-datadog
 
 require (
-	github.com/DataDog/datadog-api-client-go/v2 v2.60.1-0.20260522183654-aa58b6b70588
+	github.com/DataDog/datadog-api-client-go/v2 v2.60.1-0.20260609164814-849e9030d419
 	github.com/DataDog/dd-sdk-go-testing v0.0.0-20211116174033-1cd082e322ad
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/google/go-cmp v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-datadog
 
 require (
-	github.com/DataDog/datadog-api-client-go/v2 v2.60.1-0.20260609164814-849e9030d419
+	github.com/DataDog/datadog-api-client-go/v2 v2.60.1-0.20260616171434-3a2c1b0c9782
 	github.com/DataDog/dd-sdk-go-testing v0.0.0-20211116174033-1cd082e322ad
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.60.1-0.20260522183654-aa58b6b7058
 github.com/DataDog/datadog-api-client-go/v2 v2.60.1-0.20260522183654-aa58b6b70588/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-api-client-go/v2 v2.60.1-0.20260609164814-849e9030d419 h1:dbxVKNN4XRViySLejehaHO2yu7tRZzUnah8oV8Ttc8k=
 github.com/DataDog/datadog-api-client-go/v2 v2.60.1-0.20260609164814-849e9030d419/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
+github.com/DataDog/datadog-api-client-go/v2 v2.60.1-0.20260616171434-3a2c1b0c9782 h1:TU903gD8eSOXuhNRwUusxtsOKldHjnz6jyQ2EJxhgXg=
+github.com/DataDog/datadog-api-client-go/v2 v2.60.1-0.20260616171434-3a2c1b0c9782/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/DataDog/datadog-api-client-go/v2 v2.60.1-0.20260522183654-aa58b6b70588 h1:a36YVDBcGRXnbCgu4kkIII2XdhxJr12mz9mD6xdvaqg=
 github.com/DataDog/datadog-api-client-go/v2 v2.60.1-0.20260522183654-aa58b6b70588/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
+github.com/DataDog/datadog-api-client-go/v2 v2.60.1-0.20260609164814-849e9030d419 h1:dbxVKNN4XRViySLejehaHO2yu7tRZzUnah8oV8Ttc8k=
+github.com/DataDog/datadog-api-client-go/v2 v2.60.1-0.20260609164814-849e9030d419/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=


### PR DESCRIPTION
## Summary

- Guards \`ContextAWSVariables\` injection in both the SDK and framework providers so it only fires when static AWS credentials are actually present. Previously the provider always injected an empty map, which caused \`AWSAuth.GetCredentials\` to short-circuit before reaching the web identity exchange path — breaking Terraform Enterprise dynamic provider credentials and IRSA.
- Bumps \`datadog-api-client-go\` to [\`3a2c1b0\`](https://github.com/DataDog/datadog-api-client-go/pull/4231) (\`wyn.bennett/web-identity-credential-chain\`), which adds \`assumeRoleWithWebIdentity()\` as a fallback in \`GetCredentials\` when no static credentials are present, plus the new \`ContextAWSWebIdentityVariables\` / \`AWSWebIdentityVariables\` API.
- Adds \`aws_web_identity_token_file\`, \`aws_role_arn\`, and \`aws_role_session_name\` provider attributes so callers can configure web identity token exchange explicitly (rather than relying solely on \`AWS_WEB_IDENTITY_TOKEN_FILE\` / \`AWS_ROLE_ARN\` env var autodiscovery).
- Adds unit tests covering: no static creds → \`ContextAWSVariables\` absent; static creds present → \`ContextAWSVariables\` injected.

## Background

Terraform Enterprise uses \`TFC_AWS_PROVIDER_AUTH\` (dynamic provider credentials): TFE's internal SDK assumes the target role and exposes only \`AWS_WEB_IDENTITY_TOKEN_FILE\` + \`AWS_ROLE_ARN\` in the run environment — never \`AWS_ACCESS_KEY_ID\`/\`AWS_SECRET_ACCESS_KEY\`/\`AWS_SESSION_TOKEN\`. With the old code, the provider injected \`ContextAWSVariables\` with all three values empty, causing \`GetCredentials\` to return empty creds and \`GenerateAwsAuthData\` to fail with \`"missing AWS credentials"\` before the new web identity path could run.

## Credential flow after this fix

### TFE (env var autodiscovery, no explicit config)

1. Provider reads empty \`aws_access_key_id\`, empty \`aws_web_identity_token_file\` → injects neither context key
2. \`AWSAuth.GetCredentials\`: no context → static env vars empty → \`assumeRoleWithWebIdentity(AWS_WEB_IDENTITY_TOKEN_FILE, AWS_ROLE_ARN)\` → STS → temp creds ✓

### Explicit IRSA / cross-account config

1. Provider reads \`aws_web_identity_token_file\` + \`aws_role_arn\` → injects \`ContextAWSWebIdentityVariables\`
2. \`AWSAuth.GetCredentials\`: context key present → \`assumeRoleWithWebIdentity(tokenFile, roleARN)\` → STS → temp creds ✓
3. If STS fails, auth fails immediately — no silent fallback to ambient env-var creds

### Static credentials (existing path, unchanged)

1. Provider reads non-empty \`aws_access_key_id\` → injects \`ContextAWSVariables\`
2. \`AWSAuth.GetCredentials\`: step 1 short-circuits, returns static creds directly ✓

## \`GetCredentials\` priority after this PR

| Priority | Source |
|----------|--------|
| 1 | \`ContextAWSVariables\` in context (static, explicit) |
| 2 | \`ContextAWSWebIdentityVariables\` in context (web identity, explicit — authoritative, no fallthrough) |
| 3 | \`AWS_ACCESS_KEY_ID\` / \`AWS_SECRET_ACCESS_KEY\` / \`AWS_SESSION_TOKEN\` env vars |
| 4 | \`AWS_WEB_IDENTITY_TOKEN_FILE\` + \`AWS_ROLE_ARN\` env vars (TFE autodiscovery) |

## Dependency note

The \`datadog-api-client-go\` bump points to the open PR branch (\`wyn.bennett/web-identity-credential-chain\`). This should be updated to a released tag once that PR merges.

## Test plan

- [x] \`go test ./datadog/tests/ -run "TestProviderConfigure|TestFrameworkProviderConfigure"\` — all 24 tests pass
- [ ] Manual end-to-end: TFE workspace with \`cloud_provider_type = "aws"\` + \`org_uuid\`, dynamic provider credentials enabled, confirm delegated token is obtained
- [ ] Manual: explicit \`aws_web_identity_token_file\` + \`aws_role_arn\` in provider block, confirm token exchange succeeds
- [ ] Update \`go.mod\` to a tagged release of \`datadog-api-client-go\` once PR #4231 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)