### PR TITLE
[Tfgen] Removing modified_at

### DIFF
--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -481,10 +481,11 @@ func isObjectType(tfType string) bool { return tfType == "schema.SingleNestedBlo
 // generated data source: their timestamps and actor handles add schema noise
 // without configuration value.
 var auditFields = map[string]bool{
-	"created_at": true,
-	"updated_at": true,
-	"created_by": true,
-	"updated_by": true,
+	"created_at":  true,
+	"updated_at":  true,
+	"created_by":  true,
+	"updated_by":  true,
+	"modified_at": true,
 }
 
 // isAuditField reports whether a top-level record attribute is server-managed

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -129,16 +129,16 @@ var _ = Describe("BuildDataSourceView", func() {
 })
 
 var _ = Describe("BuildDataSourceView audit fields", func() {
-	It("drops server-managed created_at/updated_at/created_by/updated_by from a singular record and records them", func() {
+	It("drops server-managed created_at/updated_at/created_by/updated_by/modified_at from a singular record and records them", func() {
 		op := incidentTypeOperation()
 		attrs := op.ResponseSchema.Properties["data"].Properties["attributes"].Properties
-		for _, f := range []string{"created_at", "updated_at", "created_by", "updated_by"} {
+		for _, f := range []string{"created_at", "updated_at", "created_by", "updated_by", "modified_at"} {
 			attrs[f] = prim("string", "")
 		}
 		view := mustView(op)
 
 		for _, a := range view.Schema.Attributes {
-			Expect(a.TFName).NotTo(BeElementOf("created_at", "updated_at", "created_by", "updated_by"))
+			Expect(a.TFName).NotTo(BeElementOf("created_at", "updated_at", "created_by", "updated_by", "modified_at"))
 		}
 		Expect(view.Dropped).To(ContainElement(ContainSubstring("created_at")))
 	})
@@ -171,7 +171,8 @@ var _ = Describe("BuildDataSourceView audit fields", func() {
 			}
 		}
 		Expect(itemAttrs).NotTo(ContainElement("created_at"))
-		Expect(itemAttrs).To(ContainElement("modified_at"))
+		Expect(itemAttrs).NotTo(ContainElement("modified_at"))
+		Expect(itemAttrs).To(ContainElement("description"))
 	})
 })
 

--- a/.generator-v2/internal/testdata/emit/data_source_plural_no_params.golden
+++ b/.generator-v2/internal/testdata/emit/data_source_plural_no_params.golden
@@ -27,7 +27,6 @@ type DatastoreDataModel struct {
 	CreatorUserUuid              types.String `tfsdk:"creator_user_uuid"`
 	Description                  types.String `tfsdk:"description"`
 	ID                           types.String `tfsdk:"id"`
-	ModifiedAt                   types.String `tfsdk:"modified_at"`
 	Name                         types.String `tfsdk:"name"`
 	OrgId                        types.Int64  `tfsdk:"org_id"`
 	PrimaryColumnName            types.String `tfsdk:"primary_column_name"`
@@ -80,10 +79,6 @@ func (d *datadogDatastoresDataSource) Schema(_ context.Context, _ datasource.Sch
 							Description: "The unique identifier of the datastore.",
 							Computed:    true,
 						},
-						"modified_at": schema.StringAttribute{
-							Description: "Timestamp when the datastore was last modified.",
-							Computed:    true,
-						},
 						"name": schema.StringAttribute{
 							Description: "The display name of the datastore.",
 							Computed:    true,
@@ -134,7 +129,6 @@ func (d *datadogDatastoresDataSource) updateState(state *datadogDatastoresDataSo
 			CreatorUserUuid:              types.StringValue(item.Attributes.GetCreatorUserUuid()),
 			Description:                  types.StringValue(item.Attributes.GetDescription()),
 			ID:                           types.StringValue(item.GetId()),
-			ModifiedAt:                   types.StringValue(item.Attributes.GetModifiedAt().String()),
 			Name:                         types.StringValue(item.Attributes.GetName()),
 			OrgId:                        types.Int64Value(int64(item.Attributes.GetOrgId())),
 			PrimaryColumnName:            types.StringValue(item.Attributes.GetPrimaryColumnName()),

--- a/.generator-v2/internal/testdata/emit/data_source_singular_both.golden
+++ b/.generator-v2/internal/testdata/emit/data_source_singular_both.golden
@@ -24,7 +24,6 @@ type datadogDatastoreDataSourceModel struct {
 	CreatorUserId                types.Int64  `tfsdk:"creator_user_id"`
 	CreatorUserUuid              types.String `tfsdk:"creator_user_uuid"`
 	Description                  types.String `tfsdk:"description"`
-	ModifiedAt                   types.String `tfsdk:"modified_at"`
 	Name                         types.String `tfsdk:"name"`
 	OrgId                        types.Int64  `tfsdk:"org_id"`
 	PrimaryColumnName            types.String `tfsdk:"primary_column_name"`
@@ -69,10 +68,6 @@ func (d *datadogDatastoreDataSource) Schema(_ context.Context, _ datasource.Sche
 			},
 			"description": schema.StringAttribute{
 				Description: "A human-readable description about the datastore.",
-				Computed:    true,
-			},
-			"modified_at": schema.StringAttribute{
-				Description: "Timestamp when the datastore was last modified.",
 				Computed:    true,
 			},
 			"name": schema.StringAttribute{
@@ -146,9 +141,6 @@ func (d *datadogDatastoreDataSource) updateState(state *datadogDatastoreDataSour
 	}
 	if description, ok := attributes.GetDescriptionOk(); ok && description != nil {
 		state.Description = types.StringValue(*description)
-	}
-	if modifiedAt, ok := attributes.GetModifiedAtOk(); ok && modifiedAt != nil {
-		state.ModifiedAt = types.StringValue(modifiedAt.String())
 	}
 	if name, ok := attributes.GetNameOk(); ok && name != nil {
 		state.Name = types.StringValue(*name)


### PR DESCRIPTION
### Motivation
The emit builder strips server-managed audit fields (timestamps and actor
handles) from generated data sources because they add schema noise without
configuration value. `modified_at` is one such field but was missing from the
audit-field set, so it leaked into generated data source models, schemas, and
state mappers. This PR adds `modified_at` to the drop list so it's treated
consistently with `created_at`/`updated_at`/`created_by`/`updated_by`.

### Changes
- **`.generator-v2/internal/emit/builder.go`**
  - Added `"modified_at": true` to the `auditFields` map so it's dropped from
    generated data sources like the other server-managed fields.
- **`.generator-v2/internal/emit/builder_test.go`**
  - Updated the singular-record audit-field test to include `modified_at` in the
    list of fields injected and asserted-dropped.
  - Updated the plural item-list expectation: `modified_at` is now asserted
    *absent* (previously asserted present), and `description` is now the
    asserted-present item instead.
- **Regenerated emit goldens** (builder-derived output) reflecting the dropped field:
  - `data_source_plural_no_params.golden` — removed the `ModifiedAt` model field,
    its `modified_at` schema attribute, and its `updateState` assignment.
  - `data_source_singular_both.golden` — removed the `ModifiedAt` model field, its
    `modified_at` schema attribute, and its `GetModifiedAtOk`-guarded state mapping.

### Test
- Updated the Ginkgo audit-field specs in `builder_test.go` to cover `modified_at`
  (dropped from singular records and absent from plural item lists).
- Emit goldens were regenerated from the builder output and updated in-repo, so the
  golden-comparison tests assert the field is gone across both the plural-no-params
  and singular-both fixtures.
- Verified via the generator test suite (`make tfgen-test`).