### PR TITLE
Remove dbt.model and dbt.test from data-jobs monitor job_type docs

### DIFF
--- a/datadog/fwprovider/resource_datadog_monitor.go
+++ b/datadog/fwprovider/resource_datadog_monitor.go
@@ -1432,7 +1432,7 @@ func (r *monitorResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 									},
 									"job_type": schema.StringAttribute{
 										Required:    true,
-										Description: "The type of job being monitored. Valid values include `databricks.job`, `spark.application`, `airflow.dag`, `dbt.job`, `dbt.model`, `dbt.test`, `glue.job`. Custom job types are supported with the `custom.ol.` prefix.",
+										Description: "The type of job being monitored. Valid values include `databricks.job`, `spark.application`, `airflow.dag`, `dbt.job`, `glue.job`. Custom job types are supported with the `custom.ol.` prefix.",
 									},
 									"query_dialect": schema.StringAttribute{
 										Required:    true,

--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -1228,7 +1228,7 @@ func getMonitorFormulaQuerySchema() *schema.Schema {
 							"job_type": {
 								Type:        schema.TypeString,
 								Required:    true,
-								Description: "The type of job being monitored. Valid values include `databricks.job`, `spark.application`, `airflow.dag`, `dbt.job`, `dbt.model`, `dbt.test`, `glue.job`. Custom job types are supported with the `custom.ol.` prefix.",
+								Description: "The type of job being monitored. Valid values include `databricks.job`, `spark.application`, `airflow.dag`, `dbt.job`, `glue.job`. Custom job types are supported with the `custom.ol.` prefix.",
 							},
 							"query_dialect": {
 								Type:        schema.TypeString,

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -684,7 +684,7 @@ Required:
 
 Required:
 
-- `job_type` (String) The type of job being monitored. Valid values include `databricks.job`, `spark.application`, `airflow.dag`, `dbt.job`, `dbt.model`, `dbt.test`, `glue.job`. Custom job types are supported with the `custom.ol.` prefix.
+- `job_type` (String) The type of job being monitored. Valid values include `databricks.job`, `spark.application`, `airflow.dag`, `dbt.job`, `glue.job`. Custom job types are supported with the `custom.ol.` prefix.
 - `jobs_query` (String) Filter expression used to select the jobs to monitor.
 - `name` (String) Name of the query for use in formulas. Must be `run_query`.
 - `query_dialect` (String) Query dialect for data jobs queries. Currently only `metric` is supported.


### PR DESCRIPTION
## Summary
- `dbt.model` and `dbt.test` aren't valid `job_type` values for the data-jobs alert monitor (`datadog_monitor` resource). Only `dbt.job` is supported for dbt.
- Removes them from the `job_type` description in both the SDKv2 and plugin-framework resource schemas, and regenerates `docs/resources/monitor.md` accordingly.

Follow-up to #3795.

## Test plan
- [ ] Confirm no other docs/examples reference `dbt.model` or `dbt.test` as job_type values