### PR TITLE
[Tfgen] Dropped created_at / updated_at / create_by / updated_by

### DIFF
--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -250,6 +250,10 @@ func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrat
 	// a map is not.
 	leaves := make([]*model.Attribute, 0, len(attributes.Children))
 	for _, child := range attributes.Children {
+		if isAuditField(tfNameOf(child.Path)) {
+			b.dropped = append(b.dropped, droppedAuditField(child.Path))
+			continue
+		}
 		if !isLeafType(child.TfType) && !isArrayType(child.TfType) && !isObjectType(child.TfType) {
 			b.unsupported = append(b.unsupported, UnsupportedNode{
 				Path:   child.Path,
@@ -306,6 +310,12 @@ type dataSourceBuilder struct {
 // member skipped from the attributes-only view, e.g. relationships.
 func droppedEnvelopeMember(path string) string {
 	return fmt.Sprintf("dropped %q: not part of the surfaced {id, type, attributes} envelope", path)
+}
+
+// droppedAuditField is the info-diagnostic note for a top-level audit attribute
+// omitted from a generated data source.
+func droppedAuditField(path string) string {
+	return fmt.Sprintf("dropped %q: server-managed audit field", path)
 }
 
 // walk processes one struct's worth of attributes in tree order, reserving the
@@ -466,6 +476,20 @@ func isArrayType(tfType string) bool {
 // isObjectType reports whether tfType is a bare nested object the envelope
 // hoists into single-object machinery (schema.SingleNestedBlock).
 func isObjectType(tfType string) bool { return tfType == "schema.SingleNestedBlock" }
+
+// auditFields are server-managed audit attributes dropped from the top level of a
+// generated data source: their timestamps and actor handles add schema noise
+// without configuration value.
+var auditFields = map[string]bool{
+	"created_at": true,
+	"updated_at": true,
+	"created_by": true,
+	"updated_by": true,
+}
+
+// isAuditField reports whether a top-level record attribute is server-managed
+// audit metadata the emit path drops rather than surfacing.
+func isAuditField(tfName string) bool { return auditFields[tfName] }
 
 // tfNameOf returns the Terraform attribute key for an attribute path: its last
 // dot-segment with array/map markers stripped.
@@ -791,6 +815,10 @@ func flattenItemElement(block *model.Attribute, unsupported *[]UnsupportedNode, 
 				continue
 			}
 			for _, leaf := range child.Children {
+				if isAuditField(tfNameOf(leaf.Path)) {
+					*dropped = append(*dropped, droppedAuditField(leaf.Path))
+					continue
+				}
 				switch {
 				case isLeafType(leaf.TfType):
 					scalars = append(scalars, itemElementLeaf{attr: leaf, chain: itemGetter("item.Attributes", tfNameOf(leaf.Path))})

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -62,7 +62,7 @@ var _ = Describe("BuildDataSourceView", func() {
 	It("renders a date-time string via .String(), a named enum via a string() cast, and avoids shadowing state", func() {
 		op := incidentTypeOperation()
 		attrs := op.ResponseSchema.Properties["data"].Properties["attributes"].Properties
-		attrs["created_at"] = &model.Schema{Kind: model.SchemaKindPrimitive, Type: "string", Format: "date-time"}
+		attrs["resolved_at"] = &model.Schema{Kind: model.SchemaKindPrimitive, Type: "string", Format: "date-time"}
 		attrs["state"] = &model.Schema{Kind: model.SchemaKindPrimitive, Type: "string", Enum: []string{"active", "archived"}}
 		art, err := model.BuildArtifact(op)
 		Expect(err).NotTo(HaveOccurred())
@@ -74,8 +74,8 @@ var _ = Describe("BuildDataSourceView", func() {
 		for _, a := range view.State.Assignments {
 			assign[a.LHS] = a
 		}
-		Expect(assign["state.CreatedAt"].RHS).To(Equal("types.StringValue(createdAt.String())"))
-		Expect(assign["state.CreatedAt"].GetterOk).To(Equal("attributes.GetCreatedAtOk()"))
+		Expect(assign["state.ResolvedAt"].RHS).To(Equal("types.StringValue(resolvedAt.String())"))
+		Expect(assign["state.ResolvedAt"].GetterOk).To(Equal("attributes.GetResolvedAtOk()"))
 		// "state" would shadow the updateState receiver, so its local is suffixed.
 		Expect(assign["state.State"].Var).To(Equal("stateValue"))
 		Expect(assign["state.State"].RHS).To(Equal("types.StringValue(string(*stateValue))"))
@@ -125,6 +125,53 @@ var _ = Describe("BuildDataSourceView", func() {
 		view, err := BuildDataSourceView(art)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(view.Dropped).To(ContainElement(ContainSubstring("relationships")))
+	})
+})
+
+var _ = Describe("BuildDataSourceView audit fields", func() {
+	It("drops server-managed created_at/updated_at/created_by/updated_by from a singular record and records them", func() {
+		op := incidentTypeOperation()
+		attrs := op.ResponseSchema.Properties["data"].Properties["attributes"].Properties
+		for _, f := range []string{"created_at", "updated_at", "created_by", "updated_by"} {
+			attrs[f] = prim("string", "")
+		}
+		view := mustView(op)
+
+		for _, a := range view.Schema.Attributes {
+			Expect(a.TFName).NotTo(BeElementOf("created_at", "updated_at", "created_by", "updated_by"))
+		}
+		Expect(view.Dropped).To(ContainElement(ContainSubstring("created_at")))
+	})
+
+	It("keeps an audit-named field nested inside an object", func() {
+		view := mustView(retentionFilterOperation())
+
+		blocks := map[string]AttrView{}
+		for _, b := range view.Schema.Blocks {
+			blocks[b.TFName] = b
+		}
+		metadata := map[string]AttrView{}
+		for _, b := range blocks["filter"].Blocks {
+			metadata[b.TFName] = b
+		}
+		var nested []string
+		for _, a := range metadata["metadata"].Attributes {
+			nested = append(nested, a.TFName)
+		}
+		Expect(nested).To(ContainElement("created_by"))
+	})
+
+	It("drops top-level audit fields from plural item attributes but keeps non-audit siblings", func() {
+		view := mustView(datastoresOperation())
+
+		var itemAttrs []string
+		for _, b := range view.Schema.Blocks {
+			for _, a := range b.Attributes {
+				itemAttrs = append(itemAttrs, a.TFName)
+			}
+		}
+		Expect(itemAttrs).NotTo(ContainElement("created_at"))
+		Expect(itemAttrs).To(ContainElement("modified_at"))
 	})
 })
 

--- a/.generator-v2/internal/testdata/emit/data_source_plural_no_params.golden
+++ b/.generator-v2/internal/testdata/emit/data_source_plural_no_params.golden
@@ -23,7 +23,6 @@ type datadogDatastoresDataSourceModel struct {
 }
 
 type DatastoreDataModel struct {
-	CreatedAt                    types.String `tfsdk:"created_at"`
 	CreatorUserId                types.Int64  `tfsdk:"creator_user_id"`
 	CreatorUserUuid              types.String `tfsdk:"creator_user_uuid"`
 	Description                  types.String `tfsdk:"description"`
@@ -65,10 +64,6 @@ func (d *datadogDatastoresDataSource) Schema(_ context.Context, _ datasource.Sch
 				Description: "An array of datastore objects containing their configurations and metadata.",
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
-						"created_at": schema.StringAttribute{
-							Description: "Timestamp when the datastore was created.",
-							Computed:    true,
-						},
 						"creator_user_id": schema.Int64Attribute{
 							Description: "The numeric ID of the user who created the datastore.",
 							Computed:    true,
@@ -135,7 +130,6 @@ func (d *datadogDatastoresDataSource) updateState(state *datadogDatastoresDataSo
 	results := make([]*DatastoreDataModel, 0, len(*data))
 	for _, item := range *data {
 		r := DatastoreDataModel{
-			CreatedAt:                    types.StringValue(item.Attributes.GetCreatedAt().String()),
 			CreatorUserId:                types.Int64Value(int64(item.Attributes.GetCreatorUserId())),
 			CreatorUserUuid:              types.StringValue(item.Attributes.GetCreatorUserUuid()),
 			Description:                  types.StringValue(item.Attributes.GetDescription()),

--- a/.generator-v2/internal/testdata/emit/data_source_singular_both.golden
+++ b/.generator-v2/internal/testdata/emit/data_source_singular_both.golden
@@ -21,7 +21,6 @@ type datadogDatastoreDataSourceModel struct {
 	ID types.String `tfsdk:"id"`
 
 	// Computed values
-	CreatedAt                    types.String `tfsdk:"created_at"`
 	CreatorUserId                types.Int64  `tfsdk:"creator_user_id"`
 	CreatorUserUuid              types.String `tfsdk:"creator_user_uuid"`
 	Description                  types.String `tfsdk:"description"`
@@ -58,10 +57,6 @@ func (d *datadogDatastoreDataSource) Schema(_ context.Context, _ datasource.Sche
 			"id": schema.StringAttribute{
 				Description: "The ID of this datastore data source.",
 				Optional:    true,
-				Computed:    true,
-			},
-			"created_at": schema.StringAttribute{
-				Description: "Timestamp when the datastore was created.",
 				Computed:    true,
 			},
 			"creator_user_id": schema.Int64Attribute{
@@ -142,9 +137,6 @@ func (d *datadogDatastoreDataSource) updateState(state *datadogDatastoreDataSour
 	attributes := data.GetAttributes()
 	if id, ok := data.GetIdOk(); ok && id != nil {
 		state.ID = types.StringValue(*id)
-	}
-	if createdAt, ok := attributes.GetCreatedAtOk(); ok && createdAt != nil {
-		state.CreatedAt = types.StringValue(createdAt.String())
 	}
 	if creatorUserId, ok := attributes.GetCreatorUserIdOk(); ok && creatorUserId != nil {
 		state.CreatorUserId = types.Int64Value(int64(*creatorUserId))


### PR DESCRIPTION
### Motivation
Every Datadog record carries server-managed audit metadata — `created_at`, `updated_at`, `created_by`, `updated_by`. In a generated Terraform data source these add pure schema noise: they're read-only values the user never configures, and they bloat the struct, schema, and state mapper of every data source the generator emits. This PR teaches the emit path to omit those fields at the top level of a generated data source (while still recording each drop as an info diagnostic so it's visible in the run report).

### Changes
**`.generator-v2/internal/emit/builder.go`**
- Added an `auditFields` set (`created_at`, `updated_at`, `created_by`, `updated_by`) plus an `isAuditField(tfName)` helper.
- `flattenEnvelope` (singular data-source record): now skips any top-level attribute whose Terraform name is an audit field, appending an info note to `b.dropped` instead of emitting it into the model/schema/state mapper.
- `flattenItemElement` (plural data-source item attributes): applies the same top-level skip-and-record.
- Added the `droppedAuditField(path)` diagnostic helper, producing `dropped "<path>": server-managed audit field`.
- The drop is **top-level only** — audit-named fields nested inside objects/blocks are left untouched.

**`.generator-v2/internal/emit/builder_test.go`**
- New `BuildDataSourceView audit fields` describe block with three specs (singular drop + recorded, nested audit-named field kept, plural item drop with a non-audit sibling kept).
- Updated the existing date-time spec to exercise `resolved_at` instead of `created_at`, since `created_at` is now dropped.

**Golden fixtures** (regenerated to reflect the drop)
- `data_source_singular_both.golden`: removed `created_at` from the model struct, schema, and `updateState`.
- `data_source_plural_no_params.golden`: same removal from the datastore item model, nested schema block, and per-item state mapping.

### Test
- Added Ginkgo unit coverage asserting that audit fields are absent from `view.Schema` attributes, that their omission is recorded in `view.Dropped`, that an audit-named field nested inside an object is retained, and that dropping top-level audit fields from a plural item leaves non-audit siblings (e.g. `modified_at`) intact.
- The golden diffs for the datastore singular + plural data sources confirm the `created_at` column disappears from the generated struct, schema block, and state mapper while every other field is unchanged.
- Run with `make tfgen-test`.