### PR TITLE
ci (APIR-3123): default release to shared runner, add manual self-hosted release

### DIFF
--- a/.github/chainguard/self.release.create-release-self-hosted.sts.yaml
+++ b/.github/chainguard/self.release.create-release-self-hosted.sts.yaml
@@ -1,0 +1,13 @@
+---
+# Policy for: .github/workflows/release_self_hosted.yml in DataDog/terraform-provider-datadog
+# Allows the manually-dispatched self-hosted release workflow to create tags and GitHub releases
+issuer: https://token.actions.githubusercontent.com
+subject: repo:DataDog/terraform-provider-datadog:environment:release
+
+claim_pattern:
+  event_name: workflow_dispatch
+  job_workflow_ref: DataDog/terraform-provider-datadog/\.github/workflows/release_self_hosted\.yml@refs/heads/(master|v3)
+  repository: DataDog/terraform-provider-datadog
+
+permissions:
+  contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,14 +16,9 @@ on:
 jobs:
   create_release:
     name: Create release
-    runs-on: ubuntu-latest-self-hosted
+    runs-on: ubuntu-16-core-latest
     environment: release
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
-    env:
-      # Exact Go version to build the release with. Must be a full patch version
-      # (the internal mirror has no manifest to resolve "1.23" -> "1.23.x") and
-      # must satisfy go.mod's `go` directive (currently 1.25.8).
-      GO_VERSION: "1.25.12"
     steps:
       - name: Get GitHub App token
         id: get_token
@@ -57,15 +52,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "${{ env.GO_VERSION }}"
-          # This job runs on a self-hosted runner with no github.com / go.dev
-          # egress, so Go is pulled from Datadog's internal magicmirror. The
-          # mirror has no version index, so setup-go's listing probe 404s and it
-          # falls back to constructing the download URL as
-          # `${go-download-base-url}/go${go-version}.linux-amd64.tar.gz`. The
-          # mirror nests each release under a `go<version>/` directory, so the
-          # base URL must include it — hence GO_VERSION appears in both inputs.
-          go-download-base-url: "https://depot-read-api-generic.us1.ddbuild.io/magicmirror/magicmirror/@current/runtime/go/go${{ env.GO_VERSION }}"
+          # Shared runner has public egress, so Go is resolved and downloaded
+          # from go.dev. Track the minor line; must satisfy go.mod's `go`
+          # directive (currently 1.25.8).
+          go-version: "1.25"
       - name: Import GPG key
         id: import_gpg
         uses: paultyng/ghaction-import-gpg@53deb67fe3b05af114ad9488a4da7b782455d588

--- a/.github/workflows/release_self_hosted.yml
+++ b/.github/workflows/release_self_hosted.yml
@@ -1,0 +1,88 @@
+# Manually triggered variant of release.yml that runs on a self-hosted runner.
+# Kept as a separate workflow (rather than parameterizing release.yml) while
+# self-hosted runners are still in alpha and the definition is expected to
+# diverge with networking workarounds.
+name: release (self-hosted)
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write # Required for dd-octo-sts action
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version number to tag/release (e.g. '3.45.0', without the 'v' prefix)"
+        required: true
+      ref:
+        description: "Commit SHA to tag and release"
+        required: true
+
+jobs:
+  create_release:
+    name: Create release
+    runs-on: ubuntu-latest-self-hosted
+    environment: release
+    env:
+      # Exact Go version to build the release with. Must be a full patch version
+      # (the internal mirror has no manifest to resolve "1.25" -> "1.25.x") and
+      # must satisfy go.mod's `go` directive (currently 1.25.8).
+      GO_VERSION: "1.25.12"
+    steps:
+      - name: Get GitHub App token
+        id: get_token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/terraform-provider-datadog
+          policy: self.release.create-release-self-hosted
+          pool_name: dd-api-reliability
+      - name: Create tag
+        id: create_tag
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.version }}
+          RELEASE_REF: ${{ github.event.inputs.ref }}
+        with:
+          github-token: ${{ steps.get_token.outputs.token }}
+          script: |
+            const tagName = `v${process.env.RELEASE_VERSION}`;
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/${tagName}`,
+              sha: process.env.RELEASE_REF,
+            });
+            core.setOutput("tag_name", tagName);
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        with:
+          ref: ${{ steps.create_tag.outputs.tag_name }}
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+          # This job runs on a self-hosted runner with no github.com / go.dev
+          # egress, so Go is pulled from Datadog's internal magicmirror. The
+          # mirror has no version index, so setup-go's listing probe 404s and it
+          # falls back to constructing the download URL as
+          # `${go-download-base-url}/go${go-version}.linux-amd64.tar.gz`. The
+          # mirror nests each release under a `go<version>/` directory, so the
+          # base URL must include it — hence GO_VERSION appears in both inputs.
+          go-download-base-url: "https://depot-read-api-generic.us1.ddbuild.io/magicmirror/magicmirror/@current/runtime/go/go${{ env.GO_VERSION }}"
+      - name: Import GPG key
+        id: import_gpg
+        uses: paultyng/ghaction-import-gpg@53deb67fe3b05af114ad9488a4da7b782455d588
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@b953231f81b8dfd023c58e0854a721e35037f28b
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation

Cutting a provider release on the shared GitHub-hosted runner has been unreliable — the release job can't complete consistently, most likely due to resource pressure, and we have no monitoring on those runners. CI Infra is starting to provide self-hosted runners, but they are still in alpha with meaningful networking gaps (e.g. pulling Go images, reaching dd-octo-sts). We don't want to commit exclusively to either path while both are shaky. This gives us both on demand: the reliable-enough default plus a manual self-hosted escape hatch.

## Overview of changes

The automatic release (triggered on release-PR merge) goes back to running on the most powerful shared runner, restoring the last known-good setup after the recent switch to self-hosted.

A separate, manually-dispatched release workflow is added that runs the same release steps on a self-hosted runner, taking the version and commit ref as inputs. It creates the release tag (and, like the automatic job, fails if the tag already exists) before building and publishing with GoReleaser. It is kept as its own workflow — rather than parameterizing the existing one — so it can diverge with self-hosted-specific workarounds while those runners mature. It authenticates through its own dedicated dd-octo-sts policy scoped to `workflow_dispatch` from this new workflow, since the existing release policy only authorizes the `pull_request`-triggered workflow.

## Validation

- `actionlint` passes on both workflows (only the expected "unknown custom runner label" warnings for the self-hosted / large-runner labels).
- End-to-end, once merged: trigger the "release (self-hosted)" workflow from the Actions tab with a version and commit ref, and confirm it lands on a self-hosted runner, mints the dd-octo-sts token via the new policy, creates the tag, imports the GPG key, and publishes the release via GoReleaser. Confirm the automatic release still runs on the shared runner on the next normal release-PR merge.