### PR TITLE
Update actions/setup-go to v7.0.0 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Set up Go
-        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.23"
           go-download-base-url: "https://depot-read-api-github-releases.us1.ddbuild.io/internal/mirror/github-releases"


### PR DESCRIPTION
The `actions/setup-go` action used in the release workflow was pinned to an old SHA. v7.0.0 is the latest release which supports the custom url for downloading the go image.

Bumps the pinned SHA from `93397bea11091df50f3d7e59dc26a7711a8bcfbe` to `b7ad1dad31e06c5925ef5d2fc7ad053ef454303e` (v7.0.0).

Verify the release workflow runs correctly on the next release cut.