### PR TITLE
[Tfgen] Accessors formatting fixes

### DIFF
--- a/.generator-v2/internal/cli/generate.go
+++ b/.generator-v2/internal/cli/generate.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -17,6 +19,11 @@ import (
 // errCheckFailed signals that --check found files that would change.
 // Execute translates this into exit code 3.
 var errCheckFailed = fmt.Errorf("check: one or more files would change")
+
+// apiInstancesHelperPath is the provider's ApiInstances helper, the source of
+// truth for SDK API accessor names. It is read relative to the working directory
+// (the repo root), like the other default paths.
+const apiInstancesHelperPath = "datadog/internal/utils/api_instances_helper.go"
 
 func newGenerateCmd(flags *globalFlags) *cobra.Command {
 	var check bool
@@ -50,6 +57,17 @@ func newGenerateCmd(flags *globalFlags) *cobra.Command {
 
 			filter := parseInclude(include)
 
+			// Resolve the provider's SDK-accessor names, the source of truth for
+			// APIAccessor. A missing file is expected outside a full checkout; a parse
+			// failure is worth surfacing. Either way we fall back to derived names.
+			accessors, accErr := emit.ResolveAPIAccessors(apiInstancesHelperPath)
+			if accErr != nil {
+				if !errors.Is(accErr, os.ErrNotExist) {
+					cmd.PrintErrln("tfgen: could not resolve API accessors, using derived names:", accErr)
+				}
+				accessors = nil
+			}
+
 			var registrations []emit.GeneratedRegistration
 			for _, op := range spec.Operations {
 				if op.Tracking == nil {
@@ -79,7 +97,7 @@ func newGenerateCmd(flags *globalFlags) *cobra.Command {
 					continue
 				}
 
-				entry, testEntry, reg := generateArtifact(op, outputRoot, testsOutputRoot, emitTests, check)
+				entry, testEntry, reg := generateArtifact(op, outputRoot, testsOutputRoot, emitTests, check, accessors)
 				runReport.Artifacts = append(runReport.Artifacts, entry)
 				if testEntry != nil {
 					runReport.Artifacts = append(runReport.Artifacts, *testEntry)
@@ -141,7 +159,7 @@ func newGenerateCmd(flags *globalFlags) *cobra.Command {
 // operation. On success it also returns the GeneratedRegistration the caller
 // uses to wire the data source into the provider; it is nil for a skipped or
 // failed artifact.
-func generateArtifact(op *model.Operation, outputRoot, testsOutputRoot string, emitTests, check bool) (model.ArtifactReportEntry, *model.ArtifactReportEntry, *emit.GeneratedRegistration) {
+func generateArtifact(op *model.Operation, outputRoot, testsOutputRoot string, emitTests, check bool, accessors map[string]string) (model.ArtifactReportEntry, *model.ArtifactReportEntry, *emit.GeneratedRegistration) {
 	entry := model.ArtifactReportEntry{
 		Name: op.Tracking.ArtifactName,
 		Kind: op.Tracking.ArtifactKind,
@@ -170,6 +188,9 @@ func generateArtifact(op *model.Operation, outputRoot, testsOutputRoot string, e
 	if err != nil {
 		return failEntry(entry, err), nil, nil
 	}
+	// Correct APIAccessor to the name the provider's helper actually exposes,
+	// which diverges from the derived name for a few acronym/aliased APIs.
+	emit.ApplyAPIAccessor(&view, accessors)
 	// Members the emit flattener dropped (e.g. relationships) ride along as info.
 	for _, msg := range view.Dropped {
 		entry.Diagnostics = append(entry.Diagnostics, model.Diagnostic{Severity: model.SeverityInfo, Message: msg})

--- a/.generator-v2/internal/emit/accessors.go
+++ b/.generator-v2/internal/emit/accessors.go
@@ -1,0 +1,81 @@
+package emit
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+)
+
+// ResolveAPIAccessors parses the provider's ApiInstances helper at path and maps
+// each V2 SDK API struct to the accessor method that returns it, e.g. "RUMApi" ->
+// "GetRumApiV2". It is the source of truth for accessor names, which diverge from
+// the struct name for a few APIs (RUM, APM, Observability Pipelines).
+func ResolveAPIAccessors(path string) (map[string]string, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parse api instances helper %s: %w", path, err)
+	}
+
+	accessors := map[string]string{}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name == nil || !isApiInstancesReceiver(fn.Recv) {
+			continue
+		}
+		name := fn.Name.Name
+		if !strings.HasPrefix(name, "Get") || !strings.HasSuffix(name, "V2") {
+			continue
+		}
+		if t := singleV2ResultType(fn.Type); t != "" {
+			accessors[t] = name
+		}
+	}
+	return accessors, nil
+}
+
+// isApiInstancesReceiver reports whether recv is the pointer receiver
+// (i *ApiInstances).
+func isApiInstancesReceiver(recv *ast.FieldList) bool {
+	if recv == nil || len(recv.List) != 1 {
+		return false
+	}
+	star, ok := recv.List[0].Type.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	ident, ok := star.X.(*ast.Ident)
+	return ok && ident.Name == "ApiInstances"
+}
+
+// singleV2ResultType returns the struct name X of a method returning exactly one
+// *datadogV2.X value, or "" if the results do not match that shape.
+func singleV2ResultType(ft *ast.FuncType) string {
+	if ft.Results == nil || len(ft.Results.List) != 1 {
+		return ""
+	}
+	star, ok := ft.Results.List[0].Type.(*ast.StarExpr)
+	if !ok {
+		return ""
+	}
+	sel, ok := star.X.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok || pkg.Name != "datadogV2" {
+		return ""
+	}
+	return sel.Sel.Name
+}
+
+// ApplyAPIAccessor overrides view.APIAccessor with the accessor the provider
+// actually exposes for view.APIStruct when accessors resolved one; absent a match
+// it leaves the builder's derived name in place.
+func ApplyAPIAccessor(view *DataSourceView, accessors map[string]string) {
+	if acc, ok := accessors[view.APIStruct]; ok {
+		view.APIAccessor = acc
+	}
+}

--- a/.generator-v2/internal/emit/accessors_test.go
+++ b/.generator-v2/internal/emit/accessors_test.go
@@ -1,0 +1,73 @@
+package emit
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ResolveAPIAccessors", func() {
+	// A helper stub carrying the shapes that matter: a plain accessor, two whose
+	// names diverge from the struct (RUM, Observability Pipelines), a V1 accessor,
+	// and a non-accessor method.
+	const fixture = `package utils
+
+func (i *ApiInstances) GetTeamsApiV2() *datadogV2.TeamsApi { return nil }
+func (i *ApiInstances) GetRumApiV2() *datadogV2.RUMApi { return nil }
+func (i *ApiInstances) GetObsPipelinesV2() *datadogV2.ObservabilityPipelinesApi { return nil }
+func (i *ApiInstances) GetUsersApiV1() *datadogV1.UsersApi { return nil }
+func (i *ApiInstances) HttpClient() {}
+`
+
+	var path string
+	BeforeEach(func() {
+		path = filepath.Join(GinkgoT().TempDir(), "api_instances_helper.go")
+		Expect(os.WriteFile(path, []byte(fixture), 0o644)).To(Succeed())
+	})
+
+	It("maps each V2 API struct to its accessor, including diverging acronym and alias names", func() {
+		m, err := ResolveAPIAccessors(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(m).To(HaveKeyWithValue("TeamsApi", "GetTeamsApiV2"))
+		Expect(m).To(HaveKeyWithValue("RUMApi", "GetRumApiV2"))
+		Expect(m).To(HaveKeyWithValue("ObservabilityPipelinesApi", "GetObsPipelinesV2"))
+	})
+
+	It("ignores V1 accessors and non-accessor methods", func() {
+		m, err := ResolveAPIAccessors(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(m).NotTo(HaveKey("UsersApi"))
+		Expect(m).To(HaveLen(3))
+	})
+
+	It("returns an error on an unparseable file", func() {
+		bad := filepath.Join(GinkgoT().TempDir(), "bad.go")
+		Expect(os.WriteFile(bad, []byte("package x\nfunc ("), 0o644)).To(Succeed())
+		_, err := ResolveAPIAccessors(bad)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("ApplyAPIAccessor", func() {
+	accessors := map[string]string{"RUMApi": "GetRumApiV2"}
+
+	It("overrides the accessor when the provider names it differently", func() {
+		view := &DataSourceView{APIStruct: "RUMApi", APIAccessor: "GetRUMApiV2"}
+		ApplyAPIAccessor(view, accessors)
+		Expect(view.APIAccessor).To(Equal("GetRumApiV2"))
+	})
+
+	It("leaves the derived accessor when the struct name matches the accessor base", func() {
+		view := &DataSourceView{APIStruct: "TeamsApi", APIAccessor: "GetTeamsApiV2"}
+		ApplyAPIAccessor(view, accessors)
+		Expect(view.APIAccessor).To(Equal("GetTeamsApiV2"))
+	})
+
+	It("leaves the derived accessor when no accessor map was resolved", func() {
+		view := &DataSourceView{APIStruct: "RUMApi", APIAccessor: "GetRUMApiV2"}
+		ApplyAPIAccessor(view, nil)
+		Expect(view.APIAccessor).To(Equal("GetRUMApiV2"))
+	})
+})


### PR DESCRIPTION
### Motivation
The generator derives each data source's SDK API accessor name (e.g. `GetTeamsApiV2`) from the API struct name. For a handful of APIs the provider's real accessor name diverges from that derived name — acronym casing (RUM: derived `GetRUMApiV2` vs. the provider's actual `GetRumApiV2`) and aliases (Observability Pipelines: `GetObsPipelinesV2`). When the generator emits the derived name, the generated data source references an accessor that doesn't exist on `ApiInstances` and fails to compile. This PR makes the provider's `api_instances_helper.go` the source of truth: it parses that file to map each V2 API struct to the accessor that actually returns it, and corrects the emitted accessor accordingly. It falls back to the derived name when the helper is absent (outside a full checkout) or when a struct has no override.

### Changes
**`.generator-v2/internal/emit/accessors.go`** (new)
- `ResolveAPIAccessors(path)`: parses the provider's `ApiInstances` helper with `go/parser` and maps each V2 SDK API struct to its accessor method (e.g. `RUMApi` → `GetRumApiV2`). Only considers methods on the `*ApiInstances` receiver, named `Get…V2`, returning exactly one `*datadogV2.X`.
- `isApiInstancesReceiver(recv)`: reports whether the receiver is `(i *ApiInstances)`.
- `singleV2ResultType(ft)`: returns the struct name `X` for a method returning exactly one `*datadogV2.X`, else `""`.
- `ApplyAPIAccessor(view, accessors)`: overrides `view.APIAccessor` with the resolved accessor for `view.APIStruct` when one exists; otherwise leaves the builder's derived name in place.

**`.generator-v2/internal/cli/generate.go`**
- Added the `apiInstancesHelperPath` const (`datadog/internal/utils/api_instances_helper.go`, read relative to the repo root like the other default paths).
- `newGenerateCmd` now resolves accessors once up front via `ResolveAPIAccessors`. A missing file (`os.ErrNotExist`) is tolerated silently; any other (e.g. parse) error prints a warning to stderr. Either way it falls back to derived names.
- Threaded the resolved `accessors` map through `generateArtifact(...)`, which calls `emit.ApplyAPIAccessor(&view, accessors)` to correct the accessor before emitting.
- New imports: `errors`, `os`.

**`.generator-v2/internal/emit/accessors_test.go`** (new)
- `ResolveAPIAccessors` specs (against a stub helper fixture): maps V2 structs including the diverging acronym/alias names (RUM, Observability Pipelines); ignores V1 accessors and non-accessor methods; returns an error on an unparseable file.
- `ApplyAPIAccessor` specs: overrides when the provider names it differently (`RUMApi` → `GetRumApiV2`), leaves the derived name when the struct base already matches, and leaves the derived name when no accessor map was resolved (nil).

### Test
- Added Ginkgo unit coverage (accessors_test.go) exercising accessor resolution and override behavior — the diverging acronym (RUM) and alias (Observability Pipelines) cases, exclusion of V1 and non-accessor methods, parse-error propagation, and all three `ApplyAPIAccessor` branches (override / already-matching / nil map).
- Run with `make tfgen-test`.