### PR TITLE
ci(release): configure internal mirror for Go download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
           go-version: "1.23"
+          go-download-base-url: "https://depot-read-api-github-releases.us1.ddbuild.io/internal/mirror/github-releases"
       - name: Import GPG key
         id: import_gpg
         uses: paultyng/ghaction-import-gpg@53deb67fe3b05af114ad9488a4da7b782455d588


### PR DESCRIPTION
https://github.com/actions/setup-go step supports downloading Go from custom sources via the `go-download-base-url` input. This PR updates [release workflow](../blob/97fa5edf5418f789b5da5bf4a04e6743242d967b/.github/workflows/release.yml) to point it at Datadog's internal GitHub-releases mirror instead of go.dev/GitHub directly.