### PR TITLE
[datadog_metric_metadata] Oops, forgot to update the docs for distribution support

### DIFF
--- a/datadog/resource_datadog_metric_metadata.go
+++ b/datadog/resource_datadog_metric_metadata.go
@@ -33,7 +33,7 @@ func resourceDatadogMetricMetadata() *schema.Resource {
 					},
 				},
 				"type": {
-					Description: "Metric type such as `count`, `gauge`, or `rate`. Updating a metric of type `distribution` is not supported. If you would like to see the `distribution` type returned, contact [Datadog support](https://docs.datadoghq.com/help/).",
+					Description: "Metric type such as `count`, `distribution`, `gauge`, or `rate`.",
 					Type:        schema.TypeString,
 					Optional:    true,
 				},

--- a/docs/resources/metric_metadata.md
+++ b/docs/resources/metric_metadata.md
@@ -36,7 +36,7 @@ resource "datadog_metric_metadata" "request_time" {
 - `per_unit` (String) Per unit of the metric such as `second` in `bytes per second`.
 - `short_name` (String) A short name of the metric.
 - `statsd_interval` (Number) If applicable, statsd flush interval in seconds for the metric.
-- `type` (String) Metric type such as `count`, `gauge`, or `rate`. Updating a metric of type `distribution` is not supported. If you would like to see the `distribution` type returned, contact [Datadog support](https://docs.datadoghq.com/help/).
+- `type` (String) Metric type such as `count`, `distribution`, `gauge`, or `rate`.
 - `unit` (String) Primary unit of the metric such as `byte` or `operation`. For a list of allowed units, refer to [Datadog metric unit documentation](https://docs.datadoghq.com/metrics/units/#unit-list).
 
 ### Read-Only


### PR DESCRIPTION
## Overview

Oops, forgot to update the docs in #3975 — this closes that gap.

`resource_datadog_metric_metadata.go`'s `type` field still documented `distribution` as unsupported for update, pointing users at Datadog support to get it returned at all. That was accurate for the bug fixed in #3975 (perpetual `gauge -> distribution` drift caused by a stale Read-path guard). Now that `GetMetricMetadata` reliably reports `distribution` and plans stay clean, `distribution` is just a normal value in the list — the old caveat is stale and actively misleading.

## Change

- `datadog/resource_datadog_metric_metadata.go`: `type` field description → `` Metric type such as `count`, `distribution`, `gauge`, or `rate`. `` (dropped the "updating distribution is not supported, contact support" text)
- `docs/resources/metric_metadata.md`: regenerated via `make docs` — not hand-edited

## Verification

- `make fmtcheck` — clean
- `make vet` — clean
- `make check-docs` — confirms this is exactly the diff `make docs` produces from the schema change (no drift)
- Also checked sibling metric docs (`metric_tag_configuration.md`, the `metric_metadata` data source, `logs_metric`/`rum_metric`/`spans_metric`, examples, guides) for the same stale caveat — none found; `metric_tag_configuration.md` already correctly lists `distribution` as valid.

## Changelog

`changelog/documentation`
