### PR TITLE
ci (APIR-3124): treat empty PR diff as changelog-only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,12 @@ jobs:
           files=$(git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}")
           echo "Changed files:"
           echo "$files"
-          if echo "$files" | grep -qvE '^CHANGELOG\.md$'; then
+          # An empty diff (net-zero change, e.g. a commit reverting an earlier
+          # one) means no code changed, so skip. Guarding this before the grep
+          # avoids echo's blank line being counted as a non-changelog file.
+          if [ -z "$files" ]; then
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          elif echo "$files" | grep -qvE '^CHANGELOG\.md$'; then
             echo "code=true" >> "$GITHUB_OUTPUT"
           else
             echo "code=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Motivation

The changelog-only skip added in #4031 still ran the full acceptance matrices on the automated release PR (#4032). The release PR's second commit reverted content from its first, leaving the PR net-identical to master — so `git diff base...head` listed no files at all. The gate treated that empty list as "has code changes" and ran everything.

## Overview of changes

The detection step's `grep` was fed through `echo`, which emits a blank line for an empty diff; that blank line fails the `CHANGELOG.md` match and flipped the gate to run tests. An empty diff now short-circuits to skip before reaching the grep, since a net-zero change has nothing worth testing. Changelog-only, code-only, and mixed PRs are unaffected.

## Validation

Confirmed the four cases (empty, changelog-only, code-only, mixed) produce the intended skip/run decisions with the new guard. The real fix is observable on a changelog-only release PR: the `test` and `test-tofu` matrices should report skipped while `changes` passes.