### PR TITLE
[datadog_metric_metadata] Fix perpetual type drift for distribution metrics

### DIFF
--- a/datadog/resource_datadog_metric_metadata.go
+++ b/datadog/resource_datadog_metric_metadata.go
@@ -106,10 +106,18 @@ func resourceDatadogMetricMetadataCreate(ctx context.Context, d *schema.Resource
 }
 
 func updateMetricMetadataState(d *schema.ResourceData, metadata *datadogV1.MetricMetadata) diag.Diagnostics {
-	if _, ok := d.GetOk("type"); !ok || metadata.GetType() != "distribution" {
-		if err := d.Set("type", metadata.GetType()); err != nil {
-			return diag.FromErr(err)
-		}
+	// GetMetricMetadata now reliably reports `type` for distribution metrics,
+	// so we always trust the API response here.
+	// (Previously this preserved whatever `type` was already in state whenever
+	// config had `type = "distribution"` set and the API echoed the same value,
+	// as a guard against older backend behavior where GET rarely confirmed
+	// `distribution`. That guard is what caused a `datadog_metric_metadata`
+	// resource for a distribution metric to plan a `gauge -> distribution`
+	// change forever, since Create/Update's own mutate-response for `type`
+	// remains unreliable and this Read path was the only thing that could
+	// ever correct it.)
+	if err := d.Set("type", metadata.GetType()); err != nil {
+		return diag.FromErr(err)
 	}
 	if err := d.Set("description", metadata.GetDescription()); err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
### Overview

`datadog_metric_metadata` on a distribution metric plans a `gauge -> distribution` change on **every single `terraform plan`**, even immediately after a clean `apply`. It never resolves without adding `lifecycle { ignore_changes = [type] }` as a workaround, and we've seen this reported independently across multiple Terraform-managed environments.

### Root cause

`GetMetricMetadata` (used by `Read`) now reliably reports the correct `type` for distribution metrics — confirmed directly against the API, this part works correctly today.

The mutate response from `UpdateMetricMetadata` (used by both `Create` and `Update`) does not go through the same derivation — it returns `type: gauge` for the same metric, at the same instant a plain `GET` correctly says `distribution`.

`updateMetricMetadataState()` had a guard:

```go
if _, ok := d.GetOk("type"); !ok || metadata.GetType() != "distribution" {
    if err := d.Set("type", metadata.GetType()); err != nil {
        return diag.FromErr(err)
    }
}
```

Read as its contrapositive: if config already has `type = "distribution"` **and** the API response also says `distribution`, skip writing `type` into state — leave whatever's already there. This made sense when `GET` rarely actually confirmed `distribution`, protecting a user's intended value from being clobbered by an incorrect `gauge` reading.

It backfires now that `GET` is reliable:

1. On **Create**, the mutate response says `gauge` (not `distribution`) → skip-condition is false → `d.Set("type", "gauge")` *does* run → state is poisoned from the very first apply.
2. On every later **Read**, `GET` correctly returns `distribution` → skip-condition is now true → Read *refuses* to correct state.

Config says `distribution` forever, state says `gauge` forever, `plan` reports the same diff forever.

### Fix

Remove the guard — always trust the Read response:

```go
if err := d.Set("type", metadata.GetType()); err != nil {
    return diag.FromErr(err)
}
```

This only changes behavior for the `distribution` case (the guard was already a no-op for every other type). Neither `Create` nor `Update` change — both still omit `type` from the outbound request body when it equals `"distribution"`, which is what avoids a `400 {"errors":["error updating metric metadata"]}` the API returns if you try to set it explicitly on an existing metric. That logic is untouched by this PR.

### Verification

Tested against a live sandbox org (US1), building this exact diff on top of `v4.15.0`:

| Step | Result |
|---|---|
| Fresh `apply` (create) | Succeeds. State still shows `gauge` — expected, the Create mutate-response is still unreliable (separate, backend-side issue, not part of this fix) |
| `plan` immediately after | `No changes. Your infrastructure matches the configuration.` — clean on the very first plan |
| State file on disk at that point | Still shows `gauge` — a bare `plan` doesn't persist its refresh |
| `apply` again (no config changes) | `0 added, 0 changed, 0 destroyed` — state file now correctly shows `distribution` |
| `plan` × 3 more | `No changes` every time |
| Real `Update` (changed `description`) → `apply` → `plan` | Update succeeds, no `400`, plan after is clean |

Net effect: a brand-new resource plans clean from the first run; an already-poisoned resource (anything currently relying on `ignore_changes`) self-corrects after one no-op `apply` and stays clean permanently after that.

### Not in scope for this PR

The Create/Update mutate-response itself still returns `gauge` for distribution metrics — that looks like a backend issue on the Metrics API side, tracked separately. This PR only fixes the provider's failure to ever self-correct once `Read` has accurate data; it doesn't (and can't, from the provider side) fix the mutate response itself.

If exact zero-drift is wanted even for brand-new resources before that backend issue is fixed — i.e. avoiding the one no-op remediation apply for pre-existing poisoned resources — a follow-up could add an explicit `GetMetricMetadata` call inside `Create`/`Update` to populate `type` in state from a real read instead of the mutate response. Left out of this PR to keep the fix minimal and low-risk; happy to follow up if wanted.

### Changelog

```release-note:bug
resource/datadog_metric_metadata: Fix perpetual `type` drift (`gauge` -> `distribution`) for distribution metrics on every plan/apply
```
