### PR TITLE
[Tfgen] Artifact go format scope fixes

### DIFF
--- a/.github/workflows/tfgen-split.yml
+++ b/.github/workflows/tfgen-split.yml
@@ -51,6 +51,12 @@ jobs:
           terraform_version: "1.13.1"
           terraform_wrapper: false
 
+      # make build -> fmtcheck relies on goimports; without it the Go format
+      # check silently no-ops.
+      - name: Install goimports
+        shell: bash
+        run: go install golang.org/x/tools/cmd/goimports@latest
+
       - name: Build tfgen and split the incoming branch
         id: split
         working-directory: generated
@@ -300,10 +306,17 @@ jobs:
               rm -f "$doc_copy"
             fi
 
+            # Scope the format gate to this artifact's own files so unrelated
+            # pre-existing drift elsewhere in the repo can't fail the build.
+            # The compile step stays whole-repo.
+            FMTCHECK_SCOPE="$(printf '%s\n' "${files[@]}")"
+            export FMTCHECK_SCOPE
             if ! make build; then
+              unset FMTCHECK_SCOPE
               record_failure "$name" "make build failed"
               continue
             fi
+            unset FMTCHECK_SCOPE
 
             declare -A allowed=()
             for rel in "${files[@]}"; do

--- a/scripts/fmtcheck.sh
+++ b/scripts/fmtcheck.sh
@@ -4,24 +4,47 @@ EXIT_CODE=0
 
 set -o pipefail
 
+# By default fmtcheck validates the whole repository. When FMTCHECK_SCOPE is
+# set (a newline-separated list of files), only those files are checked so a
+# per-artifact caller isn't failed by unrelated formatting drift elsewhere.
+go_files=()
+tf_files=()
+if [[ -n ${FMTCHECK_SCOPE:-} ]]; then
+    while IFS= read -r scoped_file; do
+        [[ -z ${scoped_file} ]] && continue
+        case "${scoped_file}" in
+            *.go) go_files+=("${scoped_file}") ;;
+            *.tf | *.tfvars | *.tftest.hcl) tf_files+=("${scoped_file}") ;;
+        esac
+    done <<< "${FMTCHECK_SCOPE}"
+else
+    while IFS= read -r go_file; do
+        go_files+=("${go_file}")
+    done < <(find . -name '*.go' | grep -v vendor)
+    tf_files=(examples)
+fi
+
 # Check goimports
-echo "==> Checking that code complies with goimports requirements..."
-goimports_files=$(goimports -format-only -d -l $(find . -name '*.go' | grep -v vendor))
-if [[ -n ${goimports_files} ]]; then
-    echo 'gofmt needs running on the following files:'
-    echo "${goimports_files}"
-    echo "You can use the command: \`make fmt\` to reformat code."
-    EXIT_CODE=1
+if [[ ${#go_files[@]} -gt 0 ]]; then
+    echo "==> Checking that code complies with goimports requirements..."
+    goimports_files=$(goimports -format-only -d -l "${go_files[@]}")
+    if [[ -n ${goimports_files} ]]; then
+        echo 'gofmt needs running on the following files:'
+        echo "${goimports_files}"
+        echo "You can use the command: \`make fmt\` to reformat code."
+        EXIT_CODE=1
+    fi
 fi
 
 # Check the example terraform files pass terraform fmt
-echo "==> Checking that examples pass with terraform fmt requirements"
-terraform_fmt=$(terraform fmt -recursive -check -diff examples 2>&1)
-if [[ $? -ne 0 ]]; then
-    echo "Files in the \`example\` folder aren't terraform formatted"
-    echo "You can use the command \`make fmt\` to reformat the following:"
-    echo "${terraform_fmt}"
-    EXIT_CODE=2
+if [[ ${#tf_files[@]} -gt 0 ]]; then
+    echo "==> Checking that examples pass with terraform fmt requirements"
+    if ! terraform_fmt=$(terraform fmt -recursive -check -diff "${tf_files[@]}" 2>&1); then
+        echo "Files in the \`example\` folder aren't terraform formatted"
+        echo "You can use the command \`make fmt\` to reformat the following:"
+        echo "${terraform_fmt}"
+        EXIT_CODE=2
+    fi
 fi
 
 exit $EXIT_CODE


### PR DESCRIPTION
### Motivation
The `tfgen Split` workflow fans an aggregate generated branch into per-artifact
draft PRs, running `make build` as a gate for each artifact. Because `make build`
depends on `fmtcheck`, and `scripts/fmtcheck.sh` checks the *entire* repository,
any unrelated pre-existing formatting drift on `master` fails an artifact that
never touched the offending file (e.g. run `29763220668` failed the `datastores`
artifact on an unrelated `datadog_agentless_scanning_azure_scan_options` example).
Compounding this, the split runner never installs `goimports`, so the Go half of
`fmtcheck.sh` silently no-ops — the Go formatting gate effectively wasn't running.
This scopes the per-artifact format check to the artifact's own generated files
and makes the Go check actually run.

### Changes
- **`scripts/fmtcheck.sh` — optional artifact scope**
  - Added support for a `FMTCHECK_SCOPE` env var (newline-separated file list).
    When set, only those files are checked; when unset, whole-repo behavior is
    preserved unchanged, so local `make build` and all existing callers are
    unaffected.
  - Scoped files are split by extension: `.go` → `goimports`, and
    `.tf`/`.tfvars`/`.tftest.hcl` → `terraform fmt`. Each check is skipped when
    its file list is empty.
  - Kept the default whole-repo path bash 3.2-compatible by replacing the
    inlined `find` word-splitting with a `while read` loop into an array (no
    `mapfile`, which macOS's default bash lacks).
  - Cleaned up the inherited `if [[ $? -ne 0 ]]` on the terraform check into a
    direct `if ! terraform_fmt=$(...)` (SC2181).
- **`.github/workflows/tfgen-split.yml` — install goimports + drive the scope**
  - Added an `Install goimports` step (`go install .../goimports@latest`, mirroring
    the repo's `get-test-deps` pattern) after Go/Terraform setup so the Go format
    check actually executes instead of printing `goimports: command not found`.
  - Set `FMTCHECK_SCOPE` from the artifact's own `files` array immediately before
    `make build`, and `unset` it afterward (including on the failure path). The
    compile step (`go install` via `make build`) intentionally stays whole-repo.

### Test
No automated test files are part of this change. Verified manually against the
local checkout:
- Scoped clean `.go`/`.tf` files → exit 0; scoped badly-formatted `.go` → exit 1
  (confirms the scoped gate is meaningful).
- A scope excluding the pre-existing `datadog_agentless_scanning_azure_scan_options`
  example drift → passes, while the default whole-repo run still exits non-zero on
  that same drift (confirms default behavior is unchanged).
- Confirmed `FMTCHECK_SCOPE` propagates through `make fmtcheck` → `sh -c` → the
  script, and that the default path runs the Go check under bash 3.2 (no
  `mapfile: command not found`).
- Workflow YAML validated as parseable; `fmtcheck.sh` passes shellcheck.

The end-to-end split workflow itself (re-running for `datadog-api-spec/generated/6120`)
has not been exercised here — that runs in CI against the generated branch.