### PR TITLE
Fix terraform formatting, and run in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,8 @@ jobs:
           terraform_wrapper: false
       - name: Check Docs Are Up To Date
         run: make check-docs
+      - name: Run make fmtcheck
+        run: make fmtcheck
 
   # Unit tests don't touch the API, use no cassettes, and need no terraform binary,
   # so they run once here rather than being sharded across the version matrix. They

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -72,7 +72,7 @@ vet:
 
 fmt:
 	goimports -format-only -local $(LOCAL_PACKAGE) -w $(GOIMPORTS_FILES)
-	terraform fmt -recursive examples
+	terraform fmt -recursive
 
 fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/fmtcheck.sh'"

--- a/datadog/tests/resource_datadog_on_call_escalation_policy_test.tf
+++ b/datadog/tests/resource_datadog_on_call_escalation_policy_test.tf
@@ -51,7 +51,7 @@ resource "datadog_on_call_escalation_policy" "policy_test" {
   step {
     escalate_after_seconds = 600
     target {
-      schedule          = datadog_on_call_schedule.schedule.id
+      schedule = datadog_on_call_schedule.schedule.id
       position = "next"
     }
   }

--- a/datadog/tests/resource_datadog_on_call_team_routing_rules_test.tf
+++ b/datadog/tests/resource_datadog_on_call_team_routing_rules_test.tf
@@ -49,11 +49,11 @@ resource "datadog_workflow_automation" "team_rules_test" {
 }
 
 resource "datadog_on_call_escalation_policy" "team_rules_test" {
-  name                        = "POLICY_NAME"
+  name                       = "POLICY_NAME"
   resolve_page_on_policy_end = true
-  retries = 3
+  retries                    = 3
   step {
-    assignment = "round-robin"
+    assignment             = "round-robin"
     escalate_after_seconds = 300
     target {
       team = datadog_team.team_rules_test.id
@@ -92,16 +92,16 @@ resource "datadog_on_call_team_routing_rules" "team_rules_test" {
     query = "tags.service:payment"
     action {
       escalation_policy {
-        policy_id = datadog_on_call_escalation_policy.team_rules_test.id
+        policy_id           = datadog_on_call_escalation_policy.team_rules_test.id
         ack_timeout_minutes = 30
-        urgency = "low"
+        urgency             = "low"
         support_hours {
           time_zone = "America/New_York"
           restriction {
-            start_day = "monday"
+            start_day  = "monday"
             start_time = "09:00:00"
-            end_day = "friday"
-            end_time = "17:00:00"
+            end_day    = "friday"
+            end_time   = "17:00:00"
           }
           restriction {
             start_day  = "tuesday"
@@ -134,6 +134,6 @@ resource "datadog_on_call_team_routing_rules" "team_rules_test" {
 
   rule {
     escalation_policy = datadog_on_call_escalation_policy.team_rules_test.id
-    urgency = "dynamic"
+    urgency           = "dynamic"
   }
 }

--- a/datadog/tests/resource_datadog_on_call_user_email_notification_rule_test.tf
+++ b/datadog/tests/resource_datadog_on_call_user_email_notification_rule_test.tf
@@ -13,10 +13,10 @@ resource "datadog_on_call_user_notification_channel" "on_call_user_email_rule_te
 }
 
 resource "datadog_on_call_user_notification_rule" "on_call_user_email_rule_test" {
-  user_id = datadog_user.on_call_user_email_rule_test.id
+  user_id    = datadog_user.on_call_user_email_rule_test.id
   channel_id = datadog_on_call_user_notification_channel.on_call_user_email_rule_test.id
 
-  category = "high_urgency"
+  category      = "high_urgency"
   delay_minutes = DELAY_MINUTES
 }
 

--- a/datadog/tests/resource_datadog_on_call_user_phone_notification_rule_test.tf
+++ b/datadog/tests/resource_datadog_on_call_user_phone_notification_rule_test.tf
@@ -12,10 +12,10 @@ resource "datadog_on_call_user_notification_channel" "on_call_user_phone_rule_te
 }
 
 resource "datadog_on_call_user_notification_rule" "on_call_user_phone_rule_test" {
-  user_id = datadog_user.on_call_user_phone_rule_test.id
+  user_id    = datadog_user.on_call_user_phone_rule_test.id
   channel_id = datadog_on_call_user_notification_channel.on_call_user_phone_rule_test.id
 
-  category = "high_urgency"
+  category      = "high_urgency"
   delay_minutes = 1
   phone {
     method = "voice"

--- a/docs/resources/agentless_scanning_azure_scan_options.md
+++ b/docs/resources/agentless_scanning_azure_scan_options.md
@@ -16,9 +16,9 @@ Provides a Datadog Agentless Scanning Azure scan options resource. This can be u
 # Configure agentless scanning for an Azure subscription
 resource "datadog_agentless_scanning_azure_scan_options" "example" {
   azure_subscription_id = "12345678-1234-1234-1234-123456789012"
-  function               = true
-  vuln_containers_os     = true
-  vuln_host_os           = true
+  function              = true
+  vuln_containers_os    = true
+  vuln_host_os          = true
   # compliance_host  = true  # Optional. Defaults to false. Enables host compliance benchmark scanning.
 }
 ```

--- a/examples/resources/datadog_agentless_scanning_azure_scan_options/resource.tf
+++ b/examples/resources/datadog_agentless_scanning_azure_scan_options/resource.tf
@@ -1,8 +1,8 @@
 # Configure agentless scanning for an Azure subscription
 resource "datadog_agentless_scanning_azure_scan_options" "example" {
   azure_subscription_id = "12345678-1234-1234-1234-123456789012"
-  function               = true
-  vuln_containers_os     = true
-  vuln_host_os           = true
+  function              = true
+  vuln_containers_os    = true
+  vuln_host_os          = true
   # compliance_host  = true  # Optional. Defaults to false. Enables host compliance benchmark scanning.
 }

--- a/scripts/fmtcheck.sh
+++ b/scripts/fmtcheck.sh
@@ -14,11 +14,10 @@ if [[ -n ${goimports_files} ]]; then
     EXIT_CODE=1
 fi
 
-# Check the example terraform files pass terraform fmt
-echo "==> Checking that examples pass with terraform fmt requirements"
-terraform_fmt=$(terraform fmt -recursive -check -diff examples 2>&1)
+echo "==> Checking that terraform fmt passes"
+terraform_fmt=$(terraform fmt -recursive -check -diff 2>&1)
 if [[ $? -ne 0 ]]; then
-    echo "Files in the \`example\` folder aren't terraform formatted"
+    echo "Files aren't terraform formatted"
     echo "You can use the command \`make fmt\` to reformat the following:"
     echo "${terraform_fmt}"
     EXIT_CODE=2


### PR DESCRIPTION
### Motivation

The repo's `terraform fmt` enforcement only covered the `examples` directory, so
Terraform files elsewhere (notably the `.tf` fixtures under `datadog/tests`)
could drift out of formatting without CI catching it. This PR broadens formatting
to the whole repo, fixes the files that were already unformatted, and wires the
check into CI so formatting regressions are caught automatically.

### Changes

- **Formatting scope broadened to the whole repo**
  - `GNUmakefile`: `make fmt` now runs `terraform fmt -recursive` (no longer scoped to `examples`).
  - `scripts/fmtcheck.sh`: the check now runs `terraform fmt -recursive -check -diff` across the repo instead of just `examples`, with updated messaging ("Files aren't terraform formatted").
- **CI enforcement**
  - `.github/workflows/test.yml`: added a `Run make fmtcheck` step so formatting is verified on every run.
- **Reformatted Terraform files** (alignment of `=` assignments to satisfy `terraform fmt`)
  - `examples/resources/datadog_agentless_scanning_azure_scan_options/resource.tf`
  - `datadog/tests/resource_datadog_on_call_escalation_policy_test.tf`
  - `datadog/tests/resource_datadog_on_call_team_routing_rules_test.tf`
  - `datadog/tests/resource_datadog_on_call_user_email_notification_rule_test.tf`
  - `datadog/tests/resource_datadog_on_call_user_phone_notification_rule_test.tf`

### Test

- No new automated tests; changes are formatting-only plus tooling/CI config.
- Correctness is self-verifying: the reformatted files are exactly what
  `terraform fmt` produces, and the new `make fmtcheck` CI step will fail if any
  Terraform file in the repo is unformatted.
- Verified by running `make fmt` / `make fmtcheck` locally (per the commits
  "make fmt run" and "terraform format all terraform").