### PR TITLE
ci: fix fork PR approval gate for integration tests

### DIFF
--- a/.github/workflows/test_pr_integration.yml
+++ b/.github/workflows/test_pr_integration.yml
@@ -22,6 +22,9 @@ jobs:
   pr-tests-selection:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: read
+      actions: read # Required to download the selector artifact from another run
     outputs:
       should_run: ${{ steps.read.outputs.should_run }}
       test_args: ${{ steps.read.outputs.test_args }}

--- a/.github/workflows/test_pr_integration.yml
+++ b/.github/workflows/test_pr_integration.yml
@@ -3,75 +3,47 @@ name: PR Integration Tests
 permissions:
   contents: read
 
-# pull_request_target so that PRs from forks can mint Datadog credentials via
-# OIDC. The credentialed job checks out the PR head and, for forks, runs in the
-# forks-prs environment.
+# Triggers after PR Test Selection completes. Because that workflow runs on
+# pull_request, GitHub's fork-approval gate already fired before we get here.
+# No environment gate is needed: approval is implicit in Workflow A completing.
 on: # yamllint disable-line rule:truthy
-  pull_request_target:
-    branches: [master, v3]
-    types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows: ["PR Test Selection"]
+    types: [completed]
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}-pr-integration
+  group: ${{ github.event.workflow_run.head_sha }}-pr-integration
   cancel-in-progress: true
 
 env:
   TERRAFORM_VERSION: "1.13.1"
 
 jobs:
-  determine-tests:
+  pr-tests-selection:
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
     outputs:
-      test_args: ${{ steps.build-args.outputs.test_args }}
-      should_run: ${{ steps.build-args.outputs.should_run }}
+      should_run: ${{ steps.read.outputs.should_run }}
+      test_args: ${{ steps.read.outputs.test_args }}
     steps:
-      - name: Checkout base
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      - name: Download test selection
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          fetch-depth: 0
-      - name: Get changed files
-        id: changed
+          name: test-selection
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+      - name: Read test selection
+        id: read
         run: |
-          # pull_request_target checks out the base branch (trusted). Fetch the
-          # PR head so the diff and test-selection can see it. Untrusted PR code
-          # is never executed in this credential-less job: we diff by filename
-          # and the selection script only reads PR-head file *contents* (via
-          # git show) to find test function names — it never runs them.
-          git fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/head"
-          git diff --name-only "origin/${{ github.base_ref }}...${{ github.event.pull_request.head.sha }}" > /tmp/changed_files.txt
-          echo "Changed files:"
-          cat /tmp/changed_files.txt
-      - name: Select tests and build args
-        id: build-args
-        run: |
-          RUN_REGEX=$(python3 scripts/select_pr_tests.py --escape-for-make --git-ref "${{ github.event.pull_request.head.sha }}" < /tmp/changed_files.txt)
-
-          if [ -z "$RUN_REGEX" ]; then
-            echo "should_run=false" >> "$GITHUB_OUTPUT"
-            echo "No resource/datasource changes detected, skipping integration tests"
-            exit 0
-          fi
-
-          echo "should_run=true" >> "$GITHUB_OUTPUT"
-
-          ARGS="-run '${RUN_REGEX}'"
-
-          SKIP_REGEX=$(python3 scripts/build_skip_regex.py --escape-for-make)
-          if [ -n "$SKIP_REGEX" ]; then
-            ARGS="${ARGS} -skip '${SKIP_REGEX}'"
-          fi
-
-          echo "test_args=${ARGS}" >> "$GITHUB_OUTPUT"
-          echo "Test args: ${ARGS}"
+          should_run=$(jq -r '.should_run' test-selection.json)
+          test_args=$(jq -r '.test_args' test-selection.json)
+          echo "should_run=${should_run}" >> "$GITHUB_OUTPUT"
+          echo "test_args=${test_args}" >> "$GITHUB_OUTPUT"
 
   integration-tests:
-    needs: determine-tests
-    if: needs.determine-tests.outputs.should_run == 'true'
+    needs: pr-tests-selection
+    if: needs.pr-tests-selection.outputs.should_run == 'true'
     runs-on: ubuntu-latest
-    # Fork PRs run untrusted code with live (short-lived, test-org) credentials,
-    # so they run in the forks-prs environment. Same-repo PRs run without an
-    # environment gate.
-    environment: ${{ github.event.pull_request.head.repo.fork && 'forks-prs' || '' }}
     permissions:
       contents: read
       id-token: write # Required to mint Datadog credentials via dd-sts
@@ -79,7 +51,7 @@ jobs:
       - name: Checkout PR code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Mint Datadog credentials
         id: dd-sts
         uses: DataDog/dd-sts-action@7d2d231c02fd54a3da912e582ff87cb995d1fd30 # v1.0.4
@@ -113,4 +85,4 @@ jobs:
           DD_HTTP_CLIENT_RETRY_ENABLED: "true"
           TF_ACC_TERRAFORM_PATH: "/home/runner/.cache/terraform/terraform"
           TF_ACC_TEMP_DIR: "/tmp"
-          TESTARGS: ${{ needs.determine-tests.outputs.test_args }}
+          TESTARGS: ${{ needs.pr-tests-selection.outputs.test_args }}

--- a/.github/workflows/test_pr_integration.yml
+++ b/.github/workflows/test_pr_integration.yml
@@ -12,7 +12,7 @@ on: # yamllint disable-line rule:truthy
     types: [completed]
 
 concurrency:
-  group: ${{ github.event.workflow_run.head_sha }}-pr-integration
+  group: ${{ github.event.workflow_run.head_branch }}-pr-integration
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/test_pr_select.yml
+++ b/.github/workflows/test_pr_select.yml
@@ -1,0 +1,61 @@
+name: PR Test Selection
+
+permissions:
+  contents: read
+
+# Runs on the pull_request event so GitHub's fork-approval gate applies:
+# external contributors require a maintainer to approve the run before this
+# workflow executes. The PR Integration Tests workflow then triggers via
+# workflow_run once this one completes, inheriting that approval implicitly.
+on: # yamllint disable-line rule:truthy
+  pull_request:
+    branches: [master, v3]
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}-pr-select
+  cancel-in-progress: true
+
+jobs:
+  determine-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        run: |
+          # pull_request checks out the merge commit. Fetch the PR head so the
+          # diff and test-selection can see it. Untrusted PR code is never
+          # executed here: we diff by filename and the selection script only
+          # reads PR-head file *contents* (via git show) to find test function
+          # names — it never runs them.
+          git fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/head"
+          git diff --name-only "origin/${{ github.base_ref }}...${{ github.event.pull_request.head.sha }}" > /tmp/changed_files.txt
+          echo "Changed files:"
+          cat /tmp/changed_files.txt
+      - name: Select tests and build args
+        run: |
+          RUN_REGEX=$(python3 scripts/select_pr_tests.py --escape-for-make --git-ref "${{ github.event.pull_request.head.sha }}" < /tmp/changed_files.txt)
+
+          if [ -z "$RUN_REGEX" ]; then
+            echo '{"should_run":false,"test_args":""}' > /tmp/test-selection.json
+            echo "No resource/datasource changes detected, skipping integration tests"
+            exit 0
+          fi
+
+          ARGS="-run '${RUN_REGEX}'"
+
+          SKIP_REGEX=$(python3 scripts/build_skip_regex.py --escape-for-make)
+          if [ -n "$SKIP_REGEX" ]; then
+            ARGS="${ARGS} -skip '${SKIP_REGEX}'"
+          fi
+
+          jq -n --arg test_args "$ARGS" '{"should_run":true,"test_args":$test_args}' > /tmp/test-selection.json
+          echo "Test args: ${ARGS}"
+      - name: Upload test selection
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: test-selection
+          path: /tmp/test-selection.json

--- a/.github/workflows/test_pr_select.yml
+++ b/.github/workflows/test_pr_select.yml
@@ -23,14 +23,18 @@ jobs:
       - name: Checkout base
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
+          # Check out the trusted base branch, NOT the default PR merge commit.
+          # The selection scripts run here must be the base-repo versions: a PR
+          # that edited them could otherwise dictate should_run / test_args,
+          # which feed the credentialed integration workflow.
+          ref: ${{ github.base_ref }}
           fetch-depth: 0
       - name: Get changed files
         run: |
-          # pull_request checks out the merge commit. Fetch the PR head so the
-          # diff and test-selection can see it. Untrusted PR code is never
-          # executed here: we diff by filename and the selection script only
-          # reads PR-head file *contents* (via git show) to find test function
-          # names — it never runs them.
+          # Fetch the PR head so the diff and test-selection can see it.
+          # Untrusted PR code is never executed here: we diff by filename and
+          # the selection script only reads PR-head file *contents* (via git
+          # show, --git-ref below) to find test function names — never runs them.
           git fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/head"
           git diff --name-only "origin/${{ github.base_ref }}...${{ github.event.pull_request.head.sha }}" > /tmp/changed_files.txt
           echo "Changed files:"


### PR DESCRIPTION
## Motivation

Improve UX around approving workflow runs so we don't have to approve 2 things but only the native github workflow run approval, when PRs are coming from forks.

## Overview of changes

Test selection is split into a dedicated `pull_request` workflow (`test_pr_select.yml`) that runs the credential-less test-selection logic and uploads the result as an artifact. The credentialed integration-test workflow (`test_pr_integration.yml`) now triggers via `workflow_run` once selection completes, downloading the artifact and minting credentials only then. Because the selector runs on `pull_request`, GitHub's standard fork-approval gate applies — one approval, the prompt maintainers already know — and the credentialed job follows automatically with no separate "deployment" approval dialog. The `forks-prs` environment gate is removed from the credentialed job since approval is now implicit in the selector completing.

Two security hardening fixes are included: the selector checks out the trusted base branch (not the PR merge commit) so a fork cannot edit the selection scripts to control which tests run or inject shell via `TESTARGS`; and `actions: read` is scoped to the artifact-download job so the credentialed job never carries that permission alongside `id-token: write`.

## Validation

CI on this PR should show `PR Test Selection` running (on `pull_request`) and — if any resource files changed — `PR Integration Tests` triggering via `workflow_run` and minting credentials for the testing org successfully.