### PR TITLE
[SEC-31421] enrich schema descriptions for nested attributes

### DIFF
--- a/datadog/internal/fwutils/fw_enrich_schema.go
+++ b/datadog/internal/fwutils/fw_enrich_schema.go
@@ -61,6 +61,28 @@ func enrichResourceDescription(r any) resourceSchema.Attribute {
 	case resourceSchema.BoolAttribute:
 		buildEnrichedSchemaDescription(reflect.ValueOf(&v))
 		return v
+	// Nested attributes are not enriched themselves, but their child attributes are
+	// (the enum/range validators live on the leaves). This mirrors how blocks recurse.
+	case resourceSchema.SingleNestedAttribute:
+		for i, attr := range v.Attributes {
+			v.Attributes[i] = enrichResourceDescription(attr)
+		}
+		return v
+	case resourceSchema.ListNestedAttribute:
+		for i, attr := range v.NestedObject.Attributes {
+			v.NestedObject.Attributes[i] = enrichResourceDescription(attr)
+		}
+		return v
+	case resourceSchema.SetNestedAttribute:
+		for i, attr := range v.NestedObject.Attributes {
+			v.NestedObject.Attributes[i] = enrichResourceDescription(attr)
+		}
+		return v
+	case resourceSchema.MapNestedAttribute:
+		for i, attr := range v.NestedObject.Attributes {
+			v.NestedObject.Attributes[i] = enrichResourceDescription(attr)
+		}
+		return v
 	default:
 		return r.(resourceSchema.Attribute)
 	}
@@ -113,6 +135,28 @@ func enrichDatasourceDescription(r any) datasourceSchema.Attribute {
 	case datasourceSchema.BoolAttribute:
 		buildEnrichedSchemaDescription(reflect.ValueOf(&v))
 		return v
+	// Nested attributes are not enriched themselves, but their child attributes are
+	// (the enum/range validators live on the leaves). This mirrors how blocks recurse.
+	case datasourceSchema.SingleNestedAttribute:
+		for i, attr := range v.Attributes {
+			v.Attributes[i] = enrichDatasourceDescription(attr)
+		}
+		return v
+	case datasourceSchema.ListNestedAttribute:
+		for i, attr := range v.NestedObject.Attributes {
+			v.NestedObject.Attributes[i] = enrichDatasourceDescription(attr)
+		}
+		return v
+	case datasourceSchema.SetNestedAttribute:
+		for i, attr := range v.NestedObject.Attributes {
+			v.NestedObject.Attributes[i] = enrichDatasourceDescription(attr)
+		}
+		return v
+	case datasourceSchema.MapNestedAttribute:
+		for i, attr := range v.NestedObject.Attributes {
+			v.NestedObject.Attributes[i] = enrichDatasourceDescription(attr)
+		}
+		return v
 	default:
 		return r.(datasourceSchema.Attribute)
 	}
@@ -164,6 +208,28 @@ func enrichEphemeralDescription(r any) ephemeralSchema.Attribute {
 		return v
 	case ephemeralSchema.BoolAttribute:
 		buildEnrichedSchemaDescription(reflect.ValueOf(&v))
+		return v
+	// Nested attributes are not enriched themselves, but their child attributes are
+	// (the enum/range validators live on the leaves). This mirrors how blocks recurse.
+	case ephemeralSchema.SingleNestedAttribute:
+		for i, attr := range v.Attributes {
+			v.Attributes[i] = enrichEphemeralDescription(attr)
+		}
+		return v
+	case ephemeralSchema.ListNestedAttribute:
+		for i, attr := range v.NestedObject.Attributes {
+			v.NestedObject.Attributes[i] = enrichEphemeralDescription(attr)
+		}
+		return v
+	case ephemeralSchema.SetNestedAttribute:
+		for i, attr := range v.NestedObject.Attributes {
+			v.NestedObject.Attributes[i] = enrichEphemeralDescription(attr)
+		}
+		return v
+	case ephemeralSchema.MapNestedAttribute:
+		for i, attr := range v.NestedObject.Attributes {
+			v.NestedObject.Attributes[i] = enrichEphemeralDescription(attr)
+		}
 		return v
 	default:
 		return r.(ephemeralSchema.Attribute)

--- a/datadog/internal/fwutils/fw_enrich_schema.go
+++ b/datadog/internal/fwutils/fw_enrich_schema.go
@@ -61,8 +61,6 @@ func enrichResourceDescription(r any) resourceSchema.Attribute {
 	case resourceSchema.BoolAttribute:
 		buildEnrichedSchemaDescription(reflect.ValueOf(&v))
 		return v
-	// Nested attributes are not enriched themselves, but their child attributes are
-	// (the enum/range validators live on the leaves). This mirrors how blocks recurse.
 	case resourceSchema.SingleNestedAttribute:
 		for i, attr := range v.Attributes {
 			v.Attributes[i] = enrichResourceDescription(attr)
@@ -135,8 +133,6 @@ func enrichDatasourceDescription(r any) datasourceSchema.Attribute {
 	case datasourceSchema.BoolAttribute:
 		buildEnrichedSchemaDescription(reflect.ValueOf(&v))
 		return v
-	// Nested attributes are not enriched themselves, but their child attributes are
-	// (the enum/range validators live on the leaves). This mirrors how blocks recurse.
 	case datasourceSchema.SingleNestedAttribute:
 		for i, attr := range v.Attributes {
 			v.Attributes[i] = enrichDatasourceDescription(attr)
@@ -209,8 +205,6 @@ func enrichEphemeralDescription(r any) ephemeralSchema.Attribute {
 	case ephemeralSchema.BoolAttribute:
 		buildEnrichedSchemaDescription(reflect.ValueOf(&v))
 		return v
-	// Nested attributes are not enriched themselves, but their child attributes are
-	// (the enum/range validators live on the leaves). This mirrors how blocks recurse.
 	case ephemeralSchema.SingleNestedAttribute:
 		for i, attr := range v.Attributes {
 			v.Attributes[i] = enrichEphemeralDescription(attr)

--- a/datadog/internal/fwutils/fw_enrich_schema_test.go
+++ b/datadog/internal/fwutils/fw_enrich_schema_test.go
@@ -1141,9 +1141,7 @@ func TestEnrichSchemaListNestedAttribute(t *testing.T) {
 	}
 }
 
-// TestEnrichSchemaNestedAttributeWithinNestedAttribute covers a list nested attribute nested inside
-// a single nested attribute (e.g. an `action` object containing a list of typed entries), ensuring
-// enrichment recurses all the way to the leaf enum attribute.
+// TestEnrichSchemaNestedAttributeWithinNestedAttribute ensures enrichment recurses all the way to the leaf enum attribute.
 func TestEnrichSchemaNestedAttributeWithinNestedAttribute(t *testing.T) {
 	t.Parallel()
 
@@ -1156,9 +1154,9 @@ func TestEnrichSchemaNestedAttributeWithinNestedAttribute(t *testing.T) {
 						Required: true,
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
-								"severity": schema.StringAttribute{
+								"team": schema.StringAttribute{
 									Required:    true,
-									Description: "A severity level.",
+									Description: "A team level.",
 									Validators: []validator.String{
 										validators.NewEnumValidator[validator.String](datadogV2.NewTeamPermissionSettingValueFromValue),
 									},
@@ -1173,10 +1171,10 @@ func TestEnrichSchemaNestedAttributeWithinNestedAttribute(t *testing.T) {
 
 	EnrichFrameworkResourceSchema(&s)
 
-	expected := "A severity level. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`."
+	expected := "A team level. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`."
 	got := s.Attributes["action"].(schema.SingleNestedAttribute).
 		Attributes["levels"].(schema.ListNestedAttribute).
-		NestedObject.Attributes["severity"].GetDescription()
+		NestedObject.Attributes["team"].GetDescription()
 	if got != expected {
 		t.Errorf("expected description '%s', got '%s' instead.", expected, got)
 	}

--- a/datadog/internal/fwutils/fw_enrich_schema_test.go
+++ b/datadog/internal/fwutils/fw_enrich_schema_test.go
@@ -1015,3 +1015,169 @@ func TestEnrichSchemaSingleNestedBlock(t *testing.T) {
 		})
 	}
 }
+
+func TestEnrichSchemaSingleNestedAttribute(t *testing.T) {
+	t.Parallel()
+
+	type testStruct struct {
+		schema              schema.Schema
+		expectedDescription string
+	}
+	testCases := map[string]testStruct{
+		"description with string enum validator": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"nested_attribute": schema.SingleNestedAttribute{
+						Required: true,
+						Attributes: map[string]schema.Attribute{
+							"test_attribute": schema.StringAttribute{
+								Required:    true,
+								Description: "Example description.",
+								Validators: []validator.String{
+									validators.NewEnumValidator[validator.String](datadogV2.NewTeamPermissionSettingValueFromValue),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`.",
+		},
+		"description without validator": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"nested_attribute": schema.SingleNestedAttribute{
+						Required: true,
+						Attributes: map[string]schema.Attribute{
+							"test_attribute": schema.StringAttribute{
+								Required:    true,
+								Description: "Example description.",
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description.",
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			EnrichFrameworkResourceSchema(&testCase.schema)
+			description := testCase.schema.Attributes["nested_attribute"].(schema.SingleNestedAttribute).Attributes["test_attribute"].GetDescription()
+			if description != testCase.expectedDescription {
+				t.Errorf("expected description '%s', got '%s' instead.", testCase.expectedDescription, description)
+			}
+		})
+	}
+}
+
+func TestEnrichSchemaListNestedAttribute(t *testing.T) {
+	t.Parallel()
+
+	type testStruct struct {
+		schema              schema.Schema
+		expectedDescription string
+	}
+	testCases := map[string]testStruct{
+		"description with string enum validator": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"nested_attribute": schema.ListNestedAttribute{
+						Required: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.StringAttribute{
+									Required:    true,
+									Description: "Example description.",
+									Validators: []validator.String{
+										validators.NewEnumValidator[validator.String](datadogV2.NewTeamPermissionSettingValueFromValue),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`.",
+		},
+		"description with int64 between validator": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"nested_attribute": schema.ListNestedAttribute{
+						Required: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.Int64Attribute{
+									Required:    true,
+									Description: "Example description.",
+									Validators: []validator.Int64{
+										int64validator.Between(1, 500),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. Value must be between 1 and 500.",
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			EnrichFrameworkResourceSchema(&testCase.schema)
+			description := testCase.schema.Attributes["nested_attribute"].(schema.ListNestedAttribute).NestedObject.Attributes["test_attribute"].GetDescription()
+			if description != testCase.expectedDescription {
+				t.Errorf("expected description '%s', got '%s' instead.", testCase.expectedDescription, description)
+			}
+		})
+	}
+}
+
+// TestEnrichSchemaNestedAttributeWithinNestedAttribute covers a list nested attribute nested inside
+// a single nested attribute (e.g. an `action` object containing a list of typed entries), ensuring
+// enrichment recurses all the way to the leaf enum attribute.
+func TestEnrichSchemaNestedAttributeWithinNestedAttribute(t *testing.T) {
+	t.Parallel()
+
+	s := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"action": schema.SingleNestedAttribute{
+				Required: true,
+				Attributes: map[string]schema.Attribute{
+					"levels": schema.ListNestedAttribute{
+						Required: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"severity": schema.StringAttribute{
+									Required:    true,
+									Description: "A severity level.",
+									Validators: []validator.String{
+										validators.NewEnumValidator[validator.String](datadogV2.NewTeamPermissionSettingValueFromValue),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	EnrichFrameworkResourceSchema(&s)
+
+	expected := "A severity level. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`."
+	got := s.Attributes["action"].(schema.SingleNestedAttribute).
+		Attributes["levels"].(schema.ListNestedAttribute).
+		NestedObject.Attributes["severity"].GetDescription()
+	if got != expected {
+		t.Errorf("expected description '%s', got '%s' instead.", expected, got)
+	}
+}

--- a/datadog/internal/fwutils/fw_enrich_schema_test.go
+++ b/datadog/internal/fwutils/fw_enrich_schema_test.go
@@ -8,7 +8,11 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	datasourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	ephemeralSchema "github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
@@ -1043,6 +1047,64 @@ func TestEnrichSchemaSingleNestedAttribute(t *testing.T) {
 			},
 			expectedDescription: "Example description. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`.",
 		},
+		"description with int64 between validator": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"nested_attribute": schema.SingleNestedAttribute{
+						Required: true,
+						Attributes: map[string]schema.Attribute{
+							"test_attribute": schema.Int64Attribute{
+								Required:    true,
+								Description: "Example description.",
+								Validators: []validator.Int64{
+									int64validator.Between(1, 500),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. Value must be between 1 and 500.",
+		},
+		"description with bool default": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"nested_attribute": schema.SingleNestedAttribute{
+						Required: true,
+						Attributes: map[string]schema.Attribute{
+							"test_attribute": schema.BoolAttribute{
+								Optional:    true,
+								Computed:    true,
+								Description: "Example description.",
+								Default:     booldefault.StaticBool(true),
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. Defaults to `true`.",
+		},
+		"description with enum validator and default": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"nested_attribute": schema.SingleNestedAttribute{
+						Required: true,
+						Attributes: map[string]schema.Attribute{
+							"test_attribute": schema.StringAttribute{
+								Optional:    true,
+								Computed:    true,
+								Description: "Example description.",
+								Default:     stringdefault.StaticString("admins"),
+								Validators: []validator.String{
+									validators.NewEnumValidator[validator.String](datadogV2.NewTeamPermissionSettingValueFromValue),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`. Defaults to `\"admins\"`.",
+		},
 		"description without validator": {
 			schema: schema.Schema{
 				Attributes: map[string]schema.Attribute{
@@ -1125,6 +1187,67 @@ func TestEnrichSchemaListNestedAttribute(t *testing.T) {
 			},
 			expectedDescription: "Example description. Value must be between 1 and 500.",
 		},
+		"description with bool default": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"nested_attribute": schema.ListNestedAttribute{
+						Required: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.BoolAttribute{
+									Optional:    true,
+									Computed:    true,
+									Description: "Example description.",
+									Default:     booldefault.StaticBool(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. Defaults to `true`.",
+		},
+		"description with enum validator and default": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"nested_attribute": schema.ListNestedAttribute{
+						Required: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.StringAttribute{
+									Optional:    true,
+									Computed:    true,
+									Description: "Example description.",
+									Default:     stringdefault.StaticString("admins"),
+									Validators: []validator.String{
+										validators.NewEnumValidator[validator.String](datadogV2.NewTeamPermissionSettingValueFromValue),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`. Defaults to `\"admins\"`.",
+		},
+		"description without validator": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"nested_attribute": schema.ListNestedAttribute{
+						Required: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.StringAttribute{
+									Required:    true,
+									Description: "Example description.",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description.",
+		},
 	}
 
 	for name, testCase := range testCases {
@@ -1141,7 +1264,504 @@ func TestEnrichSchemaListNestedAttribute(t *testing.T) {
 	}
 }
 
-// TestEnrichSchemaNestedAttributeWithinNestedAttribute ensures enrichment recurses all the way to the leaf enum attribute.
+func TestEnrichSchemaSetNestedAttribute(t *testing.T) {
+	t.Parallel()
+
+	type testStruct struct {
+		schema              schema.Schema
+		expectedDescription string
+	}
+	testCases := map[string]testStruct{
+		"description with string enum validator": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"nested_attribute": schema.SetNestedAttribute{
+						Required: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.StringAttribute{
+									Required:    true,
+									Description: "Example description.",
+									Validators: []validator.String{
+										validators.NewEnumValidator[validator.String](datadogV2.NewTeamPermissionSettingValueFromValue),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`.",
+		},
+		"description with int64 between validator": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"nested_attribute": schema.SetNestedAttribute{
+						Required: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.Int64Attribute{
+									Required:    true,
+									Description: "Example description.",
+									Validators: []validator.Int64{
+										int64validator.Between(1, 500),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. Value must be between 1 and 500.",
+		},
+		"description with bool default": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"nested_attribute": schema.SetNestedAttribute{
+						Required: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.BoolAttribute{
+									Optional:    true,
+									Computed:    true,
+									Description: "Example description.",
+									Default:     booldefault.StaticBool(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. Defaults to `true`.",
+		},
+		"description with enum validator and default": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"nested_attribute": schema.SetNestedAttribute{
+						Required: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.StringAttribute{
+									Optional:    true,
+									Computed:    true,
+									Description: "Example description.",
+									Default:     stringdefault.StaticString("admins"),
+									Validators: []validator.String{
+										validators.NewEnumValidator[validator.String](datadogV2.NewTeamPermissionSettingValueFromValue),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`. Defaults to `\"admins\"`.",
+		},
+		"description without validator": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"nested_attribute": schema.SetNestedAttribute{
+						Required: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.StringAttribute{
+									Required:    true,
+									Description: "Example description.",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description.",
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			EnrichFrameworkResourceSchema(&testCase.schema)
+			description := testCase.schema.Attributes["nested_attribute"].(schema.SetNestedAttribute).NestedObject.Attributes["test_attribute"].GetDescription()
+			if description != testCase.expectedDescription {
+				t.Errorf("expected description '%s', got '%s' instead.", testCase.expectedDescription, description)
+			}
+		})
+	}
+}
+
+func TestEnrichSchemaMapNestedAttribute(t *testing.T) {
+	t.Parallel()
+
+	type testStruct struct {
+		schema              schema.Schema
+		expectedDescription string
+	}
+	testCases := map[string]testStruct{
+		"description with string enum validator": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"nested_attribute": schema.MapNestedAttribute{
+						Required: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.StringAttribute{
+									Required:    true,
+									Description: "Example description.",
+									Validators: []validator.String{
+										validators.NewEnumValidator[validator.String](datadogV2.NewTeamPermissionSettingValueFromValue),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`.",
+		},
+		"description with int64 between validator": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"nested_attribute": schema.MapNestedAttribute{
+						Required: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.Int64Attribute{
+									Required:    true,
+									Description: "Example description.",
+									Validators: []validator.Int64{
+										int64validator.Between(1, 500),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. Value must be between 1 and 500.",
+		},
+		"description with bool default": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"nested_attribute": schema.MapNestedAttribute{
+						Required: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.BoolAttribute{
+									Optional:    true,
+									Computed:    true,
+									Description: "Example description.",
+									Default:     booldefault.StaticBool(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. Defaults to `true`.",
+		},
+		"description with enum validator and default": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"nested_attribute": schema.MapNestedAttribute{
+						Required: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.StringAttribute{
+									Optional:    true,
+									Computed:    true,
+									Description: "Example description.",
+									Default:     stringdefault.StaticString("admins"),
+									Validators: []validator.String{
+										validators.NewEnumValidator[validator.String](datadogV2.NewTeamPermissionSettingValueFromValue),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`. Defaults to `\"admins\"`.",
+		},
+		"description without validator": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"nested_attribute": schema.MapNestedAttribute{
+						Required: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"test_attribute": schema.StringAttribute{
+									Required:    true,
+									Description: "Example description.",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescription: "Example description.",
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			EnrichFrameworkResourceSchema(&testCase.schema)
+			description := testCase.schema.Attributes["nested_attribute"].(schema.MapNestedAttribute).NestedObject.Attributes["test_attribute"].GetDescription()
+			if description != testCase.expectedDescription {
+				t.Errorf("expected description '%s', got '%s' instead.", testCase.expectedDescription, description)
+			}
+		})
+	}
+}
+
+func TestEnrichDatasourceSchemaSingleNestedAttribute(t *testing.T) {
+	t.Parallel()
+
+	s := datasourceSchema.Schema{
+		Attributes: map[string]datasourceSchema.Attribute{
+			"nested_attribute": datasourceSchema.SingleNestedAttribute{
+				Required: true,
+				Attributes: map[string]datasourceSchema.Attribute{
+					"test_attribute": datasourceSchema.StringAttribute{
+						Required:    true,
+						Description: "Example description.",
+						Validators: []validator.String{
+							validators.NewEnumValidator[validator.String](datadogV2.NewTeamPermissionSettingValueFromValue),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	EnrichFrameworkDatasourceSchema(&s)
+
+	expected := "Example description. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`."
+	description := s.Attributes["nested_attribute"].(datasourceSchema.SingleNestedAttribute).Attributes["test_attribute"].GetDescription()
+	if description != expected {
+		t.Errorf("expected description '%s', got '%s' instead.", expected, description)
+	}
+}
+
+func TestEnrichDatasourceSchemaListNestedAttribute(t *testing.T) {
+	t.Parallel()
+
+	s := datasourceSchema.Schema{
+		Attributes: map[string]datasourceSchema.Attribute{
+			"nested_attribute": datasourceSchema.ListNestedAttribute{
+				Required: true,
+				NestedObject: datasourceSchema.NestedAttributeObject{
+					Attributes: map[string]datasourceSchema.Attribute{
+						"test_attribute": datasourceSchema.StringAttribute{
+							Required:    true,
+							Description: "Example description.",
+							Validators: []validator.String{
+								validators.NewEnumValidator[validator.String](datadogV2.NewTeamPermissionSettingValueFromValue),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	EnrichFrameworkDatasourceSchema(&s)
+
+	expected := "Example description. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`."
+	description := s.Attributes["nested_attribute"].(datasourceSchema.ListNestedAttribute).NestedObject.Attributes["test_attribute"].GetDescription()
+	if description != expected {
+		t.Errorf("expected description '%s', got '%s' instead.", expected, description)
+	}
+}
+
+func TestEnrichDatasourceSchemaSetNestedAttribute(t *testing.T) {
+	t.Parallel()
+
+	s := datasourceSchema.Schema{
+		Attributes: map[string]datasourceSchema.Attribute{
+			"nested_attribute": datasourceSchema.SetNestedAttribute{
+				Required: true,
+				NestedObject: datasourceSchema.NestedAttributeObject{
+					Attributes: map[string]datasourceSchema.Attribute{
+						"test_attribute": datasourceSchema.StringAttribute{
+							Required:    true,
+							Description: "Example description.",
+							Validators: []validator.String{
+								validators.NewEnumValidator[validator.String](datadogV2.NewTeamPermissionSettingValueFromValue),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	EnrichFrameworkDatasourceSchema(&s)
+
+	expected := "Example description. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`."
+	description := s.Attributes["nested_attribute"].(datasourceSchema.SetNestedAttribute).NestedObject.Attributes["test_attribute"].GetDescription()
+	if description != expected {
+		t.Errorf("expected description '%s', got '%s' instead.", expected, description)
+	}
+}
+
+func TestEnrichDatasourceSchemaMapNestedAttribute(t *testing.T) {
+	t.Parallel()
+
+	s := datasourceSchema.Schema{
+		Attributes: map[string]datasourceSchema.Attribute{
+			"nested_attribute": datasourceSchema.MapNestedAttribute{
+				Required: true,
+				NestedObject: datasourceSchema.NestedAttributeObject{
+					Attributes: map[string]datasourceSchema.Attribute{
+						"test_attribute": datasourceSchema.StringAttribute{
+							Required:    true,
+							Description: "Example description.",
+							Validators: []validator.String{
+								validators.NewEnumValidator[validator.String](datadogV2.NewTeamPermissionSettingValueFromValue),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	EnrichFrameworkDatasourceSchema(&s)
+
+	expected := "Example description. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`."
+	description := s.Attributes["nested_attribute"].(datasourceSchema.MapNestedAttribute).NestedObject.Attributes["test_attribute"].GetDescription()
+	if description != expected {
+		t.Errorf("expected description '%s', got '%s' instead.", expected, description)
+	}
+}
+
+func TestEnrichEphemeralSchemaSingleNestedAttribute(t *testing.T) {
+	t.Parallel()
+
+	s := ephemeralSchema.Schema{
+		Attributes: map[string]ephemeralSchema.Attribute{
+			"nested_attribute": ephemeralSchema.SingleNestedAttribute{
+				Required: true,
+				Attributes: map[string]ephemeralSchema.Attribute{
+					"test_attribute": ephemeralSchema.StringAttribute{
+						Required:    true,
+						Description: "Example description.",
+						Validators: []validator.String{
+							validators.NewEnumValidator[validator.String](datadogV2.NewTeamPermissionSettingValueFromValue),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	EnrichFrameworkEphemeralResourceSchema(&s)
+
+	expected := "Example description. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`."
+	description := s.Attributes["nested_attribute"].(ephemeralSchema.SingleNestedAttribute).Attributes["test_attribute"].GetDescription()
+	if description != expected {
+		t.Errorf("expected description '%s', got '%s' instead.", expected, description)
+	}
+}
+
+func TestEnrichEphemeralSchemaListNestedAttribute(t *testing.T) {
+	t.Parallel()
+
+	s := ephemeralSchema.Schema{
+		Attributes: map[string]ephemeralSchema.Attribute{
+			"nested_attribute": ephemeralSchema.ListNestedAttribute{
+				Required: true,
+				NestedObject: ephemeralSchema.NestedAttributeObject{
+					Attributes: map[string]ephemeralSchema.Attribute{
+						"test_attribute": ephemeralSchema.StringAttribute{
+							Required:    true,
+							Description: "Example description.",
+							Validators: []validator.String{
+								validators.NewEnumValidator[validator.String](datadogV2.NewTeamPermissionSettingValueFromValue),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	EnrichFrameworkEphemeralResourceSchema(&s)
+
+	expected := "Example description. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`."
+	description := s.Attributes["nested_attribute"].(ephemeralSchema.ListNestedAttribute).NestedObject.Attributes["test_attribute"].GetDescription()
+	if description != expected {
+		t.Errorf("expected description '%s', got '%s' instead.", expected, description)
+	}
+}
+
+func TestEnrichEphemeralSchemaSetNestedAttribute(t *testing.T) {
+	t.Parallel()
+
+	s := ephemeralSchema.Schema{
+		Attributes: map[string]ephemeralSchema.Attribute{
+			"nested_attribute": ephemeralSchema.SetNestedAttribute{
+				Required: true,
+				NestedObject: ephemeralSchema.NestedAttributeObject{
+					Attributes: map[string]ephemeralSchema.Attribute{
+						"test_attribute": ephemeralSchema.StringAttribute{
+							Required:    true,
+							Description: "Example description.",
+							Validators: []validator.String{
+								validators.NewEnumValidator[validator.String](datadogV2.NewTeamPermissionSettingValueFromValue),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	EnrichFrameworkEphemeralResourceSchema(&s)
+
+	expected := "Example description. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`."
+	description := s.Attributes["nested_attribute"].(ephemeralSchema.SetNestedAttribute).NestedObject.Attributes["test_attribute"].GetDescription()
+	if description != expected {
+		t.Errorf("expected description '%s', got '%s' instead.", expected, description)
+	}
+}
+
+func TestEnrichEphemeralSchemaMapNestedAttribute(t *testing.T) {
+	t.Parallel()
+
+	s := ephemeralSchema.Schema{
+		Attributes: map[string]ephemeralSchema.Attribute{
+			"nested_attribute": ephemeralSchema.MapNestedAttribute{
+				Required: true,
+				NestedObject: ephemeralSchema.NestedAttributeObject{
+					Attributes: map[string]ephemeralSchema.Attribute{
+						"test_attribute": ephemeralSchema.StringAttribute{
+							Required:    true,
+							Description: "Example description.",
+							Validators: []validator.String{
+								validators.NewEnumValidator[validator.String](datadogV2.NewTeamPermissionSettingValueFromValue),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	EnrichFrameworkEphemeralResourceSchema(&s)
+
+	expected := "Example description. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`."
+	description := s.Attributes["nested_attribute"].(ephemeralSchema.MapNestedAttribute).NestedObject.Attributes["test_attribute"].GetDescription()
+	if description != expected {
+		t.Errorf("expected description '%s', got '%s' instead.", expected, description)
+	}
+}
+
 func TestEnrichSchemaNestedAttributeWithinNestedAttribute(t *testing.T) {
 	t.Parallel()
 
@@ -1172,10 +1792,10 @@ func TestEnrichSchemaNestedAttributeWithinNestedAttribute(t *testing.T) {
 	EnrichFrameworkResourceSchema(&s)
 
 	expected := "A team level. Valid values are `admins`, `members`, `organization`, `user_access_manage`, `teams_manage`."
-	got := s.Attributes["action"].(schema.SingleNestedAttribute).
+	description := s.Attributes["action"].(schema.SingleNestedAttribute).
 		Attributes["levels"].(schema.ListNestedAttribute).
 		NestedObject.Attributes["team"].GetDescription()
-	if got != expected {
+	if description != expected {
 		t.Errorf("expected description '%s', got '%s' instead.", expected, got)
 	}
 }

--- a/datadog/internal/fwutils/fw_enrich_schema_test.go
+++ b/datadog/internal/fwutils/fw_enrich_schema_test.go
@@ -1796,6 +1796,6 @@ func TestEnrichSchemaNestedAttributeWithinNestedAttribute(t *testing.T) {
 		Attributes["levels"].(schema.ListNestedAttribute).
 		NestedObject.Attributes["team"].GetDescription()
 	if description != expected {
-		t.Errorf("expected description '%s', got '%s' instead.", expected, got)
+		t.Errorf("expected description '%s', got '%s' instead.", expected, description)
 	}
 }

--- a/docs/resources/tag_indexing_rule.md
+++ b/docs/resources/tag_indexing_rule.md
@@ -67,9 +67,9 @@ Required:
 Optional:
 
 - `dynamic_tags` (Attributes) Configuration for including dynamically queried tags. (see [below for nested schema](#nestedatt--options--data--dynamic_tags))
-- `manage_preexisting_metrics` (Boolean) When true, the rule applies to metrics ingested before the rule was created.
+- `manage_preexisting_metrics` (Boolean) When true, the rule applies to metrics ingested before the rule was created. Defaults to `true`.
 - `metric_match` (Attributes) Criteria for matching metrics based on query state. (see [below for nested schema](#nestedatt--options--data--metric_match))
-- `override_previous_rules` (Boolean) When true, this rule's tag list overrides tags configured by earlier rules for the same metric.
+- `override_previous_rules` (Boolean) When true, this rule's tag list overrides tags configured by earlier rules for the same metric. Defaults to `false`.
 
 <a id="nestedatt--options--data--dynamic_tags"></a>
 ### Nested Schema for `options.data.dynamic_tags`


### PR DESCRIPTION
## What

The schema-description enricher (`EnrichFramework{Resource,Datasource,EphemeralResource}Schema` in `datadog/internal/fwutils`) auto-appends documentation hints to attributes — `Valid values are` ... for enum/oneOf validators, validation messages for range validators, and `Defaults to` ... for defaults.

It walked top-level attributes and recursed through **blocks**, but never recursed into **nested attributes** (`SingleNestedAttribute` / `ListNestedAttribute` / `SetNestedAttribute` / `MapNestedAttribute`). Any hint on an attribute nested inside a nested attribute was silently dropped from the generated docs.

This was easy to miss while nested blocks were the norm, but the framework now recommends nested attributes for new protocol-v6 resources, so the gap affects a growing number of attributes.

## Change

- Recurse into the four nested-attribute types in the resource, datasource, and ephemeral enrichment paths. Leaf attributes carry the validators, so the nested containers themselves aren't enriched — mirroring how blocks are already handled.
- Added unit tests for single-nested, list-nested, map-nested, list-nested and a deep single->list->enum case.
- Regenerated docs: `tag_indexing_rule` now shows the previously-missing "Defaults to" hints on its deeply-nested booleans.

## Why now

Surfaced while adding new resources in this subsequent [PR](https://github.com/DataDog/terraform-provider-datadog/pull/3907) that use nested attributes. This is the shared-infra fix so every current and future nested-attribute resource gets correct docs automatically.