### PR TITLE
[Tfgen] Enhanced handoff support

### DIFF
--- a/.generator-v2/internal/cli/generate.go
+++ b/.generator-v2/internal/cli/generate.go
@@ -385,10 +385,12 @@ func wireGeneratedDatasources(outputRoot, testsOutputRoot string, regs []emit.Ge
 }
 
 // wouldChange reports whether a write status represents a file that was (or, in
-// check mode, would be) modified. A retirement deletes files, so it counts;
-// retire_blocked leaves everything in place, so it does not.
+// check mode, would be) modified. A retirement deletes files and a registration
+// retirement rewrites the registry, so both count; retire_blocked leaves
+// everything in place, so it does not.
 func wouldChange(s model.ArtifactStatus) bool {
-	return s == model.ArtifactStatusCreated || s == model.ArtifactStatusUpdated || s == model.ArtifactStatusRetired
+	return s == model.ArtifactStatusCreated || s == model.ArtifactStatusUpdated ||
+		s == model.ArtifactStatusRetired || s == model.ArtifactStatusRegistrationRetired
 }
 
 func failEntry(e model.ArtifactReportEntry, err error) model.ArtifactReportEntry {

--- a/.generator-v2/internal/cli/reconcile.go
+++ b/.generator-v2/internal/cli/reconcile.go
@@ -162,7 +162,8 @@ func reconcileOrphans(outputRoot, testsOutputRoot, docsRoot string, desired map[
 				return entries, err
 			}
 			entries = append(entries, model.ArtifactReportEntry{
-				Name: ctor, Kind: model.ArtifactKindDataSource, Status: model.ArtifactStatusRetired,
+				Name: emit.RegistrationRetirementName(ctor), Kind: model.ArtifactKindDataSource,
+				Status: model.ArtifactStatusRegistrationRetired, Constructor: ctor,
 				Diagnostics: []model.Diagnostic{{Severity: model.SeverityWarning,
 					Message: fmt.Sprintf("registered constructor %q has no generated file; removed the stale registration only", ctor)}},
 			})

--- a/.generator-v2/internal/cli/reconcile_test.go
+++ b/.generator-v2/internal/cli/reconcile_test.go
@@ -50,6 +50,13 @@ func (f *artifactFixture) writeArtifact(name string, generated bool) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
+// registerOnly wires a constructor into the registry without laying down any of
+// its generated files, reproducing a stale registration whose source is gone.
+func (f *artifactFixture) registerOnly(name string) {
+	_, err := emit.SyncGeneratedDatasources(f.genPath(), []string{emit.DatasourceConstructor(name)}, false)
+	Expect(err).NotTo(HaveOccurred())
+}
+
 func (f *artifactFixture) writeCassette(fn string) {
 	Expect(os.WriteFile(filepath.Join(f.testsRoot, "cassettes", fn), []byte("x"), 0o644)).To(Succeed())
 }
@@ -187,6 +194,23 @@ var _ = Describe("reconcileOrphans", func() {
 		Expect(entries[0].Status).To(Equal(model.ArtifactStatusRetireBlocked))
 		Expect(f.goPath("zoo")).To(BeAnExistingFile())
 		Expect(f.registry()).To(ContainSubstring(emit.DatasourceConstructor("zoo")))
+	})
+
+	It("drops a registration whose generated files are already gone as registration_retired", func() {
+		f := newFixture()
+		f.writeArtifact("team", true)
+		f.registerOnly("ghost")
+		desired := map[string]bool{emit.DatasourceConstructor("team"): true}
+
+		entries, err := reconcileOrphans(f.outputRoot, f.testsRoot, f.docsRoot, desired, false)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(HaveLen(1))
+		Expect(entries[0].Status).To(Equal(model.ArtifactStatusRegistrationRetired))
+		Expect(entries[0].Constructor).To(Equal(emit.DatasourceConstructor("ghost")))
+		Expect(entries[0].Name).To(Equal(emit.RegistrationRetirementName(emit.DatasourceConstructor("ghost"))))
+		Expect(f.registry()).NotTo(ContainSubstring(emit.DatasourceConstructor("ghost")))
+		Expect(f.registry()).To(ContainSubstring(emit.DatasourceConstructor("team")))
 	})
 
 	It("finds no orphans when every registration is still desired", func() {

--- a/.generator-v2/internal/cli/split.go
+++ b/.generator-v2/internal/cli/split.go
@@ -11,11 +11,11 @@ import (
 
 // newSplitCmd builds the `tfgen split` subcommand. It fans one aggregate generated
 // push (a branch carrying all N data sources) out into one bundle per artifact so
-// each can land as its own PR, by diffing the provider and docs paths in a base
-// checkout against the pushed-branch checkout. It never runs the generator, the
-// spec, or git — it routes emitted files.
+// each can land as its own PR, by diffing generator-owned provider, docs, and test
+// paths in a base checkout against the pushed-branch checkout. It never runs the
+// generator, the spec, or git — it routes emitted files.
 func newSplitCmd(flags *globalFlags) *cobra.Command {
-	var baseDir, generatedDir, outDir, reportPath string
+	var baseDir, generatedDir, outDir, generationReportPath, reportPath string
 	var check bool
 
 	cmd := &cobra.Command{
@@ -23,10 +23,11 @@ func newSplitCmd(flags *globalFlags) *cobra.Command {
 		Short: "Split an aggregate generated push into per-artifact bundles",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rep, splitErr := split.Split(split.Options{
-				BaseDir:      baseDir,
-				GeneratedDir: generatedDir,
-				OutDir:       outDir,
-				Check:        check,
+				BaseDir:          baseDir,
+				GeneratedDir:     generatedDir,
+				OutDir:           outDir,
+				GenerationReport: generationReportPath,
+				Check:            check,
 			})
 
 			// Write the report even on attribution failure, so a human sees exactly
@@ -41,6 +42,7 @@ func newSplitCmd(flags *globalFlags) *cobra.Command {
 	cmd.Flags().StringVar(&baseDir, "base-dir", "", "Checkout of the base branch the push is diffed against (required)")
 	cmd.Flags().StringVar(&generatedDir, "generated-dir", "", "Checkout of the pushed branch carrying the generated artifacts (required)")
 	cmd.Flags().StringVar(&outDir, "out", "", "Directory to receive one bundle per artifact (required)")
+	cmd.Flags().StringVar(&generationReportPath, "generation-report", "", "Upstream tfgen generate report used to authorize retirement and blocked routing")
 	cmd.Flags().StringVar(&reportPath, "report", "-", "Where to write the split report (\"-\" = stdout)")
 	cmd.Flags().BoolVar(&check, "check", false, "Plan and report without writing the output bundles")
 	_ = cmd.MarkFlagRequired("base-dir")

--- a/.generator-v2/internal/emit/registration.go
+++ b/.generator-v2/internal/emit/registration.go
@@ -37,6 +37,17 @@ func DatasourceConstructor(name string) string {
 	return "New" + upperFirst(dsGoName(name)) + "DataSource"
 }
 
+// RegistrationRetirementName derives a filesystem- and branch-safe artifact name
+// for a registration-only retirement, whose generated files are already gone so
+// its real artifact name can no longer be read back. It strips the New/DataSource
+// affixes from the constructor and snake-cases the remainder, e.g.
+// NewDatadogTeamDataSource -> datadog_team. The result only labels the split
+// directory; the constructor stays authoritative for editing the registry.
+func RegistrationRetirementName(constructor string) string {
+	base := strings.TrimSuffix(strings.TrimPrefix(constructor, "New"), "DataSource")
+	return model.SnakeCase(base)
+}
+
 // datasourceConstructorRe matches a New<...>DataSource constructor identifier.
 // datasources_generated.go holds nothing else that fits the pattern, so it
 // safely recovers the already-registered set from the file's current contents.

--- a/.generator-v2/internal/emit/registration.go
+++ b/.generator-v2/internal/emit/registration.go
@@ -271,6 +271,49 @@ func endpointTagsBlock(lines []string, path string) (start, end int, err error) 
 	return 0, 0, fmt.Errorf("emit: %s: testFiles2EndpointTags map is not terminated", path)
 }
 
+// RegisteredEndpointTags returns the testFiles2EndpointTags entries in path.
+// A missing file yields an empty map. Split uses this reader to reconstruct each
+// per-artifact provider_test.go from the base map plus or minus one exact key.
+func RegisteredEndpointTags(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]string{}, nil
+		}
+		return nil, err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	emptyMapLine := strings.TrimSuffix(endpointTagsMapHeader, "{") + "{}"
+	for _, line := range lines {
+		if strings.TrimSpace(line) == emptyMapLine {
+			return map[string]string{}, nil
+		}
+	}
+	start, end, err := endpointTagsBlock(lines, path)
+	if err != nil {
+		return nil, err
+	}
+
+	tags := map[string]string{}
+	for _, line := range lines[start+1 : end] {
+		keyText, valueText, ok := strings.Cut(strings.TrimSpace(line), ":")
+		if !ok {
+			continue
+		}
+		key, err := strconv.Unquote(strings.TrimSpace(keyText))
+		if err != nil {
+			return nil, fmt.Errorf("emit: %s: invalid endpoint-tag key %q: %w", path, keyText, err)
+		}
+		value, err := strconv.Unquote(strings.TrimSuffix(strings.TrimSpace(valueText), ","))
+		if err != nil {
+			return nil, fmt.Errorf("emit: %s: invalid endpoint-tag value %q: %w", path, valueText, err)
+		}
+		tags[key] = value
+	}
+	return tags, nil
+}
+
 // InsertEndpointTag sets `"<key>": "<value>",` in the testFiles2EndpointTags map in
 // provider_test.go (the file at path), scoped between endpointTagsMapHeader and its
 // closing brace. An existing entry for key is rewritten in place (minimal diff, no

--- a/.generator-v2/internal/emit/registration_test.go
+++ b/.generator-v2/internal/emit/registration_test.go
@@ -261,6 +261,27 @@ var testFiles2EndpointTags = map[string]string{
 }
 `
 
+var _ = Describe("RegisteredEndpointTags", func() {
+	It("returns only entries from testFiles2EndpointTags", func() {
+		dir := GinkgoT().TempDir()
+		path := filepath.Join(dir, "provider_test.go")
+		Expect(os.WriteFile(path, []byte(endpointTagsFixture), 0o644)).To(Succeed())
+
+		tags, err := RegisteredEndpointTags(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tags).To(Equal(map[string]string{
+			"tests/data_source_datadog_team_test":             "team",
+			"tests/data_source_datadog_team_memberships_test": "team",
+		}))
+	})
+
+	It("returns an empty map when provider_test.go is absent", func() {
+		tags, err := RegisteredEndpointTags(filepath.Join(GinkgoT().TempDir(), "provider_test.go"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tags).To(BeEmpty())
+	})
+})
+
 var _ = Describe("InsertEndpointTag", func() {
 	var path string
 

--- a/.generator-v2/internal/model/artifact.go
+++ b/.generator-v2/internal/model/artifact.go
@@ -291,7 +291,7 @@ func buildFilterLeaves(op *Operation) ([]*Attribute, []Diagnostic) {
 			continue
 		}
 		leaves = append(leaves, &Attribute{
-			Path:        snakeCase(p.Name),
+			Path:        SnakeCase(p.Name),
 			TfType:      tfType,
 			GoType:      goType,
 			Format:      p.Schema.Format,

--- a/.generator-v2/internal/model/identifier.go
+++ b/.generator-v2/internal/model/identifier.go
@@ -16,7 +16,8 @@ var (
 	patternDoubleUnderscore = regexp.MustCompile(`__+`)
 )
 
-func snakeCase(value string) string {
+// SnakeCase converts a camelCase or PascalCase identifier to snake_case.
+func SnakeCase(value string) string {
 	value = patternLeadingAlpha.ReplaceAllString(value, "${1}_${2}")
 	value = strings.ToLower(patternFollowingAlpha.ReplaceAllString(value, "${1}_${2}"))
 	value = patternWhitespace.ReplaceAllString(value, "_")
@@ -31,7 +32,7 @@ func snakeCase(value string) string {
 // method anchors directly; SdkName is for snake_case property and parameter names.
 func SdkName(openapiName string) string {
 	var b strings.Builder
-	for _, part := range strings.Split(snakeCase(openapiName), "_") {
+	for _, part := range strings.Split(SnakeCase(openapiName), "_") {
 		if part == "" {
 			continue
 		}

--- a/.generator-v2/internal/model/report.go
+++ b/.generator-v2/internal/model/report.go
@@ -30,6 +30,8 @@ func summarize(entries []ArtifactReportEntry) *RunSummary {
 			s.Retired++
 		case ArtifactStatusRetireBlocked:
 			s.RetireBlocked++
+		case ArtifactStatusRegistrationRetired:
+			s.RegistrationRetired++
 		}
 	}
 	return s

--- a/.generator-v2/internal/model/schema.go
+++ b/.generator-v2/internal/model/schema.go
@@ -196,9 +196,9 @@ func buildChildren(props map[string]*Schema, prefix string, mode nestingMode, di
 
 	children := make([]*Attribute, 0, len(props))
 	for _, key := range keys {
-		// Terraform attribute names must be snake_case; snakeCase normalizes camelCase
+		// Terraform attribute names must be snake_case; SnakeCase normalizes camelCase
 		// OAS names and is idempotent on already-snake names (SdkName recovers the getter).
-		child, err := buildAttribute(props[key], prefix+snakeCase(key), mode, diags)
+		child, err := buildAttribute(props[key], prefix+SnakeCase(key), mode, diags)
 		if err != nil {
 			return nil, err
 		}

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -349,6 +349,12 @@ const (
 	// ArtifactStatusRetireBlocked marks an orphaned artifact left in place because
 	// a recorded cassette (or a missing generated marker) makes deletion unsafe.
 	ArtifactStatusRetireBlocked ArtifactStatus = "retire_blocked"
+	// ArtifactStatusRegistrationRetired marks a stale registration dropped on its
+	// own: the constructor was still listed in datasources_generated.go but its
+	// generated files were already gone, so only the registration line changed.
+	// The entry's Constructor carries the removed identifier, since no file
+	// remains to recover the artifact name from.
+	ArtifactStatusRegistrationRetired ArtifactStatus = "registration_retired"
 )
 
 // DiagnosticSeverity classifies a Diagnostic.
@@ -382,13 +388,14 @@ type RunReport struct {
 
 // RunSummary holds convenience counts for CI assertions, one per ArtifactStatus.
 type RunSummary struct {
-	Created       int `json:"created"`
-	Updated       int `json:"updated"`
-	Unchanged     int `json:"unchanged"`
-	Skipped       int `json:"skipped"`
-	Failed        int `json:"failed"`
-	Retired       int `json:"retired"`
-	RetireBlocked int `json:"retire_blocked"`
+	Created             int `json:"created"`
+	Updated             int `json:"updated"`
+	Unchanged           int `json:"unchanged"`
+	Skipped             int `json:"skipped"`
+	Failed              int `json:"failed"`
+	Retired             int `json:"retired"`
+	RetireBlocked       int `json:"retire_blocked"`
+	RegistrationRetired int `json:"registration_retired"`
 }
 
 // ArtifactReportEntry is the per-artifact section of a RunReport.
@@ -400,6 +407,10 @@ type ArtifactReportEntry struct {
 	Diagnostics []Diagnostic   `json:"diagnostics,omitempty"`
 	// OrphanedHooks lists hook functions declared but no longer referenced.
 	OrphanedHooks []string `json:"orphaned_hooks,omitempty"`
+	// Constructor is set only on registration_retired entries: the removed
+	// registration identifier. It is authoritative because the artifact name
+	// cannot be recovered once the generated files are gone.
+	Constructor string `json:"constructor,omitempty"`
 }
 
 // Diagnostic is a single error/warning/info collected during generation.

--- a/.generator-v2/internal/split/split.go
+++ b/.generator-v2/internal/split/split.go
@@ -165,6 +165,9 @@ type artifactPlan struct {
 type generationArtifact struct {
 	status      model.ArtifactStatus
 	diagnostics []model.Diagnostic
+	// constructor is set only for registration_retired artifacts; it is the
+	// registration to drop, since no file names the artifact.
+	constructor string
 }
 
 // Split diffs the two trees, routes each artifact into OutDir/<name>/, and returns
@@ -270,6 +273,9 @@ func Split(opts Options) (*Result, error) {
 		case model.ArtifactStatusRetired:
 			want = without(want, emit.DatasourceConstructor(name))
 			prProducing++
+		case model.ArtifactStatusRegistrationRetired:
+			want = without(want, p.report.constructor)
+			prProducing++
 		}
 	}
 	registrySetChanged := len(onlyIn(want, baseSet)) > 0 || len(onlyIn(baseSet, want)) > 0
@@ -331,6 +337,8 @@ func Split(opts Options) (*Result, error) {
 			art, artProblems = materializeActive(opts, name, p, registryRel, baseSet, overwrites[name], provider, providerTestRel, incomingTags)
 		case model.ArtifactStatusRetired:
 			art, artProblems = materializeRetired(opts, name, p, registryRel, providerTestRel, baseTags)
+		case model.ArtifactStatusRegistrationRetired:
+			art, artProblems = materializeRegistrationRetired(opts, name, p, registryRel)
 		case model.ArtifactStatusRetireBlocked:
 			art = &Artifact{
 				Name:        name,
@@ -459,6 +467,29 @@ func materializeRetired(opts Options, name string, p *artifactPlan, registryRel,
 	return art, problems
 }
 
+// materializeRegistrationRetired reconstructs the sole change of a
+// registration-only retirement: dropping the orphan's constructor from the
+// generated registry. Its files were already gone, so nothing else is touched
+// and the constructor — not the artifact name — drives the edit.
+func materializeRegistrationRetired(opts Options, name string, p *artifactPlan, registryRel string) (*Artifact, []string) {
+	var problems []string
+	art := &Artifact{
+		Name:        name,
+		Status:      model.ArtifactStatusRegistrationRetired,
+		Files:       []string{registryRel},
+		Diagnostics: slices.Clone(p.report.diagnostics),
+	}
+	if !opts.Check {
+		registryOut := filepath.Join(opts.OutDir, name, registryRel)
+		if err := copyFile(filepath.Join(opts.BaseDir, registryRel), registryOut); err != nil {
+			problems = append(problems, fmt.Sprintf("copying %s for %q: %v", registryRel, name, err))
+		} else if _, err := emit.RemoveGeneratedDatasource(registryOut, p.report.constructor, false); err != nil {
+			problems = append(problems, fmt.Sprintf("reconstructing %s for registration retirement %q: %v", registryRel, name, err))
+		}
+	}
+	return art, problems
+}
+
 func validatePlan(name string, p *artifactPlan, reportRequired bool) (model.ArtifactStatus, []string) {
 	var problems []string
 	fail := func(format string, a ...any) { problems = append(problems, fmt.Sprintf(format, a...)) }
@@ -509,6 +540,10 @@ func validatePlan(name string, p *artifactPlan, reportRequired bool) (model.Arti
 		if p.source != nil || p.test != nil || p.doc != nil || len(p.removed) > 0 {
 			fail("retire_blocked artifact %q unexpectedly changes files", name)
 		}
+	case model.ArtifactStatusRegistrationRetired:
+		if p.source != nil || p.test != nil || p.doc != nil || len(p.removed) > 0 {
+			fail("registration_retired artifact %q unexpectedly changes files", name)
+		}
 	case "":
 		if len(p.removed) > 0 {
 			fail("removed file for %q requires a generation report declaring retired", name)
@@ -541,6 +576,7 @@ func readGenerationArtifacts(path string) (map[string]generationArtifact, error)
 		mainStatus  model.ArtifactStatus
 		testChanged bool
 		diagnostics []model.Diagnostic
+		constructor string
 	}
 	acc := map[string]*accumulated{}
 	for _, entry := range report.Artifacts {
@@ -548,7 +584,9 @@ func readGenerationArtifacts(path string) (map[string]generationArtifact, error)
 			continue
 		}
 		if !artifactNameRe.MatchString(entry.Name) {
-			if entry.Status == model.ArtifactStatusRetired || entry.Status == model.ArtifactStatusRetireBlocked {
+			if entry.Status == model.ArtifactStatusRetired ||
+				entry.Status == model.ArtifactStatusRetireBlocked ||
+				entry.Status == model.ArtifactStatusRegistrationRetired {
 				return nil, fmt.Errorf("unsafe retired artifact name %q", entry.Name)
 			}
 			continue
@@ -567,7 +605,8 @@ func readGenerationArtifacts(path string) (map[string]generationArtifact, error)
 		}
 		if base != "" && base != "data_source_datadog_"+entry.Name+".go" &&
 			entry.Status != model.ArtifactStatusRetired &&
-			entry.Status != model.ArtifactStatusRetireBlocked {
+			entry.Status != model.ArtifactStatusRetireBlocked &&
+			entry.Status != model.ArtifactStatusRegistrationRetired {
 			continue
 		}
 		if a.mainSeen {
@@ -576,6 +615,7 @@ func readGenerationArtifacts(path string) (map[string]generationArtifact, error)
 		a.mainSeen = true
 		a.mainStatus = entry.Status
 		a.diagnostics = slices.Clone(entry.Diagnostics)
+		a.constructor = entry.Constructor
 	}
 
 	out := map[string]generationArtifact{}
@@ -591,8 +631,8 @@ func readGenerationArtifacts(path string) (map[string]generationArtifact, error)
 			status = model.ArtifactStatusUpdated
 		}
 		switch status {
-		case model.ArtifactStatusCreated, model.ArtifactStatusUpdated, model.ArtifactStatusRetired, model.ArtifactStatusRetireBlocked:
-			out[name] = generationArtifact{status: status, diagnostics: a.diagnostics}
+		case model.ArtifactStatusCreated, model.ArtifactStatusUpdated, model.ArtifactStatusRetired, model.ArtifactStatusRetireBlocked, model.ArtifactStatusRegistrationRetired:
+			out[name] = generationArtifact{status: status, diagnostics: a.diagnostics, constructor: a.constructor}
 		case model.ArtifactStatusUnchanged, model.ArtifactStatusSkipped:
 			continue
 		case model.ArtifactStatusFailed:

--- a/.generator-v2/internal/split/split.go
+++ b/.generator-v2/internal/split/split.go
@@ -8,8 +8,8 @@
 //
 // Attribution is exact and fail-loud: a changed file that maps to no artifact and
 // is not a known shared registry file is a hard error, never silently dropped, so
-// a future shared helper file can't vanish. Removals (retirement) are out of scope
-// for this create/update MVP and are reported as errors.
+// a future shared helper file can't vanish. Retirements require the upstream
+// generation report and are emitted as explicit file-removal plans.
 package split
 
 import (
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/emit"
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
 )
 
 // Options configures a split run.
@@ -37,6 +38,9 @@ type Options struct {
 	// OutDir receives one <name>/ subdirectory per artifact, each holding the exact
 	// files to commit at their repo-relative paths.
 	OutDir string
+	// GenerationReport is the upstream tfgen generate report. When supplied, it
+	// authorizes and cross-checks retirement and retire_blocked routing.
+	GenerationReport string
 	// Check computes the plan and report without writing any output bundle.
 	Check bool
 }
@@ -54,12 +58,11 @@ type Result struct {
 // Artifact is one routed data source: the files materialized under OutDir/<name>/
 // (repo-relative), and how it changed relative to base.
 type Artifact struct {
-	Name   string `json:"name"`
-	Status string `json:"status"` // "created" (net-new) or "updated" (overwrote an existing file)
-	// ServiceTag is the [service] PR-title prefix; derived in Phase 2 (the incoming
-	// diff carries no OpenAPI tag), so it is left empty here.
-	ServiceTag string   `json:"service_tag,omitempty"`
-	Files      []string `json:"files"`
+	Name         string               `json:"name"`
+	Status       model.ArtifactStatus `json:"status"`
+	Files        []string             `json:"files"`
+	RemovedFiles []string             `json:"removed_files,omitempty"`
+	Diagnostics  []model.Diagnostic   `json:"diagnostics,omitempty"`
 }
 
 // WriteJSON encodes the report as indented JSON.
@@ -83,14 +86,18 @@ const (
 var (
 	dataSourceFileRe     = regexp.MustCompile(`^data_source_datadog_([a-z][a-z0-9_]*)\.go$`)
 	dataSourceTestFileRe = regexp.MustCompile(`^data_source_datadog_([a-z][a-z0-9_]*)_test\.go$`)
+	dataSourceDocFileRe  = regexp.MustCompile(`^([a-z][a-z0-9_]*)\.md$`)
+	artifactNameRe       = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 	// constructorDeclRe recovers the constructor(s) a data-source file declares.
 	constructorDeclRe = regexp.MustCompile(`func (New[A-Za-z0-9_]+DataSource)\(`)
 	// constructorRe recovers constructor identifiers listed inside a slice literal.
 	constructorRe = regexp.MustCompile(`New[A-Za-z0-9_]+DataSource`)
-	// diffScopes limits routing to provider and generated-documentation paths.
-	// Upstream branches can lag master without unrelated repository drift making
-	// the split fail; unexpected changes inside these owned paths still fail loud.
-	diffScopes = []string{filepath.FromSlash("datadog/fwprovider"), "docs"}
+	// Directory scopes are walked in full. Test routing is added separately by
+	// scopedFiles so unrelated acceptance-test and cassette drift is ignored.
+	diffDirectoryScopes = []string{
+		filepath.FromSlash("datadog/fwprovider"),
+		filepath.FromSlash("docs/data-sources"),
+	}
 )
 
 // datasourcesSliceHeader opens the hand-written Datasources slice in
@@ -107,23 +114,35 @@ const (
 	kindRegistry
 	kindProvider
 	kindProviderTest
+	kindDataSourceDoc
 )
 
-// classify maps a changed file's basename to its role in the split.
-func classify(base string) (fileKind, string) {
-	switch base {
-	case registryFile:
+// classify maps an exact repo-relative path to its role in the split.
+func classify(rel string) (fileKind, string) {
+	clean := filepath.Clean(rel)
+	base := filepath.Base(clean)
+	switch clean {
+	case filepath.Join("datadog", "fwprovider", registryFile):
 		return kindRegistry, ""
-	case providerFile:
+	case filepath.Join("datadog", "fwprovider", providerFile):
 		return kindProvider, ""
-	case providerTestFile:
+	case filepath.Join("datadog", "tests", providerTestFile):
 		return kindProviderTest, ""
 	}
-	if m := dataSourceTestFileRe.FindStringSubmatch(base); m != nil {
-		return kindDataSourceTest, m[1]
+	if filepath.Dir(clean) == filepath.Join("datadog", "fwprovider") {
+		if m := dataSourceFileRe.FindStringSubmatch(base); m != nil {
+			return kindDataSource, m[1]
+		}
 	}
-	if m := dataSourceFileRe.FindStringSubmatch(base); m != nil {
-		return kindDataSource, m[1]
+	if filepath.Dir(clean) == filepath.Join("datadog", "tests") {
+		if m := dataSourceTestFileRe.FindStringSubmatch(base); m != nil {
+			return kindDataSourceTest, m[1]
+		}
+	}
+	if filepath.Dir(clean) == filepath.Join("docs", "data-sources") {
+		if m := dataSourceDocFileRe.FindStringSubmatch(base); m != nil {
+			return kindDataSourceDoc, m[1]
+		}
 	}
 	return kindUnknown, ""
 }
@@ -131,14 +150,21 @@ func classify(base string) (fileKind, string) {
 // changedFile is a file differing between base and generated.
 type changedFile struct {
 	rel   string // repo-relative path
-	base  string // basename
 	added bool   // absent in base (net-new) vs. modified
 }
 
 // artifactPlan gathers the self-contained files discovered for one data source.
 type artifactPlan struct {
-	source *changedFile
-	test   *changedFile
+	source  *changedFile
+	test    *changedFile
+	doc     *changedFile
+	removed []string
+	report  *generationArtifact
+}
+
+type generationArtifact struct {
+	status      model.ArtifactStatus
+	diagnostics []model.Diagnostic
 }
 
 // Split diffs the two trees, routes each artifact into OutDir/<name>/, and returns
@@ -146,6 +172,15 @@ type artifactPlan struct {
 // as an error (so the caller exits non-zero); the report is still complete.
 func Split(opts Options) (*Result, error) {
 	rep := &Result{BaseDir: opts.BaseDir, GeneratedDir: opts.GeneratedDir, OutDir: opts.OutDir}
+
+	reportArtifacts := map[string]generationArtifact{}
+	if opts.GenerationReport != "" {
+		var err error
+		reportArtifacts, err = readGenerationArtifacts(opts.GenerationReport)
+		if err != nil {
+			return rep, fmt.Errorf("split: reading generation report: %w", err)
+		}
+	}
 
 	changed, deleted, err := diffTrees(opts.BaseDir, opts.GeneratedDir)
 	if err != nil {
@@ -159,7 +194,7 @@ func Split(opts Options) (*Result, error) {
 	var registry, provider, providerTest *changedFile
 	for i := range changed {
 		cf := &changed[i]
-		kind, name := classify(cf.base)
+		kind, name := classify(cf.rel)
 		switch kind {
 		case kindRegistry:
 			registry = cf
@@ -171,17 +206,25 @@ func Split(opts Options) (*Result, error) {
 			planFor(plans, name).source = cf
 		case kindDataSourceTest:
 			planFor(plans, name).test = cf
+		case kindDataSourceDoc:
+			planFor(plans, name).doc = cf
 		default:
 			fail("changed file maps to no artifact and is not a known shared file: %s", cf.rel)
 		}
 	}
 	for _, d := range deleted {
-		fail("file removed (retirement is out of scope for the create/update MVP): %s", d)
+		kind, name := classify(d)
+		switch kind {
+		case kindDataSource, kindDataSourceTest, kindDataSourceDoc:
+			planFor(plans, name).removed = append(planFor(plans, name).removed, d)
+		default:
+			fail("removed file maps to no artifact or is a shared file that cannot be deleted: %s", d)
+		}
 	}
-	// The shared endpoint-tag map only appears with --emit-tests, which the pipeline
-	// omits; reconstructing it needs the OpenAPI tag the branch does not carry.
-	if providerTest != nil {
-		fail("%s changed, but test routing (--emit-tests) is deferred; the incoming push must omit --emit-tests", providerTest.rel)
+	for name, reported := range reportArtifacts {
+		p := planFor(plans, name)
+		reportedCopy := reported
+		p.report = &reportedCopy
 	}
 
 	if len(plans) == 0 {
@@ -191,12 +234,18 @@ func Split(opts Options) (*Result, error) {
 		}
 		return finish(rep, problems)
 	}
-	if registry == nil {
-		fail("data source files changed but %s did not", registryFile)
-		return finish(rep, problems)
+
+	for _, name := range sortedNames(plans) {
+		p := plans[name]
+		status, statusProblems := validatePlan(name, p, opts.GenerationReport != "")
+		problems = append(problems, statusProblems...)
+		if p.report == nil && status != "" {
+			p.report = &generationArtifact{status: status}
+		}
 	}
 
-	baseSet, err := emit.RegisteredGeneratedDatasources(filepath.Join(opts.BaseDir, registry.rel))
+	registryRel := filepath.Join("datadog", "fwprovider", registryFile)
+	baseSet, err := emit.RegisteredGeneratedDatasources(filepath.Join(opts.BaseDir, registryRel))
 	if err != nil {
 		return rep, fmt.Errorf("split: reading base registry: %w", err)
 	}
@@ -204,23 +253,92 @@ func Split(opts Options) (*Result, error) {
 	overwrites, provProblems := attributeOverwrites(opts, plans, provider)
 	problems = append(problems, provProblems...)
 
-	// Cross-check: base ∪ every artifact's constructor must equal the incoming
-	// registry, or an artifact is unaccounted for (a registration with no file, or
-	// vice versa).
-	incoming, err := emit.RegisteredGeneratedDatasources(filepath.Join(opts.GeneratedDir, registry.rel))
+	incoming, err := emit.RegisteredGeneratedDatasources(filepath.Join(opts.GeneratedDir, registryRel))
 	if err != nil {
 		return rep, fmt.Errorf("split: reading generated registry: %w", err)
 	}
-	want := append(slices.Clone(baseSet), constructorsFor(plans)...)
+	want := slices.Clone(baseSet)
+	prProducing := 0
+	for name, p := range plans {
+		if p.report == nil {
+			continue
+		}
+		switch p.report.status {
+		case model.ArtifactStatusCreated, model.ArtifactStatusUpdated:
+			want = append(want, emit.DatasourceConstructor(name))
+			prProducing++
+		case model.ArtifactStatusRetired:
+			want = without(want, emit.DatasourceConstructor(name))
+			prProducing++
+		}
+	}
+	registrySetChanged := len(onlyIn(want, baseSet)) > 0 || len(onlyIn(baseSet, want)) > 0
+	if prProducing > 0 && registrySetChanged && registry == nil {
+		fail("PR-producing data source changes require %s to change", registryRel)
+	}
 	if diff := onlyIn(incoming, want); len(diff) > 0 {
-		fail("%s registers constructor(s) not accounted for by any changed data source file: %s", registry.rel, strings.Join(diff, ", "))
+		fail("%s registers constructor(s) not accounted for by the generation report: %s", registryRel, strings.Join(diff, ", "))
 	}
 	if diff := onlyIn(want, incoming); len(diff) > 0 {
-		fail("data source(s) changed whose constructor is missing from the incoming %s: %s", registry.rel, strings.Join(diff, ", "))
+		fail("generation report expects constructor(s) missing from incoming %s: %s", registryRel, strings.Join(diff, ", "))
+	}
+
+	providerTestRel := filepath.Join("datadog", "tests", providerTestFile)
+	baseTags, err := emit.RegisteredEndpointTags(filepath.Join(opts.BaseDir, providerTestRel))
+	if err != nil {
+		return rep, fmt.Errorf("split: reading base endpoint tags: %w", err)
+	}
+	incomingTags, err := emit.RegisteredEndpointTags(filepath.Join(opts.GeneratedDir, providerTestRel))
+	if err != nil {
+		return rep, fmt.Errorf("split: reading generated endpoint tags: %w", err)
+	}
+	wantTags := cloneMap(baseTags)
+	for name, p := range plans {
+		if p.report == nil {
+			continue
+		}
+		key := emit.EndpointTagTestKey(name)
+		switch p.report.status {
+		case model.ArtifactStatusCreated, model.ArtifactStatusUpdated:
+			if p.test != nil {
+				tag, ok := incomingTags[key]
+				if !ok {
+					fail("%s changed for %q, but %s has no %q entry", p.test.rel, name, providerTestRel, key)
+				} else {
+					wantTags[key] = tag
+				}
+			}
+		case model.ArtifactStatusRetired:
+			delete(wantTags, key)
+		}
+	}
+	if !mapsEqual(wantTags, incomingTags) {
+		fail("%s changes are not fully attributable to the reported artifacts", providerTestRel)
+	}
+	if !mapsEqual(baseTags, incomingTags) && providerTest == nil {
+		fail("%s content changed but was not discovered in the scoped diff", providerTestRel)
 	}
 
 	for _, name := range sortedNames(plans) {
-		art, artProblems := materialize(opts, name, plans[name], registry.rel, baseSet, overwrites[name], provider)
+		p := plans[name]
+		if p.report == nil {
+			continue
+		}
+		var art *Artifact
+		var artProblems []string
+		switch p.report.status {
+		case model.ArtifactStatusCreated, model.ArtifactStatusUpdated:
+			art, artProblems = materializeActive(opts, name, p, registryRel, baseSet, overwrites[name], provider, providerTestRel, incomingTags)
+		case model.ArtifactStatusRetired:
+			art, artProblems = materializeRetired(opts, name, p, registryRel, providerTestRel, baseTags)
+		case model.ArtifactStatusRetireBlocked:
+			art = &Artifact{
+				Name:        name,
+				Status:      model.ArtifactStatusRetireBlocked,
+				Files:       []string{},
+				Diagnostics: slices.Clone(p.report.diagnostics),
+			}
+		}
 		problems = append(problems, artProblems...)
 		if art != nil {
 			rep.Artifacts = append(rep.Artifacts, *art)
@@ -230,22 +348,20 @@ func Split(opts Options) (*Result, error) {
 	return finish(rep, problems)
 }
 
-// materialize writes one artifact's bundle under OutDir/<name>/ and returns its
-// report entry. The self-contained files (source, optional test) are copied
-// verbatim; datasources_generated.go is reconstructed as baseSet ∪ {this
-// constructor}; framework_provider.go is base with this artifact's overwritten
-// constructor(s) removed.
-func materialize(opts Options, name string, p *artifactPlan, registryRel string, baseSet, overwritten []string, provider *changedFile) (*Artifact, []string) {
+func materializeActive(opts Options, name string, p *artifactPlan, registryRel string, baseSet, overwritten []string, provider *changedFile, providerTestRel string, incomingTags map[string]string) (*Artifact, []string) {
 	var problems []string
-	art := &Artifact{Name: name}
-	if p.source.added {
-		art.Status = "created"
-	} else {
-		art.Status = "updated"
+	art := &Artifact{
+		Name:        name,
+		Status:      p.report.status,
+		Files:       []string{},
+		Diagnostics: slices.Clone(p.report.diagnostics),
 	}
 	outDir := filepath.Join(opts.OutDir, name)
 
-	files := []string{p.source.rel}
+	var files []string
+	if p.source != nil {
+		files = append(files, p.source.rel)
+	}
 	if p.test != nil {
 		files = append(files, p.test.rel)
 	}
@@ -266,26 +382,226 @@ func materialize(opts Options, name string, p *artifactPlan, registryRel string,
 	}
 	art.Files = append(art.Files, registryRel)
 
-	// An overwrite retires hand-written constructor(s) from framework_provider.go;
-	// replay that removal against the base copy (there is no from-set rebuild for it).
 	if len(overwritten) > 0 {
 		provOut := filepath.Join(outDir, provider.rel)
 		if !opts.Check {
 			if err := copyFile(filepath.Join(opts.BaseDir, provider.rel), provOut); err != nil {
 				problems = append(problems, fmt.Sprintf("copying %s for %q: %v", provider.rel, name, err))
 			}
-		}
-		for _, c := range overwritten {
-			if _, err := emit.RemoveHandwrittenDatasource(provOut, c, opts.Check); err != nil {
-				problems = append(problems, fmt.Sprintf("retiring %s from %s for %q: %v", c, provider.rel, name, err))
+			for _, c := range overwritten {
+				if _, err := emit.RemoveHandwrittenDatasource(provOut, c, false); err != nil {
+					problems = append(problems, fmt.Sprintf("retiring %s from %s for %q: %v", c, provider.rel, name, err))
+				}
 			}
 		}
 		art.Files = append(art.Files, provider.rel)
 	}
 
+	if p.test != nil {
+		key := emit.EndpointTagTestKey(name)
+		tag, ok := incomingTags[key]
+		if !ok {
+			problems = append(problems, fmt.Sprintf("reconstructing %s for %q: endpoint tag %q is absent", providerTestRel, name, key))
+		} else {
+			testOut := filepath.Join(outDir, providerTestRel)
+			if !opts.Check {
+				if err := copyFile(filepath.Join(opts.BaseDir, providerTestRel), testOut); err != nil {
+					problems = append(problems, fmt.Sprintf("copying %s for %q: %v", providerTestRel, name, err))
+				} else if _, err := emit.InsertEndpointTag(testOut, key, tag, false); err != nil {
+					problems = append(problems, fmt.Sprintf("reconstructing %s for %q: %v", providerTestRel, name, err))
+				}
+			}
+			art.Files = append(art.Files, providerTestRel)
+		}
+	}
+
 	sort.Strings(art.Files)
 	art.Files = slices.Compact(art.Files)
 	return art, problems
+}
+
+func materializeRetired(opts Options, name string, p *artifactPlan, registryRel, providerTestRel string, baseTags map[string]string) (*Artifact, []string) {
+	var problems []string
+	art := &Artifact{
+		Name:         name,
+		Status:       model.ArtifactStatusRetired,
+		Files:        []string{registryRel},
+		RemovedFiles: slices.Clone(p.removed),
+		Diagnostics:  slices.Clone(p.report.diagnostics),
+	}
+	outDir := filepath.Join(opts.OutDir, name)
+	registryOut := filepath.Join(outDir, registryRel)
+	if !opts.Check {
+		if err := copyFile(filepath.Join(opts.BaseDir, registryRel), registryOut); err != nil {
+			problems = append(problems, fmt.Sprintf("copying %s for %q: %v", registryRel, name, err))
+		} else if _, err := emit.RemoveGeneratedDatasource(registryOut, emit.DatasourceConstructor(name), false); err != nil {
+			problems = append(problems, fmt.Sprintf("reconstructing %s for retirement %q: %v", registryRel, name, err))
+		}
+	}
+
+	key := emit.EndpointTagTestKey(name)
+	if _, ok := baseTags[key]; ok {
+		testOut := filepath.Join(outDir, providerTestRel)
+		if !opts.Check {
+			if err := copyFile(filepath.Join(opts.BaseDir, providerTestRel), testOut); err != nil {
+				problems = append(problems, fmt.Sprintf("copying %s for %q: %v", providerTestRel, name, err))
+			} else if _, err := emit.RemoveEndpointTag(testOut, key, false); err != nil {
+				problems = append(problems, fmt.Sprintf("reconstructing %s for retirement %q: %v", providerTestRel, name, err))
+			}
+		}
+		art.Files = append(art.Files, providerTestRel)
+	}
+
+	sort.Strings(art.Files)
+	art.Files = slices.Compact(art.Files)
+	sort.Strings(art.RemovedFiles)
+	art.RemovedFiles = slices.Compact(art.RemovedFiles)
+	return art, problems
+}
+
+func validatePlan(name string, p *artifactPlan, reportRequired bool) (model.ArtifactStatus, []string) {
+	var problems []string
+	fail := func(format string, a ...any) { problems = append(problems, fmt.Sprintf(format, a...)) }
+
+	if !artifactNameRe.MatchString(name) {
+		fail("artifact name %q from diff/report is unsafe", name)
+		return "", problems
+	}
+	if reportRequired && p.report == nil {
+		fail("artifact %q changed but is absent from the generation report", name)
+		return "", problems
+	}
+
+	status := model.ArtifactStatus("")
+	if p.report != nil {
+		status = p.report.status
+	} else if p.source != nil {
+		if p.source.added {
+			status = model.ArtifactStatusCreated
+		} else {
+			status = model.ArtifactStatusUpdated
+		}
+	}
+
+	switch status {
+	case model.ArtifactStatusCreated:
+		if p.source == nil || !p.source.added {
+			fail("generation report marks %q created, but its source file is not newly added", name)
+		}
+		if len(p.removed) > 0 {
+			fail("created artifact %q also removes files: %s", name, strings.Join(p.removed, ", "))
+		}
+	case model.ArtifactStatusUpdated:
+		if p.source == nil && p.test == nil {
+			fail("generation report marks %q updated, but no source or test file changed", name)
+		}
+		if p.source != nil && p.source.added {
+			fail("generation report marks %q updated, but its source file is newly added", name)
+		}
+		if len(p.removed) > 0 {
+			fail("updated artifact %q also removes files: %s", name, strings.Join(p.removed, ", "))
+		}
+	case model.ArtifactStatusRetired:
+		if p.source != nil || p.test != nil || p.doc != nil {
+			fail("retired artifact %q contains added or modified self-contained files", name)
+		}
+	case model.ArtifactStatusRetireBlocked:
+		if p.source != nil || p.test != nil || p.doc != nil || len(p.removed) > 0 {
+			fail("retire_blocked artifact %q unexpectedly changes files", name)
+		}
+	case "":
+		if len(p.removed) > 0 {
+			fail("removed file for %q requires a generation report declaring retired", name)
+		} else {
+			fail("artifact %q has no routable source change or report status", name)
+		}
+	default:
+		fail("artifact %q has unsupported generation status %q", name, status)
+	}
+	if p.doc != nil {
+		fail("documentation file changed upstream for %q (%s); docs must be generated per artifact in CI", name, p.doc.rel)
+	}
+	return status, problems
+}
+
+func readGenerationArtifacts(path string) (map[string]generationArtifact, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var report model.RunReport
+	if err := json.NewDecoder(f).Decode(&report); err != nil {
+		return nil, err
+	}
+
+	type accumulated struct {
+		mainSeen    bool
+		mainStatus  model.ArtifactStatus
+		testChanged bool
+		diagnostics []model.Diagnostic
+	}
+	acc := map[string]*accumulated{}
+	for _, entry := range report.Artifacts {
+		if entry.Kind != model.ArtifactKindDataSource {
+			continue
+		}
+		if !artifactNameRe.MatchString(entry.Name) {
+			if entry.Status == model.ArtifactStatusRetired || entry.Status == model.ArtifactStatusRetireBlocked {
+				return nil, fmt.Errorf("unsafe retired artifact name %q", entry.Name)
+			}
+			continue
+		}
+		a := acc[entry.Name]
+		if a == nil {
+			a = &accumulated{}
+			acc[entry.Name] = a
+		}
+		base := filepath.Base(entry.Path)
+		if base == "data_source_datadog_"+entry.Name+"_test.go" {
+			if entry.Status == model.ArtifactStatusCreated || entry.Status == model.ArtifactStatusUpdated {
+				a.testChanged = true
+			}
+			continue
+		}
+		if base != "" && base != "data_source_datadog_"+entry.Name+".go" &&
+			entry.Status != model.ArtifactStatusRetired &&
+			entry.Status != model.ArtifactStatusRetireBlocked {
+			continue
+		}
+		if a.mainSeen {
+			return nil, fmt.Errorf("duplicate generation report entry for artifact %q", entry.Name)
+		}
+		a.mainSeen = true
+		a.mainStatus = entry.Status
+		a.diagnostics = slices.Clone(entry.Diagnostics)
+	}
+
+	out := map[string]generationArtifact{}
+	for name, a := range acc {
+		if !a.mainSeen {
+			if a.testChanged {
+				return nil, fmt.Errorf("generation report has a changed test for %q without a data-source entry", name)
+			}
+			continue
+		}
+		status := a.mainStatus
+		if status == model.ArtifactStatusUnchanged && a.testChanged {
+			status = model.ArtifactStatusUpdated
+		}
+		switch status {
+		case model.ArtifactStatusCreated, model.ArtifactStatusUpdated, model.ArtifactStatusRetired, model.ArtifactStatusRetireBlocked:
+			out[name] = generationArtifact{status: status, diagnostics: a.diagnostics}
+		case model.ArtifactStatusUnchanged, model.ArtifactStatusSkipped:
+			continue
+		case model.ArtifactStatusFailed:
+			return nil, fmt.Errorf("generation report contains failed artifact %q", name)
+		default:
+			return nil, fmt.Errorf("generation report contains unknown status %q for %q", status, name)
+		}
+	}
+	return out, nil
 }
 
 // attributeOverwrites maps each hand-written constructor removed from
@@ -317,6 +633,10 @@ func attributeOverwrites(opts Options, plans map[string]*artifactPlan, provider 
 	claimed := map[string]bool{}
 	for _, name := range sortedNames(plans) {
 		p := plans[name]
+		if p.source == nil || p.report == nil ||
+			(p.report.status != model.ArtifactStatusCreated && p.report.status != model.ArtifactStatusUpdated) {
+			continue
+		}
 		if p.source.added {
 			continue // net-new file: nothing pre-existed to overwrite
 		}
@@ -342,50 +662,54 @@ func attributeOverwrites(opts Options, plans map[string]*artifactPlan, provider 
 
 // diffTrees returns scoped files that differ between base and generated (added
 // or modified), plus scoped files present in base but gone from generated
-// (deleted). Paths outside diffScopes are intentionally ignored so unrelated
-// master drift cannot invalidate an otherwise self-contained generator push.
+// (deleted). scopedFiles limits the comparison to generator-owned directories
+// and selected test files so unrelated master drift cannot invalidate an
+// otherwise self-contained generator push.
 func diffTrees(baseDir, genDir string) (changed []changedFile, deleted []string, err error) {
-	err = walkDiffScopes(genDir, func(path, rel string, d fs.DirEntry) error {
-		same, existed, cmpErr := sameContent(filepath.Join(baseDir, rel), path)
-		if cmpErr != nil {
-			return cmpErr
-		}
-		if !same {
-			changed = append(changed, changedFile{rel: rel, base: d.Name(), added: !existed})
-		}
-		return nil
-	})
+	generatedFiles, err := scopedFiles(genDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	baseFiles, err := scopedFiles(baseDir)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	err = walkDiffScopes(baseDir, func(_ string, rel string, _ fs.DirEntry) error {
+	for _, rel := range generatedFiles {
+		path := filepath.Join(genDir, rel)
+		same, existed, cmpErr := sameContent(filepath.Join(baseDir, rel), path)
+		if cmpErr != nil {
+			return nil, nil, cmpErr
+		}
+		if !same {
+			changed = append(changed, changedFile{rel: rel, added: !existed})
+		}
+	}
+
+	for _, rel := range baseFiles {
 		_, statErr := os.Stat(filepath.Join(genDir, rel))
 		if os.IsNotExist(statErr) {
 			deleted = append(deleted, rel)
 		} else if statErr != nil {
-			return statErr
+			return nil, nil, statErr
 		}
-		return nil
-	})
-	if err != nil {
-		return nil, nil, err
 	}
 	sort.Strings(deleted)
 	return changed, deleted, nil
 }
 
-// walkDiffScopes visits files under the paths split owns. A scope may be absent
-// from either synthetic test fixture or checkout; the other tree's walk will
-// still classify its files as additions or removals.
-func walkDiffScopes(root string, visit func(path, rel string, d fs.DirEntry) error) error {
-	for _, scope := range diffScopes {
+// scopedFiles returns every file under provider/docs plus only generated
+// data-source tests and provider_test.go. This preserves fail-loud attribution
+// without making unrelated test-suite or cassette drift part of the split.
+func scopedFiles(root string) ([]string, error) {
+	var out []string
+	for _, scope := range diffDirectoryScopes {
 		scopePath := filepath.Join(root, scope)
 		if _, err := os.Stat(scopePath); err != nil {
 			if os.IsNotExist(err) {
 				continue
 			}
-			return err
+			return nil, err
 		}
 		if err := filepath.WalkDir(scopePath, func(path string, d fs.DirEntry, walkErr error) error {
 			if walkErr != nil {
@@ -398,12 +722,32 @@ func walkDiffScopes(root string, visit func(path, rel string, d fs.DirEntry) err
 			if err != nil {
 				return err
 			}
-			return visit(path, rel, d)
+			out = append(out, rel)
+			return nil
 		}); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return nil
+
+	providerTestRel := filepath.Join("datadog", "tests", providerTestFile)
+	if info, err := os.Stat(filepath.Join(root, providerTestRel)); err == nil && !info.IsDir() {
+		out = append(out, providerTestRel)
+	} else if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	testMatches, err := filepath.Glob(filepath.Join(root, "datadog", "tests", "data_source_datadog_*_test.go"))
+	if err != nil {
+		return nil, err
+	}
+	for _, path := range testMatches {
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, rel)
+	}
+	sort.Strings(out)
+	return slices.Compact(out), nil
 }
 
 // sameContent reports whether basePath and genPath hold identical bytes, and
@@ -507,12 +851,34 @@ func sortedNames(m map[string]*artifactPlan) []string {
 	return names
 }
 
-func constructorsFor(m map[string]*artifactPlan) []string {
-	out := make([]string, 0, len(m))
-	for _, n := range sortedNames(m) {
-		out = append(out, emit.DatasourceConstructor(n))
+func without(items []string, target string) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if item != target {
+			out = append(out, item)
+		}
 	}
 	return out
+}
+
+func cloneMap[K comparable, V any](in map[K]V) map[K]V {
+	out := make(map[K]V, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func mapsEqual[K comparable, V comparable](a, b map[K]V) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 // onlyIn returns the sorted, de-duplicated members of a not present in b.

--- a/.generator-v2/internal/split/split_test.go
+++ b/.generator-v2/internal/split/split_test.go
@@ -326,6 +326,34 @@ var _ = Describe("Split", func() {
 		Expect(os.IsNotExist(statErr)).To(BeTrue())
 	})
 
+	It("routes a registration-only retirement as a registry edit with no file deletions", func() {
+		ghostCtor := emit.DatasourceConstructor("ghost")
+		existing := emit.DatasourceConstructor("existing")
+		slug := emit.RegistrationRetirementName(ghostCtor)
+
+		writeRegistry(base, existing, ghostCtor)
+		writeRegistry(gen, existing)
+		reportPath := writeGenerationReport(gen, model.ArtifactReportEntry{
+			Name: slug, Kind: model.ArtifactKindDataSource,
+			Status: model.ArtifactStatusRegistrationRetired, Constructor: ghostCtor,
+			Diagnostics: []model.Diagnostic{{Severity: model.SeverityWarning, Message: "no generated file"}},
+		})
+
+		rep, err := Split(Options{BaseDir: base, GeneratedDir: gen, OutDir: out, GenerationReport: reportPath})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rep.Errors).To(BeEmpty())
+		Expect(rep.Artifacts).To(HaveLen(1))
+		artifact := rep.Artifacts[0]
+		Expect(artifact.Status).To(Equal(model.ArtifactStatusRegistrationRetired))
+		Expect(artifact.Name).To(Equal(slug))
+		Expect(artifact.Files).To(ConsistOf(filepath.Join(fwDir, registryFile)))
+		Expect(artifact.RemovedFiles).To(BeEmpty())
+
+		routedRegistry := readFile(filepath.Join(out, slug, fwDir, registryFile))
+		Expect(routedRegistry).NotTo(ContainSubstring(ghostCtor))
+		Expect(routedRegistry).To(ContainSubstring(existing))
+	})
+
 	It("fails loud when the generation report contradicts the tree diff", func() {
 		name := "mismatch"
 		constructor := emit.DatasourceConstructor(name)

--- a/.generator-v2/internal/split/split_test.go
+++ b/.generator-v2/internal/split/split_test.go
@@ -1,19 +1,26 @@
 package split
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/emit"
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
 )
 
 const fwDir = "datadog/fwprovider"
+const testsDir = "datadog/tests"
 
 func dsFileName(name string) string { return "data_source_datadog_" + name + ".go" }
+func dsTestFileName(name string) string {
+	return "data_source_datadog_" + name + "_test.go"
+}
 
 func writeFile(root, rel, content string) {
 	GinkgoHelper()
@@ -35,6 +42,30 @@ func writeRegistry(root string, constructors ...string) {
 	GinkgoHelper()
 	_, err := emit.SyncGeneratedDatasources(filepath.Join(root, fwDir, registryFile), constructors, false)
 	Expect(err).NotTo(HaveOccurred())
+}
+
+func writeGenerationReport(root string, entries ...model.ArtifactReportEntry) string {
+	GinkgoHelper()
+	data, err := json.Marshal(model.RunReport{Artifacts: entries})
+	Expect(err).NotTo(HaveOccurred())
+	const rel = "generation-report.json"
+	writeFile(root, rel, string(data))
+	return filepath.Join(root, rel)
+}
+
+func writeEndpointTags(root string, tags map[string]string) {
+	GinkgoHelper()
+	path := filepath.Join(root, testsDir, providerTestFile)
+	writeFile(root, filepath.Join(testsDir, providerTestFile), "package test\n\nvar testFiles2EndpointTags = map[string]string{\n}\n")
+	keys := make([]string, 0, len(tags))
+	for key := range tags {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		_, err := emit.InsertEndpointTag(path, key, tags[key], false)
+		Expect(err).NotTo(HaveOccurred())
+	}
 }
 
 // dataSourceContent is a minimal generated-file body declaring one constructor;
@@ -81,7 +112,7 @@ var _ = Describe("Split", func() {
 
 		art := rep.Artifacts[0]
 		Expect(art.Name).To(Equal("rum_applications"))
-		Expect(art.Status).To(Equal("created"))
+		Expect(art.Status).To(Equal(model.ArtifactStatusCreated))
 		Expect(art.Files).To(ConsistOf(
 			filepath.Join(fwDir, dsFileName("rum_applications")),
 			filepath.Join(fwDir, registryFile),
@@ -98,6 +129,9 @@ var _ = Describe("Split", func() {
 		writeFile(gen, "README.md", "newer generated-branch content\n")
 		writeFile(base, "scripts/removed_upstream.sh", "removed after the branch was cut\n")
 		writeFile(gen, "config/new_upstream.yaml", "added after the branch was cut\n")
+		writeFile(base, filepath.Join(testsDir, "unrelated_test.go"), "package test\n// old\n")
+		writeFile(gen, filepath.Join(testsDir, "unrelated_test.go"), "package test\n// new\n")
+		writeFile(base, filepath.Join(testsDir, "cassettes", "unrelated.yaml"), "old cassette\n")
 
 		writeRegistry(base)
 		ctor := emit.DatasourceConstructor("rum_applications")
@@ -154,6 +188,162 @@ var _ = Describe("Split", func() {
 		}
 	})
 
+	It("routes generated tests and gives each artifact only its own endpoint tag", func() {
+		writeRegistry(base)
+		writeEndpointTags(base, nil)
+
+		names := []string{"alpha", "bravo"}
+		var entries []model.ArtifactReportEntry
+		var constructors []string
+		tags := map[string]string{}
+		for _, name := range names {
+			constructor := emit.DatasourceConstructor(name)
+			constructors = append(constructors, constructor)
+			writeFile(gen, filepath.Join(fwDir, dsFileName(name)), dataSourceContent(constructor))
+			writeFile(gen, filepath.Join(testsDir, dsTestFileName(name)), "package test\n")
+			tags[emit.EndpointTagTestKey(name)] = name + "-service"
+			entries = append(entries,
+				model.ArtifactReportEntry{
+					Name: name, Kind: model.ArtifactKindDataSource, Status: model.ArtifactStatusCreated,
+					Path:        filepath.Join(fwDir, dsFileName(name)),
+					Diagnostics: []model.Diagnostic{{Severity: model.SeverityInfo, Message: name + " diagnostic"}},
+				},
+				model.ArtifactReportEntry{
+					Name: name, Kind: model.ArtifactKindDataSource, Status: model.ArtifactStatusCreated,
+					Path: filepath.Join(testsDir, dsTestFileName(name)),
+				},
+			)
+		}
+		writeRegistry(gen, constructors...)
+		writeEndpointTags(gen, tags)
+		reportPath := writeGenerationReport(gen, entries...)
+
+		rep, err := Split(Options{BaseDir: base, GeneratedDir: gen, OutDir: out, GenerationReport: reportPath})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rep.Artifacts).To(HaveLen(2))
+
+		for _, artifact := range rep.Artifacts {
+			Expect(artifact.Files).To(ContainElement(filepath.Join(testsDir, dsTestFileName(artifact.Name))))
+			Expect(artifact.Files).To(ContainElement(filepath.Join(testsDir, providerTestFile)))
+			Expect(artifact.Diagnostics).To(ConsistOf(model.Diagnostic{Severity: model.SeverityInfo, Message: artifact.Name + " diagnostic"}))
+
+			routedTags, err := emit.RegisteredEndpointTags(filepath.Join(out, artifact.Name, testsDir, providerTestFile))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(routedTags).To(Equal(map[string]string{
+				emit.EndpointTagTestKey(artifact.Name): artifact.Name + "-service",
+			}))
+		}
+	})
+
+	It("routes a test-only rollout as an updated artifact when its generated source is unchanged", func() {
+		name := "existing"
+		constructor := emit.DatasourceConstructor(name)
+		sourceRel := filepath.Join(fwDir, dsFileName(name))
+		source := dataSourceContent(constructor)
+		writeFile(base, sourceRel, source)
+		writeFile(gen, sourceRel, source)
+		writeRegistry(base, constructor)
+		writeRegistry(gen, constructor)
+		writeEndpointTags(base, nil)
+		writeEndpointTags(gen, map[string]string{emit.EndpointTagTestKey(name): "existing-service"})
+		writeFile(gen, filepath.Join(testsDir, dsTestFileName(name)), "package test\n")
+		reportPath := writeGenerationReport(gen,
+			model.ArtifactReportEntry{Name: name, Kind: model.ArtifactKindDataSource, Status: model.ArtifactStatusUnchanged, Path: sourceRel},
+			model.ArtifactReportEntry{Name: name, Kind: model.ArtifactKindDataSource, Status: model.ArtifactStatusCreated, Path: filepath.Join(testsDir, dsTestFileName(name))},
+		)
+
+		rep, err := Split(Options{BaseDir: base, GeneratedDir: gen, OutDir: out, GenerationReport: reportPath})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rep.Artifacts).To(HaveLen(1))
+		Expect(rep.Artifacts[0].Status).To(Equal(model.ArtifactStatusUpdated))
+		Expect(rep.Artifacts[0].Files).To(ConsistOf(
+			filepath.Join(fwDir, registryFile),
+			filepath.Join(testsDir, dsTestFileName(name)),
+			filepath.Join(testsDir, providerTestFile),
+		))
+	})
+
+	It("routes a retirement as exact file deletions plus reconstructed shared registrations", func() {
+		name := "gone"
+		constructor := emit.DatasourceConstructor(name)
+		existing := emit.DatasourceConstructor("existing")
+		sourceRel := filepath.Join(fwDir, dsFileName(name))
+		testRel := filepath.Join(testsDir, dsTestFileName(name))
+		docRel := filepath.Join("docs", "data-sources", name+".md")
+
+		writeRegistry(base, existing, constructor)
+		writeRegistry(gen, existing)
+		writeFile(base, sourceRel, dataSourceContent(constructor))
+		writeFile(base, testRel, "package test\n")
+		writeFile(base, docRel, "# gone\n")
+		writeEndpointTags(base, map[string]string{emit.EndpointTagTestKey(name): "gone-service"})
+		writeEndpointTags(gen, nil)
+		reportPath := writeGenerationReport(gen, model.ArtifactReportEntry{
+			Name: name, Kind: model.ArtifactKindDataSource, Status: model.ArtifactStatusRetired, Path: sourceRel,
+			Diagnostics: []model.Diagnostic{{Severity: model.SeverityInfo, Message: "safe to retire"}},
+		})
+
+		rep, err := Split(Options{BaseDir: base, GeneratedDir: gen, OutDir: out, GenerationReport: reportPath})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rep.Artifacts).To(HaveLen(1))
+		artifact := rep.Artifacts[0]
+		Expect(artifact.Status).To(Equal(model.ArtifactStatusRetired))
+		Expect(artifact.RemovedFiles).To(ConsistOf(sourceRel, testRel, docRel))
+		Expect(artifact.Files).To(ConsistOf(
+			filepath.Join(fwDir, registryFile),
+			filepath.Join(testsDir, providerTestFile),
+		))
+
+		routedRegistry := readFile(filepath.Join(out, name, fwDir, registryFile))
+		Expect(routedRegistry).NotTo(ContainSubstring(constructor))
+		Expect(routedRegistry).To(ContainSubstring(existing))
+		routedTags, err := emit.RegisteredEndpointTags(filepath.Join(out, name, testsDir, providerTestFile))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(routedTags).NotTo(HaveKey(emit.EndpointTagTestKey(name)))
+	})
+
+	It("reports retire_blocked without materializing a deletion bundle", func() {
+		name := "adopted"
+		constructor := emit.DatasourceConstructor(name)
+		sourceRel := filepath.Join(fwDir, dsFileName(name))
+		source := dataSourceContent(constructor)
+		writeRegistry(base, constructor)
+		writeRegistry(gen, constructor)
+		writeFile(base, sourceRel, source)
+		writeFile(gen, sourceRel, source)
+		reportPath := writeGenerationReport(gen, model.ArtifactReportEntry{
+			Name: name, Kind: model.ArtifactKindDataSource, Status: model.ArtifactStatusRetireBlocked, Path: sourceRel,
+			Diagnostics: []model.Diagnostic{{Severity: model.SeverityWarning, Message: "recorded cassette"}},
+		})
+
+		rep, err := Split(Options{BaseDir: base, GeneratedDir: gen, OutDir: out, GenerationReport: reportPath})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rep.Artifacts).To(HaveLen(1))
+		Expect(rep.Artifacts[0].Status).To(Equal(model.ArtifactStatusRetireBlocked))
+		Expect(rep.Artifacts[0].Files).To(BeEmpty())
+		Expect(rep.Artifacts[0].RemovedFiles).To(BeEmpty())
+		_, statErr := os.Stat(filepath.Join(out, name))
+		Expect(os.IsNotExist(statErr)).To(BeTrue())
+	})
+
+	It("fails loud when the generation report contradicts the tree diff", func() {
+		name := "mismatch"
+		constructor := emit.DatasourceConstructor(name)
+		sourceRel := filepath.Join(fwDir, dsFileName(name))
+		source := dataSourceContent(constructor)
+		writeRegistry(base, constructor)
+		writeRegistry(gen, constructor)
+		writeFile(base, sourceRel, source)
+		writeFile(gen, sourceRel, source)
+		reportPath := writeGenerationReport(gen, model.ArtifactReportEntry{
+			Name: name, Kind: model.ArtifactKindDataSource, Status: model.ArtifactStatusCreated, Path: sourceRel,
+		})
+
+		rep, err := Split(Options{BaseDir: base, GeneratedDir: gen, OutDir: out, GenerationReport: reportPath})
+		Expect(err).To(HaveOccurred())
+		Expect(rep.Errors).To(ContainElement(ContainSubstring("not newly added")))
+	})
+
 	It("fails loud on a changed file it cannot attribute to any artifact", func() {
 		writeRegistry(base)
 		writeFile(gen, filepath.Join(fwDir, registryFile), readFile(filepath.Join(base, fwDir, registryFile)))
@@ -183,7 +373,7 @@ var _ = Describe("Split", func() {
 		rep, err := Split(Options{BaseDir: base, GeneratedDir: gen, OutDir: out})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rep.Artifacts).To(HaveLen(1))
-		Expect(rep.Artifacts[0].Status).To(Equal("updated"))
+		Expect(rep.Artifacts[0].Status).To(Equal(model.ArtifactStatusUpdated))
 		Expect(rep.Artifacts[0].Files).To(ContainElement(filepath.Join(fwDir, providerFile)))
 
 		routedProvider := readFile(filepath.Join(out, "team", fwDir, providerFile))

--- a/.github/workflows/tfgen-split.yml
+++ b/.github/workflows/tfgen-split.yml
@@ -2,6 +2,7 @@ name: tfgen Split
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
   id-token: write
 
@@ -59,15 +60,21 @@ jobs:
 
           BASE_DIR="$GITHUB_WORKSPACE/base"
           GENERATED_DIR="$GITHUB_WORKSPACE/generated"
+          GENERATION_REPORT="$GENERATED_DIR/.tfgen-run-report.json"
           PLAN_PATH="$RUNNER_TEMP/tfgen-split-plan.json"
           SPLIT_DIR="$RUNNER_TEMP/tfgen-split"
 
           make tfgen-build
           mkdir -p "$SPLIT_DIR"
+          if [[ ! -f "$GENERATION_REPORT" ]]; then
+            echo "::error::Incoming branch is missing .tfgen-run-report.json"
+            exit 1
+          fi
 
           if ! ./bin/tfgen split \
             --base-dir "$BASE_DIR" \
             --generated-dir "$GENERATED_DIR" \
+            --generation-report "$GENERATION_REPORT" \
             --out "$SPLIT_DIR" \
             --report "$PLAN_PATH"; then
             {
@@ -83,15 +90,28 @@ jobs:
           fi
 
           artifact_count="$(jq -r '.artifacts | length' "$PLAN_PATH")"
+          pr_count="$(jq -r '[.artifacts[] | select(.status == "created" or .status == "updated" or .status == "retired")] | length' "$PLAN_PATH")"
+          blocked_count="$(jq -r '[.artifacts[] | select(.status == "retire_blocked")] | length' "$PLAN_PATH")"
+          max_prs=25
+          if [[ "$pr_count" -gt "$max_prs" ]]; then
+            {
+              echo "## tfgen split blocked"
+              echo
+              echo "The batch would open $pr_count PRs, exceeding the safety cap of $max_prs."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
           echo "artifact_count=$artifact_count" >> "$GITHUB_OUTPUT"
+          echo "pr_count=$pr_count" >> "$GITHUB_OUTPUT"
+          echo "blocked_count=$blocked_count" >> "$GITHUB_OUTPUT"
           {
             echo "## tfgen split"
             echo
-            echo "Routed $artifact_count artifact(s) from \`$GITHUB_REF_NAME\`."
+            echo "Routed $pr_count PR artifact(s) and $blocked_count blocked retirement(s) from \`$GITHUB_REF_NAME\`."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # Deployment prerequisite: provision this policy with contents:write and
-      # pull-requests:write before enabling the upstream generated-branch push.
+      # Deployment prerequisite: provision this policy with contents:write,
+      # pull-requests:write, and issues:write.
       - name: Mint Octo token
         if: steps.split.outputs.artifact_count != '0'
         id: octo-sts
@@ -135,6 +155,9 @@ jobs:
 
           failures=0
           successes=0
+          created_count=0
+          updated_count=0
+          retired_count=0
 
           reset_to_base() {
             git reset --hard >/dev/null 2>&1 || true
@@ -152,7 +175,7 @@ jobs:
           }
 
           reset_to_base
-          mapfile -t artifact_names < <(jq -r '.artifacts[].name' "$PLAN_PATH")
+          mapfile -t artifact_names < <(jq -r '.artifacts[] | select(.status != "retire_blocked") | .name' "$PLAN_PATH")
 
           for name in "${artifact_names[@]}"; do
             if [[ ! "$name" =~ ^[a-z][a-z0-9_]*$ ]]; then
@@ -163,15 +186,15 @@ jobs:
             status="$(jq -r --arg name "$name" \
               '.artifacts[] | select(.name == $name) | .status' "$PLAN_PATH")"
             case "$status" in
-              created) verb="Add" ;;
-              updated) verb="Update" ;;
+              created) verb="Add"; branch="generate/datadog_${name}_datasource" ;;
+              updated) verb="Update"; branch="generate/datadog_${name}_datasource" ;;
+              retired) verb="Retire"; branch="retire/datadog_${name}_datasource" ;;
               *)
                 record_failure "$name" "unsupported artifact status '$status'"
                 continue
                 ;;
             esac
 
-            branch="generate/datadog_${name}_datasource"
             if ! remote_ref="$(git ls-remote --heads origin "refs/heads/$branch")"; then
               record_failure "$name" "could not check whether branch '$branch' exists"
               continue
@@ -188,6 +211,8 @@ jobs:
 
             mapfile -t files < <(jq -r --arg name "$name" \
               '.artifacts[] | select(.name == $name) | .files[]' "$PLAN_PATH")
+            mapfile -t removed_files < <(jq -r --arg name "$name" \
+              '.artifacts[] | select(.name == $name) | .removed_files[]?' "$PLAN_PATH")
             if [[ "${#files[@]}" -eq 0 ]]; then
               record_failure "$name" "split report contains no files"
               continue
@@ -217,27 +242,63 @@ jobs:
               continue
             fi
 
+            removal_error=""
+            for rel in "${removed_files[@]}"; do
+              case "$rel" in
+                /* | .. | ../* | */../*)
+                  removal_error="unsafe removal path '$rel'"
+                  break
+                  ;;
+              esac
+              if ! git rm --ignore-unmatch -- "$rel"; then
+                removal_error="could not remove report-declared file: $rel"
+                break
+              fi
+            done
+            if [[ -n "$removal_error" ]]; then
+              record_failure "$name" "$removal_error"
+              continue
+            fi
+
             if ! make docs; then
               record_failure "$name" "make docs failed"
               continue
             fi
 
             doc_rel="docs/data-sources/${name}.md"
-            if [[ ! -f "$doc_rel" ]]; then
-              record_failure "$name" "make docs did not generate '$doc_rel'"
-              continue
-            fi
-            doc_copy="$(mktemp)"
-            if ! cp "$doc_rel" "$doc_copy" \
-              || ! git restore --source=HEAD --staged --worktree -- docs \
-              || ! git clean -fdq -- docs \
-              || ! mkdir -p "$(dirname "$doc_rel")" \
-              || ! cp "$doc_copy" "$doc_rel"; then
+            if [[ "$status" == "retired" ]]; then
+              if [[ -e "$doc_rel" ]]; then
+                record_failure "$name" "make docs still generated retired page '$doc_rel'"
+                continue
+              fi
+              if ! git restore --source=HEAD --staged --worktree -- docs \
+                || ! git clean -fdq -- docs; then
+                record_failure "$name" "could not restore unrelated docs drift"
+                continue
+              fi
+              for rel in "${removed_files[@]}"; do
+                if [[ "$rel" == "$doc_rel" ]] && ! git rm --ignore-unmatch -- "$doc_rel"; then
+                  record_failure "$name" "could not restore report-declared docs deletion"
+                  continue 2
+                fi
+              done
+            else
+              if [[ ! -f "$doc_rel" ]]; then
+                record_failure "$name" "make docs did not generate '$doc_rel'"
+                continue
+              fi
+              doc_copy="$(mktemp)"
+              if ! cp "$doc_rel" "$doc_copy" \
+                || ! git restore --source=HEAD --staged --worktree -- docs \
+                || ! git clean -fdq -- docs \
+                || ! mkdir -p "$(dirname "$doc_rel")" \
+                || ! cp "$doc_copy" "$doc_rel"; then
+                rm -f "$doc_copy"
+                record_failure "$name" "could not isolate '$doc_rel' from unrelated docs drift"
+                continue
+              fi
               rm -f "$doc_copy"
-              record_failure "$name" "could not isolate '$doc_rel' from unrelated docs drift"
-              continue
             fi
-            rm -f "$doc_copy"
 
             if ! make build; then
               record_failure "$name" "make build failed"
@@ -248,7 +309,12 @@ jobs:
             for rel in "${files[@]}"; do
               allowed["$rel"]=1
             done
-            allowed["$doc_rel"]=1
+            for rel in "${removed_files[@]}"; do
+              allowed["$rel"]=1
+            done
+            if [[ "$status" != "retired" ]]; then
+              allowed["$doc_rel"]=1
+            fi
 
             unexpected=()
             while IFS= read -r status_line; do
@@ -263,7 +329,11 @@ jobs:
               continue
             fi
 
-            if ! git add -- "${files[@]}" "$doc_rel"; then
+            stage_paths=("${files[@]}" "${removed_files[@]}")
+            if [[ "$status" != "retired" ]]; then
+              stage_paths+=("$doc_rel")
+            fi
+            if ! git add -A -- "${stage_paths[@]}"; then
               record_failure "$name" "could not stage generated files"
               continue
             fi
@@ -294,8 +364,39 @@ jobs:
             test_function="TestAccDatadog${pascal_name}DataSource"
             test_file="datadog/tests/data_source_datadog_${name}_test.go"
             body_file="$(mktemp)"
-            {
-              cat <<'BODY_HEADER'
+            if [[ "$status" == "retired" ]]; then
+              {
+                cat <<'RETIRE_HEADER'
+          > ℹ️ **This PR is part of a project that auto-generates Terraform provider data
+          > sources to keep generated coverage aligned with the annotated OpenAPI spec.**
+          > The retirement was selected deterministically by tfgen and still requires human review.
+          RETIRE_HEADER
+                printf '\n## Retire %s data source (generator-v2)\n\n' "$name"
+                printf 'The annotation for `datadog_%s` is no longer present, and tfgen reported the artifact safe to retire.\n\n' "$name"
+                echo "### Removed"
+                for rel in "${removed_files[@]}"; do
+                  printf -- '- `%s`\n' "$rel"
+                done
+                echo
+                echo "### Updated registrations"
+                for rel in "${files[@]}"; do
+                  printf -- '- `%s`\n' "$rel"
+                done
+                cat <<'RETIRE_FOOT'
+
+          ### Reviewer notes / risks
+          - Confirm this data source was never adopted or published. `retire_blocked` artifacts are routed to a tracking issue instead of an automatic deletion PR.
+          - Registry conflicts must be resolved by preserving this removal and unrelated registrations; additive “keep both” guidance does not apply to retirement.
+          - If this generated data source replaced a hand-written implementation, restoring that implementation is out of scope and requires manual review.
+
+          ---
+          > 🚧 **This Terraform data source generation is still under development.** Reach out to
+          > **#api-platform** with any questions.
+          RETIRE_FOOT
+              } > "$body_file"
+            else
+              {
+                cat <<'BODY_HEADER'
           > ℹ️ **This PR is part of a project that auto-generates Terraform provider data
           > sources to increase coverage.** The code is generated **deterministically by tfgen from an
           > annotated OpenAPI spec, without the use of LLMs**, and **reviewed via AI, though human review
@@ -315,12 +416,12 @@ jobs:
               printf -- '- `%s` (generated via `make docs`)\n\n' "$doc_rel"
               cat <<BODY_TEST
           ### Test / cassette
-          - Acceptance test: not generated; add \`$test_function\` in \`$test_file\`.
+          - Acceptance-test scaffold: \`$test_function\` in \`$test_file\`; complete its TODOs before recording.
           - Cassette: not recorded.
 
           ### Reviewer notes / risks
           - Automated risk scan skipped; a reviewer must inspect runtime behavior manually.
-          - The upstream MVP intentionally omits acceptance-test generation.
+          - Generated acceptance tests are boilerplate and do not prove runtime correctness.
 
           ### How to test
           Add and complete the acceptance test, record it once against the Frog org, then replay it:
@@ -345,7 +446,8 @@ jobs:
           > 🚧 **This Terraform data source generation is still under development.** Reach out to
           > **#api-platform** with any questions.
           BODY_TEST
-            } > "$body_file"
+              } > "$body_file"
+            fi
 
             if ! pr_url="$(gh pr create \
               --draft \
@@ -362,12 +464,50 @@ jobs:
 
             echo "- Created draft PR for \`$name\`: $pr_url" >> "$GITHUB_STEP_SUMMARY"
             successes=$((successes + 1))
+            case "$status" in
+              created) created_count=$((created_count + 1)) ;;
+              updated) updated_count=$((updated_count + 1)) ;;
+              retired) retired_count=$((retired_count + 1)) ;;
+            esac
             reset_to_base
           done
 
+          blocked_count="$(jq -r '[.artifacts[] | select(.status == "retire_blocked")] | length' "$PLAN_PATH")"
+          issue_url=""
+          if [[ "$blocked_count" -gt 0 ]]; then
+            issue_body="$(mktemp)"
+            {
+              echo "Reconcile found generated data sources whose automatic retirement was blocked."
+              echo "A recorded cassette or missing tfgen marker means deletion could be a breaking change."
+              echo "Each artifact requires a human deprecation or migration decision:"
+              echo
+              jq -r '.artifacts[]
+                | select(.status == "retire_blocked")
+                | "- [ ] `datadog_\(.name)`\n  - " +
+                  (if (.diagnostics | length) == 0
+                   then "No diagnostic supplied."
+                   else ([.diagnostics[].message] | join("; "))
+                   end)' "$PLAN_PATH"
+              echo
+              echo "Source branch: \`$GITHUB_REF_NAME\`"
+              echo "Source SHA: \`$GITHUB_SHA\`"
+              echo "Workflow run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            } > "$issue_body"
+            issue_title="Retire blocked generated data sources (${GITHUB_SHA:0:7})"
+            if issue_url="$(gh issue create --title "$issue_title" --body-file "$issue_body" 2>&1)"; then
+              echo "- Created retirement tracking issue: $issue_url" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "::error title=tfgen blocked-retirement issue failed::$issue_url"
+              echo "- Failed to create the blocked-retirement tracking issue: $issue_url" >> "$GITHUB_STEP_SUMMARY"
+              failures=$((failures + 1))
+            fi
+            rm -f "$issue_body"
+          fi
+
           {
             echo
-            echo "Created $successes draft PR(s); $failures artifact(s) failed."
+            echo "Created $successes draft PR(s): $created_count created, $updated_count updated, $retired_count retired."
+            echo "Reported $blocked_count blocked retirement(s); $failures operation(s) failed."
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [[ "$failures" -gt 0 ]]; then


### PR DESCRIPTION
### Motivation
Extend the tfgen split pipeline beyond create/update-only handling so aggregate generation runs can safely fan out multiple artifacts, generated acceptance-test scaffolds, retirements, and blocked retirements. The pipeline must preserve each artifact’s registrations independently and prevent unsafe or excessive automated changes.

### Changes
- Extended `tfgen split`:
  - Added `--generation-report` input for validating upstream tfgen outcomes.
  - Supports `created`, `updated`, `retired`, and `retire_blocked` statuses.
  - Cross-checks generation-report declarations against source-tree, registry, and endpoint-tag changes.
  - Emits explicit `removed_files` and generator diagnostics per artifact.
  - Reconstructs per-artifact `datasources_generated.go` files for additions and retirements.
  - Rejects unsafe names, contradictory reports, unexplained changes, and accidental removals.
- Added generated acceptance-test routing:
  - Reads `testFiles2EndpointTags` from `provider_test.go`.
  - Copies only each artifact’s `_test.go` scaffold.
  - Reconstructs `provider_test.go` as base plus or minus the artifact’s endpoint tag.
  - Limits test-tree comparison to generated data-source tests and `provider_test.go`, ignoring unrelated test and cassette drift.
- Added retirement behavior:
  - Produces retirement bundles with exact file deletions and reconstructed shared registrations.
  - Reports `retire_blocked` artifacts without creating deletion bundles.
  - Preserves overwrite handling for `framework_provider.go`.
- Extended the GitHub Actions orchestrator:
  - Requires the upstream `.tfgen-run-report.json`.
  - Enforces a maximum of 25 PR-producing artifacts per run.
  - Routes create/update artifacts to `generate/…` branches and retirements to `retire/…` branches.
  - Applies only report-declared removals and validates the resulting staged diff.
  - Generates retirement-specific draft PR bodies and merge-conflict guidance.
  - Creates one tracking issue per run for blocked retirements.
  - Reports created, updated, retired, blocked, successful, and failed counts.
  - Requests `issues: write` permission for blocked-retirement tracking.

### Test
- Added Ginkgo coverage for:
  - Reading endpoint-tag registrations.
  - N-way generated-test and endpoint-tag isolation.
  - Test-only rollout of previously generated artifacts.
  - Exact retirement file and registration routing.
  - `retire_blocked` behavior without deletion bundles.
  - Generation-report/tree mismatch failures.
  - Selective test-path and unrelated repository-drift handling.
- Ran `make tfgen-test`; all generator tests and race checks passed.
- Ran `make fmtcheck`; formatting checks passed.
- Validated the workflow YAML and embedded Bash syntax.
- IDE lint and `git diff --check` reported no errors.
- No provider acceptance tests or cassettes were added; generated scaffolds still require human completion, recording, and replay.