### PR TITLE
[flaky_tests] Skip TestAccDatadogObservabilityPipeline_tagCardinalityLimitProcessor

### DIFF
--- a/flaky_tests.yaml
+++ b/flaky_tests.yaml
@@ -304,3 +304,9 @@ skipped_tests:
     reason: "retention_filter_ids count mismatch — expected 3, got 2 — pre-existing filters in org"
     added: "2026-04-24"
     author: fpighi
+
+  # ObservabilityPipeline tag_cardinality_limit — backend/spec drift (1 test)
+  - test: TestAccDatadogObservabilityPipeline_tagCardinalityLimitProcessor
+    reason: "400 Bad Request — backend now requires tracking_mode/override_type, but datadog-api-client-go still models mode. Needs api-spec update + client regen before this can pass live."
+    added: "2026-07-09"
+    author: andrei.patru


### PR DESCRIPTION
## Summary
- Adds `TestAccDatadogObservabilityPipeline_tagCardinalityLimitProcessor` to `flaky_tests.yaml` so the live PR integration-tests job skips it.
- The backend contract for `tag-cardinality-limit-processor` has drifted ahead of the generated client: it now requires `tracking_mode` (processor-level) and `override_type` (replacing `mode` on both `per_metric_limits` and `per_tag_limits`). `datadog-api-client-go` (even at `master`) still only models `mode`, so the provider cannot emit a valid payload and the test 400s against the live API.
- The PR integration-tests workflow builds its skip regex from the **base branch** (`build_skip_regex.py` reads the trusted base checkout), so the skip entry must live on `master` to take effect for open PRs.

## Context
Full fix requires an upstream `datadog-api-spec` update + client regen, then updating the provider schema/expand/flatten + test + docs + re-recording the cassette. Tracked separately. This entry should be removed once that lands.

## Test plan
- [ ] Merge to `master`; subsequent PRs touching the observability pipeline resource will skip this test in the `integration-tests` job.
- Note: this PR only touches `flaky_tests.yaml`, so its own integration-tests job selects no tests and is skipped.