### PR TITLE
Pull release Go from internal magicmirror

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,6 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.23"
-          go-download-base-url: "https://depot-read-api-github-releases.us1.ddbuild.io/internal/mirror/github-releases/actions/go-versions/releases/download"
       - name: Import GPG key
         id: import_gpg
         uses: paultyng/ghaction-import-gpg@53deb67fe3b05af114ad9488a4da7b782455d588

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ jobs:
     runs-on: ubuntu-latest-self-hosted
     environment: release
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
+    env:
+      # Exact Go version to build the release with. Must be a full patch version
+      # (the internal mirror has no manifest to resolve "1.23" -> "1.23.x") and
+      # must satisfy go.mod's `go` directive (currently 1.25.8).
+      GO_VERSION: "1.25.12"
     steps:
       - name: Get GitHub App token
         id: get_token
@@ -52,7 +57,15 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.23"
+          go-version: "${{ env.GO_VERSION }}"
+          # This job runs on a self-hosted runner with no github.com / go.dev
+          # egress, so Go is pulled from Datadog's internal magicmirror. The
+          # mirror has no version index, so setup-go's listing probe 404s and it
+          # falls back to constructing the download URL as
+          # `${go-download-base-url}/go${go-version}.linux-amd64.tar.gz`. The
+          # mirror nests each release under a `go<version>/` directory, so the
+          # base URL must include it — hence GO_VERSION appears in both inputs.
+          go-download-base-url: "https://depot-read-api-generic.us1.ddbuild.io/magicmirror/magicmirror/@current/runtime/go/go${{ env.GO_VERSION }}"
       - name: Import GPG key
         id: import_gpg
         uses: paultyng/ghaction-import-gpg@53deb67fe3b05af114ad9488a4da7b782455d588

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.23"
-          go-download-base-url: "https://depot-read-api-github-releases.us1.ddbuild.io/internal/mirror/github-releases"
+          go-download-base-url: "https://depot-read-api-github-releases.us1.ddbuild.io/internal/mirror/github-releases/actions/go-versions/releases/download"
       - name: Import GPG key
         id: import_gpg
         uses: paultyng/ghaction-import-gpg@53deb67fe3b05af114ad9488a4da7b782455d588


### PR DESCRIPTION
## Motivation

The release job moved to a self-hosted runner with no github.com / go.dev egress. `actions/setup-go` could not download the Go toolchain there: it normally resolves a version via the public `actions/go-versions` manifest and downloads the asset from github.com, both unreachable on the runner. A prior attempt set `go-download-base-url` to the internal `github-releases` mirror, but that mirror serves `actions/go-versions`-style asset names (`go-1.25.12-linux-x64.tar.gz`) while setup-go constructs go.dev-style names (`go1.25.12.linux-amd64.tar.gz`), so every download 404'd and the release job was broken.

## Overview of changes

Point `go-download-base-url` at Datadog's internal generic magicmirror, which serves go.dev-named Go tarballs. The mirror nests each release under a per-version directory and exposes no version index, so setup-go's listing probe 404s and it falls back to constructing the download URL directly — meaning the base URL must itself include the version directory. The exact Go version is defined once as a job-level `GO_VERSION` env var and interpolated into both `go-version` and the base URL to keep them in sync.

The version is also bumped from 1.23 to 1.25.12 so the toolchain satisfies `go.mod`'s `go 1.25.8` directive; the previous 1.23 pin would fail the build's minimum-version check independently of the download issue.

## Validation

Cut a release (merge a `release/*` PR) and confirm the `Set up Go` step downloads and installs Go from the magicmirror URL and the GoReleaser build succeeds. The resolved download URL and its availability were verified out of band (HTTP 206 with valid gzip content for `go1.25.12` on the mirror).