### PR TITLE
[datadog_integration_slack_channel] Do not use the error message as a format string in TranslateClientError

### DIFF
--- a/datadog/internal/utils/utils.go
+++ b/datadog/internal/utils/utils.go
@@ -176,16 +176,16 @@ func TranslateClientError(err error, httpresp *http.Response, msg string) error 
 	}
 
 	if apiErr, ok := err.(CustomRequestAPIError); ok {
-		return fmt.Errorf(msg+": %v: %s", err, apiErr.Body())
+		return fmt.Errorf("%s: %w: %s", msg, err, apiErr.Body())
 	}
 	if apiErr, ok := err.(datadog.GenericOpenAPIError); ok {
-		return fmt.Errorf(msg+": %v: %s", err, apiErr.Body())
+		return fmt.Errorf("%s: %w: %s", msg, err, apiErr.Body())
 	}
 	if errURL, ok := err.(*url.Error); ok {
-		return fmt.Errorf(msg+" (url.Error): %s", errURL)
+		return fmt.Errorf("%s (url.Error): %w", msg, errURL)
 	}
 
-	return fmt.Errorf(msg+": %s", err.Error())
+	return fmt.Errorf("%s: %w", msg, err)
 }
 
 // CheckForUnparsed takes in a API response object and returns an error if it contains an unparsed element

--- a/datadog/internal/utils/utils_test.go
+++ b/datadog/internal/utils/utils_test.go
@@ -2,7 +2,10 @@ package utils
 
 import (
 	"fmt"
+	"net/http"
+	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -472,6 +475,72 @@ func TestAppBuilderAppJSONStringSemanticEquals(t *testing.T) {
 
 			if diff := cmp.Diff(diags, testCase.expectedDiags); diff != "" {
 				t.Errorf("Unexpected diagnostics (-got, +expected): %s", diff)
+			}
+		})
+	}
+}
+
+func TestTranslateClientError(t *testing.T) {
+	// A "#channel" path segment percent-encodes to "%23channel". msg embeds the
+	// request path, so concatenating it into the format string made fmt read that
+	// as a width-23 verb, which mangled the message and swallowed the body.
+	const path = "/api/v1/integration/slack/configuration/accounts/example-account/channels/%23example-channel"
+	reqURL, err := url.Parse("https://api.datadoghq.com" + path)
+	if err != nil {
+		t.Fatalf("failed to parse test URL: %s", err)
+	}
+	httpresp := &http.Response{Request: &http.Request{URL: reqURL}}
+	body := []byte(`{"errors":["Account is not configured: example-account"]}`)
+
+	cases := map[string]struct {
+		err      error
+		httpresp *http.Response
+		msg      string
+		expected string
+	}{
+		"custom request api error": {
+			err:      CustomRequestAPIError{body: body, error: "400 Bad Request"},
+			httpresp: httpresp,
+			msg:      "error getting slack channel",
+			expected: `error getting slack channel from ` + path + `: 400 Bad Request: {"errors":["Account is not configured: example-account"]}`,
+		},
+		"url error": {
+			err:      &url.Error{Op: "Get", URL: reqURL.String(), Err: fmt.Errorf("connection refused")},
+			httpresp: httpresp,
+			msg:      "error getting slack channel",
+			expected: `error getting slack channel from ` + path + ` (url.Error): Get "` + reqURL.String() + `": connection refused`,
+		},
+		"plain error": {
+			err:      fmt.Errorf("boom"),
+			httpresp: httpresp,
+			msg:      "error getting slack channel",
+			expected: "error getting slack channel from " + path + ": boom",
+		},
+		"no http response": {
+			err:      fmt.Errorf("boom"),
+			httpresp: nil,
+			msg:      "error getting slack channel",
+			expected: "error getting slack channel: boom",
+		},
+		"empty message": {
+			err:      fmt.Errorf("boom"),
+			httpresp: nil,
+			msg:      "",
+			expected: "an error occurred: boom",
+		},
+	}
+
+	for name, tc := range cases {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := TranslateClientError(tc.err, tc.httpresp, tc.msg).Error()
+			if actual != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, actual)
+			}
+			if strings.Contains(actual, "%!") {
+				t.Errorf("message contains an unexpanded fmt verb: %q", actual)
 			}
 		})
 	}


### PR DESCRIPTION
 ### What does this PR do?

Stops `TranslateClientError` from using its own error message as a format string, which mangled every error whose request path contained a percent-encoded character.

  **The fix** — pass `msg` as an argument, in all four return paths:

  ```diff
  -return fmt.Errorf(msg+": %v: %s", err, apiErr.Body())
  +return fmt.Errorf("%s: %v: %s", msg, err, apiErr.Body())
  ```

  The message text is otherwise identical, so all ~320 `TranslateClientError`/`TranslateClientErrorDiag` call sites are fixed with no change to what they print.

  **Why it broke** — `msg` has the request path folded into it before being used as the format:

  ```go
  msg = fmt.Sprintf("%s from %s", msg, httpresp.Request.URL.EscapedPath())
  ```

  `EscapedPath()` percent-encodes the path, so escaped characters become `fmt` verbs. A `#channel` segment escapes to `%23channel`, which `fmt` reads as `%c` with width 23 — it
  consumes an argument, mangles the message, and leaves the trailing `%s` as `%!s(MISSING)`. A plain `400 Bad Request` on a `datadog_integration_slack_channel` refresh
  surfaced like this:

  ```
  error getting slack channel from .../channels/{[%!e(uint8=       123) ...] %!e(string=   400 Bad Request) ...}}xample-channel: [123 34 101 ...]: %!s(MISSING)
  ```