### PR TITLE
[datadog_software_catalog] Add includeDiscovered support

### DIFF
--- a/datadog/fwprovider/data_source_datadog_software_catalog.go
+++ b/datadog/fwprovider/data_source_datadog_software_catalog.go
@@ -220,10 +220,15 @@ func (d *datadogSoftwareCatalogDataSource) updateState(ctx context.Context, resp
 		return softwareEntities[i].Name.String() < softwareEntities[j].Name.String()
 	})
 
+	includeDiscoveredStr := ""
+	if !state.IncludeDiscovered.IsNull() {
+		includeDiscoveredStr = strconv.FormatBool(state.IncludeDiscovered.ValueBool())
+	}
+
 	idHash := fmt.Sprintf("%x", sha256.Sum256([]byte(
 		state.FilterID.ValueString()+state.FilterName.ValueString()+state.FilterExcludeSnapshot.ValueString()+
 			state.FilterKind.ValueString()+state.FilterOwner.ValueString()+state.FilterRelationType.ValueString()+
-			state.FilterRef.ValueString()+strconv.FormatBool(state.IncludeDiscovered.ValueBool()),
+			state.FilterRef.ValueString()+includeDiscoveredStr,
 	)))
 
 	state.ID = types.StringValue(idHash)

--- a/datadog/fwprovider/data_source_datadog_software_catalog.go
+++ b/datadog/fwprovider/data_source_datadog_software_catalog.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"sort"
+	"strconv"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -41,6 +42,7 @@ type datadogSoftwareCatalogDataSourceModel struct {
 	FilterKind            types.String `tfsdk:"filter_kind"`
 	FilterOwner           types.String `tfsdk:"filter_owner"`
 	FilterRelationType    types.String `tfsdk:"filter_relation_type"`
+	IncludeDiscovered     types.Bool   `tfsdk:"include_discovered"`
 
 	// Results
 	Entities []*CatalogEntityModel `tfsdk:"entities"`
@@ -100,6 +102,10 @@ func (d *datadogSoftwareCatalogDataSource) Schema(_ context.Context, _ datasourc
 				Optional:    true,
 				Validators:  []validator.String{validators.NewEnumValidator[validator.String](datadogV2.NewRelationTypeFromValue)},
 			},
+			"include_discovered": schema.BoolAttribute{
+				Description: "Include entities that have been discovered but not yet enriched.",
+				Optional:    true,
+			},
 
 			// Computed values
 			"entities": schema.ListAttribute{
@@ -154,6 +160,9 @@ func (d *datadogSoftwareCatalogDataSource) Read(ctx context.Context, req datasou
 	}
 	if !state.FilterRef.IsNull() {
 		optionalParams.WithFilterRef(state.FilterRef.ValueString())
+	}
+	if !state.IncludeDiscovered.IsNull() {
+		optionalParams.WithIncludeDiscovered(state.IncludeDiscovered.ValueBool())
 	}
 
 	offset := int64(0)
@@ -214,7 +223,7 @@ func (d *datadogSoftwareCatalogDataSource) updateState(ctx context.Context, resp
 	idHash := fmt.Sprintf("%x", sha256.Sum256([]byte(
 		state.FilterID.ValueString()+state.FilterName.ValueString()+state.FilterExcludeSnapshot.ValueString()+
 			state.FilterKind.ValueString()+state.FilterOwner.ValueString()+state.FilterRelationType.ValueString()+
-			state.FilterRef.ValueString(),
+			state.FilterRef.ValueString()+strconv.FormatBool(state.IncludeDiscovered.ValueBool()),
 	)))
 
 	state.ID = types.StringValue(idHash)

--- a/datadog/fwprovider/resource_datadog_software_catalog.go
+++ b/datadog/fwprovider/resource_datadog_software_catalog.go
@@ -238,7 +238,7 @@ func (r *catalogEntityResource) Read(ctx context.Context, request resource.ReadR
 	// A plain lookup only finds entities already written to via this API. Retry with
 	// includeDiscovered=true so an auto-discovered, never-touched entity is also found.
 	if len(entityResp.Included) == 0 {
-		path = path + "&includeDiscovered=true"
+		path += "&includeDiscovered=true"
 		httpRespByte, _, err = utils.SendRequest(r.Auth, r.Api, "GET", path, nil)
 		if err != nil {
 			response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error getting entity"))

--- a/datadog/fwprovider/resource_datadog_software_catalog.go
+++ b/datadog/fwprovider/resource_datadog_software_catalog.go
@@ -221,7 +221,8 @@ func (r *catalogEntityResource) Read(ctx context.Context, request resource.ReadR
 	}
 
 	id := state.ID.ValueString()
-	path := catalogPath + "?include=raw_schema&filter[ref]=" + id
+	// includeDiscovered=true so entities Datadog has auto-discovered but never written to via this API are also found.
+	path := catalogPath + "?include=raw_schema&filter[ref]=" + id + "&includeDiscovered=true"
 	httpRespByte, _, err := utils.SendRequest(r.Auth, r.Api, "GET", path, nil)
 
 	if err != nil {

--- a/datadog/fwprovider/resource_datadog_software_catalog.go
+++ b/datadog/fwprovider/resource_datadog_software_catalog.go
@@ -221,8 +221,7 @@ func (r *catalogEntityResource) Read(ctx context.Context, request resource.ReadR
 	}
 
 	id := state.ID.ValueString()
-	// includeDiscovered=true so entities Datadog has auto-discovered but never written to via this API are also found.
-	path := catalogPath + "?include=raw_schema&filter[ref]=" + id + "&includeDiscovered=true"
+	path := catalogPath + "?include=raw_schema&filter[ref]=" + id
 	httpRespByte, _, err := utils.SendRequest(r.Auth, r.Api, "GET", path, nil)
 
 	if err != nil {
@@ -234,6 +233,23 @@ func (r *catalogEntityResource) Read(ctx context.Context, request resource.ReadR
 	if err != nil {
 		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error unmarshalling entity"))
 		return
+	}
+
+	// A plain filter[ref] lookup only finds entities already written to via this API at
+	// least once. Retry with includeDiscovered=true so an entity Datadog has auto-discovered
+	// but that's never been touched via the API (e.g. on first import) is also found.
+	if len(entityResp.Included) == 0 {
+		path = path + "&includeDiscovered=true"
+		httpRespByte, _, err = utils.SendRequest(r.Auth, r.Api, "GET", path, nil)
+		if err != nil {
+			response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error getting entity"))
+			return
+		}
+		err = json.Unmarshal(httpRespByte, &entityResp)
+		if err != nil {
+			response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error unmarshalling entity"))
+			return
+		}
 	}
 
 	// Entity not found via filter - remove from Terraform state (drift detection)

--- a/datadog/fwprovider/resource_datadog_software_catalog.go
+++ b/datadog/fwprovider/resource_datadog_software_catalog.go
@@ -235,9 +235,8 @@ func (r *catalogEntityResource) Read(ctx context.Context, request resource.ReadR
 		return
 	}
 
-	// A plain filter[ref] lookup only finds entities already written to via this API at
-	// least once. Retry with includeDiscovered=true so an entity Datadog has auto-discovered
-	// but that's never been touched via the API (e.g. on first import) is also found.
+	// A plain lookup only finds entities already written to via this API. Retry with
+	// includeDiscovered=true so an auto-discovered, never-touched entity is also found.
 	if len(entityResp.Included) == 0 {
 		path = path + "&includeDiscovered=true"
 		httpRespByte, _, err = utils.SendRequest(r.Auth, r.Api, "GET", path, nil)

--- a/docs/data-sources/software_catalog.md
+++ b/docs/data-sources/software_catalog.md
@@ -28,6 +28,7 @@ data "datadog_software_catalog" "test" {}
 - `filter_owner` (String) Filter entities by owner.
 - `filter_ref` (String) Filter entities by reference.
 - `filter_relation_type` (String) Filter entities by relation type. Valid values are `RelationTypeOwns`, `RelationTypeOwnedBy`, `RelationTypeDependsOn`, `RelationTypeDependencyOf`, `RelationTypePartsOf`, `RelationTypeHasPart`, `RelationTypeOtherOwns`, `RelationTypeOtherOwnedBy`, `RelationTypeImplementedBy`, `RelationTypeImplements`.
+- `include_discovered` (Boolean) Include entities that have been discovered but not yet enriched.
 
 ### Read-Only
 


### PR DESCRIPTION
## Summary

This PR adds `includeDiscovered` support to `datadog_software_catalog`, so entities Datadog's APM/infra integrations have auto-discovered but that have never been written to via the API before can actually be found.
**Fixes #3948**

## Problem

`GET /api/v2/catalog/entity` only returns entities that already have an `ingestionSource` set unless the request also passes `includeDiscovered=true`. `datadog-api-client-go`'s `ListCatalogEntityOptionalParameters` already supports this, but neither the `datadog_software_catalog` data source nor the resource's `Read` (used by refresh and `terraform import`) ever pass it — so a real, freshly-discovered entity can never be found or enriched for the first time via Terraform.

## Changes

### `data_source_datadog_software_catalog.go`
- Added a new optional `include_discovered` (Boolean) schema attribute, wired to `ListCatalogEntityOptionalParameters.WithIncludeDiscovered`.
- The `id` hash only factors this attribute in when it's actually set, so existing configurations that don't use it get an unchanged `id`.

### `resource_datadog_software_catalog.go`
- `Read` now retries with `includeDiscovered=true` only when the plain `filter[ref]` lookup finds nothing — the common case (an entity already tracked/created by this resource) sends the exact same request as before, so no existing recorded acceptance-test cassette needed changes. Confirmed `TestAccDatadogSoftwareCatalogEntity_Basic`, `TestAccDatadogCatalogEntity_Order`, and `TestAccDatadogSoftwareCatalogEntity_Datasource` all still pass unmodified under `RECORD=false`.

### `docs/data-sources/software_catalog.md`
- Regenerated via `make docs` for the new attribute.

## Testing

- [x] `gofmt`, `go build`, `go vet` clean
- [x] `make docs` — exactly the expected one-line diff
- [x] Ran the existing `datadog_software_catalog` acceptance tests against their recorded cassettes: `RECORD=false TF_ACC=1 go test ./datadog/tests/... -run 'SoftwareCatalog|CatalogEntity'` — all pass unmodified.
- [ ] Didn't add a new cassette-based acceptance test for the `includeDiscovered=true` retry path itself — no sandbox credentials to record one. Verified that specific behavior directly against the live API instead: for a known real, previously API-untouched entity, `filter[ref]` alone returns nothing, and the same query with `includeDiscovered=true` added returns it.

## Related

- `datadog-api-client-go`'s `ListCatalogEntityOptionalParameters.IncludeDiscovered` already exists — this only wires the provider to use it.
- Datadog API docs: https://docs.datadoghq.com/api/latest/software-catalog/#get-a-list-of-entities
- Per `DEVELOPMENT.md`, this should get a `changelog/bugfix` label — I don't have permission to add it myself as an external contributor.
