### PR TITLE
Fix toplist formula sort zero index

### DIFF
--- a/datadog/dashboardmapping/engine.go
+++ b/datadog/dashboardmapping/engine.go
@@ -2093,9 +2093,9 @@ func buildWidgetSortByJSONFromMap(sortMap map[string]interface{}) map[string]int
 			entry := map[string]interface{}{}
 			if fsMap := getBlockFromMap(obMap, "formula_sort"); fsMap != nil {
 				entry["type"] = "formula"
-				if idx := getIntFromMap(fsMap, "index"); idx != 0 {
-					entry["index"] = idx
-				}
+				// index is a required field and 0 (the first/only formula) is a valid
+				// value, so it must always be set rather than treated as "unset".
+				entry["index"] = getIntFromMap(fsMap, "index")
 				if ord := getStringFromMap(fsMap, "order"); ord != "" {
 					entry["order"] = ord
 				}

--- a/datadog/dashboardmapping/engine_sort_test.go
+++ b/datadog/dashboardmapping/engine_sort_test.go
@@ -1,0 +1,69 @@
+package dashboardmapping
+
+import "testing"
+
+// TestBuildWidgetSortByJSONFromMap_PreservesZeroFormulaIndex guards against a
+// regression where formula_sort.index == 0 (the first/only formula, the most
+// common case) was dropped from the built JSON because it was mistaken for
+// "unset" rather than a valid required value.
+func TestBuildWidgetSortByJSONFromMap_PreservesZeroFormulaIndex(t *testing.T) {
+	sortMap := map[string]interface{}{
+		"count": 10,
+		"order_by": []interface{}{
+			map[string]interface{}{
+				"formula_sort": []interface{}{
+					map[string]interface{}{
+						"index": 0,
+						"order": "desc",
+					},
+				},
+			},
+		},
+	}
+
+	result := buildWidgetSortByJSONFromMap(sortMap)
+
+	orderBy, ok := result["order_by"].([]interface{})
+	if !ok || len(orderBy) != 1 {
+		t.Fatalf("expected one order_by entry, got: %#v", result["order_by"])
+	}
+	entry, ok := orderBy[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected order_by entry to be a map, got: %T", orderBy[0])
+	}
+	if entry["type"] != "formula" {
+		t.Errorf("expected type=formula, got %v", entry["type"])
+	}
+	if idx, ok := entry["index"]; !ok || idx != 0 {
+		t.Errorf("expected index=0 to be present, got %#v (present: %v)", idx, ok)
+	}
+	if entry["order"] != "desc" {
+		t.Errorf("expected order=desc, got %v", entry["order"])
+	}
+}
+
+// TestBuildWidgetSortByJSONFromMap_PreservesNonZeroFormulaIndex is the
+// non-zero counterpart, verifying the fix didn't change behavior for indexes
+// that were already serialized correctly.
+func TestBuildWidgetSortByJSONFromMap_PreservesNonZeroFormulaIndex(t *testing.T) {
+	sortMap := map[string]interface{}{
+		"order_by": []interface{}{
+			map[string]interface{}{
+				"formula_sort": []interface{}{
+					map[string]interface{}{
+						"index": 2,
+						"order": "asc",
+					},
+				},
+			},
+		},
+	}
+
+	result := buildWidgetSortByJSONFromMap(sortMap)
+
+	orderBy := result["order_by"].([]interface{})
+	entry := orderBy[0].(map[string]interface{})
+	if entry["index"] != 2 {
+		t.Errorf("expected index=2, got %#v", entry["index"])
+	}
+}


### PR DESCRIPTION
**Summary**
- `buildWidgetSortByJSONFromMap` only serialized `formula_sort.index` into the outgoing API JSON when it was non-zero. Since index is a required field, this silently dropped index whenever a toplist/sunburst/treemap/bar_chart widget sorted by its first formula.
- Without index, Datadog's API can no longer identify the order_by entry as a valid formula sort and rejects the dashboard update with: `Bad Request: attribute "order_by" one of formula_name or group_by must be provided.`

**Fix**
Always serialize index regardless of value, matching how order/type are already always required. 

**Test plan**
- [x] Added engine_sort_test.go with a regression test asserting index=0 is preserved in the built JSON, plus a non-zero case confirming unchanged behavior.
- [x] go test ./datadog/dashboardmapping/... passes (22 tests).
- [x] go build ./... succeeds.
