### PR TITLE
[datadog_critical_asset] Add description field to critical asset example

### DIFF
--- a/docs/resources/security_monitoring_critical_asset.md
+++ b/docs/resources/security_monitoring_critical_asset.md
@@ -14,11 +14,12 @@ Provides a Datadog Security Monitoring Critical Asset resource. It can be used t
 
 ```terraform
 resource "datadog_security_monitoring_critical_asset" "my_critical_asset" {
-  enabled    = true
-  query      = "source:runtime-security-agent"
-  rule_query = "type:(log_detection OR signal_correlation OR workload_security OR application_security) ruleId:007-d1a-1f3"
-  severity   = "increase"
-  tags       = ["env:production", "team:security"]
+  description = "Production database servers that should trigger critical alerts"
+  enabled     = true
+  query       = "source:runtime-security-agent"
+  rule_query  = "type:(log_detection OR signal_correlation OR workload_security OR application_security) ruleId:007-d1a-1f3"
+  severity    = "increase"
+  tags        = ["env:production", "team:security"]
 }
 ```
 

--- a/docs/resources/security_monitoring_critical_asset.md
+++ b/docs/resources/security_monitoring_critical_asset.md
@@ -16,7 +16,7 @@ Provides a Datadog Security Monitoring Critical Asset resource. It can be used t
 resource "datadog_security_monitoring_critical_asset" "my_critical_asset" {
   description = "Production database servers that should trigger critical alerts"
   enabled     = true
-  query       = "source:runtime-security-agent"
+  query       = "env:production service:database"
   rule_query  = "type:(log_detection OR signal_correlation OR workload_security OR application_security) ruleId:007-d1a-1f3"
   severity    = "increase"
   tags        = ["env:production", "team:security"]

--- a/examples/resources/datadog_security_monitoring_critical_asset/resource.tf
+++ b/examples/resources/datadog_security_monitoring_critical_asset/resource.tf
@@ -1,7 +1,8 @@
 resource "datadog_security_monitoring_critical_asset" "my_critical_asset" {
-  enabled    = true
-  query      = "source:runtime-security-agent"
-  rule_query = "type:(log_detection OR signal_correlation OR workload_security OR application_security) ruleId:007-d1a-1f3"
-  severity   = "increase"
-  tags       = ["env:production", "team:security"]
+  description = "Production database servers that should trigger critical alerts"
+  enabled     = true
+  query       = "env:production service:database"
+  rule_query  = "type:(log_detection OR signal_correlation OR workload_security OR application_security) ruleId:007-d1a-1f3"
+  severity    = "increase"
+  tags        = ["env:production", "team:security"]
 }


### PR DESCRIPTION
## What does this PR do?

- Adds the `description` field to the `datadog_security_monitoring_critical_asset` resource example in the documentation.
- The field was already supported by the resource but was missing from the example, leaving users unaware it could be set (and cleared) via Terraform.

No JIRA ticket — follow-up to [0b412f06](https://github.com/DataDog/terraform-provider-datadog/commit/0b412f0612e652313ceca9d0507ed1b064df3db0) which fixed description update semantics but omitted the doc update.

## Will it impact other teams?

Documentation-only change. No impact on other teams or services.

## Deploy plan

No deployment needed — docs-only change. The updated page will be published when the provider docs are regenerated/released.

## Rollback plan

Revert this PR. No state modifications.

## Testing Guidelines

- [x] **Is this change retro-compatible?** Yes — documentation only.
- [ ] **Tested in staging** — N/A (docs change).
- [ ] **Acceptable performance** — N/A (docs change).