### PR TITLE
ci: Skip acceptance test matrices on changelog-only PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Detects whether a PR changes anything other than CHANGELOG.md, so the
+  # acceptance-test matrices can be skipped on changelog-only PRs (e.g. the
+  # automated release PR). Only runs for pull_request events; on schedule/push
+  # it is skipped and its empty `code` output leaves the matrices running.
+  changes:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        with:
+          fetch-depth: 0
+      - name: Detect non-changelog changes
+        id: filter
+        run: |
+          files=$(git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}")
+          echo "Changed files:"
+          echo "$files"
+          if echo "$files" | grep -qvE '^CHANGELOG\.md$'; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
   pre-commit:
     runs-on: ubuntu-latest
     if: (github.event.action != 'closed' && github.event.pull_request.merged != true) || github.event_name == 'schedule'
@@ -96,6 +122,11 @@ jobs:
         run: make test
 
   test:
+    needs: changes
+    # Skip on changelog-only PRs. !cancelled() drops the implicit success()
+    # gate on `changes` so schedule/push runs (where `changes` is skipped and
+    # `code` is empty) still execute the matrix.
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
     strategy:
       fail-fast: false
       matrix:
@@ -136,6 +167,9 @@ jobs:
           DD_TERRAFORM_DATABRICKS_INTEGRATION_ENABLED: "true"
 
   test-tofu:
+    needs: changes
+    # See the `test` job: skip on changelog-only PRs, still run on schedule/push.
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
     strategy:
       fail-fast: false
       matrix:
@@ -178,12 +212,12 @@ jobs:
   # Final job for branch protection rules - depends on all other jobs
   all-checks:
     runs-on: ubuntu-latest
-    needs: [linter-checks, unit-tests, test, test-tofu]
+    needs: [changes, linter-checks, unit-tests, test, test-tofu]
     if: always()
     steps:
       - name: Check all jobs passed
         run: |
-          results="${{ needs.linter-checks.result }} ${{ needs.unit-tests.result }} ${{ needs.test.result }} ${{ needs.test-tofu.result }}"
+          results="${{ needs.changes.result }} ${{ needs.linter-checks.result }} ${{ needs.unit-tests.result }} ${{ needs.test.result }} ${{ needs.test-tofu.result }}"
           for result in $results; do
             if [[ "$result" != "success" && "$result" != "skipped" ]]; then
               echo "One or more jobs failed or were cancelled"


### PR DESCRIPTION
## Motivation

The "Prepare release" workflow opens a PR that only updates `CHANGELOG.md`. Despite touching nothing else, that PR triggers the full sharded acceptance-test matrices in the Run Tests workflow, wasting CI and humans time on a change that cannot affect any test, delaying the release process for no good reason.

## Overview of changes

Diffs a pull request against its base and reports whether anything other than `CHANGELOG.md` changed, skipping the two acceptance-test matrices based on that result. 

* Scheduled and merge-queue push runs are unaffected and always run the full matrices.
* Unit tests, linters, and pre-commit continue to run on every PR.

## Validation

- Changelog-only PR (this behavior mirrors the release PR): the acceptance matrices should show as skipped, and the required `all-checks` job should still succeed.
- A PR touching any non-changelog file: both matrices run as before.
- Scheduled and `mq-working-branch-*` push runs: matrices run (detector is skipped, empty output leaves them enabled).

APIR-3124