### PR TITLE
ci (APIR-3073): run unit tests in their own job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,23 @@ jobs:
       - name: Check Docs Are Up To Date
         run: make check-docs
 
+  # Unit tests don't touch the API, use no cassettes, and need no terraform binary,
+  # so they run once here rather than being sharded across the version matrix. They
+  # are also excluded from the sharded jobs' -run filter, so this is the only place
+  # they execute in CI.
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      - name: Install Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
+        with:
+          go-version: "1.23"
+          cache: true
+      - name: Unit tests
+        run: make test
+
   test:
     strategy:
       fail-fast: false
@@ -109,7 +126,7 @@ jobs:
           SHARD_REGEX=$(python3 scripts/shard_tests.py --shard ${{ matrix.shard }} --total 4 --escape-for-make)
           echo "test_args=-run '${SHARD_REGEX}'" >> "$GITHUB_OUTPUT"
       - name: Test
-        run: make testall
+        run: make testacc
         env:
           RECORD: false
           TESTARGS: ${{ steps.shard.outputs.test_args }}
@@ -158,12 +175,12 @@ jobs:
   # Final job for branch protection rules - depends on all other jobs
   all-checks:
     runs-on: ubuntu-latest
-    needs: [linter-checks, test, test-tofu]
+    needs: [linter-checks, unit-tests, test, test-tofu]
     if: always()
     steps:
       - name: Check all jobs passed
         run: |
-          results="${{ needs.linter-checks.result }} ${{ needs.test.result }} ${{ needs.test-tofu.result }}"
+          results="${{ needs.linter-checks.result }} ${{ needs.unit-tests.result }} ${{ needs.test.result }} ${{ needs.test-tofu.result }}"
           for result in $results; do
             if [[ "$result" != "success" && "$result" != "skipped" ]]; then
               echo "One or more jobs failed or were cancelled"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -47,7 +47,7 @@ dev-clean:
 # Run unit tests; these tests don't interact with the API and don't support/need RECORD.
 # Scoped to UNIT_PKGS so the datadog/tests acceptance suite is never compiled or run here,
 # and so these tests always run regardless of the shard -run filter passed via TESTARGS.
-test: get-test-deps fmtcheck
+test: get-test-deps
 	gotestsum --format testname --debug --packages $(UNIT_PKGS) -- $(TESTARGS) -timeout=120s
 
 # Run acceptance tests (this runs integration CRUD tests through the terraform test framework)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,7 @@
 TEST?=$$(go list ./...)
+# Unit-test packages: everything except the datadog/tests acceptance suite. These
+# don't interact with the API, use no cassettes, and need no terraform binary.
+UNIT_PKGS?=$$(go list ./... | grep -vE '/datadog/tests(/|$$)')
 RECORD?=false
 GOIMPORTS_FILES?=$$(find . -name '*.go')
 PKG_NAME=datadog
@@ -41,13 +44,15 @@ dev-build:
 dev-clean:
 	@rm -vf $(DEV_PLUGIN_DIR)/terraform-provider-datadog $(DEV_TFRC)
 
-# Run unit tests; these tests don't interact with the API and don't support/need RECORD
+# Run unit tests; these tests don't interact with the API and don't support/need RECORD.
+# Scoped to UNIT_PKGS so the datadog/tests acceptance suite is never compiled or run here,
+# and so these tests always run regardless of the shard -run filter passed via TESTARGS.
 test: get-test-deps fmtcheck
-	gotestsum --hide-summary skipped --format testname --debug --packages $(TEST) -- $(TESTARGS) -timeout=30s
+	gotestsum --format testname --debug --packages $(UNIT_PKGS) -- $(TESTARGS) -timeout=120s
 
 # Run acceptance tests (this runs integration CRUD tests through the terraform test framework)
 testacc: get-test-deps
-	RECORD=$(RECORD) TF_ACC=1 gotestsum --format testname --debug --rerun-fails --packages ./... -- -v $(TESTARGS) -timeout 120m
+	RECORD=$(RECORD) TF_ACC=1 gotestsum --format testname --debug --rerun-fails --packages ./datadog/tests/... -- -v $(TESTARGS) -timeout 120m
 
 # Run both unit and acceptance tests
 testall: test testacc


### PR DESCRIPTION
## Motivation

Our unit tests weren't actually running in CI. The sharded test jobs pass a `-run` filter built by `scripts/shard_tests.py`, which only scans `datadog/tests/*_test.go` for test names. That regex is applied globally across `go list ./...`, so the ~72 unit tests living in the other packages (`datadog/`, `datadog/internal/{utils,fwutils,validators}`, `datadog/dashboardmapping`) never matched any shard and never executed on any CI path.

Separately, the `test` job ran `make testall`, which runs the whole suite twice over `./...` — once without `TF_ACC` (every acceptance test self-skips) and once with it (they run against cassettes). That made every acceptance test appear twice in the output, once skipped and once passing, which was confusing to read.

APIR-3073 asks to split non-acceptance tests from the acceptance suite so we can keep the sharding expression as-is while always running unit tests in a separate job.

## Overview of changes

Unit and acceptance tests are now executed by separate, non-overlapping paths. `make test` runs only the non-acceptance packages, so unit tests run independently of the shard filter; `make testacc` is scoped to the acceptance suite. A new, un-matrixed `unit-tests` job runs the unit suite exactly once (it needs no terraform binary and is version-independent), and the sharded matrix jobs now run acceptance tests only — so each acceptance test appears once instead of twice.

## Validation

- `make test` runs the previously-excluded unit packages (207 tests including subtests) and passes, with no acceptance/skip lines.
- Replaying an acceptance test with `RECORD=false` runs it exactly once against its cassette and passes, confirming the scoped `make testacc` still works.
- CI on this PR should show a single `unit-tests` job that runs the unit suite, and the sharded `test`/`test-tofu` jobs reporting each acceptance test once.