### PR TITLE
ci (APIR-3129): bump workflow actions off deprecated Node 20 runtimes

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -26,7 +26,7 @@ jobs:
           exit 1;
       - name: Check PR title
         if: github.event.pull_request.draft == false && false == contains(join(github.event.pull_request.labels.*.name, ','), 'changelog/note') && false == contains(join(github.event.pull_request.labels.*.name, ','), 'changelog/no-changelog')
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const re = /^\[(?:datadog_\w+|generated)\] .+/;

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -30,11 +30,11 @@ jobs:
         with:
           scope: DataDog/terraform-provider-datadog
           policy: self.release.prepare-release
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.inputs.branch }}
       - name: Create PR
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RELEASE_VERSION: ${{ github.event.inputs.version }}
           TARGET_BRANCH: ${{ github.event.inputs.branch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           pool_name: dd-api-reliability
       - name: Create tag
         id: create_tag
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RELEASE_BRANCH: ${{ github.head_ref }}
         with:
@@ -44,7 +44,7 @@ jobs:
             });
             core.setOutput("tag_name", tagName);
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.create_tag.outputs.tag_name }}
       - name: Unshallow
@@ -58,12 +58,12 @@ jobs:
           go-version: "1.25"
       - name: Import GPG key
         id: import_gpg
-        uses: paultyng/ghaction-import-gpg@53deb67fe3b05af114ad9488a4da7b782455d588
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@b953231f81b8dfd023c58e0854a721e35037f28b
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: latest
           args: release --clean

--- a/.github/workflows/release_self_hosted.yml
+++ b/.github/workflows/release_self_hosted.yml
@@ -39,7 +39,7 @@ jobs:
           pool_name: dd-api-reliability
       - name: Create tag
         id: create_tag
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RELEASE_VERSION: ${{ github.event.inputs.version }}
           RELEASE_REF: ${{ github.event.inputs.ref }}
@@ -55,7 +55,7 @@ jobs:
             });
             core.setOutput("tag_name", tagName);
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.create_tag.outputs.tag_name }}
       - name: Unshallow
@@ -74,12 +74,12 @@ jobs:
           go-download-base-url: "https://depot-read-api-generic.us1.ddbuild.io/magicmirror/magicmirror/@current/runtime/go/go${{ env.GO_VERSION }}"
       - name: Import GPG key
         id: import_gpg
-        uses: paultyng/ghaction-import-gpg@53deb67fe3b05af114ad9488a4da7b782455d588
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@b953231f81b8dfd023c58e0854a721e35037f28b
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: latest
           args: release --clean

--- a/.github/workflows/sdkv2_deprecation.yaml
+++ b/.github/workflows/sdkv2_deprecation.yaml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 2
       - name: Get changed files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Detect non-changelog changes
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     if: (github.event.action != 'closed' && github.event.pull_request.merged != true) || github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236
         with:
           python-version: '3.11'
@@ -80,7 +80,7 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
       - name: Checkout code
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Install Go
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
@@ -144,7 +144,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Install Go
@@ -186,7 +186,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - name: Checkout code
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Install Go

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -38,7 +38,7 @@ jobs:
       id-token: write # Required to mint Datadog credentials via dd-sts
     steps:
       - name: Checkout code
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # PR head for pull_request_target; the triggering ref for the schedule.
           ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/test_pr_integration.yml
+++ b/.github/workflows/test_pr_integration.yml
@@ -52,7 +52,7 @@ jobs:
       id-token: write # Required to mint Datadog credentials via dd-sts
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
       - name: Mint Datadog credentials

--- a/.github/workflows/test_pr_select.yml
+++ b/.github/workflows/test_pr_select.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout base
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Check out the trusted base branch, NOT the default PR merge commit.
           # The selection scripts run here must be the base-repo versions: a PR

--- a/.github/workflows/tfgen-split.yml
+++ b/.github/workflows/tfgen-split.yml
@@ -23,13 +23,13 @@ jobs:
       BASE_BRANCH: master
     steps:
       - name: Checkout generated branch
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: generated
           persist-credentials: false
 
       - name: Checkout master
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: master
           fetch-depth: 0

--- a/.github/workflows/tfgen.yml
+++ b/.github/workflows/tfgen.yml
@@ -26,7 +26,7 @@ jobs:
         working-directory: .generator-v2
     steps:
       - name: Checkout code
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe


### PR DESCRIPTION
## Motivation

Our workflows emit Node 20 deprecation warnings on every run. GitHub Actions runners now default to Node 24 and are force-running our older actions — pinned to the deprecated Node 20 runtime — on 24 as a temporary grace period. When that grace period ends those steps break. The outdated `goreleaser-action` and GPG-import action additionally still use the removed `set-output`/`save-state` workflow commands. This clears every Node 20 warning across the repo's workflows before they turn into failures.

## Overview of changes

Two commits.

The first bumps the release and release (self-hosted) workflows.

The second commit applies the same `checkout` (→ v7.0.1) and `github-script` (→ v9.0.0) bumps to the remaining workflows.


## Validation

The non-release workflows (test/tfgen/changelog/PR-test) run on this PR itself, so their bumps are exercised directly by CI here. `release.yml` only runs on merge of a `release/*` PR and can't be dry-run, but `release_self_hosted.yml` is `workflow_dispatch` and can be triggered manually against a throwaway ref/version to exercise its bumped actions end-to-end; GoReleaser is configured with `release.draft: true`, so any resulting release lands as a draft and can be deleted without publishing.