### PR TITLE
Adds make dev-build to create custom tf binary that we can use in an override config

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -71,7 +71,32 @@ The Datadog Provider can be built to use the binary as a terraform plugin. This 
 
 This provider can be built by running `make build`, or just `make`. This will place the binary in `$GOPATH/bin`
 
+### Quick dev override (`make dev-build`)
+
+For iterating on a feature branch, `make dev-build` automates the whole [`dev_overrides`][4] setup in one step. It:
+
+- builds the provider from your current branch into `~/.terraform.d/dev/datadog/`, and
+- generates a self-contained Terraform CLI config at `~/.terraform.d/dev/datadog.tfrc` that points the `DataDog/datadog` provider at that build.
+
+Then run Terraform against your local build by pointing `TF_CLI_CONFIG_FILE` at the generated config:
+
+```sh
+make dev-build
+
+# In your HCL directory (do NOT run `terraform init` — dev overrides bypass it):
+TF_CLI_CONFIG_FILE=~/.terraform.d/dev/datadog.tfrc terraform plan
+TF_CLI_CONFIG_FILE=~/.terraform.d/dev/datadog.tfrc terraform apply
+```
+
+Terraform prints a `Provider development overrides are in effect` warning on each run — that confirms it is using your local build. Scoping the override to `TF_CLI_CONFIG_FILE` (instead of a global `~/.terraformrc`) means only commands where you set the variable use the branch build; everything else uses registry providers as normal.
+
+Re-run `make dev-build` after each code change to pick it up. Run `make dev-clean` to remove the local build and generated config.
+
+> **Note:** don't set a `version` constraint for the `datadog` provider in your config — version constraints are ignored under a dev override.
+
 ### Local Development Setup
+
+The steps below set the override up manually (equivalent to what `make dev-build` automates above).
 
 1. Setup a `~/.terraformrc` file with the following content:
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,6 +3,8 @@ RECORD?=false
 GOIMPORTS_FILES?=$$(find . -name '*.go')
 PKG_NAME=datadog
 DIR=~/.terraform.d/plugins
+DEV_PLUGIN_DIR=$(HOME)/.terraform.d/dev/datadog
+DEV_TFRC=$(HOME)/.terraform.d/dev/datadog.tfrc
 ZORKIAN_VERSION?=master
 API_CLIENT_VERSION?=master
 LOCAL_PACKAGE="github.com/terraform-providers/terraform-provider-datadog"
@@ -18,6 +20,26 @@ install: fmtcheck
 
 uninstall:
 	@rm -vf $(DIR)/terraform-provider-datadog
+
+# Build the provider from the current branch and generate a Terraform CLI config
+# that points the datadog provider at this local build via dev_overrides. This lets
+# you exercise in-development changes with the regular `terraform` CLI.
+# Re-run after any code change. Usage:
+#   make dev-build
+#   TF_CLI_CONFIG_FILE=$(DEV_TFRC) terraform apply   # do NOT run `terraform init`
+dev-build:
+	@mkdir -p $(DEV_PLUGIN_DIR)
+	go build -o $(DEV_PLUGIN_DIR)/terraform-provider-datadog .
+	@printf 'provider_installation {\n  dev_overrides {\n    "DataDog/datadog" = "%s"\n  }\n  direct {}\n}\n' "$(DEV_PLUGIN_DIR)" > $(DEV_TFRC)
+	@echo ""
+	@echo "Local provider built -> $(DEV_PLUGIN_DIR)/terraform-provider-datadog"
+	@echo "CLI config written   -> $(DEV_TFRC)"
+	@echo ""
+	@echo "Run terraform against this build (do NOT run 'terraform init'):"
+	@echo "  TF_CLI_CONFIG_FILE=$(DEV_TFRC) terraform apply"
+
+dev-clean:
+	@rm -vf $(DEV_PLUGIN_DIR)/terraform-provider-datadog $(DEV_TFRC)
 
 # Run unit tests; these tests don't interact with the API and don't support/need RECORD
 test: get-test-deps fmtcheck
@@ -103,4 +125,4 @@ check-docs: docs
 		echo "Success: No generated documentation changes detected"; \
 	fi
 
-.PHONY: build check-docs docs test testall testacc cassettes vet fmt fmtcheck errcheck lint lint-new lint-fix test-compile get-test-deps license-check sweep
+.PHONY: build dev-build dev-clean check-docs docs test testall testacc cassettes vet fmt fmtcheck errcheck lint lint-new lint-fix test-compile get-test-deps license-check sweep


### PR DESCRIPTION
Adds new `make dev-build` command to create a custom .tfrc file that allows terraform to use a custom TF provider when using this command:

```
TF_CLI_CONFIG_FILE=~/.terraform.d/dev/datadog.tfrc terraform plan
TF_CLI_CONFIG_FILE=~/.terraform.d/dev/datadog.tfrc terraform apply
```

.tfrc file looks like this:
```
provider_installation {
  dev_overrides {
    "DataDog/datadog" = "/Users/andrei.patru/.terraform.d/dev/datadog"
  }
  direct {}
}
```