### PR TITLE
[datadog_integration_aws_logs_services] deprecate v1 AWS data sources for logs services and namespace rules

### DIFF
--- a/datadog/data_source_datadog_integration_aws_logs_services.go
+++ b/datadog/data_source_datadog_integration_aws_logs_services.go
@@ -13,8 +13,9 @@ import (
 
 func dataSourceDatadogIntegrationAWSLogsServices() *schema.Resource {
 	return &schema.Resource{
-		Description: "Use this data source to retrieve all AWS log ready services.",
-		ReadContext: dataSourceDatadogIntegrationAWSLogsServicesRead,
+		Description:        "Use this data source to retrieve all AWS log ready services.",
+		DeprecationMessage: "This data source is deprecated — use the `datadog_integration_aws_available_logs_services` data source instead.",
+		ReadContext:        dataSourceDatadogIntegrationAWSLogsServicesRead,
 		SchemaFunc: func() map[string]*schema.Schema {
 			return map[string]*schema.Schema{
 				// Computed

--- a/datadog/fwprovider/data_source_datadog_integration_aws_namespace_rules.go
+++ b/datadog/fwprovider/data_source_datadog_integration_aws_namespace_rules.go
@@ -40,7 +40,8 @@ func (d *datadogIntegrationAWSNamespaceRulesDatasource) Metadata(_ context.Conte
 
 func (d *datadogIntegrationAWSNamespaceRulesDatasource) Schema(_ context.Context, _ datasource.SchemaRequest, response *datasource.SchemaResponse) {
 	response.Schema = schema.Schema{
-		Description: "Provides a Datadog AWS Integration Namespace Rules data source. This can be used to retrieve all available namespace rules for a Datadog-AWS integration.",
+		Description:        "Provides a Datadog AWS Integration Namespace Rules data source. This can be used to retrieve all available namespace rules for a Datadog-AWS integration.",
+		DeprecationMessage: "This data source is deprecated — use the `datadog_integration_aws_available_namespaces` data source instead. Note: the replacement returns AWS namespace strings (e.g. `AWS/EC2`) rather than legacy Datadog IDs (e.g. `ec2`).",
 		Attributes: map[string]schema.Attribute{
 			"namespace_rules": schema.ListAttribute{
 				Description: "The list of available namespace rules for a Datadog-AWS integration.",


### PR DESCRIPTION
## Summary

- Marks `datadog_integration_aws_logs_services` as deprecated in favour of `datadog_integration_aws_available_logs_services`
- Marks `datadog_integration_aws_namespace_rules` as deprecated in favour of `datadog_integration_aws_available_namespaces`

These data sources call v1 AWS Integration API endpoints that are being sunset as part of the AWS Integrations v1 → v2 migration.

## V1 → V2 endpoint mapping

| Data source | V1 endpoint | V2 endpoint |
|---|---|---|
| `datadog_integration_aws_logs_services` | `GET /api/v1/integration/aws/logs/services` (`ListAWSLogsServices`) | `GET /api/v2/integration/aws/logs/services` (`ListAWSLogsServices`) |
| `datadog_integration_aws_namespace_rules` | `GET /api/v1/integration/aws/available_namespace_rules` (`ListAvailableAWSNamespaces`) | `GET /api/v2/integration/aws/namespaces` (`ListAWSNamespaces`) |

## Migration notes

**`datadog_integration_aws_logs_services` → `datadog_integration_aws_available_logs_services`**

The v2 data source returns a flat list of service ID strings instead of `{id, label}` objects. Update attribute references accordingly.

**`datadog_integration_aws_namespace_rules` → `datadog_integration_aws_available_namespaces`**

The v2 data source returns AWS namespace strings (e.g. `AWS/EC2`) instead of legacy Datadog IDs (e.g. `ec2`). The `namespace_rules` output attribute is renamed to `aws_namespaces`. The new format is already what `datadog_integration_aws_account`'s `metrics_config.namespace_filters` expects.

## Test plan

- [ ] Verify `terraform plan` emits a deprecation warning when either data source is referenced
- [ ] Confirm existing acceptance tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)