### PR TITLE
[SEC-33535][chore] replace @DataDog/k9-cloud-siem code owners with @DataDog/cloud-siem

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,7 +27,7 @@ datadog/*datadog_metric_metadata*          @DataDog/metrics-experience
 datadog/*datadog_metric_tag_configuration* @DataDog/metrics-experience
 datadog/*datadog_monitor*                  @DataDog/monitor-app
 datadog/*datadog_screenboard*              @DataDog/dashboards-backend
-datadog/*datadog_security_monitoring*       @DataDog/k9-cloud-siem
+datadog/*datadog_security_monitoring*       @DataDog/cloud-siem
 datadog/*datadog_security_notification_rule* @DataDog/k9-shared-capabilities
 datadog/*datadog_service_definition*       @DataDog/service-catalog
 datadog/*datadog_service_level_objective*  @DataDog/slo-app
@@ -101,7 +101,7 @@ datadog/**/*datadog_workflow_automation*         @DataDog/workflow-automation-ba
 datadog/**/*datadog_powerpack*                   @DataDog/dashboards-backend
 datadog/**/*datadog_role_users*                  @DataDog/team-aaa
 datadog/**/*datadog_rum*                         @DataDog/rum-backend
-datadog/**/*datadog_security_monitoring*          @DataDog/k9-cloud-siem
+datadog/**/*datadog_security_monitoring*          @DataDog/cloud-siem
 datadog/**/*datadog_security_notification_rule*   @DataDog/k9-shared-capabilities
 datadog/**/*datadog_csm_threats*                 @DataDog/k9-cws-backend
 datadog/**/*datadog_cloud_workload_security*     @DataDog/k9-cws-backend


### PR DESCRIPTION
## What does this PR do?
- Replaces the manually-managed `@DataDog/k9-cloud-siem` GitHub team with the canonical `@DataDog/cloud-siem` team in CODEOWNERS.
- Part of migrating SIEM code ownership off manual GitHub groups onto the `cloud-siem` team / Datadog pack. All other owning teams are preserved.
- [SEC-33535](https://datadoghq.atlassian.net/browse/SEC-33535) — epic [SEC-33533](https://datadoghq.atlassian.net/browse/SEC-33533)

[SEC-33535]: https://datadoghq.atlassian.net/browse/SEC-33535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SEC-33533]: https://datadoghq.atlassian.net/browse/SEC-33533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ