### PR TITLE
[datadog_cloud_configuration_rule] Document message Markdown section formatting

### DIFF
--- a/datadog/resource_datadog_cloud_configuration_rule.go
+++ b/datadog/resource_datadog_cloud_configuration_rule.go
@@ -55,10 +55,11 @@ func cloudConfigurationRuleSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Required: true,
 			Description: "The message associated to the rule that will be shown in findings and signals. " +
-				"For cloud configuration rules, the message is rendered in the finding side panel. When the message is written as Markdown " +
-				"using the following top-level section headers, each section is shown in a dedicated area of the finding: `Description` and " +
+				"For cloud configuration rules, the message is rendered in the finding side panel. When the message is written as Markdown, " +
+				"you can use the following top-level section headers to control where each part appears in the finding: `Description` and " +
 				"`Rationale` appear under **What Happened**, `Remediation` appears in its own **Remediation** section, and `References` are " +
-				"shown separately. Use level-2 (`##`) headers for each section. If none of these headers are present, the entire message is " +
+				"shown separately. All of these sections are optional and can appear in any order; a typical message uses only `Description` " +
+				"and `Remediation`. Use level-2 (`##`) headers for each section. If none of these headers are present, the entire message is " +
 				"shown as the description.",
 		},
 		enabledField: {

--- a/datadog/resource_datadog_cloud_configuration_rule.go
+++ b/datadog/resource_datadog_cloud_configuration_rule.go
@@ -52,9 +52,14 @@ func cloudConfigurationRuleSchema() map[string]*schema.Schema {
 			Description: "The name of the cloud configuration rule.",
 		},
 		messageField: {
-			Type:        schema.TypeString,
-			Required:    true,
-			Description: "The message associated to the rule that will be shown in findings and signals.",
+			Type:     schema.TypeString,
+			Required: true,
+			Description: "The message associated to the rule that will be shown in findings and signals. " +
+				"For cloud configuration rules, the message is rendered in the finding side panel. When the message is written as Markdown " +
+				"using the following top-level section headers, each section is shown in a dedicated area of the finding: `Description` and " +
+				"`Rationale` appear under **What Happened**, `Remediation` appears in its own **Remediation** section, and `References` are " +
+				"shown separately. Use level-2 (`##`) headers for each section. If none of these headers are present, the entire message is " +
+				"shown as the description.",
 		},
 		enabledField: {
 			Type:        schema.TypeBool,

--- a/docs/resources/cloud_configuration_rule.md
+++ b/docs/resources/cloud_configuration_rule.md
@@ -58,7 +58,7 @@ resource "datadog_cloud_configuration_rule" "myrule" {
 ### Required
 
 - `enabled` (Boolean) Whether the cloud configuration rule is enabled.
-- `message` (String) The message associated to the rule that will be shown in findings and signals.
+- `message` (String) The message associated to the rule that will be shown in findings and signals. For cloud configuration rules, the message is rendered in the finding side panel. When the message is written as Markdown using the following top-level section headers, each section is shown in a dedicated area of the finding: `Description` and `Rationale` appear under **What Happened**, `Remediation` appears in its own **Remediation** section, and `References` are shown separately. Use level-2 (`##`) headers for each section. If none of these headers are present, the entire message is shown as the description.
 - `name` (String) The name of the cloud configuration rule.
 - `policy` (String) Policy written in Rego format.
 - `resource_type` (String) Main resource type to be checked by the rule.

--- a/docs/resources/cloud_configuration_rule.md
+++ b/docs/resources/cloud_configuration_rule.md
@@ -58,7 +58,7 @@ resource "datadog_cloud_configuration_rule" "myrule" {
 ### Required
 
 - `enabled` (Boolean) Whether the cloud configuration rule is enabled.
-- `message` (String) The message associated to the rule that will be shown in findings and signals. For cloud configuration rules, the message is rendered in the finding side panel. When the message is written as Markdown using the following top-level section headers, each section is shown in a dedicated area of the finding: `Description` and `Rationale` appear under **What Happened**, `Remediation` appears in its own **Remediation** section, and `References` are shown separately. Use level-2 (`##`) headers for each section. If none of these headers are present, the entire message is shown as the description.
+- `message` (String) The message associated to the rule that will be shown in findings and signals. For cloud configuration rules, the message is rendered in the finding side panel. When the message is written as Markdown, you can use the following top-level section headers to control where each part appears in the finding: `Description` and `Rationale` appear under **What Happened**, `Remediation` appears in its own **Remediation** section, and `References` are shown separately. All of these sections are optional and can appear in any order; a typical message uses only `Description` and `Remediation`. Use level-2 (`##`) headers for each section. If none of these headers are present, the entire message is shown as the description.
 - `name` (String) The name of the cloud configuration rule.
 - `policy` (String) Policy written in Rego format.
 - `resource_type` (String) Main resource type to be checked by the rule.


### PR DESCRIPTION
## Motivation

The Datadog finding side panel ("Misconfigurations and attack paths") splits a cloud configuration rule's `message` into dedicated areas — the description shows under **What Happened** and remediation gets its own **Remediation** section. This split is produced by parsing Markdown section headers in the `message`, and it applies to custom rules (created via this resource) exactly as it does to Datadog's out-of-the-box rules.

Until now this behavior was undocumented. Custom-rule authors could only discover it by reverse-engineering the format, and had no way to know whether it was intentional or how to structure their `message` to get the split. This surfaced as a customer request to document the behavior.

## Changes

- Expand the `message` attribute description on `datadog_cloud_configuration_rule` to document the recognized Markdown section headers (`Description`, `Rationale`, `Remediation`, `References`), where each renders in the finding panel, and the formatting rules (use `##` headers; fall back to a plain description when no headers are present).
- Regenerate `docs/resources/cloud_configuration_rule.md` via `make docs`.

## QA Instructions

- **Docs generation is reproducible:** run `make docs` on this branch and confirm it produces no further diff (the committed `docs/resources/cloud_configuration_rule.md` matches generated output).
- **Rendered text:** confirm the new `message` guidance appears on `docs/resources/cloud_configuration_rule.md` and reads correctly (Markdown backticks/bold render on the Terraform Registry).
- **Behavior sanity (optional, in-app):** create a custom cloud configuration rule whose `message` uses `## Description` and `## Remediation` headers; open a resulting finding and confirm the panel shows the description under **What Happened** and the remediation in its own **Remediation** section.
- No functional/provider code changed, so acceptance tests are unaffected; CI runs the full suite.

## Blast Radius

- Documentation only — `datadog_cloud_configuration_rule` resource reference page on the Terraform Registry.
- No changes to provider behavior, schema shape, or CRUD logic.

## ⚠️ Before merging

- [ ] **Product sign-off:** CSPM/CSM product to confirm the Markdown-header convention is supported as a stable contract (documenting it commits us to it).
- [ ] **#api-clients sync** before this public-repo PR is reviewed/merged, per the provider contribution guide.
- [ ] Add the `changelog/documentation` label.