### PR TITLE
Octo provisioning for generator-v2

### DIFF
--- a/.github/chainguard/self.generator.tfgen-split.sts.yaml
+++ b/.github/chainguard/self.generator.tfgen-split.sts.yaml
@@ -2,7 +2,7 @@
 # Policy for: .github/workflows/tfgen-split.yml in DataDog/terraform-provider-datadog
 # Allows generated-branch pushes to create per-artifact branches and draft PRs.
 issuer: https://token.actions.githubusercontent.com
-subject_pattern: "repo:DataDog/terraform-provider-datadog:ref:refs/heads/datadog-api-spec/generated/.*"
+subject_pattern: "repo:DataDog/terraform-provider-datadog:ref:refs/heads/datadog-api-spec/generated/.+"
 
 claim_pattern:
   event_name: push

--- a/.github/chainguard/self.generator.tfgen-split.sts.yaml
+++ b/.github/chainguard/self.generator.tfgen-split.sts.yaml
@@ -1,0 +1,15 @@
+---
+# Policy for: .github/workflows/tfgen-split.yml in DataDog/terraform-provider-datadog
+# Allows generated-branch pushes to create per-artifact branches and draft PRs.
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: "repo:DataDog/terraform-provider-datadog:ref:refs/heads/datadog-api-spec/generated/.*"
+
+claim_pattern:
+  event_name: push
+  job_workflow_ref: DataDog/terraform-provider-datadog/\.github/workflows/tfgen-split\.yml@refs/heads/datadog-api-spec/generated/.*
+  repository: DataDog/terraform-provider-datadog
+  ref: refs/heads/datadog-api-spec/generated/.*
+
+permissions:
+  contents: write
+  pull_requests: write


### PR DESCRIPTION
### Motivation
Provision Octo STS access for the tfgen split workflow so generated-branch runs can create per-artifact branches and draft pull requests using short-lived credentials.

### Changes
- Add a repository-scoped Octo STS trust policy for `tfgen-split.yml`.
- Restrict federation to pushes under `datadog-api-spec/generated/**`.
- Grant `contents: write` and `pull_requests: write`.

### Test
- Validated the policy as well-formed YAML.
- No CI results are available because the PR is not open yet.