### PR TITLE
[TFgen] (OneOf) Add normalized model

### DIFF
--- a/.generator-v2/internal/model/framework_types_test.go
+++ b/.generator-v2/internal/model/framework_types_test.go
@@ -61,8 +61,8 @@ var _ = Describe("FrameworkType", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(wantSubstr))
 		},
-		Entry("a variant (oneOf/anyOf) has no framework equivalent",
-			&Schema{Kind: SchemaKindVariant}, "variant"),
+		Entry("a oneOf has no direct framework equivalent",
+			&Schema{Kind: SchemaKindOneOf}, "one_of"),
 		Entry("a ref_cycle has no framework equivalent",
 			&Schema{Kind: SchemaKindRefCycle}, "ref_cycle"),
 		Entry("an unsupported node has no framework equivalent",

--- a/.generator-v2/internal/model/oneof_test.go
+++ b/.generator-v2/internal/model/oneof_test.go
@@ -37,7 +37,7 @@ var _ = Describe("normalized oneOf model", func() {
 		}))
 	})
 
-	It("keeps ordered non-null alternatives and their Terraform/SDK bindings", func() {
+	It("carries non-null alternatives and their Terraform/SDK bindings", func() {
 		booleanSchema := &Schema{Kind: SchemaKindPrimitive, Type: "boolean"}
 		objectSchema := &Schema{
 			Kind: SchemaKindObject,
@@ -90,23 +90,6 @@ var _ = Describe("normalized oneOf model", func() {
 			SDKConstructor: "ObjectMockedOutputAsActionQueryMockedOutputs",
 			ValueWrapped:   false,
 		}))
-	})
-
-	It("keeps null separate from the non-null variant list", func() {
-		union := &OneOfSpec{
-			Nullable: true,
-			Variants: []OneOfVariant{
-				{TFName: "boolean", Schema: &Schema{Kind: SchemaKindPrimitive, Type: "boolean"}},
-				{TFName: "string", Schema: &Schema{Kind: SchemaKindPrimitive, Type: "string"}},
-			},
-		}
-
-		Expect(union.Nullable).To(BeTrue())
-		Expect(union.Variants).To(HaveLen(2))
-		Expect(union.Variants).To(ConsistOf(
-			HaveField("TFName", "boolean"),
-			HaveField("TFName", "string"),
-		))
 	})
 
 	It("retains the legacy kind alias during parser migration", func() {

--- a/.generator-v2/internal/model/oneof_test.go
+++ b/.generator-v2/internal/model/oneof_test.go
@@ -1,0 +1,115 @@
+package model
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("normalized oneOf model", func() {
+
+	It("keeps the envelope identity, presence semantics, and discriminator metadata", func() {
+		union := &Schema{
+			Kind: SchemaKindOneOf,
+			OneOf: &OneOfSpec{
+				Name:     "ActionQueryMockedOutputsEnabled",
+				Path:     "request.data.attributes.enabled",
+				Optional: true,
+				Nullable: true,
+				Discriminator: &OneOfDiscriminator{
+					PropertyName: "type",
+					Mapping: map[string]string{
+						"boolean": "#/components/schemas/BooleanEnabled",
+						"string":  "#/components/schemas/StringEnabled",
+					},
+				},
+			},
+		}
+
+		Expect(union.Kind).To(Equal(SchemaKindOneOf))
+		Expect(union.OneOf.Name).To(Equal("ActionQueryMockedOutputsEnabled"))
+		Expect(union.OneOf.Path).To(Equal("request.data.attributes.enabled"))
+		Expect(union.OneOf.Optional).To(BeTrue())
+		Expect(union.OneOf.Nullable).To(BeTrue())
+		Expect(union.OneOf.Discriminator.PropertyName).To(Equal("type"))
+		Expect(union.OneOf.Discriminator.Mapping).To(Equal(map[string]string{
+			"boolean": "#/components/schemas/BooleanEnabled",
+			"string":  "#/components/schemas/StringEnabled",
+		}))
+	})
+
+	It("keeps ordered non-null alternatives and their Terraform/SDK bindings", func() {
+		booleanSchema := &Schema{Kind: SchemaKindPrimitive, Type: "boolean"}
+		objectSchema := &Schema{
+			Kind: SchemaKindObject,
+			Properties: map[string]*Schema{
+				"name": {Kind: SchemaKindPrimitive, Type: "string"},
+			},
+		}
+		union := &OneOfSpec{
+			Name:     "MockedOutput",
+			Path:     "response.data.attributes.output",
+			Nullable: true,
+			Variants: []OneOfVariant{
+				{
+					TFName:         "boolean",
+					GoName:         "Boolean",
+					Schema:         booleanSchema,
+					RefName:        "BooleanMockedOutput",
+					SDKField:       "Bool",
+					SDKConstructor: "BoolAsActionQueryMockedOutputs",
+					ValueWrapped:   true,
+				},
+				{
+					TFName:         "object",
+					GoName:         "Object",
+					Schema:         objectSchema,
+					RefName:        "ObjectMockedOutput",
+					SDKField:       "ObjectMockedOutput",
+					SDKConstructor: "ObjectMockedOutputAsActionQueryMockedOutputs",
+					ValueWrapped:   false,
+				},
+			},
+		}
+
+		Expect(union.Variants).To(HaveLen(2))
+		Expect(union.Variants[0]).To(Equal(OneOfVariant{
+			TFName:         "boolean",
+			GoName:         "Boolean",
+			Schema:         booleanSchema,
+			RefName:        "BooleanMockedOutput",
+			SDKField:       "Bool",
+			SDKConstructor: "BoolAsActionQueryMockedOutputs",
+			ValueWrapped:   true,
+		}))
+		Expect(union.Variants[1]).To(Equal(OneOfVariant{
+			TFName:         "object",
+			GoName:         "Object",
+			Schema:         objectSchema,
+			RefName:        "ObjectMockedOutput",
+			SDKField:       "ObjectMockedOutput",
+			SDKConstructor: "ObjectMockedOutputAsActionQueryMockedOutputs",
+			ValueWrapped:   false,
+		}))
+	})
+
+	It("keeps null separate from the non-null variant list", func() {
+		union := &OneOfSpec{
+			Nullable: true,
+			Variants: []OneOfVariant{
+				{TFName: "boolean", Schema: &Schema{Kind: SchemaKindPrimitive, Type: "boolean"}},
+				{TFName: "string", Schema: &Schema{Kind: SchemaKindPrimitive, Type: "string"}},
+			},
+		}
+
+		Expect(union.Nullable).To(BeTrue())
+		Expect(union.Variants).To(HaveLen(2))
+		Expect(union.Variants).To(ConsistOf(
+			HaveField("TFName", "boolean"),
+			HaveField("TFName", "string"),
+		))
+	})
+
+	It("retains the legacy kind alias during parser migration", func() {
+		Expect(SchemaKindVariant).To(Equal(SchemaKindOneOf))
+	})
+})

--- a/.generator-v2/internal/model/schema_test.go
+++ b/.generator-v2/internal/model/schema_test.go
@@ -21,7 +21,7 @@ func objSchema(props map[string]*Schema) *Schema {
 func arrSchema(item *Schema) *Schema { return &Schema{Kind: SchemaKindArray, Items: item} }
 func mapSchema(val *Schema) *Schema  { return &Schema{Kind: SchemaKindMap, Items: val} }
 func oneOfSchema(variants ...*Schema) *Schema {
-	return &Schema{Kind: SchemaKindVariant, Variants: variants}
+	return &Schema{Kind: SchemaKindOneOf, Variants: variants}
 }
 
 // richSchema is a response schema exercising one of every shape, including the

--- a/.generator-v2/internal/model/schema_test.go
+++ b/.generator-v2/internal/model/schema_test.go
@@ -20,8 +20,30 @@ func objSchema(props map[string]*Schema) *Schema {
 }
 func arrSchema(item *Schema) *Schema { return &Schema{Kind: SchemaKindArray, Items: item} }
 func mapSchema(val *Schema) *Schema  { return &Schema{Kind: SchemaKindMap, Items: val} }
-func oneOfSchema(variants ...*Schema) *Schema {
-	return &Schema{Kind: SchemaKindOneOf, Variants: variants}
+func oneOfSchema(path, name string, variants ...OneOfVariant) *Schema {
+	return &Schema{
+		Kind: SchemaKindOneOf,
+		OneOf: &OneOfSpec{
+			Name:     name,
+			Path:     path,
+			Variants: variants,
+		},
+	}
+}
+func primitiveOneOfVariant(name, typ string) OneOfVariant {
+	return OneOfVariant{
+		TFName:       name,
+		GoName:       SdkName(name),
+		Schema:       primSchema(typ),
+		ValueWrapped: true,
+	}
+}
+func objectOneOfVariant(name string, props map[string]*Schema) OneOfVariant {
+	return OneOfVariant{
+		TFName: name,
+		GoName: SdkName(name),
+		Schema: objSchema(props),
+	}
 }
 
 // richSchema is a response schema exercising one of every shape, including the
@@ -445,71 +467,299 @@ var _ = Describe("BuildResponseTree defensive guard", func() {
 // check on that commit rather than decoration.
 var _ = PDescribe("BuildResponseTree retains oneOf envelopes", func() {
 
-	assertRetained := func(schema *Schema, path string) {
+	assertRetained := func(
+		buildTree func(*Schema) (*AttributeTree, []Diagnostic, error),
+		schema *Schema,
+		path, tfType string,
+		required, computed bool,
+		wantPaths ...string,
+	) *AttributeTree {
 		GinkgoHelper()
 
-		tree, diags, err := BuildResponseTree(schema)
+		tree, diags, err := buildTree(schema)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(attrByPath(tree, path)).NotTo(BeNil())
-		for _, diag := range diags {
-			Expect(diag.Message).NotTo(
-				ContainSubstring("dropped"),
-				"oneOf at %q must not be silently dropped", path,
-			)
+		Expect(diags).To(BeEmpty(), "supported oneOf at %q must not emit diagnostics", path)
+
+		envelope := attrByPath(tree, path)
+		Expect(envelope.TfType).To(Equal(tfType))
+		Expect(envelope.Required).To(Equal(required))
+		Expect(envelope.Computed).To(Equal(computed))
+		envelopeAttrs := allAttrs(&AttributeTree{Attributes: []*Attribute{envelope}})
+		Expect(pathsOf(envelopeAttrs)).To(Equal(wantPaths))
+		for _, attr := range envelopeAttrs {
+			Expect(attr.Computed).To(Equal(computed), "unexpected Computed flag at %q", attr.Path)
 		}
+		return tree
 	}
 
 	It("retains a root oneOf as an envelope at the response root", func() {
-		assertRetained(
-			oneOfSchema(primSchema("boolean"), primSchema("string")),
+		tree := assertRetained(
+			BuildResponseTree,
+			oneOfSchema(
+				"response",
+				"RootChoice",
+				primitiveOneOfVariant("boolean", "boolean"),
+				primitiveOneOfVariant("string", "string"),
+			),
 			"response",
+			"schema.SingleNestedBlock",
+			false,
+			true,
+			"response",
+			"response.boolean",
+			"response.boolean.value",
+			"response.string",
+			"response.string.value",
 		)
+		Expect(attrByPath(tree, "response.boolean").TfType).To(Equal("schema.SingleNestedBlock"))
+		Expect(attrByPath(tree, "response.boolean.value").TfType).To(Equal("schema.BoolAttribute"))
+		Expect(attrByPath(tree, "response.string").TfType).To(Equal("schema.SingleNestedBlock"))
+		Expect(attrByPath(tree, "response.string.value").TfType).To(Equal("schema.StringAttribute"))
 	})
 
 	It("retains a oneOf object property as an envelope attribute", func() {
-		assertRetained(
+		tree := assertRetained(
+			BuildResponseTree,
 			objSchema(map[string]*Schema{
 				"choice": oneOfSchema(
-					primSchema("string"),
-					objSchema(map[string]*Schema{"name": primSchema("string")}),
+					"response.choice",
+					"Choice",
+					objectOneOfVariant("object", map[string]*Schema{"name": primSchema("string")}),
+					primitiveOneOfVariant("string", "string"),
 				),
 			}),
 			"response.choice",
+			"schema.SingleNestedBlock",
+			false,
+			true,
+			"response.choice",
+			"response.choice.object",
+			"response.choice.object.name",
+			"response.choice.string",
+			"response.choice.string.value",
 		)
+		Expect(attrByPath(tree, "response.choice.object").TfType).To(Equal("schema.SingleNestedBlock"))
+		Expect(attrByPath(tree, "response.choice.object.name").TfType).To(Equal("schema.StringAttribute"))
+		Expect(attrByPath(tree, "response.choice.string").TfType).To(Equal("schema.SingleNestedBlock"))
+		Expect(attrByPath(tree, "response.choice.string.value").TfType).To(Equal("schema.StringAttribute"))
 	})
 
 	It("retains a oneOf nested inside another object", func() {
 		assertRetained(
+			BuildResponseTree,
 			objSchema(map[string]*Schema{
 				"container": objSchema(map[string]*Schema{
 					"choice": oneOfSchema(
-						objSchema(map[string]*Schema{"enabled": primSchema("boolean")}),
-						objSchema(map[string]*Schema{"threshold": primSchema("number")}),
+						"response.container.choice",
+						"ContainerChoice",
+						objectOneOfVariant("enabled", map[string]*Schema{"enabled": primSchema("boolean")}),
+						objectOneOfVariant("threshold", map[string]*Schema{"threshold": primSchema("number")}),
 					),
 				}),
 			}),
 			"response.container.choice",
+			"schema.SingleNestedBlock",
+			false,
+			true,
+			"response.container.choice",
+			"response.container.choice.enabled",
+			"response.container.choice.enabled.enabled",
+			"response.container.choice.threshold",
+			"response.container.choice.threshold.threshold",
 		)
 	})
 
 	DescribeTable("retains a collection whose element is a oneOf envelope",
-		func(collection *Schema, path string) {
-			assertRetained(
+		func(collection *Schema, tfType, elementPath string) {
+			tree := assertRetained(
+				BuildResponseTree,
 				objSchema(map[string]*Schema{"choices": collection}),
-				path,
+				"response.choices",
+				tfType,
+				false,
+				true,
+				"response.choices",
+				elementPath+".boolean",
+				elementPath+".boolean.value",
+				elementPath+".string",
+				elementPath+".string.value",
 			)
+			variantType := "schema.SingleNestedBlock"
+			if tfType == "schema.MapNestedAttribute" {
+				variantType = "schema.SingleNestedAttribute"
+			}
+			Expect(attrByPath(tree, elementPath+".boolean").TfType).To(Equal(variantType))
+			Expect(attrByPath(tree, elementPath+".boolean.value").TfType).To(Equal("schema.BoolAttribute"))
+			Expect(attrByPath(tree, elementPath+".string").TfType).To(Equal(variantType))
+			Expect(attrByPath(tree, elementPath+".string.value").TfType).To(Equal("schema.StringAttribute"))
 		},
 		Entry(
 			"array element",
-			arrSchema(oneOfSchema(primSchema("boolean"), primSchema("string"))),
-			"response.choices",
+			arrSchema(oneOfSchema(
+				"response.choices[]",
+				"ChoicesItem",
+				primitiveOneOfVariant("boolean", "boolean"),
+				primitiveOneOfVariant("string", "string"),
+			)),
+			"schema.ListNestedBlock",
+			"response.choices[]",
 		),
 		Entry(
 			"map value",
-			mapSchema(oneOfSchema(primSchema("integer"), primSchema("string"))),
-			"response.choices",
+			mapSchema(oneOfSchema(
+				"response.choices{}",
+				"ChoicesValue",
+				primitiveOneOfVariant("boolean", "boolean"),
+				primitiveOneOfVariant("string", "string"),
+			)),
+			"schema.MapNestedAttribute",
+			"response.choices{}",
 		),
 	)
+
+	DescribeTable("retains a root collection whose element is a oneOf envelope",
+		func(collection *Schema, tfType, elementPath string) {
+			assertRetained(
+				BuildResponseTree,
+				collection,
+				"response",
+				tfType,
+				false,
+				true,
+				"response",
+				elementPath+".boolean",
+				elementPath+".boolean.value",
+				elementPath+".string",
+				elementPath+".string.value",
+			)
+		},
+		Entry(
+			"root array",
+			arrSchema(oneOfSchema(
+				"response[]",
+				"RootItem",
+				primitiveOneOfVariant("boolean", "boolean"),
+				primitiveOneOfVariant("string", "string"),
+			)),
+			"schema.ListNestedBlock",
+			"response[]",
+		),
+		Entry(
+			"root map",
+			mapSchema(oneOfSchema(
+				"response{}",
+				"RootValue",
+				primitiveOneOfVariant("boolean", "boolean"),
+				primitiveOneOfVariant("string", "string"),
+			)),
+			"schema.MapNestedAttribute",
+			"response{}",
+		),
+	)
+
+	It("retains a required request oneOf instead of treating it as computed response state", func() {
+		assertRetained(
+			BuildRequestTree,
+			oneOfSchema(
+				"request",
+				"RequestChoice",
+				primitiveOneOfVariant("boolean", "boolean"),
+				primitiveOneOfVariant("string", "string"),
+			),
+			"request",
+			"schema.SingleNestedBlock",
+			true,
+			false,
+			"request",
+			"request.boolean",
+			"request.boolean.value",
+			"request.string",
+			"request.string.value",
+		)
+	})
+
+	DescribeTable("retains a oneOf nested in a collection element object",
+		func(schema *Schema, path, tfType string, wantPaths []string) {
+			assertRetained(BuildResponseTree, schema, path, tfType, false, true, wantPaths...)
+		},
+		Entry(
+			"array element object",
+			objSchema(map[string]*Schema{
+				"containers": arrSchema(objSchema(map[string]*Schema{
+					"choice": oneOfSchema(
+						"response.containers[].choice",
+						"ContainerChoice",
+						primitiveOneOfVariant("boolean", "boolean"),
+						primitiveOneOfVariant("string", "string"),
+					),
+				})),
+			}),
+			"response.containers[].choice",
+			"schema.SingleNestedBlock",
+			[]string{
+				"response.containers[].choice",
+				"response.containers[].choice.boolean",
+				"response.containers[].choice.boolean.value",
+				"response.containers[].choice.string",
+				"response.containers[].choice.string.value",
+			},
+		),
+		Entry(
+			"map value object",
+			objSchema(map[string]*Schema{
+				"containers": mapSchema(objSchema(map[string]*Schema{
+					"choice": oneOfSchema(
+						"response.containers{}.choice",
+						"ContainerChoice",
+						primitiveOneOfVariant("boolean", "boolean"),
+						primitiveOneOfVariant("string", "string"),
+					),
+				})),
+			}),
+			"response.containers{}.choice",
+			"schema.SingleNestedAttribute",
+			[]string{
+				"response.containers{}.choice",
+				"response.containers{}.choice.boolean",
+				"response.containers{}.choice.boolean.value",
+				"response.containers{}.choice.string",
+				"response.containers{}.choice.string.value",
+			},
+		),
+	)
+
+	It("retains a recursively nested oneOf inside an object alternative", func() {
+		inner := oneOfSchema(
+			"response.object.nested",
+			"NestedChoice",
+			primitiveOneOfVariant("boolean", "boolean"),
+			primitiveOneOfVariant("string", "string"),
+		)
+		outer := oneOfSchema(
+			"response",
+			"OuterChoice",
+			objectOneOfVariant("object", map[string]*Schema{"nested": inner}),
+			primitiveOneOfVariant("string", "string"),
+		)
+
+		assertRetained(
+			BuildResponseTree,
+			outer,
+			"response",
+			"schema.SingleNestedBlock",
+			false,
+			true,
+			"response",
+			"response.object",
+			"response.object.nested",
+			"response.object.nested.boolean",
+			"response.object.nested.boolean.value",
+			"response.object.nested.string",
+			"response.object.nested.string.value",
+			"response.string",
+			"response.string.value",
+		)
+	})
 })
 
 // ---------------------------------------------------------------------------

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -31,12 +31,11 @@ const (
 )
 
 // SchemaKind classifies a normalized Schema node by structure. Primitive,
-// Object, Array and Map are emittable as Terraform attributes. Variant (oneOf)
-// has no Terraform equivalent, so the attribute-tree builder drops it (skipping
-// the property, or the whole collection when it is an array/map element). RefCycle
-// ($ref cycle or beyond --max-depth) and Unsupported (no representable type or
-// structure, and anyOf) are fatal — the builder fails the artifact rather than
-// emitting a types.Dynamic escape hatch.
+// Object, Array and Map are directly emittable as Terraform attributes. OneOf
+// requires a synthetic envelope described by Schema.OneOf. RefCycle ($ref cycle
+// or beyond --max-depth) and Unsupported (no representable type or structure,
+// and anyOf) are fatal — the builder fails the artifact rather than emitting a
+// types.Dynamic escape hatch.
 type SchemaKind string
 
 const (
@@ -44,9 +43,14 @@ const (
 	SchemaKindObject      SchemaKind = "object"
 	SchemaKindArray       SchemaKind = "array"
 	SchemaKindMap         SchemaKind = "map"
-	SchemaKindVariant     SchemaKind = "variant"     // oneOf; dropped from the attribute tree
+	SchemaKindOneOf       SchemaKind = "one_of"
 	SchemaKindRefCycle    SchemaKind = "ref_cycle"   // $ref cycle or beyond --max-depth
 	SchemaKindUnsupported SchemaKind = "unsupported" // no representable type/structure, or anyOf; always rejected
+
+	// SchemaKindVariant is the legacy parser name for SchemaKindOneOf. It stays
+	// as an alias until the parser migration populates Schema.OneOf directly.
+	// New model code should use SchemaKindOneOf.
+	SchemaKindVariant = SchemaKindOneOf
 )
 
 // Cardinality distinguishes a singular data source (resolves one item by id)
@@ -155,7 +159,7 @@ type Pagination struct {
 }
 
 // Schema is a normalized, recursive view of an OpenAPI schema after allOf
-// flattening and oneOf/anyOf variant detection.
+// flattening, oneOf-envelope detection, and explicit anyOf rejection.
 type Schema struct {
 	Kind SchemaKind
 	// Properties is populated for objects only; iteration is always sorted.
@@ -164,7 +168,15 @@ type Schema struct {
 	Required []string
 	// Items is populated for arrays only.
 	Items *Schema
-	// Variants is populated for oneOf/anyOf only.
+	// OneOf is populated when Kind is SchemaKindOneOf. It carries the stable
+	// Terraform envelope identity, its non-null alternatives, and the metadata
+	// required to bind those alternatives to the generated SDK wrapper.
+	OneOf *OneOfSpec
+	// Variants is the parser's legacy oneOf representation. It remains only as a
+	// compatibility bridge until normalization constructs OneOfSpec; new model
+	// and emit code must consume OneOf instead.
+	//
+	// Deprecated: use OneOf.Variants.
 	Variants []*Schema
 	// Type is the primitive type (string/integer/number/boolean).
 	Type string
@@ -176,6 +188,62 @@ type Schema struct {
 	Sensitive bool
 	// Description is the OpenAPI description, populated during NormalizeSchemas.
 	Description string
+}
+
+// OneOfSpec is the normalized representation of an OpenAPI oneOf. The envelope
+// exists only in generated Terraform/Go code; request and response mappers
+// unwrap/wrap it when interacting with the Datadog go-sdk.
+type OneOfSpec struct {
+	// Name is the deterministic generated envelope type name. Reusable
+	// component unions use their component name; inline unions use a
+	// schema-path-derived name.
+	Name string
+	// Path is the canonical request/response schema path used for diagnostics
+	// and as an input to inline envelope naming.
+	Path string
+	// Optional permits the whole envelope to be absent because the containing
+	// OpenAPI field is not required.
+	Optional bool
+	// Nullable permits OpenAPI null. Null is represented by an absent envelope,
+	// never by a synthetic null variant.
+	Nullable bool
+	// Discriminator retains optional OpenAPI discriminator metadata for stable
+	// naming and diagnostics. It is not required for branch selection.
+	Discriminator *OneOfDiscriminator
+	// Variants contains only non-null alternatives, sorted by TFName. Parser
+	// source order and map iteration order must not affect this slice.
+	Variants []OneOfVariant
+}
+
+// OneOfDiscriminator retains the OpenAPI discriminator metadata relevant to a
+// normalized union. Mapping keys may participate in stable variant naming;
+// consumers must sort keys before iterating over Mapping.
+type OneOfDiscriminator struct {
+	PropertyName string
+	Mapping      map[string]string
+}
+
+// OneOfVariant is one non-null oneOf alternative and its Terraform/SDK binding.
+type OneOfVariant struct {
+	// TFName is the stable snake_case nested-block name.
+	TFName string
+	// GoName is the generated Go model/field stem corresponding to TFName.
+	GoName string
+	// Schema is the fully normalized alternative, including constraints common
+	// to the parent oneOf. It may recursively contain another oneOf.
+	Schema *Schema
+	// RefName is the referenced OpenAPI component name, when present.
+	RefName string
+	// SDKField is the Datadog go-sdk wrapper member whose presence selects this
+	// alternative.
+	SDKField string
+	// SDKConstructor is the generated SDK convenience constructor for this
+	// alternative, when the SDK exposes one.
+	SDKConstructor string
+	// ValueWrapped is true for primitive, list, and map alternatives, whose
+	// Terraform variant model exposes a single field named value. Object
+	// alternatives expose their generated fields directly.
+	ValueWrapped bool
 }
 
 // ----------------------------------------------------------------------------

--- a/.generator-v2/internal/parser/schema_test.go
+++ b/.generator-v2/internal/parser/schema_test.go
@@ -52,7 +52,7 @@ var _ = Describe("NormalizeSchemas kind classification", func() {
 		Entry("type:object with properties → object", "CreateObject", model.SchemaKindObject),
 		Entry("type:array with items → array", "CreateArray", model.SchemaKindArray),
 		Entry("additionalProperties without properties → map", "CreateMap", model.SchemaKindMap),
-		Entry("oneOf → variant", "CreateVariantOneOf", model.SchemaKindVariant),
+		Entry("oneOf → one_of", "CreateVariantOneOf", model.SchemaKindOneOf),
 		Entry("anyOf → unsupported", "CreateVariantAnyOf", model.SchemaKindUnsupported),
 	)
 

--- a/.generator-v2/internal/parser/schema_test.go
+++ b/.generator-v2/internal/parser/schema_test.go
@@ -208,6 +208,166 @@ var _ = Describe("NormalizeSchemas field carrying", func() {
 })
 
 // -------------------------------------------------------------------
+//  Normalized oneOf metadata
+// -------------------------------------------------------------------
+
+// Pending: these specs describe the normalized oneOf metadata the parser does not
+// populate yet -- they assert Schema.OneOf where the parser still writes the
+// legacy Schema.Variants. Written ahead of the implementation on purpose, but a
+// red suite cannot be merged and this stack merges bottom-up, so PDescribe reports
+// them as pending rather than failing.
+//
+// The commit that updates the parser to populate Schema.OneOf turns this back into
+// Describe; all six specs must pass at that point, which is what makes them a
+// check on that commit.
+var _ = PDescribe("NormalizeSchemas oneOf metadata", func() {
+
+	var spec *model.Spec
+
+	BeforeEach(func() {
+		spec = loadSpecMust("schema_normalize_oneof.yaml")
+	})
+
+	oneOfFor := func(operationID string) *model.OneOfSpec {
+		GinkgoHelper()
+		schema := opByID(spec, operationID).RequestSchema
+		Expect(schema).NotTo(BeNil())
+		Expect(schema.Kind).To(Equal(model.SchemaKindOneOf))
+		Expect(schema.OneOf).NotTo(BeNil(), "normalized oneOf must use Schema.OneOf, not legacy Schema.Variants")
+		Expect(schema.Variants).To(BeEmpty(), "legacy Schema.Variants must be empty after oneOf normalization")
+		return schema.OneOf
+	}
+
+	It("normalizes an inline discriminator-less union and separates nullable from its variants", func() {
+		union := oneOfFor("CreateInlineOneOf")
+
+		Expect(union.Name).NotTo(BeEmpty())
+		Expect(union.Path).To(Equal("request"))
+		Expect(union.Optional).To(BeFalse())
+		Expect(union.Nullable).To(BeTrue())
+		Expect(union.Discriminator).To(BeNil())
+		Expect(union.Variants).To(HaveLen(2))
+		Expect(union.Variants).To(HaveEach(Not(HaveField("TFName", "null"))))
+		Expect(union.Variants).To(ConsistOf(
+			SatisfyAll(
+				HaveField("TFName", "boolean"),
+				HaveField("Schema.Kind", model.SchemaKindPrimitive),
+				HaveField("Schema.Type", "boolean"),
+				HaveField("ValueWrapped", true),
+			),
+			SatisfyAll(
+				HaveField("TFName", "string"),
+				HaveField("Schema.Kind", model.SchemaKindPrimitive),
+				HaveField("Schema.Type", "string"),
+				HaveField("ValueWrapped", true),
+			),
+		))
+	})
+
+	It("retains component identity, discriminator mapping, and referenced alternatives", func() {
+		union := oneOfFor("CreateAnimal")
+
+		Expect(union.Name).To(Equal("AnimalUnion"))
+		Expect(union.Discriminator).To(Equal(&model.OneOfDiscriminator{
+			PropertyName: "kind",
+			Mapping: map[string]string{
+				"dog": "#/components/schemas/Dog",
+				"cat": "#/components/schemas/Cat",
+			},
+		}))
+		Expect(union.Variants).To(HaveLen(2))
+		Expect(union.Variants[0]).To(SatisfyAll(
+			HaveField("TFName", "cat"),
+			HaveField("RefName", "Cat"),
+			HaveField("Schema.Kind", model.SchemaKindObject),
+			HaveField("ValueWrapped", false),
+		))
+		Expect(union.Variants[1]).To(SatisfyAll(
+			HaveField("TFName", "dog"),
+			HaveField("RefName", "Dog"),
+			HaveField("Schema.Kind", model.SchemaKindObject),
+			HaveField("ValueWrapped", false),
+		))
+	})
+
+	It("assigns canonical paths and optionality at property and collection placements", func() {
+		root := opByID(spec, "CreateNestedOneOf").RequestSchema
+		Expect(root.Kind).To(Equal(model.SchemaKindObject))
+
+		choice := root.Properties["choice"].OneOf
+		Expect(choice).NotTo(BeNil())
+		Expect(choice.Path).To(Equal("request.choice"))
+		Expect(choice.Optional).To(BeFalse())
+
+		optional := root.Properties["optional_choice"].OneOf
+		Expect(optional).NotTo(BeNil())
+		Expect(optional.Path).To(Equal("request.optional_choice"))
+		Expect(optional.Optional).To(BeTrue())
+
+		listItem := root.Properties["choices"].Items.OneOf
+		Expect(listItem).NotTo(BeNil())
+		Expect(listItem.Path).To(Equal("request.choices[]"))
+		Expect(listItem.Optional).To(BeFalse())
+
+		mapValue := root.Properties["choice_map"].Items.OneOf
+		Expect(mapValue).NotTo(BeNil())
+		Expect(mapValue.Path).To(Equal("request.choice_map{}"))
+		Expect(mapValue.Optional).To(BeFalse())
+	})
+
+	It("normalizes a oneOf recursively inside another alternative", func() {
+		outer := opByID(spec, "CreateNestedOneOf").RequestSchema.Properties["recursive"].OneOf
+		Expect(outer).NotTo(BeNil())
+
+		var objectVariant *model.OneOfVariant
+		for i := range outer.Variants {
+			if outer.Variants[i].Schema.Kind == model.SchemaKindObject {
+				objectVariant = &outer.Variants[i]
+				break
+			}
+		}
+		Expect(objectVariant).NotTo(BeNil())
+
+		nested := objectVariant.Schema.Properties["nested"].OneOf
+		Expect(nested).NotTo(BeNil())
+		Expect(nested.Path).To(Equal("request.recursive." + objectVariant.TFName + ".nested"))
+		Expect(nested.Variants).To(HaveLen(2))
+	})
+
+	It("merges properties and required constraints adjacent to oneOf into every alternative", func() {
+		union := oneOfFor("CreateOneOfWithSiblings")
+		Expect(union.Variants).To(HaveLen(2))
+
+		for _, variant := range union.Variants {
+			Expect(variant.Schema.Kind).To(Equal(model.SchemaKindObject))
+			Expect(variant.Schema.Properties).To(HaveKey("shared"))
+			Expect(variant.Schema.Required).To(ContainElement("shared"))
+		}
+		Expect(union.Variants).To(ConsistOf(
+			SatisfyAll(
+				HaveField("Schema.Properties", HaveKey("alpha")),
+				HaveField("Schema.Required", ConsistOf("alpha", "shared")),
+			),
+			SatisfyAll(
+				HaveField("Schema.Properties", HaveKey("beta")),
+				HaveField("Schema.Required", ConsistOf("beta", "shared")),
+			),
+		))
+	})
+
+	It("produces stable names and sorted variants across independent loads", func() {
+		first := oneOfFor("CreateInlineOneOf")
+		secondSpec := loadSpecMust("schema_normalize_oneof.yaml")
+		second := opByID(secondSpec, "CreateInlineOneOf").RequestSchema.OneOf
+		Expect(second).NotTo(BeNil())
+
+		Expect(second.Name).To(Equal(first.Name))
+		Expect(second.Variants).To(Equal(first.Variants))
+		Expect([]string{first.Variants[0].TFName, first.Variants[1].TFName}).To(Equal([]string{"boolean", "string"}))
+	})
+})
+
+// -------------------------------------------------------------------
 //  2xx response selection
 // -------------------------------------------------------------------
 

--- a/.generator-v2/internal/testdata/parser/schema_normalize_oneof.yaml
+++ b/.generator-v2/internal/testdata/parser/schema_normalize_oneof.yaml
@@ -1,0 +1,157 @@
+openapi: 3.0.0
+info:
+  title: normalized oneOf fixture
+  version: 1.0.0
+paths:
+  /inline:
+    post:
+      operationId: CreateInlineOneOf
+      tags: [OneOf]
+      x-datadog-tf-generator:
+        artifact_kind: resource
+        artifact_name: inline_oneof
+        group:
+          create: CreateInlineOneOf
+          read: CreateInlineOneOf
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              nullable: true
+              oneOf:
+                - type: string
+                - type: boolean
+      responses:
+        "204":
+          description: no content
+  /animals:
+    post:
+      operationId: CreateAnimal
+      tags: [OneOf]
+      x-datadog-tf-generator:
+        artifact_kind: resource
+        artifact_name: animal
+        group:
+          create: CreateAnimal
+          read: CreateAnimal
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AnimalUnion"
+      responses:
+        "204":
+          description: no content
+  /nested:
+    post:
+      operationId: CreateNestedOneOf
+      tags: [OneOf]
+      x-datadog-tf-generator:
+        artifact_kind: resource
+        artifact_name: nested_oneof
+        group:
+          create: CreateNestedOneOf
+          read: CreateNestedOneOf
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [choice, choices]
+              properties:
+                choice:
+                  oneOf:
+                    - type: string
+                    - type: boolean
+                optional_choice:
+                  oneOf:
+                    - type: integer
+                    - type: string
+                choices:
+                  type: array
+                  items:
+                    oneOf:
+                      - type: string
+                      - type: integer
+                choice_map:
+                  type: object
+                  additionalProperties:
+                    oneOf:
+                      - type: string
+                      - type: number
+                recursive:
+                  oneOf:
+                    - type: string
+                    - type: object
+                      properties:
+                        nested:
+                          oneOf:
+                            - type: boolean
+                            - type: string
+      responses:
+        "204":
+          description: no content
+  /siblings:
+    post:
+      operationId: CreateOneOfWithSiblings
+      tags: [OneOf]
+      x-datadog-tf-generator:
+        artifact_kind: resource
+        artifact_name: oneof_with_siblings
+        group:
+          create: CreateOneOfWithSiblings
+          read: CreateOneOfWithSiblings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [shared]
+              properties:
+                shared:
+                  type: string
+              oneOf:
+                - type: object
+                  required: [alpha]
+                  properties:
+                    alpha:
+                      type: boolean
+                - type: object
+                  required: [beta]
+                  properties:
+                    beta:
+                      type: integer
+      responses:
+        "204":
+          description: no content
+components:
+  schemas:
+    AnimalUnion:
+      discriminator:
+        propertyName: kind
+        mapping:
+          dog: "#/components/schemas/Dog"
+          cat: "#/components/schemas/Cat"
+      oneOf:
+        - $ref: "#/components/schemas/Dog"
+        - $ref: "#/components/schemas/Cat"
+    Cat:
+      type: object
+      required: [kind, lives]
+      properties:
+        kind:
+          type: string
+        lives:
+          type: integer
+    Dog:
+      type: object
+      required: [kind, bark]
+      properties:
+        kind:
+          type: string
+        bark:
+          type: boolean


### PR DESCRIPTION
## Motivation

Introduce the normalized oneOf model the parser and projection will both target, replacing the legacy `Schema.Variants` representation.

## Changes

- Adds `Schema.OneOf` / `OneOfSpec` / `OneOfVariant` and the deterministic variant-naming rules, leaving `Schema.Variants` as a deprecated bridge.
- Adds parser specs for the normalized metadata under `NormalizeSchemas oneOf metadata`, marked `PDescribe` — they assert `Schema.OneOf` where the parser still writes `Schema.Variants`, so they cannot pass until #4049 updates normalization. Pending rather than failing keeps the branch mergeable; #4049 un-pends them.

## Testing

`go test ./...` green: model `98 passed | 0 failed | 5 pending`, parser `98 passed | 0 failed | 6 pending`.


