### PR TITLE
[Tfgen] Example generation support

### DIFF
--- a/.generator-v2/internal/cli/generate.go
+++ b/.generator-v2/internal/cli/generate.go
@@ -307,9 +307,7 @@ func emitDatasourceExample(entry *model.ArtifactReportEntry, view emit.DataSourc
 		return &failed
 	}
 	if status != model.ArtifactStatusSkipped {
-		for _, msg := range example.Diagnostics {
-			entry.Diagnostics = append(entry.Diagnostics, model.Diagnostic{Severity: model.SeverityInfo, Message: msg})
-		}
+		entry.Diagnostics = append(entry.Diagnostics, example.Diagnostics...)
 	}
 	return &model.ArtifactReportEntry{Name: name, Kind: model.ArtifactKindDataSource, Status: status, Path: path}
 }

--- a/.generator-v2/internal/cli/generate.go
+++ b/.generator-v2/internal/cli/generate.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -306,7 +307,16 @@ func emitDatasourceExample(entry *model.ArtifactReportEntry, view emit.DataSourc
 		failed := failEntry(model.ArtifactReportEntry{Name: name, Kind: model.ArtifactKindDataSource, Path: path}, err)
 		return &failed
 	}
-	if status != model.ArtifactStatusSkipped {
+	// if the on-disk file still byte-matches what we would generate, nobody has touched the
+	// placeholder so we should keep the diagnostics so an incomplete example is still flagged
+	// rather than silently suppressed.
+	untouchedPlaceholder := false
+	if status == model.ArtifactStatusSkipped {
+		if onDisk, readErr := os.ReadFile(path); readErr == nil {
+			untouchedPlaceholder = bytes.Equal(onDisk, example.Content)
+		}
+	}
+	if status != model.ArtifactStatusSkipped || untouchedPlaceholder {
 		entry.Diagnostics = append(entry.Diagnostics, example.Diagnostics...)
 	}
 	return &model.ArtifactReportEntry{Name: name, Kind: model.ArtifactKindDataSource, Status: status, Path: path}

--- a/.generator-v2/internal/cli/generate.go
+++ b/.generator-v2/internal/cli/generate.go
@@ -36,6 +36,7 @@ func newGenerateCmd(flags *globalFlags) *cobra.Command {
 	var reportPath string
 	var emitTests bool
 	var testsOutputRoot string
+	var examplesOutputRoot string
 	var docsRoot string
 	var reconcile bool
 	var retire string
@@ -67,7 +68,7 @@ func newGenerateCmd(flags *globalFlags) *cobra.Command {
 					if name == "" {
 						continue
 					}
-					runReport.Artifacts = append(runReport.Artifacts, retireArtifact(name, outputRoot, testsOutputRoot, docsRoot, check))
+					runReport.Artifacts = append(runReport.Artifacts, retireArtifact(name, outputRoot, testsOutputRoot, docsRoot, examplesOutputRoot, check))
 				}
 			} else {
 				spec, err := parser.LoadSpec(specPath,
@@ -120,10 +121,13 @@ func newGenerateCmd(flags *globalFlags) *cobra.Command {
 						continue
 					}
 
-					entry, testEntry, reg := generateArtifact(op, outputRoot, testsOutputRoot, emitTests, check, accessors)
+					entry, testEntry, exampleEntry, reg := generateArtifact(op, outputRoot, testsOutputRoot, examplesOutputRoot, emitTests, check, accessors)
 					runReport.Artifacts = append(runReport.Artifacts, entry)
 					if testEntry != nil {
 						runReport.Artifacts = append(runReport.Artifacts, *testEntry)
+					}
+					if exampleEntry != nil {
+						runReport.Artifacts = append(runReport.Artifacts, *exampleEntry)
 					}
 					if reg != nil {
 						registrations = append(registrations, *reg)
@@ -158,7 +162,7 @@ func newGenerateCmd(flags *globalFlags) *cobra.Command {
 						for _, reg := range registrations {
 							desired[reg.Constructor] = true
 						}
-						orphanEntries, recErr := reconcileOrphans(outputRoot, testsOutputRoot, docsRoot, desired, check)
+						orphanEntries, recErr := reconcileOrphans(outputRoot, testsOutputRoot, docsRoot, examplesOutputRoot, desired, check)
 						runReport.Artifacts = append(runReport.Artifacts, orphanEntries...)
 						deferredErr = recErr
 					}
@@ -204,6 +208,7 @@ func newGenerateCmd(flags *globalFlags) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&reportPath, "report", "-", "Where to write the run report (\"-\" = stdout)")
 	cmd.PersistentFlags().BoolVar(&emitTests, "emit-tests", false, "Also emit a generated acceptance-test scaffold for each data source")
 	cmd.PersistentFlags().StringVar(&testsOutputRoot, "tests-output-root", "datadog/tests", "Root directory for generated acceptance-test files")
+	cmd.PersistentFlags().StringVar(&examplesOutputRoot, "examples-output-root", "examples/data-sources", "Root directory for generated data-source examples")
 	cmd.PersistentFlags().StringVar(&docsRoot, "docs-root", "docs/data-sources", "Root directory for data-source docs pages (used when retiring)")
 	cmd.PersistentFlags().BoolVar(&reconcile, "reconcile", false, "Retire generated data sources no longer annotated (requires the full spec; incompatible with --include)")
 	cmd.PersistentFlags().StringVar(&retire, "retire", "", "Comma-separated artifact names to retire without generating (deletes files + registration)")
@@ -215,7 +220,7 @@ func newGenerateCmd(flags *globalFlags) *cobra.Command {
 // operation. On success it also returns the GeneratedRegistration the caller
 // uses to wire the data source into the provider; it is nil for a skipped or
 // failed artifact.
-func generateArtifact(op *model.Operation, outputRoot, testsOutputRoot string, emitTests, check bool, accessors map[string]string) (model.ArtifactReportEntry, *model.ArtifactReportEntry, *emit.GeneratedRegistration) {
+func generateArtifact(op *model.Operation, outputRoot, testsOutputRoot, examplesOutputRoot string, emitTests, check bool, accessors map[string]string) (model.ArtifactReportEntry, *model.ArtifactReportEntry, *model.ArtifactReportEntry, *emit.GeneratedRegistration) {
 	entry := model.ArtifactReportEntry{
 		Name: op.Tracking.ArtifactName,
 		Kind: op.Tracking.ArtifactKind,
@@ -227,12 +232,12 @@ func generateArtifact(op *model.Operation, outputRoot, testsOutputRoot string, e
 			Severity: model.SeverityWarning,
 			Message:  fmt.Sprintf("resource generation not yet supported (kind=%s)", op.Tracking.ArtifactKind),
 		}}
-		return entry, nil, nil
+		return entry, nil, nil, nil
 	}
 
 	artifact, err := model.BuildArtifact(op)
 	if err != nil {
-		return failEntry(entry, err), nil, nil
+		return failEntry(entry, err), nil, nil, nil
 	}
 	artifact.SourceFile = filepath.Join(outputRoot, "data_source_datadog_"+artifact.Name+".go")
 	entry.Path = artifact.SourceFile
@@ -242,7 +247,7 @@ func generateArtifact(op *model.Operation, outputRoot, testsOutputRoot string, e
 
 	view, err := emit.BuildDataSourceView(artifact)
 	if err != nil {
-		return failEntry(entry, err), nil, nil
+		return failEntry(entry, err), nil, nil, nil
 	}
 	// Correct APIAccessor to the name the provider's helper actually exposes,
 	// which diverges from the derived name for a few acronym/aliased APIs.
@@ -254,14 +259,16 @@ func generateArtifact(op *model.Operation, outputRoot, testsOutputRoot string, e
 
 	src, err := emit.RenderDataSource(view)
 	if err != nil {
-		return failEntry(entry, err), nil, nil
+		return failEntry(entry, err), nil, nil, nil
 	}
 
 	status, err := emit.WriteFile(artifact.SourceFile, src, check)
 	if err != nil {
-		return failEntry(entry, err), nil, nil
+		return failEntry(entry, err), nil, nil, nil
 	}
 	entry.Status = status
+
+	exampleEntry := emitDatasourceExample(&entry, view, artifact.Name, examplesOutputRoot, check)
 
 	var testEntry *model.ArtifactReportEntry
 	if emitTests {
@@ -285,7 +292,26 @@ func generateArtifact(op *model.Operation, outputRoot, testsOutputRoot string, e
 		}
 	}
 
-	return entry, testEntry, reg
+	return entry, testEntry, exampleEntry, reg
+}
+
+// emitDatasourceExample writes the tfplugindocs input for a data source. Like
+// acceptance-test scaffolds, examples are created once and never overwritten so
+// a hand-written or subsequently improved example remains authoritative.
+func emitDatasourceExample(entry *model.ArtifactReportEntry, view emit.DataSourceView, name, examplesOutputRoot string, check bool) *model.ArtifactReportEntry {
+	path := filepath.Join(examplesOutputRoot, "datadog_"+name, "data-source.tf")
+	example := emit.RenderDataSourceExample(view)
+	status, err := emit.WriteFileIfAbsent(path, example.Content, check)
+	if err != nil {
+		failed := failEntry(model.ArtifactReportEntry{Name: name, Kind: model.ArtifactKindDataSource, Path: path}, err)
+		return &failed
+	}
+	if status != model.ArtifactStatusSkipped {
+		for _, msg := range example.Diagnostics {
+			entry.Diagnostics = append(entry.Diagnostics, model.Diagnostic{Severity: model.SeverityInfo, Message: msg})
+		}
+	}
+	return &model.ArtifactReportEntry{Name: name, Kind: model.ArtifactKindDataSource, Status: status, Path: path}
 }
 
 // emitDatasourceTest renders and writes the acceptance-test scaffold for a data

--- a/.generator-v2/internal/cli/generate_test.go
+++ b/.generator-v2/internal/cli/generate_test.go
@@ -347,16 +347,31 @@ func TestEmitDatasourceExampleSurfacesIncompleteScaffold(t *testing.T) {
 		t.Fatalf("unexpected example diagnostic: %#v", mainEntry.Diagnostics[0])
 	}
 
-	// Once a maintainer owns the example, regeneration skips it and must not
-	// report limitations from a scaffold that was not written.
-	preservedEntry := model.ArtifactReportEntry{Name: "widgets", Kind: model.ArtifactKindDataSource}
-	skipped := emitDatasourceExample(&preservedEntry, view, "widgets", examplesRoot, false)
-	if skipped.Status != model.ArtifactStatusSkipped {
-		t.Fatalf("preserved example status = %q, want skipped", skipped.Status)
-	}
-	if len(preservedEntry.Diagnostics) != 0 {
-		t.Fatalf("preserved example produced diagnostics: %#v", preservedEntry.Diagnostics)
-	}
+	t.Run("re-flags an untouched placeholder even though the write is skipped", func(t *testing.T) {
+		entry := model.ArtifactReportEntry{Name: "widgets", Kind: model.ArtifactKindDataSource}
+		skipped := emitDatasourceExample(&entry, view, "widgets", examplesRoot, false)
+		if skipped.Status != model.ArtifactStatusSkipped {
+			t.Fatalf("status = %q, want skipped", skipped.Status)
+		}
+		if len(entry.Diagnostics) != 1 {
+			t.Fatalf("diagnostics = %#v, want the limitation to persist while the placeholder is unedited", entry.Diagnostics)
+		}
+	})
+
+	t.Run("stays silent once a maintainer has edited the example", func(t *testing.T) {
+		examplePath := filepath.Join(examplesRoot, "datadog_widgets", "data-source.tf")
+		if err := os.WriteFile(examplePath, []byte("data \"datadog_widgets\" \"example\" {\n  account_ids = [\"abc\"]\n}\n"), 0o644); err != nil {
+			t.Fatalf("hand-editing example: %v", err)
+		}
+		entry := model.ArtifactReportEntry{Name: "widgets", Kind: model.ArtifactKindDataSource}
+		skipped := emitDatasourceExample(&entry, view, "widgets", examplesRoot, false)
+		if skipped.Status != model.ArtifactStatusSkipped {
+			t.Fatalf("status = %q, want skipped", skipped.Status)
+		}
+		if len(entry.Diagnostics) != 0 {
+			t.Fatalf("edited example produced diagnostics: %#v", entry.Diagnostics)
+		}
+	})
 }
 
 func mustRead(t *testing.T, path string) string {

--- a/.generator-v2/internal/cli/generate_test.go
+++ b/.generator-v2/internal/cli/generate_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/emit"
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
 	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/parser"
 )
 
@@ -80,7 +81,10 @@ func TestGenerateWiresOverwrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := runTfgen("generate", "--spec", specPath, "--output-root", dir, "--report", filepath.Join(dir, "report.json")); err != nil {
+	if err := runTfgen("generate", "--spec", specPath,
+		"--output-root", dir,
+		"--examples-output-root", filepath.Join(dir, "examples"),
+		"--report", filepath.Join(dir, "report.json")); err != nil {
 		t.Fatalf("generate: %v", err)
 	}
 
@@ -115,6 +119,7 @@ func TestGenerateWiresEndpointTag(t *testing.T) {
 
 	dir := t.TempDir()
 	testsDir := filepath.Join(dir, "tests")
+	examplesDir := filepath.Join(dir, "examples")
 	if err := os.MkdirAll(testsDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -126,6 +131,7 @@ func TestGenerateWiresEndpointTag(t *testing.T) {
 
 	if err := runTfgen("generate", "--spec", specPath, "--emit-tests",
 		"--output-root", dir, "--tests-output-root", testsDir,
+		"--examples-output-root", examplesDir,
 		"--report", filepath.Join(dir, "report.json")); err != nil {
 		t.Fatalf("generate: %v", err)
 	}
@@ -137,6 +143,7 @@ func TestGenerateWiresEndpointTag(t *testing.T) {
 
 	if err := runTfgen("generate", "--retire", "datastore",
 		"--output-root", dir, "--tests-output-root", testsDir,
+		"--examples-output-root", examplesDir,
 		"--report", filepath.Join(dir, "retire-report.json")); err != nil {
 		t.Fatalf("retire: %v", err)
 	}
@@ -175,7 +182,10 @@ func TestGenerateFailsOnMissingOverwriteTarget(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = runTfgen("generate", "--spec", specPath, "--output-root", dir, "--report", filepath.Join(dir, "report.json"))
+	err = runTfgen("generate", "--spec", specPath,
+		"--output-root", dir,
+		"--examples-output-root", filepath.Join(dir, "examples"),
+		"--report", filepath.Join(dir, "report.json"))
 	if err == nil {
 		t.Fatal("expected an error when overwrites names a constructor absent from the Datasources slice, got nil")
 	}
@@ -242,6 +252,7 @@ func TestReconcileSkippedWhenAnArtifactFails(t *testing.T) {
 		"--output-root", out,
 		"--tests-output-root", filepath.Join(dir, "tests"),
 		"--docs-root", filepath.Join(dir, "docs"),
+		"--examples-output-root", filepath.Join(dir, "examples"),
 		"--report", filepath.Join(dir, "report.json"))
 	if err == nil {
 		t.Fatal("expected the run to fail because the datastore artifact failed to build, got nil")
@@ -253,6 +264,98 @@ func TestReconcileSkippedWhenAnArtifactFails(t *testing.T) {
 	}
 	if reg := mustRead(t, genPath); !strings.Contains(reg, emit.DatasourceConstructor("ghost")) {
 		t.Errorf("orphan registration was removed despite a failed artifact:\n%s", reg)
+	}
+}
+
+func TestGenerateEmitsAndPreservesDatasourceExample(t *testing.T) {
+	specPath := filepath.Join("..", "testdata", "mini-oas", "scripts", "gen-test", "datastore.yaml")
+	dir := t.TempDir()
+	outputRoot := filepath.Join(dir, "fwprovider")
+	examplesRoot := filepath.Join(dir, "examples")
+	examplePath := filepath.Join(examplesRoot, "datadog_datastore", "data-source.tf")
+	args := []string{
+		"generate",
+		"--spec", specPath,
+		"--output-root", outputRoot,
+		"--examples-output-root", examplesRoot,
+		"--report", filepath.Join(dir, "report.json"),
+	}
+
+	if err := runTfgen(args...); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	const generated = `data "datadog_datastore" "example" {
+  id = "11111111-2222-3333-4444-555555555555"
+}
+`
+	if got := mustRead(t, examplePath); got != generated {
+		t.Fatalf("generated example mismatch:\n%s", got)
+	}
+
+	const handWritten = "data \"datadog_datastore\" \"custom\" {}\n"
+	if err := os.WriteFile(examplePath, []byte(handWritten), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runTfgen(args...); err != nil {
+		t.Fatalf("regenerate: %v", err)
+	}
+	if got := mustRead(t, examplePath); got != handWritten {
+		t.Fatalf("regeneration overwrote the existing example:\n%s", got)
+	}
+}
+
+func TestGenerateCheckReportsMissingDatasourceExampleWithoutWritingIt(t *testing.T) {
+	specPath := filepath.Join("..", "testdata", "mini-oas", "scripts", "gen-test", "datastore.yaml")
+	dir := t.TempDir()
+	examplePath := filepath.Join(dir, "examples", "datadog_datastore", "data-source.tf")
+
+	err := runTfgen("generate",
+		"--check",
+		"--spec", specPath,
+		"--output-root", filepath.Join(dir, "fwprovider"),
+		"--examples-output-root", filepath.Join(dir, "examples"),
+		"--report", filepath.Join(dir, "report.json"))
+	if !errors.Is(err, errCheckFailed) {
+		t.Fatalf("check error = %v, want errCheckFailed", err)
+	}
+	if _, statErr := os.Stat(examplePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("check mode wrote example %s: %v", examplePath, statErr)
+	}
+}
+
+func TestEmitDatasourceExampleSurfacesIncompleteScaffold(t *testing.T) {
+	examplesRoot := t.TempDir()
+	view := emit.DataSourceView{
+		Cardinality: emit.Plural,
+		TypeName:    "widgets",
+		Schema: emit.SchemaView{Attributes: []emit.AttrView{
+			{TFName: "account_ids", TFType: "schema.ListAttribute", Required: true},
+		}},
+	}
+	mainEntry := model.ArtifactReportEntry{Name: "widgets", Kind: model.ArtifactKindDataSource}
+
+	exampleEntry := emitDatasourceExample(&mainEntry, view, "widgets", examplesRoot, false)
+
+	if exampleEntry.Status != model.ArtifactStatusCreated {
+		t.Fatalf("example status = %q, want created", exampleEntry.Status)
+	}
+	if len(mainEntry.Diagnostics) != 1 {
+		t.Fatalf("main artifact diagnostics = %#v, want one example limitation", mainEntry.Diagnostics)
+	}
+	if mainEntry.Diagnostics[0].Severity != model.SeverityInfo ||
+		!strings.Contains(mainEntry.Diagnostics[0].Message, `required attribute "account_ids"`) {
+		t.Fatalf("unexpected example diagnostic: %#v", mainEntry.Diagnostics[0])
+	}
+
+	// Once a maintainer owns the example, regeneration skips it and must not
+	// report limitations from a scaffold that was not written.
+	preservedEntry := model.ArtifactReportEntry{Name: "widgets", Kind: model.ArtifactKindDataSource}
+	skipped := emitDatasourceExample(&preservedEntry, view, "widgets", examplesRoot, false)
+	if skipped.Status != model.ArtifactStatusSkipped {
+		t.Fatalf("preserved example status = %q, want skipped", skipped.Status)
+	}
+	if len(preservedEntry.Diagnostics) != 0 {
+		t.Fatalf("preserved example produced diagnostics: %#v", preservedEntry.Diagnostics)
 	}
 }
 

--- a/.generator-v2/internal/cli/generate_test.go
+++ b/.generator-v2/internal/cli/generate_test.go
@@ -342,7 +342,7 @@ func TestEmitDatasourceExampleSurfacesIncompleteScaffold(t *testing.T) {
 	if len(mainEntry.Diagnostics) != 1 {
 		t.Fatalf("main artifact diagnostics = %#v, want one example limitation", mainEntry.Diagnostics)
 	}
-	if mainEntry.Diagnostics[0].Severity != model.SeverityInfo ||
+	if mainEntry.Diagnostics[0].Severity != model.SeverityWarning ||
 		!strings.Contains(mainEntry.Diagnostics[0].Message, `required attribute "account_ids"`) {
 		t.Fatalf("unexpected example diagnostic: %#v", mainEntry.Diagnostics[0])
 	}

--- a/.generator-v2/internal/cli/reconcile.go
+++ b/.generator-v2/internal/cli/reconcile.go
@@ -38,11 +38,11 @@ var artifactNameRe = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 //     a human adopted it toward release; deleting a published data source is a
 //     breaking change, so it is left in place with status retire_blocked.
 //
-// When both pass it removes the data source .go, its _test.go, its docs page and
-// its registration in generatedDatasources, reporting retired. Check mode skips
-// the file deletes and the registry write, reporting the status the run would
-// produce.
-func retireArtifact(name, outputRoot, testsOutputRoot, docsRoot string, check bool) model.ArtifactReportEntry {
+// When both pass it removes the data source .go, its _test.go, its docs page,
+// its example and its registration in generatedDatasources, reporting retired.
+// Check mode skips the file deletes and the registry write, reporting the
+// status the run would produce.
+func retireArtifact(name, outputRoot, testsOutputRoot, docsRoot, examplesOutputRoot string, check bool) model.ArtifactReportEntry {
 	// Fail closed on an unsafe name before any path is built from it: an invalid
 	// name deletes nothing.
 	if !artifactNameRe.MatchString(name) {
@@ -53,6 +53,7 @@ func retireArtifact(name, outputRoot, testsOutputRoot, docsRoot string, check bo
 	goPath := filepath.Join(outputRoot, "data_source_datadog_"+name+".go")
 	testPath := filepath.Join(testsOutputRoot, "data_source_datadog_"+name+"_test.go")
 	docPath := filepath.Join(docsRoot, name+".md")
+	examplePath := filepath.Join(examplesOutputRoot, "datadog_"+name, "data-source.tf")
 	genPath := filepath.Join(outputRoot, "datasources_generated.go")
 	cassettesDir := filepath.Join(testsOutputRoot, "cassettes")
 
@@ -68,7 +69,7 @@ func retireArtifact(name, outputRoot, testsOutputRoot, docsRoot string, check bo
 			return entry
 		}
 	case errors.Is(err, os.ErrNotExist):
-		// No source to guard; still clean up any stray test/doc/registration below.
+		// No source to guard; still clean up any stray test/doc/example/registration below.
 	default:
 		return failEntry(entry, err)
 	}
@@ -81,10 +82,13 @@ func retireArtifact(name, outputRoot, testsOutputRoot, docsRoot string, check bo
 	}
 
 	if !check {
-		for _, p := range []string{goPath, testPath, docPath} {
+		for _, p := range []string{goPath, testPath, docPath, examplePath} {
 			if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
 				return failEntry(entry, err)
 			}
+		}
+		if err := removeDirIfEmpty(filepath.Dir(examplePath)); err != nil {
+			return failEntry(entry, err)
 		}
 	}
 	if _, err := emit.RemoveGeneratedDatasource(genPath, emit.DatasourceConstructor(name), check); err != nil {
@@ -98,6 +102,23 @@ func retireArtifact(name, outputRoot, testsOutputRoot, docsRoot string, check bo
 	}
 	entry.Status = model.ArtifactStatusRetired
 	return entry
+}
+
+// removeDirIfEmpty removes path only when it has no remaining entries. This
+// cleans up the per-artifact example directory without deleting unrelated files
+// a maintainer may have placed alongside data-source.tf.
+func removeDirIfEmpty(path string) error {
+	entries, err := os.ReadDir(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if len(entries) > 0 {
+		return nil
+	}
+	return os.Remove(path)
 }
 
 // hasRecordedCassette reports whether a recorded cassette exists for any
@@ -138,7 +159,7 @@ func hasRecordedCassette(testPath, cassettesDir string) (bool, string) {
 // orphan constructor is mapped back to its artifact name through the generated
 // files on disk, since the name→constructor transform is not reversible. Returns
 // one report entry per orphan.
-func reconcileOrphans(outputRoot, testsOutputRoot, docsRoot string, desired map[string]bool, check bool) ([]model.ArtifactReportEntry, error) {
+func reconcileOrphans(outputRoot, testsOutputRoot, docsRoot, examplesOutputRoot string, desired map[string]bool, check bool) ([]model.ArtifactReportEntry, error) {
 	genPath := filepath.Join(outputRoot, "datasources_generated.go")
 	registered, err := emit.RegisteredGeneratedDatasources(genPath)
 	if err != nil {
@@ -169,7 +190,7 @@ func reconcileOrphans(outputRoot, testsOutputRoot, docsRoot string, desired map[
 			})
 			continue
 		}
-		entries = append(entries, retireArtifact(name, outputRoot, testsOutputRoot, docsRoot, check))
+		entries = append(entries, retireArtifact(name, outputRoot, testsOutputRoot, docsRoot, examplesOutputRoot, check))
 	}
 	return entries, nil
 }

--- a/.generator-v2/internal/cli/reconcile_test.go
+++ b/.generator-v2/internal/cli/reconcile_test.go
@@ -12,26 +12,28 @@ import (
 )
 
 // artifactFixture lays down the on-disk footprint of one generated data source
-// (source, test, doc, registration) under a fresh set of roots, so retirement
-// and reconcile can be exercised end-to-end against real files.
+// (source, test, doc, example, registration) under a fresh set of roots, so
+// retirement and reconcile can be exercised end-to-end against real files.
 type artifactFixture struct {
-	outputRoot, testsRoot, docsRoot string
+	outputRoot, testsRoot, docsRoot, examplesRoot string
 }
 
 func newFixture() *artifactFixture {
 	dir := GinkgoT().TempDir()
 	f := &artifactFixture{
-		outputRoot: filepath.Join(dir, "fwprovider"),
-		testsRoot:  filepath.Join(dir, "tests"),
-		docsRoot:   filepath.Join(dir, "docs"),
+		outputRoot:   filepath.Join(dir, "fwprovider"),
+		testsRoot:    filepath.Join(dir, "tests"),
+		docsRoot:     filepath.Join(dir, "docs"),
+		examplesRoot: filepath.Join(dir, "examples"),
 	}
 	Expect(os.MkdirAll(f.outputRoot, 0o755)).To(Succeed())
 	Expect(os.MkdirAll(filepath.Join(f.testsRoot, "cassettes"), 0o755)).To(Succeed())
 	Expect(os.MkdirAll(f.docsRoot, 0o755)).To(Succeed())
+	Expect(os.MkdirAll(f.examplesRoot, 0o755)).To(Succeed())
 	return f
 }
 
-// writeArtifact creates the four files for name; generated controls whether the
+// writeArtifact creates the artifact files for name; generated controls whether the
 // .go source carries the tfgen generated-code marker.
 func (f *artifactFixture) writeArtifact(name string, generated bool) {
 	src := "package fwprovider\n\n"
@@ -45,6 +47,8 @@ func (f *artifactFixture) writeArtifact(name string, generated bool) {
 	Expect(os.WriteFile(f.testPath(name), []byte(test), 0o644)).To(Succeed())
 
 	Expect(os.WriteFile(f.docPath(name), []byte("# "+name), 0o644)).To(Succeed())
+	Expect(os.MkdirAll(filepath.Dir(f.examplePath(name)), 0o755)).To(Succeed())
+	Expect(os.WriteFile(f.examplePath(name), []byte("data \"datadog_"+name+"\" \"example\" {}\n"), 0o644)).To(Succeed())
 
 	_, err := emit.SyncGeneratedDatasources(f.genPath(), []string{emit.DatasourceConstructor(name)}, false)
 	Expect(err).NotTo(HaveOccurred())
@@ -70,6 +74,12 @@ func (f *artifactFixture) testPath(name string) string {
 func (f *artifactFixture) docPath(name string) string {
 	return filepath.Join(f.docsRoot, name+".md")
 }
+func (f *artifactFixture) exampleDir(name string) string {
+	return filepath.Join(f.examplesRoot, "datadog_"+name)
+}
+func (f *artifactFixture) examplePath(name string) string {
+	return filepath.Join(f.exampleDir(name), "data-source.tf")
+}
 func (f *artifactFixture) genPath() string {
 	return filepath.Join(f.outputRoot, "datasources_generated.go")
 }
@@ -80,11 +90,11 @@ func (f *artifactFixture) registry() string {
 }
 
 func (f *artifactFixture) retire(name string, check bool) model.ArtifactReportEntry {
-	return retireArtifact(name, f.outputRoot, f.testsRoot, f.docsRoot, check)
+	return retireArtifact(name, f.outputRoot, f.testsRoot, f.docsRoot, f.examplesRoot, check)
 }
 
 var _ = Describe("retireArtifact", func() {
-	It("deletes the source, test and doc and removes the registration", func() {
+	It("deletes the source, test, doc and example and removes the registration", func() {
 		f := newFixture()
 		f.writeArtifact("team", true)
 
@@ -94,7 +104,23 @@ var _ = Describe("retireArtifact", func() {
 		Expect(f.goPath("team")).NotTo(BeAnExistingFile())
 		Expect(f.testPath("team")).NotTo(BeAnExistingFile())
 		Expect(f.docPath("team")).NotTo(BeAnExistingFile())
+		Expect(f.examplePath("team")).NotTo(BeAnExistingFile())
+		Expect(f.exampleDir("team")).NotTo(BeADirectory())
 		Expect(f.registry()).NotTo(ContainSubstring(emit.DatasourceConstructor("team")))
+	})
+
+	It("preserves a non-empty example directory", func() {
+		f := newFixture()
+		f.writeArtifact("team", true)
+		sidecar := filepath.Join(f.exampleDir("team"), "README.md")
+		Expect(os.WriteFile(sidecar, []byte("keep me"), 0o644)).To(Succeed())
+
+		entry := f.retire("team", false)
+
+		Expect(entry.Status).To(Equal(model.ArtifactStatusRetired))
+		Expect(f.examplePath("team")).NotTo(BeAnExistingFile())
+		Expect(f.exampleDir("team")).To(BeADirectory())
+		Expect(sidecar).To(BeAnExistingFile())
 	})
 
 	It("blocks retirement and keeps every file when a recorded cassette adopted it", func() {
@@ -108,6 +134,8 @@ var _ = Describe("retireArtifact", func() {
 		Expect(f.goPath("team")).To(BeAnExistingFile())
 		Expect(f.testPath("team")).To(BeAnExistingFile())
 		Expect(f.docPath("team")).To(BeAnExistingFile())
+		Expect(f.examplePath("team")).To(BeAnExistingFile())
+		Expect(f.exampleDir("team")).To(BeADirectory())
 		Expect(f.registry()).To(ContainSubstring(emit.DatasourceConstructor("team")))
 	})
 
@@ -138,6 +166,8 @@ var _ = Describe("retireArtifact", func() {
 
 		Expect(entry.Status).To(Equal(model.ArtifactStatusRetired))
 		Expect(f.goPath("team")).To(BeAnExistingFile())
+		Expect(f.examplePath("team")).To(BeAnExistingFile())
+		Expect(f.exampleDir("team")).To(BeADirectory())
 		Expect(f.registry()).To(ContainSubstring(emit.DatasourceConstructor("team")))
 	})
 
@@ -170,14 +200,16 @@ var _ = Describe("reconcileOrphans", func() {
 		f.writeArtifact("zoo", true)
 		desired := map[string]bool{emit.DatasourceConstructor("team"): true}
 
-		entries, err := reconcileOrphans(f.outputRoot, f.testsRoot, f.docsRoot, desired, false)
+		entries, err := reconcileOrphans(f.outputRoot, f.testsRoot, f.docsRoot, f.examplesRoot, desired, false)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(entries).To(HaveLen(1))
 		Expect(entries[0].Name).To(Equal("zoo"))
 		Expect(entries[0].Status).To(Equal(model.ArtifactStatusRetired))
 		Expect(f.goPath("zoo")).NotTo(BeAnExistingFile())
+		Expect(f.examplePath("zoo")).NotTo(BeAnExistingFile())
 		Expect(f.goPath("team")).To(BeAnExistingFile())
+		Expect(f.examplePath("team")).To(BeAnExistingFile())
 		Expect(f.registry()).To(ContainSubstring(emit.DatasourceConstructor("team")))
 		Expect(f.registry()).NotTo(ContainSubstring(emit.DatasourceConstructor("zoo")))
 	})
@@ -187,12 +219,13 @@ var _ = Describe("reconcileOrphans", func() {
 		f.writeArtifact("zoo", true)
 		f.writeCassette("TestAccDatadogzooDataSource.yaml")
 
-		entries, err := reconcileOrphans(f.outputRoot, f.testsRoot, f.docsRoot, map[string]bool{}, false)
+		entries, err := reconcileOrphans(f.outputRoot, f.testsRoot, f.docsRoot, f.examplesRoot, map[string]bool{}, false)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(entries).To(HaveLen(1))
 		Expect(entries[0].Status).To(Equal(model.ArtifactStatusRetireBlocked))
 		Expect(f.goPath("zoo")).To(BeAnExistingFile())
+		Expect(f.examplePath("zoo")).To(BeAnExistingFile())
 		Expect(f.registry()).To(ContainSubstring(emit.DatasourceConstructor("zoo")))
 	})
 
@@ -218,7 +251,7 @@ var _ = Describe("reconcileOrphans", func() {
 		f.writeArtifact("team", true)
 		desired := map[string]bool{emit.DatasourceConstructor("team"): true}
 
-		entries, err := reconcileOrphans(f.outputRoot, f.testsRoot, f.docsRoot, desired, false)
+		entries, err := reconcileOrphans(f.outputRoot, f.testsRoot, f.docsRoot, f.examplesRoot, desired, false)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(entries).To(BeEmpty())

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -199,6 +199,7 @@ var _ = Describe("BuildDataSourceView singular search", func() {
 			Expect(view.State.ParamType).To(Equal("datadogV2.PowerpackData"))
 			Expect(view.State.Preamble).To(Equal([]string{"attributes := data.GetAttributes()"}))
 		})
+
 	})
 
 	Context("both", func() {
@@ -232,6 +233,7 @@ var _ = Describe("BuildDataSourceView singular search", func() {
 				Optional:    true,
 			}))
 		})
+
 	})
 
 	DescribeTable("the emitted Read guards the result count and indexes only the single match",

--- a/.generator-v2/internal/emit/example_render.go
+++ b/.generator-v2/internal/emit/example_render.go
@@ -3,9 +3,16 @@ package emit
 import (
 	"fmt"
 	"strings"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
 )
 
 const exampleDataSourceID = "11111111-2222-3333-4444-555555555555"
+
+// maxPluralAutoFilters caps how many optional scalar filters the renderer will
+// auto-select for an all-optional plural shape. One keeps the example minimal,
+// illustrative, and byte-deterministic.
+const maxPluralAutoFilters = 1
 
 type exampleAttribute struct {
 	name  string
@@ -14,20 +21,22 @@ type exampleAttribute struct {
 
 // DataSourceExample is the rendered tfplugindocs input plus any limitations the
 // generator could not express in HCL. Diagnostics are attached to the main
-// artifact's run-report entry so downstream PR generation surfaces them.
+// artifact's run-report entry so downstream PR generation surfaces them; a
+// warning marks an example a human must complete by hand.
 type DataSourceExample struct {
 	Content     []byte
-	Diagnostics []string
+	Diagnostics []model.Diagnostic
 }
 
 // RenderDataSourceExample returns a deterministic HCL scaffold for a generated
 // data source. By-ID shapes use the repository's conventional example UUID,
-// search-only shapes include their scalar filters, and every shape includes
-// required scalar attributes. It reports any required input or lookup shape it
-// cannot represent rather than silently presenting an incomplete example.
+// search-only shapes include their scalar filters, all-optional plural shapes
+// auto-select a representative filter, and every shape includes required scalar
+// attributes. It reports any input or lookup shape it cannot represent rather
+// than silently presenting an incomplete example.
 func RenderDataSourceExample(v DataSourceView) DataSourceExample {
 	var attributes []exampleAttribute
-	var diagnostics []string
+	var diagnostics []model.Diagnostic
 
 	if v.Cardinality == Singular && v.ByID {
 		attributes = append(attributes, exampleAttribute{name: "id", value: fmt.Sprintf("%q", exampleDataSourceID)})
@@ -35,17 +44,19 @@ func RenderDataSourceExample(v DataSourceView) DataSourceExample {
 
 	includeOptionalFilters := v.Cardinality == Singular && v.Searchable && !v.ByID
 	renderedFilter := false
+	requiredInputSeen := false
 	for _, attr := range v.Schema.Attributes {
+		if attr.Required {
+			requiredInputSeen = true
+		}
 		if !attr.Required && !(includeOptionalFilters && attr.Optional) {
 			continue
 		}
 		value, ok := hclExampleValue(attr.TFType)
 		if !ok {
 			if attr.Required {
-				diagnostics = append(diagnostics, fmt.Sprintf(
-					"generated example for %q may be incomplete: required attribute %q has unsupported type %q",
-					v.TypeName, attr.TFName, attr.TFType,
-				))
+				diagnostics = append(diagnostics, incompleteExample(v.TypeName, fmt.Sprintf(
+					"required attribute %q has unsupported type %q", attr.TFName, attr.TFType)))
 			}
 			continue
 		}
@@ -56,24 +67,52 @@ func RenderDataSourceExample(v DataSourceView) DataSourceExample {
 	}
 	for _, block := range v.Schema.Blocks {
 		if block.Required {
-			diagnostics = append(diagnostics, fmt.Sprintf(
-				"generated example for %q may be incomplete: required block %q cannot be rendered",
-				v.TypeName, block.TFName,
-			))
+			requiredInputSeen = true
+			diagnostics = append(diagnostics, incompleteExample(v.TypeName, fmt.Sprintf(
+				"required block %q cannot be rendered", block.TFName)))
+		}
+	}
+
+	// A plural shape usually exposes only optional query parameters, so the
+	// passes above collect nothing and the example would fall through to an
+	// empty block. Auto-select a stable, capped subset of the optional scalar
+	// filters and flag it so a reviewer confirms the choice is representative.
+	if v.Cardinality == Plural && len(attributes) == 0 && !requiredInputSeen {
+		picked := 0
+		for _, attr := range v.Schema.Attributes {
+			if picked >= maxPluralAutoFilters {
+				break
+			}
+			if !attr.Optional {
+				continue
+			}
+			value, ok := hclExampleValue(attr.TFType)
+			if !ok {
+				continue
+			}
+			attributes = append(attributes, exampleAttribute{name: attr.TFName, value: value})
+			picked++
+		}
+		if picked > 0 {
+			diagnostics = append(diagnostics, model.Diagnostic{
+				Severity: model.SeverityInfo,
+				Message: fmt.Sprintf(
+					"generated example for %q uses an auto-selected optional filter; confirm it is representative and add others as needed",
+					v.TypeName),
+			})
+		} else {
+			diagnostics = append(diagnostics, incompleteExample(v.TypeName,
+				"all inputs are optional and none is a renderable scalar; a usable filter must be added by hand"))
 		}
 	}
 
 	if v.Cardinality == Singular && !v.ByID && !v.Searchable {
-		diagnostics = append(diagnostics, fmt.Sprintf(
-			"generated example for %q may be incomplete: singular lookup has neither by-ID nor searchable resolution",
-			v.TypeName,
-		))
+		diagnostics = append(diagnostics, incompleteExample(v.TypeName,
+			"singular lookup has neither by-ID nor searchable resolution"))
 	}
 	if includeOptionalFilters && !renderedFilter {
-		diagnostics = append(diagnostics, fmt.Sprintf(
-			"generated example for %q may be incomplete: search-only lookup has no renderable scalar filters",
-			v.TypeName,
-		))
+		diagnostics = append(diagnostics, incompleteExample(v.TypeName,
+			"search-only lookup has no renderable scalar filters"))
 	}
 
 	typeName := "datadog_" + v.TypeName
@@ -98,6 +137,15 @@ func RenderDataSourceExample(v DataSourceView) DataSourceExample {
 	}
 	b.WriteString("}\n")
 	return DataSourceExample{Content: []byte(b.String()), Diagnostics: diagnostics}
+}
+
+// incompleteExample builds a warning-severity diagnostic for an example the
+// generator could not fully render, so CI can flag that a human must supply one.
+func incompleteExample(typeName, detail string) model.Diagnostic {
+	return model.Diagnostic{
+		Severity: model.SeverityWarning,
+		Message:  fmt.Sprintf("generated example for %q may be incomplete: %s", typeName, detail),
+	}
 }
 
 // hclExampleValue returns a stable HCL literal for a scalar schema attribute.

--- a/.generator-v2/internal/emit/example_render.go
+++ b/.generator-v2/internal/emit/example_render.go
@@ -1,0 +1,115 @@
+package emit
+
+import (
+	"fmt"
+	"strings"
+)
+
+const exampleDataSourceID = "11111111-2222-3333-4444-555555555555"
+
+type exampleAttribute struct {
+	name  string
+	value string
+}
+
+// DataSourceExample is the rendered tfplugindocs input plus any limitations the
+// generator could not express in HCL. Diagnostics are attached to the main
+// artifact's run-report entry so downstream PR generation surfaces them.
+type DataSourceExample struct {
+	Content     []byte
+	Diagnostics []string
+}
+
+// RenderDataSourceExample returns a deterministic HCL scaffold for a generated
+// data source. By-ID shapes use the repository's conventional example UUID,
+// search-only shapes include their scalar filters, and every shape includes
+// required scalar attributes. It reports any required input or lookup shape it
+// cannot represent rather than silently presenting an incomplete example.
+func RenderDataSourceExample(v DataSourceView) DataSourceExample {
+	var attributes []exampleAttribute
+	var diagnostics []string
+
+	if v.Cardinality == Singular && v.ByID {
+		attributes = append(attributes, exampleAttribute{name: "id", value: fmt.Sprintf("%q", exampleDataSourceID)})
+	}
+
+	includeOptionalFilters := v.Cardinality == Singular && v.Searchable && !v.ByID
+	renderedFilter := false
+	for _, attr := range v.Schema.Attributes {
+		if !attr.Required && !(includeOptionalFilters && attr.Optional) {
+			continue
+		}
+		value, ok := hclExampleValue(attr.TFType)
+		if !ok {
+			if attr.Required {
+				diagnostics = append(diagnostics, fmt.Sprintf(
+					"generated example for %q may be incomplete: required attribute %q has unsupported type %q",
+					v.TypeName, attr.TFName, attr.TFType,
+				))
+			}
+			continue
+		}
+		attributes = append(attributes, exampleAttribute{name: attr.TFName, value: value})
+		if includeOptionalFilters {
+			renderedFilter = true
+		}
+	}
+	for _, block := range v.Schema.Blocks {
+		if block.Required {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"generated example for %q may be incomplete: required block %q cannot be rendered",
+				v.TypeName, block.TFName,
+			))
+		}
+	}
+
+	if v.Cardinality == Singular && !v.ByID && !v.Searchable {
+		diagnostics = append(diagnostics, fmt.Sprintf(
+			"generated example for %q may be incomplete: singular lookup has neither by-ID nor searchable resolution",
+			v.TypeName,
+		))
+	}
+	if includeOptionalFilters && !renderedFilter {
+		diagnostics = append(diagnostics, fmt.Sprintf(
+			"generated example for %q may be incomplete: search-only lookup has no renderable scalar filters",
+			v.TypeName,
+		))
+	}
+
+	typeName := "datadog_" + v.TypeName
+	if len(attributes) == 0 {
+		return DataSourceExample{
+			Content:     []byte(fmt.Sprintf("data %q \"example\" {}\n", typeName)),
+			Diagnostics: diagnostics,
+		}
+	}
+
+	width := 0
+	for _, attr := range attributes {
+		if len(attr.name) > width {
+			width = len(attr.name)
+		}
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "data %q \"example\" {\n", typeName)
+	for _, attr := range attributes {
+		fmt.Fprintf(&b, "  %-*s = %s\n", width, attr.name, attr.value)
+	}
+	b.WriteString("}\n")
+	return DataSourceExample{Content: []byte(b.String()), Diagnostics: diagnostics}
+}
+
+// hclExampleValue returns a stable HCL literal for a scalar schema attribute.
+func hclExampleValue(tfType string) (string, bool) {
+	switch {
+	case strings.Contains(tfType, "String"):
+		return `"example"`, true
+	case strings.Contains(tfType, "Bool"):
+		return "false", true
+	case strings.Contains(tfType, "Int"), strings.Contains(tfType, "Float"):
+		return "0", true
+	default:
+		return "", false
+	}
+}

--- a/.generator-v2/internal/emit/example_render_test.go
+++ b/.generator-v2/internal/emit/example_render_test.go
@@ -1,0 +1,112 @@
+package emit
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("data-source examples", func() {
+	It("renders a singular by-ID lookup with the conventional example UUID", func() {
+		got := RenderDataSourceExample(incidentTypeView())
+
+		Expect(string(got.Content)).To(Equal(`data "datadog_incident_type" "example" {
+  id = "11111111-2222-3333-4444-555555555555"
+}
+`))
+		Expect(got.Diagnostics).To(BeEmpty())
+	})
+
+	It("renders deterministic scalar filters for a search-only singular lookup", func() {
+		got := RenderDataSourceExample(powerpackSearchView())
+
+		Expect(string(got.Content)).To(Equal(`data "datadog_powerpack" "example" {
+  filter_name = "example"
+}
+`))
+		Expect(got.Diagnostics).To(BeEmpty())
+	})
+
+	It("renders an unfiltered plural lookup", func() {
+		got := RenderDataSourceExample(pluralFixture())
+
+		Expect(string(got.Content)).To(Equal("data \"datadog_teams\" \"example\" {}\n"))
+		Expect(got.Diagnostics).To(BeEmpty())
+	})
+
+	It("uses type-appropriate, terraform-formatted filter placeholders", func() {
+		view := DataSourceView{
+			Cardinality: Singular,
+			TypeName:    "widgets",
+			Searchable:  true,
+			Schema: SchemaView{Attributes: []AttrView{
+				{TFName: "filter_keyword", TFType: "schema.StringAttribute", Optional: true},
+				{TFName: "filter_me", TFType: "schema.BoolAttribute", Optional: true},
+				{TFName: "page_size", TFType: "schema.Int64Attribute", Optional: true},
+				{TFName: "computed_value", TFType: "schema.StringAttribute", Computed: true},
+			}},
+		}
+
+		got := RenderDataSourceExample(view)
+		Expect(string(got.Content)).To(Equal(`data "datadog_widgets" "example" {
+  filter_keyword = "example"
+  filter_me      = false
+  page_size      = 0
+}
+`))
+		Expect(got.Diagnostics).To(BeEmpty())
+	})
+
+	It("renders required scalar inputs for plural shapes", func() {
+		view := DataSourceView{
+			Cardinality: Plural,
+			TypeName:    "widgets",
+			Schema: SchemaView{Attributes: []AttrView{
+				{TFName: "account_id", TFType: "schema.StringAttribute", Required: true},
+				{TFName: "optional_filter", TFType: "schema.StringAttribute", Optional: true},
+			}},
+		}
+
+		got := RenderDataSourceExample(view)
+		Expect(string(got.Content)).To(Equal(`data "datadog_widgets" "example" {
+  account_id = "example"
+}
+`))
+		Expect(got.Diagnostics).To(BeEmpty())
+	})
+
+	It("reports required inputs it cannot render", func() {
+		view := DataSourceView{
+			Cardinality: Plural,
+			TypeName:    "widgets",
+			Schema: SchemaView{
+				Attributes: []AttrView{
+					{TFName: "account_ids", TFType: "schema.ListAttribute", Required: true},
+				},
+				Blocks: []AttrView{
+					{TFName: "scope", IsBlock: true, Required: true},
+				},
+			},
+		}
+
+		got := RenderDataSourceExample(view)
+		Expect(string(got.Content)).To(Equal("data \"datadog_widgets\" \"example\" {}\n"))
+		Expect(got.Diagnostics).To(ConsistOf(
+			`generated example for "widgets" may be incomplete: required attribute "account_ids" has unsupported type "schema.ListAttribute"`,
+			`generated example for "widgets" may be incomplete: required block "scope" cannot be rendered`,
+		))
+	})
+
+	It("reports a singular shape with no supported lookup strategy", func() {
+		got := RenderDataSourceExample(DataSourceView{Cardinality: Singular, TypeName: "widgets"})
+
+		Expect(string(got.Content)).To(Equal("data \"datadog_widgets\" \"example\" {}\n"))
+		Expect(got.Diagnostics).To(ConsistOf(
+			`generated example for "widgets" may be incomplete: singular lookup has neither by-ID nor searchable resolution`,
+		))
+	})
+
+	It("renders deterministically", func() {
+		view := powerpackSearchView()
+		Expect(RenderDataSourceExample(view)).To(Equal(RenderDataSourceExample(view)))
+	})
+})

--- a/.generator-v2/internal/emit/example_render_test.go
+++ b/.generator-v2/internal/emit/example_render_test.go
@@ -3,6 +3,8 @@ package emit
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
 )
 
 var _ = Describe("data-source examples", func() {
@@ -26,11 +28,35 @@ var _ = Describe("data-source examples", func() {
 		Expect(got.Diagnostics).To(BeEmpty())
 	})
 
-	It("renders an unfiltered plural lookup", func() {
+	It("auto-selects a representative filter for an all-optional plural lookup", func() {
 		got := RenderDataSourceExample(pluralFixture())
 
-		Expect(string(got.Content)).To(Equal("data \"datadog_teams\" \"example\" {}\n"))
-		Expect(got.Diagnostics).To(BeEmpty())
+		Expect(string(got.Content)).To(Equal(`data "datadog_teams" "example" {
+  filter_keyword = "example"
+}
+`))
+		Expect(got.Diagnostics).To(ConsistOf(model.Diagnostic{
+			Severity: model.SeverityInfo,
+			Message:  `generated example for "teams" uses an auto-selected optional filter; confirm it is representative and add others as needed`,
+		}))
+	})
+
+	It("reports and leaves an empty block when a plural shape has no renderable scalar filter", func() {
+		view := DataSourceView{
+			Cardinality: Plural,
+			TypeName:    "widgets",
+			Schema: SchemaView{Attributes: []AttrView{
+				{TFName: "filter_ids", TFType: "schema.ListAttribute", Optional: true},
+			}},
+		}
+
+		got := RenderDataSourceExample(view)
+
+		Expect(string(got.Content)).To(Equal("data \"datadog_widgets\" \"example\" {}\n"))
+		Expect(got.Diagnostics).To(ConsistOf(model.Diagnostic{
+			Severity: model.SeverityWarning,
+			Message:  `generated example for "widgets" may be incomplete: all inputs are optional and none is a renderable scalar; a usable filter must be added by hand`,
+		}))
 	})
 
 	It("uses type-appropriate, terraform-formatted filter placeholders", func() {
@@ -91,8 +117,14 @@ var _ = Describe("data-source examples", func() {
 		got := RenderDataSourceExample(view)
 		Expect(string(got.Content)).To(Equal("data \"datadog_widgets\" \"example\" {}\n"))
 		Expect(got.Diagnostics).To(ConsistOf(
-			`generated example for "widgets" may be incomplete: required attribute "account_ids" has unsupported type "schema.ListAttribute"`,
-			`generated example for "widgets" may be incomplete: required block "scope" cannot be rendered`,
+			model.Diagnostic{
+				Severity: model.SeverityWarning,
+				Message:  `generated example for "widgets" may be incomplete: required attribute "account_ids" has unsupported type "schema.ListAttribute"`,
+			},
+			model.Diagnostic{
+				Severity: model.SeverityWarning,
+				Message:  `generated example for "widgets" may be incomplete: required block "scope" cannot be rendered`,
+			},
 		))
 	})
 
@@ -100,9 +132,10 @@ var _ = Describe("data-source examples", func() {
 		got := RenderDataSourceExample(DataSourceView{Cardinality: Singular, TypeName: "widgets"})
 
 		Expect(string(got.Content)).To(Equal("data \"datadog_widgets\" \"example\" {}\n"))
-		Expect(got.Diagnostics).To(ConsistOf(
-			`generated example for "widgets" may be incomplete: singular lookup has neither by-ID nor searchable resolution`,
-		))
+		Expect(got.Diagnostics).To(ConsistOf(model.Diagnostic{
+			Severity: model.SeverityWarning,
+			Message:  `generated example for "widgets" may be incomplete: singular lookup has neither by-ID nor searchable resolution`,
+		}))
 	})
 
 	It("renders deterministically", func() {

--- a/.generator-v2/internal/emit/test_render.go
+++ b/.generator-v2/internal/emit/test_render.go
@@ -31,7 +31,7 @@ type testView struct {
 	// UseUniq threads uniqueEntityName through the config so a recording produces
 	// stable unique names. True when at least one string filter is seeded.
 	UseUniq bool
-	// Filters are the optional attributes seeded in the data-source block.
+	// Filters are the configurable scalar attributes seeded in the data-source block.
 	Filters []testFilter
 	// CollectionKey is the plural item block's Terraform name, e.g. "teams",
 	// checked as "<CollectionKey>.#".
@@ -64,7 +64,7 @@ func buildTestView(v DataSourceView) testView {
 	tv.CassettePath = "datadog/tests/cassettes/" + tv.FuncName + ".yaml"
 
 	for _, a := range v.Schema.Attributes {
-		if !a.Optional {
+		if !a.Optional && !a.Required {
 			continue
 		}
 		value, ok := hclFilterValue(a.TFType)

--- a/.generator-v2/internal/model/artifact.go
+++ b/.generator-v2/internal/model/artifact.go
@@ -266,8 +266,9 @@ func listCall(op *Operation) *SDKCall {
 // buildFilterLeaves converts op's scalar query parameters into Optional
 // top-level filter attributes. Pagination params are excluded (the SDK's
 // pagination form handles them); array- and enum-valued params are dropped with
-// an info Diagnostic rather than failing the build. The result preserves
-// QueryParams' name order.
+// an info Diagnostic rather than failing the build. Required query parameters
+// are surfaced as info diagnostics because the current SDK-call binding cannot
+// represent required query arguments. The result preserves QueryParams' order.
 func buildFilterLeaves(op *Operation) ([]*Attribute, []Diagnostic) {
 	var leaves []*Attribute
 	var diags []Diagnostic
@@ -276,19 +277,36 @@ func buildFilterLeaves(op *Operation) ([]*Attribute, []Diagnostic) {
 			continue
 		}
 		if reason := unsupportedFilterReason(p.Schema); reason != "" {
+			required := ""
+			if p.Required {
+				required = "required "
+			}
 			diags = append(diags, Diagnostic{
 				Severity: SeverityInfo,
-				Message:  fmt.Sprintf("dropped query parameter %q from filters: %s", p.Name, reason),
+				Message:  fmt.Sprintf("dropped %squery parameter %q from filters: %s", required, p.Name, reason),
 			})
 			continue
 		}
 		tfType, goType, err := FrameworkType(p.Schema)
 		if err != nil {
+			required := ""
+			if p.Required {
+				required = "required "
+			}
 			diags = append(diags, Diagnostic{
 				Severity: SeverityInfo,
-				Message:  fmt.Sprintf("dropped query parameter %q from filters: %v", p.Name, err),
+				Message:  fmt.Sprintf("dropped %squery parameter %q from filters: %v", required, p.Name, err),
 			})
 			continue
+		}
+		if p.Required {
+			diags = append(diags, Diagnostic{
+				Severity: SeverityInfo,
+				Message: fmt.Sprintf(
+					"required query parameter %q is represented as an optional Terraform filter; generated example may be incomplete and requires review",
+					p.Name,
+				),
+			})
 		}
 		leaves = append(leaves, &Attribute{
 			Path:        SnakeCase(p.Name),

--- a/.generator-v2/internal/model/artifact_test.go
+++ b/.generator-v2/internal/model/artifact_test.go
@@ -78,24 +78,59 @@ var _ = Describe("BuildArtifact plural", func() {
 		Expect(names).To(Equal([]string{"filter_keyword", "filter_me", "response.data"}))
 		Expect(types).To(Equal([]string{"schema.StringAttribute", "schema.BoolAttribute", "schema.ListNestedBlock"}))
 
-		// Filter leaves are Optional inputs, not Computed.
+		// Filter leaves remain Optional inputs and are not Computed.
 		Expect(art.Schema.Attributes[0].Optional).To(BeTrue())
 		Expect(art.Schema.Attributes[0].Computed).To(BeFalse())
+		Expect(art.Schema.Attributes[1].Required).To(BeFalse())
+		Expect(art.Schema.Attributes[1].Optional).To(BeTrue())
+	})
+
+	It("reports required query parameters that remain optional filters", func() {
+		op := listThingsOp()
+		op.QueryParams[0].Required = true
+
+		art, err := BuildArtifact(op)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(art.Schema.Attributes[0].Optional).To(BeTrue())
+		var msgs []string
+		for _, d := range art.Diagnostics {
+			msgs = append(msgs, d.Message)
+		}
+		Expect(msgs).To(ContainElement(ContainSubstring(
+			`required query parameter "filter[keyword]" is represented as an optional Terraform filter`,
+		)))
 	})
 
 	It("excludes pagination params and drops array/enum params with an info diagnostic", func() {
 		art, err := BuildArtifact(listThingsOp())
 		Expect(err).NotTo(HaveOccurred())
 
-		// page[number]/page[size] excluded silently; include (array) + sort (enum) dropped + logged.
+		// page[number]/page[size] excluded silently; include (array), sort
+		// (enum), and the required filter are logged.
 		var msgs []string
 		for _, d := range art.Diagnostics {
 			Expect(d.Severity).To(Equal(SeverityInfo))
 			msgs = append(msgs, d.Message)
 		}
-		Expect(msgs).To(HaveLen(2))
+		Expect(msgs).To(HaveLen(3))
 		Expect(msgs).To(ContainElement(ContainSubstring(`"include"`)))
 		Expect(msgs).To(ContainElement(ContainSubstring(`"sort"`)))
+		Expect(msgs).To(ContainElement(ContainSubstring(`required query parameter "filter[me]"`)))
+	})
+
+	It("identifies a dropped required query parameter in its diagnostic", func() {
+		op := listThingsOp()
+		op.QueryParams[2].Required = true // include: unsupported array-valued filter
+
+		art, err := BuildArtifact(op)
+		Expect(err).NotTo(HaveOccurred())
+
+		var msgs []string
+		for _, d := range art.Diagnostics {
+			msgs = append(msgs, d.Message)
+		}
+		Expect(msgs).To(ContainElement(ContainSubstring(`dropped required query parameter "include"`)))
 	})
 
 	It("produces a deeply-equal plural artifact across two runs", func() {

--- a/.generator-v2/internal/split/split.go
+++ b/.generator-v2/internal/split/split.go
@@ -1,8 +1,8 @@
 // Package split turns one aggregate tfgen push — all N generated data sources on
 // a single branch — into per-artifact bundles, one directory per data source, so
-// each can land as its own PR. It is pure: it diffs the provider and docs paths
-// in two on-disk trees (a master checkout and the pushed-branch checkout), reuses
-// tfgen's registry serializer to reconstruct each artifact's
+// each can land as its own PR. It is pure: it diffs the provider, docs and
+// examples paths in two on-disk trees (a master checkout and the pushed-branch
+// checkout), reuses tfgen's registry serializer to reconstruct each artifact's
 // datasources_generated.go as "the base set plus this one artifact", and never
 // touches git, the network, or the OpenAPI spec.
 //
@@ -84,10 +84,11 @@ const (
 )
 
 var (
-	dataSourceFileRe     = regexp.MustCompile(`^data_source_datadog_([a-z][a-z0-9_]*)\.go$`)
-	dataSourceTestFileRe = regexp.MustCompile(`^data_source_datadog_([a-z][a-z0-9_]*)_test\.go$`)
-	dataSourceDocFileRe  = regexp.MustCompile(`^([a-z][a-z0-9_]*)\.md$`)
-	artifactNameRe       = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+	dataSourceFileRe       = regexp.MustCompile(`^data_source_datadog_([a-z][a-z0-9_]*)\.go$`)
+	dataSourceTestFileRe   = regexp.MustCompile(`^data_source_datadog_([a-z][a-z0-9_]*)_test\.go$`)
+	dataSourceDocFileRe    = regexp.MustCompile(`^([a-z][a-z0-9_]*)\.md$`)
+	dataSourceExampleDirRe = regexp.MustCompile(`^datadog_([a-z][a-z0-9_]*)$`)
+	artifactNameRe         = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 	// constructorDeclRe recovers the constructor(s) a data-source file declares.
 	constructorDeclRe = regexp.MustCompile(`func (New[A-Za-z0-9_]+DataSource)\(`)
 	// constructorRe recovers constructor identifiers listed inside a slice literal.
@@ -97,6 +98,7 @@ var (
 	diffDirectoryScopes = []string{
 		filepath.FromSlash("datadog/fwprovider"),
 		filepath.FromSlash("docs/data-sources"),
+		filepath.FromSlash("examples/data-sources"),
 	}
 )
 
@@ -115,6 +117,7 @@ const (
 	kindProvider
 	kindProviderTest
 	kindDataSourceDoc
+	kindDataSourceExample
 )
 
 // classify maps an exact repo-relative path to its role in the split.
@@ -144,6 +147,11 @@ func classify(rel string) (fileKind, string) {
 			return kindDataSourceDoc, m[1]
 		}
 	}
+	if base == "data-source.tf" && filepath.Dir(filepath.Dir(clean)) == filepath.Join("examples", "data-sources") {
+		if m := dataSourceExampleDirRe.FindStringSubmatch(filepath.Base(filepath.Dir(clean))); m != nil {
+			return kindDataSourceExample, m[1]
+		}
+	}
 	return kindUnknown, ""
 }
 
@@ -158,6 +166,7 @@ type artifactPlan struct {
 	source  *changedFile
 	test    *changedFile
 	doc     *changedFile
+	example *changedFile
 	removed []string
 	report  *generationArtifact
 }
@@ -211,6 +220,8 @@ func Split(opts Options) (*Result, error) {
 			planFor(plans, name).test = cf
 		case kindDataSourceDoc:
 			planFor(plans, name).doc = cf
+		case kindDataSourceExample:
+			planFor(plans, name).example = cf
 		default:
 			fail("changed file maps to no artifact and is not a known shared file: %s", cf.rel)
 		}
@@ -218,7 +229,7 @@ func Split(opts Options) (*Result, error) {
 	for _, d := range deleted {
 		kind, name := classify(d)
 		switch kind {
-		case kindDataSource, kindDataSourceTest, kindDataSourceDoc:
+		case kindDataSource, kindDataSourceTest, kindDataSourceDoc, kindDataSourceExample:
 			planFor(plans, name).removed = append(planFor(plans, name).removed, d)
 		default:
 			fail("removed file maps to no artifact or is a shared file that cannot be deleted: %s", d)
@@ -373,6 +384,9 @@ func materializeActive(opts Options, name string, p *artifactPlan, registryRel s
 	if p.test != nil {
 		files = append(files, p.test.rel)
 	}
+	if p.example != nil {
+		files = append(files, p.example.rel)
+	}
 	for _, rel := range files {
 		if !opts.Check {
 			if err := copyFile(filepath.Join(opts.GeneratedDir, rel), filepath.Join(outDir, rel)); err != nil {
@@ -523,8 +537,8 @@ func validatePlan(name string, p *artifactPlan, reportRequired bool) (model.Arti
 			fail("created artifact %q also removes files: %s", name, strings.Join(p.removed, ", "))
 		}
 	case model.ArtifactStatusUpdated:
-		if p.source == nil && p.test == nil {
-			fail("generation report marks %q updated, but no source or test file changed", name)
+		if p.source == nil && p.test == nil && p.example == nil {
+			fail("generation report marks %q updated, but no source, test or example file changed", name)
 		}
 		if p.source != nil && p.source.added {
 			fail("generation report marks %q updated, but its source file is newly added", name)
@@ -533,11 +547,11 @@ func validatePlan(name string, p *artifactPlan, reportRequired bool) (model.Arti
 			fail("updated artifact %q also removes files: %s", name, strings.Join(p.removed, ", "))
 		}
 	case model.ArtifactStatusRetired:
-		if p.source != nil || p.test != nil || p.doc != nil {
+		if p.source != nil || p.test != nil || p.doc != nil || p.example != nil {
 			fail("retired artifact %q contains added or modified self-contained files", name)
 		}
 	case model.ArtifactStatusRetireBlocked:
-		if p.source != nil || p.test != nil || p.doc != nil || len(p.removed) > 0 {
+		if p.source != nil || p.test != nil || p.doc != nil || p.example != nil || len(p.removed) > 0 {
 			fail("retire_blocked artifact %q unexpectedly changes files", name)
 		}
 	case model.ArtifactStatusRegistrationRetired:
@@ -572,11 +586,12 @@ func readGenerationArtifacts(path string) (map[string]generationArtifact, error)
 	}
 
 	type accumulated struct {
-		mainSeen    bool
-		mainStatus  model.ArtifactStatus
-		testChanged bool
-		diagnostics []model.Diagnostic
-		constructor string
+		mainSeen       bool
+		mainStatus     model.ArtifactStatus
+		testChanged    bool
+		exampleChanged bool
+		diagnostics    []model.Diagnostic
+		constructor    string
 	}
 	acc := map[string]*accumulated{}
 	for _, entry := range report.Artifacts {
@@ -603,6 +618,12 @@ func readGenerationArtifacts(path string) (map[string]generationArtifact, error)
 			}
 			continue
 		}
+		if base == "data-source.tf" && filepath.Base(filepath.Dir(entry.Path)) == "datadog_"+entry.Name {
+			if entry.Status == model.ArtifactStatusCreated || entry.Status == model.ArtifactStatusUpdated {
+				a.exampleChanged = true
+			}
+			continue
+		}
 		if base != "" && base != "data_source_datadog_"+entry.Name+".go" &&
 			entry.Status != model.ArtifactStatusRetired &&
 			entry.Status != model.ArtifactStatusRetireBlocked &&
@@ -621,13 +642,13 @@ func readGenerationArtifacts(path string) (map[string]generationArtifact, error)
 	out := map[string]generationArtifact{}
 	for name, a := range acc {
 		if !a.mainSeen {
-			if a.testChanged {
-				return nil, fmt.Errorf("generation report has a changed test for %q without a data-source entry", name)
+			if a.testChanged || a.exampleChanged {
+				return nil, fmt.Errorf("generation report has a changed auxiliary file for %q without a data-source entry", name)
 			}
 			continue
 		}
 		status := a.mainStatus
-		if status == model.ArtifactStatusUnchanged && a.testChanged {
+		if status == model.ArtifactStatusUnchanged && (a.testChanged || a.exampleChanged) {
 			status = model.ArtifactStatusUpdated
 		}
 		switch status {
@@ -738,9 +759,10 @@ func diffTrees(baseDir, genDir string) (changed []changedFile, deleted []string,
 	return changed, deleted, nil
 }
 
-// scopedFiles returns every file under provider/docs plus only generated
-// data-source tests and provider_test.go. This preserves fail-loud attribution
-// without making unrelated test-suite or cassette drift part of the split.
+// scopedFiles returns every file under provider/docs/examples plus only
+// generated data-source tests and provider_test.go. This preserves fail-loud
+// attribution without making unrelated test-suite or cassette drift part of
+// the split.
 func scopedFiles(root string) ([]string, error) {
 	var out []string
 	for _, scope := range diffDirectoryScopes {

--- a/.generator-v2/internal/split/split_test.go
+++ b/.generator-v2/internal/split/split_test.go
@@ -16,10 +16,14 @@ import (
 
 const fwDir = "datadog/fwprovider"
 const testsDir = "datadog/tests"
+const examplesDir = "examples/data-sources"
 
 func dsFileName(name string) string { return "data_source_datadog_" + name + ".go" }
 func dsTestFileName(name string) string {
 	return "data_source_datadog_" + name + "_test.go"
+}
+func dsExampleFileName(name string) string {
+	return filepath.Join(examplesDir, "datadog_"+name, "data-source.tf")
 }
 
 func writeFile(root, rel, content string) {
@@ -103,6 +107,7 @@ var _ = Describe("Split", func() {
 		writeRegistry(base) // empty
 		ctor := emit.DatasourceConstructor("rum_applications")
 		writeFile(gen, filepath.Join(fwDir, dsFileName("rum_applications")), dataSourceContent(ctor))
+		writeFile(gen, dsExampleFileName("rum_applications"), "data \"datadog_rum_applications\" \"example\" {}\n")
 		writeRegistry(gen, ctor)
 
 		rep, err := Split(Options{BaseDir: base, GeneratedDir: gen, OutDir: out})
@@ -116,12 +121,15 @@ var _ = Describe("Split", func() {
 		Expect(art.Files).To(ConsistOf(
 			filepath.Join(fwDir, dsFileName("rum_applications")),
 			filepath.Join(fwDir, registryFile),
+			dsExampleFileName("rum_applications"),
 		))
 
 		routedReg := readFile(filepath.Join(out, "rum_applications", fwDir, registryFile))
 		Expect(routedReg).To(ContainSubstring(ctor))
 		routedSrc := readFile(filepath.Join(out, "rum_applications", fwDir, dsFileName("rum_applications")))
 		Expect(routedSrc).To(Equal(dataSourceContent(ctor)), "source file must be copied verbatim")
+		routedExample := readFile(filepath.Join(out, "rum_applications", dsExampleFileName("rum_applications")))
+		Expect(routedExample).To(Equal("data \"datadog_rum_applications\" \"example\" {}\n"))
 	})
 
 	It("ignores unrelated repository drift outside the provider and docs scopes", func() {
@@ -155,6 +163,19 @@ var _ = Describe("Split", func() {
 		rep, err := Split(Options{BaseDir: base, GeneratedDir: gen, OutDir: out})
 		Expect(err).To(HaveOccurred())
 		Expect(rep.Errors).To(ContainElement(ContainSubstring(filepath.Join("docs", "data-sources", "unexpected.md"))))
+	})
+
+	It("fails loud on an unrecognized file inside the scoped examples path", func() {
+		writeRegistry(base)
+		ctor := emit.DatasourceConstructor("rum_applications")
+		writeFile(gen, filepath.Join(fwDir, dsFileName("rum_applications")), dataSourceContent(ctor))
+		writeFile(gen, filepath.Join(examplesDir, "datadog_rum_applications", "README.md"), "unexpected\n")
+		writeRegistry(gen, ctor)
+
+		rep, err := Split(Options{BaseDir: base, GeneratedDir: gen, OutDir: out})
+
+		Expect(err).To(HaveOccurred())
+		Expect(rep.Errors).To(ContainElement(ContainSubstring("changed file maps to no artifact")))
 	})
 
 	It("gives each artifact of a multi-artifact push its own bundle whose registry holds base plus only that artifact", func() {
@@ -263,6 +284,33 @@ var _ = Describe("Split", func() {
 		))
 	})
 
+	It("routes an example-only rollout as an updated artifact when its generated source is unchanged", func() {
+		name := "existing"
+		constructor := emit.DatasourceConstructor(name)
+		sourceRel := filepath.Join(fwDir, dsFileName(name))
+		source := dataSourceContent(constructor)
+		exampleRel := dsExampleFileName(name)
+		writeFile(base, sourceRel, source)
+		writeFile(gen, sourceRel, source)
+		writeFile(gen, exampleRel, "data \"datadog_existing\" \"example\" {}\n")
+		writeRegistry(base, constructor)
+		writeRegistry(gen, constructor)
+		reportPath := writeGenerationReport(gen,
+			model.ArtifactReportEntry{Name: name, Kind: model.ArtifactKindDataSource, Status: model.ArtifactStatusUnchanged, Path: sourceRel},
+			model.ArtifactReportEntry{Name: name, Kind: model.ArtifactKindDataSource, Status: model.ArtifactStatusCreated, Path: exampleRel},
+		)
+
+		rep, err := Split(Options{BaseDir: base, GeneratedDir: gen, OutDir: out, GenerationReport: reportPath})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rep.Artifacts).To(HaveLen(1))
+		Expect(rep.Artifacts[0].Status).To(Equal(model.ArtifactStatusUpdated))
+		Expect(rep.Artifacts[0].Files).To(ConsistOf(
+			filepath.Join(fwDir, registryFile),
+			exampleRel,
+		))
+		Expect(readFile(filepath.Join(out, name, exampleRel))).To(Equal("data \"datadog_existing\" \"example\" {}\n"))
+	})
+
 	It("routes a retirement as exact file deletions plus reconstructed shared registrations", func() {
 		name := "gone"
 		constructor := emit.DatasourceConstructor(name)
@@ -270,12 +318,14 @@ var _ = Describe("Split", func() {
 		sourceRel := filepath.Join(fwDir, dsFileName(name))
 		testRel := filepath.Join(testsDir, dsTestFileName(name))
 		docRel := filepath.Join("docs", "data-sources", name+".md")
+		exampleRel := dsExampleFileName(name)
 
 		writeRegistry(base, existing, constructor)
 		writeRegistry(gen, existing)
 		writeFile(base, sourceRel, dataSourceContent(constructor))
 		writeFile(base, testRel, "package test\n")
 		writeFile(base, docRel, "# gone\n")
+		writeFile(base, exampleRel, "data \"datadog_gone\" \"example\" {}\n")
 		writeEndpointTags(base, map[string]string{emit.EndpointTagTestKey(name): "gone-service"})
 		writeEndpointTags(gen, nil)
 		reportPath := writeGenerationReport(gen, model.ArtifactReportEntry{
@@ -288,7 +338,7 @@ var _ = Describe("Split", func() {
 		Expect(rep.Artifacts).To(HaveLen(1))
 		artifact := rep.Artifacts[0]
 		Expect(artifact.Status).To(Equal(model.ArtifactStatusRetired))
-		Expect(artifact.RemovedFiles).To(ConsistOf(sourceRel, testRel, docRel))
+		Expect(artifact.RemovedFiles).To(ConsistOf(sourceRel, testRel, docRel, exampleRel))
 		Expect(artifact.Files).To(ConsistOf(
 			filepath.Join(fwDir, registryFile),
 			filepath.Join(testsDir, providerTestFile),

--- a/.generator-v2/scripts/README.md
+++ b/.generator-v2/scripts/README.md
@@ -6,8 +6,9 @@ prompts and no human in the loop. It is the non-interactive counterpart to the
 script takes every answer up front as a flag and fails fast if anything is unclear.
 
 The script is a deterministic orchestrator. It runs `slice_and_annotate.py` and `tfgen`,
-gates on the generator report, runs `make docs` / `make build`, checks only the expected
-files changed, then branches, commits, and opens the PR. The only non-deterministic step is
+which creates a data-source example when one does not already exist, gates on the generator
+report, runs `make docs` / `make build`, checks only the expected files changed, then
+branches, commits, and opens the PR. The only non-deterministic step is
 two small calls to the `claude` CLI that write the PR's risk notes and "How to test"
 section; both degrade gracefully if `claude` is missing.
 
@@ -17,8 +18,10 @@ section; both degrade gracefully if `claude` is missing.
 2. Start a fresh branch from `--base` (see below).
 3. Download the v2 OpenAPI spec (latest by default) and record which commit it was.
 4. Slice + annotate the chosen operation(s) with `slice_and_annotate.py`.
-5. Run `tfgen`, then stop if the report has any failure or error.
-6. `make docs` and `make build`; stop if either fails.
+5. Run `tfgen`, then stop if the report has any failure or error. The run creates
+   `examples/data-sources/datadog_<name>/data-source.tf` only when that path is absent;
+   existing hand-written examples are preserved.
+6. `make docs` (which consumes that example) and `make build`; stop if either fails.
 7. Confirm only the generated files changed.
 8. Ask `claude` for the risk notes and testing steps (skipped cleanly if unavailable).
 9. Commit, push, and open a **draft** PR against `--base`.
@@ -128,6 +131,10 @@ prose calls (and count cost even when a reply was unusable, since it was still b
   data source is verified.
 - **Overwrite is opt-in.** It will not retire a hand-written data source unless you pass
   `--overwrites`.
+- **Examples are create-only scaffolds.** tfgen supplies a deterministic HCL example for
+  tfplugindocs, but never overwrites an existing example that a maintainer has improved.
+  If a required input or lookup shape cannot be represented completely, the RunReport
+  carries an `info` diagnostic into the generated PR for reviewer follow-up.
 
 ## Running it in a pipeline
 
@@ -165,8 +172,8 @@ draft PRs; a human records cassettes afterward.
 1. Validate arguments/environment; stop if the working tree is dirty.
 2. `make tfgen-build`.
 3. **One** expensive run on a staging branch: `tfgen generate --reconcile` (generate-all +
-   retire orphans) → `make docs` → `make build`. This proves the whole impacted set compiles
-   together. On any failure it restores the tree and stops.
+   create missing examples + retire orphans) → `make docs` → `make build`. This proves the
+   whole impacted set compiles together. On any failure it restores the tree and stops.
 4. Capture the generated docs + report, then restore the tree to base.
 5. Enforce `--max-prs`; with `--dry-run`, print the plan and stop here (no branches/PRs).
 6. **Fan out** (fail-slow — a bad artifact is recorded and skipped, never aborting the batch):

--- a/.generator-v2/scripts/generate_batch.sh
+++ b/.generator-v2/scripts/generate_batch.sh
@@ -73,7 +73,7 @@ die() {
 restore_base() {
   if [[ "${MUTATED:-0}" -eq 1 ]]; then
     git reset --hard >/dev/null 2>&1 || true
-    git clean -fdq datadog/fwprovider datadog/tests docs/data-sources >/dev/null 2>&1 || true
+    git clean -fdq datadog/fwprovider datadog/tests docs/data-sources examples/data-sources >/dev/null 2>&1 || true
   fi
   if [[ -n "${ORIG_BRANCH:-}" ]]; then
     git checkout -f "$ORIG_BRANCH" >/dev/null 2>&1 || true
@@ -295,6 +295,10 @@ mapfile -t BLOCKED  < <(ds_names retire_blocked)
 # Stage: docs — regenerate, keep only impacted pages, revert unrelated drift
 # ---------------------------------------------------------------------------
 STAGE="docs"
+for n in "${CREATED[@]}" "${UPDATED[@]}"; do
+  [[ -z "$n" ]] && continue
+  [[ -f "examples/data-sources/datadog_${n}/data-source.tf" ]] || die "tfgen produced no example for '$n'"
+done
 make docs >&2 || die "make docs failed"
 
 # Pages we intend to change: created/updated stay (present), retired stay deleted.
@@ -438,7 +442,7 @@ process_artifact() {
     err="$1"; jlog "artifact '$name' failed: $err"
     if [[ "$branch_created" -eq 1 ]]; then
       git reset --hard >/dev/null 2>&1 || true
-      git clean -fdq datadog/fwprovider datadog/tests docs/data-sources >/dev/null 2>&1 || true
+      git clean -fdq datadog/fwprovider datadog/tests docs/data-sources examples/data-sources >/dev/null 2>&1 || true
       git checkout -f "$ORIG_BRANCH" >/dev/null 2>&1 || true
       [[ "$committed" -eq 0 ]] && git branch -D "$branch" >/dev/null 2>&1 || true
     fi
@@ -474,6 +478,8 @@ process_artifact() {
     if [[ "$(jq -r '.summary.failed // 0' "$report")" != "0" ]]; then
       rm -f "$report"; pa_fail "scoped re-emit reported a failed artifact"; return 1
     fi
+    [[ -f "examples/data-sources/datadog_${name}/data-source.tf" ]] \
+      || { rm -f "$report"; pa_fail "scoped re-emit produced no example for '$name'"; return 1; }
     cp "$CAPTURE_DIR/${name}.md" "docs/data-sources/${name}.md" 2>/dev/null \
       || { rm -f "$report"; pa_fail "captured docs page missing for '$name'"; return 1; }
   fi
@@ -482,10 +488,11 @@ process_artifact() {
   local go_f="datadog/fwprovider/data_source_datadog_${name}.go"
   local test_f="datadog/tests/data_source_datadog_${name}_test.go"
   local doc_f="docs/data-sources/${name}.md"
+  local example_f="examples/data-sources/datadog_${name}/data-source.tf"
   local reg_f="datadog/fwprovider/datasources_generated.go"
   local pt_f="datadog/tests/provider_test.go"
   declare -A allow=()
-  allow["$go_f"]=1; allow["$test_f"]=1; allow["$doc_f"]=1; allow["$reg_f"]=1
+  allow["$go_f"]=1; allow["$test_f"]=1; allow["$doc_f"]=1; allow["$example_f"]=1; allow["$reg_f"]=1
   # Every action touches provider_test.go's testFiles2EndpointTags: generate adds
   # the entry, retire removes it.
   allow["$pt_f"]=1
@@ -566,7 +573,7 @@ process_artifact() {
   fi
   rm -f "$report"
 
-  git add -A "$go_f" "$test_f" "$reg_f" "$pt_f" "$doc_f" datadog/fwprovider/framework_provider.go >/dev/null 2>&1 || true
+  git add -A "$go_f" "$test_f" "$reg_f" "$pt_f" "$doc_f" "$example_f" datadog/fwprovider/framework_provider.go >/dev/null 2>&1 || true
   git commit -m "$title (generated)" >&2 || { rm -f "$body_file"; pa_fail "git commit failed"; return 1; }
   committed=1
 
@@ -592,8 +599,11 @@ process_artifact() {
 # build_generate_body — writes the add/update PR body to a temp file, prints path.
 build_generate_body() {
   local name="$1" svc="$2" action="$3" test_func="$4" test_f="$5" risk_callout="$6" bullets="$7" warn_md="$8" howto="$9"
-  local f; f="$(mktemp -t tfgen-batch-body.XXXXXX.md)"
+  local f example_line=""; f="$(mktemp -t tfgen-batch-body.XXXXXX.md)"
   local verb_lc="added"; [[ "$action" == "updated" ]] && verb_lc="updated"
+  if [[ -n "$(git status --porcelain -- "examples/data-sources/datadog_${name}/data-source.tf")" ]]; then
+    example_line="- \`examples/data-sources/datadog_${name}/data-source.tf\` — supplies the tfplugindocs example"
+  fi
   cat >"$f" <<EOF
 ${DISCLAIMER_TOP}
 
@@ -616,6 +626,7 @@ a batch that keeps the generated set in lockstep with the spec. It is registered
 ### Generated
 - \`datadog/fwprovider/data_source_datadog_${name}.go\`
 - \`datadog/tests/data_source_datadog_${name}_test.go\`
+${example_line}
 - \`datadog/fwprovider/datasources_generated.go\` — registers the constructor
 - \`datadog/tests/provider_test.go\` — registers the test's endpoint tag
 - \`docs/data-sources/${name}.md\`
@@ -639,22 +650,27 @@ EOF
 # build_retire_body — writes the retirement PR body to a temp file, prints path.
 build_retire_body() {
   local name="$1"
-  local f; f="$(mktemp -t tfgen-batch-body.XXXXXX.md)"
+  local f example_line=""; f="$(mktemp -t tfgen-batch-body.XXXXXX.md)"
+  if [[ -n "$(git status --porcelain -- "examples/data-sources/datadog_${name}/data-source.tf")" ]]; then
+    example_line="- \`examples/data-sources/datadog_${name}/data-source.tf\`"
+  fi
   cat >"$f" <<EOF
 ${DISCLAIMER_TOP}
 
 ## Retire ${name} data source (generator-v2)
 
 The \`x-datadog-tf-generator\` annotation for \`datadog_${name}\` is no longer present in the
-spec, so tfgen retired it: this PR deletes the generated data source, its test scaffold and its
-docs page, and removes the constructor from \`datasources_generated.go\`. No recorded cassette
-was found for it, so it was never verified toward release and is safe to remove.
+spec, so tfgen retired it: this PR deletes the generated data source, its test scaffold, generated
+example when present, and docs page, and removes the constructor from
+\`datasources_generated.go\`. No recorded cassette was found for it, so it was never verified
+toward release and is safe to remove.
 
 **Spec hash:** \`${SPEC_HASH:-unknown}\`
 
 ### Removed
 - \`datadog/fwprovider/data_source_datadog_${name}.go\`
 - \`datadog/tests/data_source_datadog_${name}_test.go\`
+${example_line}
 - \`datadog/fwprovider/datasources_generated.go\` — constructor removed
 - \`datadog/tests/provider_test.go\` — test's endpoint tag removed
 - \`docs/data-sources/${name}.md\`

--- a/.generator-v2/scripts/generate_headless.sh
+++ b/.generator-v2/scripts/generate_headless.sh
@@ -60,7 +60,7 @@ die() {
     # would refuse while tracked files (e.g. framework_provider.go under
     # --overwrites) are still modified, stranding us on the throwaway branch.
     git reset --hard >/dev/null 2>&1 || true
-    git clean -fdq datadog/fwprovider datadog/tests docs/data-sources >/dev/null 2>&1 || true
+    git clean -fdq datadog/fwprovider datadog/tests docs/data-sources examples/data-sources >/dev/null 2>&1 || true
     git checkout -f "${ORIG_BRANCH:-master}" >/dev/null 2>&1 || true
     git branch -D "$BRANCH" >/dev/null 2>&1 || true
   fi
@@ -345,7 +345,7 @@ if [ "$FAILED" != "0" ] || [ "$ERROR_DIAGS" != "[]" ]; then
   jlog "GATE FAILED — failed=$FAILED errors=$ERROR_DIAGS"
   # Discard partial output and drop the branch we just made.
   git checkout -- datadog/ 2>/dev/null || true
-  git clean -fdq datadog/fwprovider datadog/tests docs/data-sources 2>/dev/null || true
+  git clean -fdq datadog/fwprovider datadog/tests docs/data-sources examples/data-sources 2>/dev/null || true
   if [ "${BRANCH_CREATED:-0}" = 1 ]; then
     git checkout "${ORIG_BRANCH:-master}" >/dev/null 2>&1 || true
     git branch -D "$BRANCH" >/dev/null 2>&1 || true
@@ -367,6 +367,8 @@ jlog "gate passed (failed=0, no error diagnostics)"
 # ---------------------------------------------------------------------------
 STAGE="docs"
 DOCS_FILE="docs/data-sources/${ARTIFACT_NAME}.md"
+EXAMPLE_FILE="examples/data-sources/datadog_${ARTIFACT_NAME}/data-source.tf"
+[ -f "$EXAMPLE_FILE" ] || die "tfgen produced no $EXAMPLE_FILE"
 make docs >&2 || die "make docs failed"
 
 # tfplugindocs regenerates the WHOLE docs/ tree, so any pre-existing drift (often
@@ -401,6 +403,7 @@ declare -a ALLOWED=(
   "datadog/tests/data_source_datadog_${ARTIFACT_NAME}_test.go"
   "datadog/fwprovider/datasources_generated.go"
   "datadog/tests/provider_test.go"
+  "$EXAMPLE_FILE"
   "$DOCS_FILE"
 )
 [ -n "$OVERWRITES" ] && ALLOWED+=("datadog/fwprovider/framework_provider.go")
@@ -549,6 +552,10 @@ GEN_LIST="- \`datadog/fwprovider/data_source_datadog_${ARTIFACT_NAME}.go\`
 - \`datadog/tests/data_source_datadog_${ARTIFACT_NAME}_test.go\`
 - \`datadog/fwprovider/datasources_generated.go\` — registers the new constructor
 - \`datadog/tests/provider_test.go\` (updated) — registers the test's endpoint tag"
+if [ -n "$(git status --porcelain -- "$EXAMPLE_FILE")" ]; then
+  GEN_LIST="${GEN_LIST}
+- \`${EXAMPLE_FILE}\` — supplies the tfplugindocs example"
+fi
 if [ -n "$OVERWRITES" ]; then
   GEN_LIST="${GEN_LIST}
 - \`datadog/fwprovider/framework_provider.go\` (updated) — retired constructor removed"
@@ -621,6 +628,7 @@ git add "datadog/fwprovider/data_source_datadog_${ARTIFACT_NAME}.go" \
         "datadog/tests/data_source_datadog_${ARTIFACT_NAME}_test.go" \
         "datadog/fwprovider/datasources_generated.go" \
         "datadog/tests/provider_test.go" \
+        "$EXAMPLE_FILE" \
         "$DOCS_FILE" >&2
 [ -n "$OVERWRITES" ] && git add "datadog/fwprovider/framework_provider.go" >&2
 git commit -m "$TITLE (generated)" >&2 || die "git commit failed"

--- a/.github/workflows/tfgen-split.yml
+++ b/.github/workflows/tfgen-split.yml
@@ -363,6 +363,10 @@ jobs:
             done
             test_function="TestAccDatadog${pascal_name}DataSource"
             test_file="datadog/tests/data_source_datadog_${name}_test.go"
+            example_warnings="$(jq -r --arg name "$name" \
+              '.artifacts[] | select(.name == $name) | .diagnostics[]?
+               | select(.severity == "warning" and (.message | startswith("generated example for")))
+               | "> - " + .message' "$PLAN_PATH")"
             body_file="$(mktemp)"
             if [[ "$status" == "retired" ]]; then
               {
@@ -406,6 +410,15 @@ jobs:
           > merge until an acceptance test is recorded and replays green against the Frog org. A clean
           > build and a successful split report do **not** prove runtime correctness.
           BODY_HEADER
+              if [[ -n "$example_warnings" ]]; then
+                cat <<'EXAMPLE_WARN_HEADER'
+
+          > 🚨 **Manual `Example Usage` required — do not merge as-is.** tfgen could not render a
+          > complete example for this data source. The committed `data-source.tf` (listed below) is a
+          > placeholder; replace it with a real, working example before merging:
+          EXAMPLE_WARN_HEADER
+                printf '%s\n' "$example_warnings"
+              fi
               printf '\n## %s data source (generator-v2)\n\n' "$name"
               printf 'This data source was %s by tfgen and routed from an aggregate upstream generation run.\n' "$status"
               printf 'The split, documentation generation, and compile/format gate completed successfully.\n\n'


### PR DESCRIPTION
### Motivation

Generated data sources previously shipped without an `Example Usage` block, and
plural / all-optional shapes in particular rendered an empty `data "x" "example" {}`
in the docs. This branch teaches tfgen to emit a deterministic, per-data-source
HCL example that `tfplugindocs` consumes, and — where an accurate example can't be
fully synthesized — to record a diagnostic that CI escalates into a "manual example
required" banner on the generated PR, so an incomplete example is never merged
silently.

### Changes

- **Example rendering (`internal/emit/example_render.go`, new)**
  - `RenderDataSourceExample` produces a deterministic HCL scaffold per data source:
    by-ID singular uses the conventional example UUID, search-only singular emits its
    scalar filters, and every shape includes required scalar attributes.
  - All-optional plural shapes (which otherwise collect no inputs) auto-select the
    first renderable optional scalar filter — capped at one, in schema order — so the
    example is illustrative rather than empty, and flag the choice with an `info`
    "confirm this is representative" diagnostic.
  - Cases it cannot represent (unsupported required attribute/block type, singular
    with no by-ID/search resolution, plural with no renderable scalar) emit a
    `warning`-severity diagnostic and fall back to an empty block.
  - `hclExampleValue` maps scalar framework types to stable literals; non-scalars
    are unsupported by design.
- **Generate wiring (`internal/cli/generate.go`)**
  - `emitDatasourceExample` writes `examples/data-sources/datadog_<name>/data-source.tf`
    via `WriteFileIfAbsent` (create-only: hand-written/improved examples are preserved).
    Example diagnostics are attached to the artifact's report entry only when the file
    is actually written, so preserved examples don't re-warn.
  - New `--examples-output-root` flag (default `examples/data-sources`); examples are
    emitted on every run (independent of `--emit-tests`).
- **Retire / reconcile (`internal/cli/reconcile.go`)**
  - Retirement now also deletes the artifact's example file, plus `removeDirIfEmpty`
    to clean up the per-artifact example directory without removing maintainer-placed
    sidecar files. Threaded through `reconcileOrphans` and the retire path.
- **Required query parameters (`internal/model/artifact.go`)**
  - `buildFilterLeaves` now surfaces required query params (which the SDK-call binding
    can only represent as optional TF filters) with an `info` diagnostic, and labels
    dropped array/enum params as "required" in their diagnostic when applicable.
- **Test scaffold (`internal/emit/test_render.go`)**
  - Acceptance-test scaffolds now seed required scalar attributes in addition to
    optional ones.
- **Per-artifact split (`internal/split/split.go`)**
  - Adds `examples/data-sources` to the diff scopes, a `kindDataSourceExample` file
    kind, and routing so an example file travels with its artifact bundle — including
    example-only rollouts (routed as `updated` when the source is unchanged),
    retirements, and fail-loud on unrecognized files in the examples scope.
- **CI (`.github/workflows/tfgen-split.yml`)**
  - Injects a 🚨 **"Manual `Example Usage` required — do not merge as-is"** block into
    the generated PR body when an artifact carries `warning`-severity example
    diagnostics.
- **Headless pipeline (`.generator-v2/scripts/`)**
  - `generate_batch.sh` / `generate_headless.sh`: include the example path in
    clean-up scopes, allow-lists, git adds, and PR-body "Generated"/"Removed" file
    lists; fail if tfgen produced no example for a created/updated artifact.
  - `README.md` documents examples as create-only scaffolds and the incomplete-example
    diagnostic behavior.

### Test

- **Ginkgo / unit suites** (all green via `make tfgen-test -race`):
  - `example_render_test.go` (new): by-ID, search-only, plural auto-pick, empty-block
    -with-warning, type-appropriate placeholders, required-input reporting,
    unrenderable-input reporting, and byte-determinism.
  - `generate_test.go`: emits-and-preserves-on-regen, `--check` reports a missing
    example without writing it, and the incomplete-scaffold diagnostic surfaces on
    first write but not on a preserved (skipped) example.
  - `reconcile_test.go`: example deleted on retire, non-empty example dir preserved,
    example kept when retirement is blocked, and orphan reconcile removes the example.
  - `split_test.go`: example routed with its bundle, example-only update, retirement
    removes the example, and fail-loud on an unrecognized examples-scope file.
  - `artifact_test.go`: required query params reported as optional filters; dropped
    required params labeled in their diagnostic.
- **Generated artifacts are not exercised by the generation flow.** Per this repo's
  convention, generated data sources are validated only by compile/format/`make docs`
  gates; cassettes and acceptance tests are recorded separately by a human reviewer
  against the Frog org. No cassettes are included in this branch.