### PR TITLE
[TFgen] (OneOf) Updated the parsing to include OneOf objects

### DIFF
--- a/.generator-v2/internal/model/oneof.go
+++ b/.generator-v2/internal/model/oneof.go
@@ -8,19 +8,35 @@ import (
 
 // OneOfVariantNameCandidates contains the stable OpenAPI-derived identifiers
 // available for naming one Terraform oneOf variant block. The resolver considers
-// them in field order; StructuralFingerprint is the final fallback.
+// them in field order and rejects alternatives with no meaningful candidate.
 type OneOfVariantNameCandidates struct {
 	DiscriminatorKey string
 	RefName          string
 	PrimitiveType    string
 	PrimitiveFormat  string
-	ShaSum           string
+}
+
+// OneOfVariantNameResolutionError reports an alternative that has no
+// compatibility-stable source for its public Terraform block name.
+type OneOfVariantNameResolutionError struct {
+	Path        string
+	Alternative int
+}
+
+func (e *OneOfVariantNameResolutionError) Error() string {
+	return fmt.Sprintf(
+		"oneOf at %q alternative %d has no stable Terraform variant name; use a discriminator mapping key or a named schema reference",
+		e.Path,
+		e.Alternative,
+	)
 }
 
 // ResolveOneOfVariantName returns the stable snake_case Terraform block name for
 // a oneOf alternative. Empty or punctuation-only candidates are skipped so the
-// next meaningful source in the precedence chain can be used.
-func ResolveOneOfVariantName(candidates OneOfVariantNameCandidates) string {
+// next meaningful source in the precedence chain can be used. Anonymous
+// non-primitive alternatives fail rather than exposing a content- or
+// source-order-derived name as part of the public Terraform schema.
+func ResolveOneOfVariantName(path string, alternative int, candidates OneOfVariantNameCandidates) (string, error) {
 	primitive := candidates.PrimitiveType
 	if primitive != "" && candidates.PrimitiveFormat != "" {
 		primitive += "_" + candidates.PrimitiveFormat
@@ -32,20 +48,11 @@ func ResolveOneOfVariantName(candidates OneOfVariantNameCandidates) string {
 		primitive,
 	} {
 		if name := normalizeOneOfVariantName(candidate); name != "" {
-			return name
+			return name, nil
 		}
 	}
 
-	fallback := "variant"
-	if candidates.ShaSum != "" {
-		fallback += "_" + candidates.ShaSum
-	}
-	// "variant" makes this non-empty even when a caller supplies an unusable
-	// fingerprint, but normalize it for consistency with every other candidate.
-	if name := normalizeOneOfVariantName(fallback); name != "" {
-		return name
-	}
-	return "variant"
+	return "", &OneOfVariantNameResolutionError{Path: path, Alternative: alternative}
 }
 
 func normalizeOneOfVariantName(candidate string) string {

--- a/.generator-v2/internal/model/oneof.go
+++ b/.generator-v2/internal/model/oneof.go
@@ -1,0 +1,94 @@
+package model
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// OneOfVariantNameCandidates contains the stable OpenAPI-derived identifiers
+// available for naming one Terraform oneOf variant block. The resolver considers
+// them in field order; StructuralFingerprint is the final fallback.
+type OneOfVariantNameCandidates struct {
+	DiscriminatorKey string
+	RefName          string
+	PrimitiveType    string
+	PrimitiveFormat  string
+	ShaSum           string
+}
+
+// ResolveOneOfVariantName returns the stable snake_case Terraform block name for
+// a oneOf alternative. Empty or punctuation-only candidates are skipped so the
+// next meaningful source in the precedence chain can be used.
+func ResolveOneOfVariantName(candidates OneOfVariantNameCandidates) string {
+	primitive := candidates.PrimitiveType
+	if primitive != "" && candidates.PrimitiveFormat != "" {
+		primitive += "_" + candidates.PrimitiveFormat
+	}
+
+	for _, candidate := range []string{
+		candidates.DiscriminatorKey,
+		candidates.RefName,
+		primitive,
+	} {
+		if name := normalizeOneOfVariantName(candidate); name != "" {
+			return name
+		}
+	}
+
+	fallback := "variant"
+	if candidates.ShaSum != "" {
+		fallback += "_" + candidates.ShaSum
+	}
+	// "variant" makes this non-empty even when a caller supplies an unusable
+	// fingerprint, but normalize it for consistency with every other candidate.
+	if name := normalizeOneOfVariantName(fallback); name != "" {
+		return name
+	}
+	return "variant"
+}
+
+func normalizeOneOfVariantName(candidate string) string {
+	name := strings.Trim(SnakeCase(candidate), "_")
+	if name == "" {
+		return ""
+	}
+	if name[0] >= '0' && name[0] <= '9' {
+		return "variant_" + name
+	}
+	return name
+}
+
+// OneOfVariantNameCollisionError reports alternatives that normalize to the
+// same Terraform block name. Name is deterministic even if the alternatives
+// arrive in a different source order.
+type OneOfVariantNameCollisionError struct {
+	Path string
+	Name string
+}
+
+func (e *OneOfVariantNameCollisionError) Error() string {
+	return fmt.Sprintf("oneOf at %q has colliding variant name %q", e.Path, e.Name)
+}
+
+// ValidateOneOfVariantNames rejects post-normalization name collisions. If more
+// than one name collides, the lexicographically first duplicate is reported so
+// diagnostics do not depend on OpenAPI alternative order.
+func ValidateOneOfVariantNames(path string, variants []OneOfVariant) error {
+	counts := make(map[string]int, len(variants))
+	for _, variant := range variants {
+		counts[variant.TFName]++
+	}
+
+	var duplicates []string
+	for name, count := range counts {
+		if count > 1 {
+			duplicates = append(duplicates, name)
+		}
+	}
+	if len(duplicates) == 0 {
+		return nil
+	}
+	sort.Strings(duplicates)
+	return &OneOfVariantNameCollisionError{Path: path, Name: duplicates[0]}
+}

--- a/.generator-v2/internal/model/oneof_test.go
+++ b/.generator-v2/internal/model/oneof_test.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"errors"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -94,5 +96,95 @@ var _ = Describe("normalized oneOf model", func() {
 
 	It("retains the legacy kind alias during parser migration", func() {
 		Expect(SchemaKindVariant).To(Equal(SchemaKindOneOf))
+	})
+})
+
+var _ = Describe("deterministic oneOf variant naming", func() {
+
+	DescribeTable("uses the first meaningful candidate in the stable precedence order",
+		func(candidates OneOfVariantNameCandidates, want string) {
+			Expect(ResolveOneOfVariantName(candidates)).To(Equal(want))
+		},
+		Entry("discriminator mapping key wins",
+			OneOfVariantNameCandidates{
+				DiscriminatorKey: "HTTP Result",
+				RefName:          "ReferencedResult",
+				PrimitiveType:    "string",
+				PrimitiveFormat:  "uuid",
+				ShaSum:           "deadbeef",
+			},
+			"http_result",
+		),
+		Entry("referenced schema name wins over primitive type",
+			OneOfVariantNameCandidates{
+				RefName:       "ReferencedResult",
+				PrimitiveType: "string",
+				ShaSum:        "deadbeef",
+			},
+			"referenced_result",
+		),
+		Entry("primitive type includes its format",
+			OneOfVariantNameCandidates{
+				PrimitiveType:   "string",
+				PrimitiveFormat: "uuid",
+				ShaSum:          "deadbeef",
+			},
+			"string_uuid",
+		),
+		Entry("structural fingerprint is the final fallback",
+			OneOfVariantNameCandidates{ShaSum: "deadbeef"},
+			"variant_deadbeef",
+		),
+		Entry("an unusable reference name falls through to the primitive name",
+			OneOfVariantNameCandidates{
+				RefName:       "!!!",
+				PrimitiveType: "boolean",
+				ShaSum:        "deadbeef",
+			},
+			"boolean",
+		),
+		Entry("a numeric-leading name receives a Terraform-safe prefix",
+			OneOfVariantNameCandidates{DiscriminatorKey: "123 result"},
+			"variant_123_result",
+		),
+		Entry("empty candidates still produce a stable name",
+			OneOfVariantNameCandidates{},
+			"variant",
+		),
+	)
+
+	It("rejects names that collide after normalization", func() {
+		first := ResolveOneOfVariantName(OneOfVariantNameCandidates{DiscriminatorKey: "Foo Bar"})
+		second := ResolveOneOfVariantName(OneOfVariantNameCandidates{DiscriminatorKey: "foo_bar"})
+		Expect(first).To(Equal("foo_bar"))
+		Expect(second).To(Equal(first))
+
+		err := ValidateOneOfVariantNames("request.choice", []OneOfVariant{
+			{TFName: first},
+			{TFName: second},
+		})
+		Expect(err).To(HaveOccurred())
+
+		var collision *OneOfVariantNameCollisionError
+		Expect(errors.As(err, &collision)).To(BeTrue())
+		Expect(collision.Path).To(Equal("request.choice"))
+		Expect(collision.Name).To(Equal("foo_bar"))
+	})
+
+	It("reports the same collision regardless of alternative order", func() {
+		forward := []OneOfVariant{
+			{TFName: "zeta"}, {TFName: "zeta"},
+			{TFName: "alpha"}, {TFName: "alpha"},
+		}
+		reversed := []OneOfVariant{
+			{TFName: "alpha"}, {TFName: "alpha"},
+			{TFName: "zeta"}, {TFName: "zeta"},
+		}
+
+		var first, second *OneOfVariantNameCollisionError
+		Expect(errors.As(ValidateOneOfVariantNames("request", forward), &first)).To(BeTrue())
+		Expect(errors.As(ValidateOneOfVariantNames("request", reversed), &second)).To(BeTrue())
+		Expect(first).To(Equal(second))
+		Expect(first.Name).To(Equal("alpha"))
 	})
 })

--- a/.generator-v2/internal/model/oneof_test.go
+++ b/.generator-v2/internal/model/oneof_test.go
@@ -103,7 +103,9 @@ var _ = Describe("deterministic oneOf variant naming", func() {
 
 	DescribeTable("uses the first meaningful candidate in the stable precedence order",
 		func(candidates OneOfVariantNameCandidates, want string) {
-			Expect(ResolveOneOfVariantName(candidates)).To(Equal(want))
+			name, err := ResolveOneOfVariantName("request.choice", 1, candidates)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(name).To(Equal(want))
 		},
 		Entry("discriminator mapping key wins",
 			OneOfVariantNameCandidates{
@@ -111,7 +113,6 @@ var _ = Describe("deterministic oneOf variant naming", func() {
 				RefName:          "ReferencedResult",
 				PrimitiveType:    "string",
 				PrimitiveFormat:  "uuid",
-				ShaSum:           "deadbeef",
 			},
 			"http_result",
 		),
@@ -119,7 +120,6 @@ var _ = Describe("deterministic oneOf variant naming", func() {
 			OneOfVariantNameCandidates{
 				RefName:       "ReferencedResult",
 				PrimitiveType: "string",
-				ShaSum:        "deadbeef",
 			},
 			"referenced_result",
 		),
@@ -127,19 +127,13 @@ var _ = Describe("deterministic oneOf variant naming", func() {
 			OneOfVariantNameCandidates{
 				PrimitiveType:   "string",
 				PrimitiveFormat: "uuid",
-				ShaSum:          "deadbeef",
 			},
 			"string_uuid",
-		),
-		Entry("structural fingerprint is the final fallback",
-			OneOfVariantNameCandidates{ShaSum: "deadbeef"},
-			"variant_deadbeef",
 		),
 		Entry("an unusable reference name falls through to the primitive name",
 			OneOfVariantNameCandidates{
 				RefName:       "!!!",
 				PrimitiveType: "boolean",
-				ShaSum:        "deadbeef",
 			},
 			"boolean",
 		),
@@ -147,19 +141,38 @@ var _ = Describe("deterministic oneOf variant naming", func() {
 			OneOfVariantNameCandidates{DiscriminatorKey: "123 result"},
 			"variant_123_result",
 		),
-		Entry("empty candidates still produce a stable name",
-			OneOfVariantNameCandidates{},
-			"variant",
-		),
 	)
 
+	It("rejects an anonymous non-primitive alternative", func() {
+		name, err := ResolveOneOfVariantName("request.choice", 2, OneOfVariantNameCandidates{})
+		Expect(name).To(BeEmpty())
+
+		var unresolved *OneOfVariantNameResolutionError
+		Expect(errors.As(err, &unresolved)).To(BeTrue())
+		Expect(unresolved.Path).To(Equal("request.choice"))
+		Expect(unresolved.Alternative).To(Equal(2))
+		Expect(err.Error()).To(Equal(
+			`oneOf at "request.choice" alternative 2 has no stable Terraform variant name; use a discriminator mapping key or a named schema reference`,
+		))
+	})
+
 	It("rejects names that collide after normalization", func() {
-		first := ResolveOneOfVariantName(OneOfVariantNameCandidates{DiscriminatorKey: "Foo Bar"})
-		second := ResolveOneOfVariantName(OneOfVariantNameCandidates{DiscriminatorKey: "foo_bar"})
+		first, err := ResolveOneOfVariantName(
+			"request.choice",
+			1,
+			OneOfVariantNameCandidates{DiscriminatorKey: "Foo Bar"},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		second, err := ResolveOneOfVariantName(
+			"request.choice",
+			2,
+			OneOfVariantNameCandidates{DiscriminatorKey: "foo_bar"},
+		)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(first).To(Equal("foo_bar"))
 		Expect(second).To(Equal(first))
 
-		err := ValidateOneOfVariantNames("request.choice", []OneOfVariant{
+		err = ValidateOneOfVariantNames("request.choice", []OneOfVariant{
 			{TFName: first},
 			{TFName: second},
 		})

--- a/.generator-v2/internal/model/schema.go
+++ b/.generator-v2/internal/model/schema.go
@@ -22,11 +22,20 @@ const (
 // one rather than emitting a types.Dynamic escape hatch. (oneOf variants are
 // dropped, not errored.)
 type UnsupportedKindError struct {
-	Path string
-	Kind SchemaKind
+	Path   string
+	Kind   SchemaKind
+	Reason string
 }
 
 func (e *UnsupportedKindError) Error() string {
+	if e.Reason != "" {
+		return fmt.Sprintf(
+			"model: cannot build attribute at %q: schema kind %q is not representable: %s",
+			e.Path,
+			e.Kind,
+			e.Reason,
+		)
+	}
 	return fmt.Sprintf("model: cannot build attribute at %q: schema kind %q is not representable", e.Path, e.Kind)
 }
 
@@ -92,7 +101,11 @@ func buildAttribute(s *Schema, path string, mode nestingMode, diags *[]Diagnosti
 	case SchemaKindPrimitive, SchemaKindObject, SchemaKindArray, SchemaKindMap:
 		// representable — continue
 	default:
-		return nil, &UnsupportedKindError{Path: path, Kind: s.Kind}
+		return nil, &UnsupportedKindError{
+			Path:   path,
+			Kind:   s.Kind,
+			Reason: s.UnsupportedReason,
+		}
 	}
 
 	// A collection whose element is a oneOf variant has no representable element

--- a/.generator-v2/internal/model/schema_test.go
+++ b/.generator-v2/internal/model/schema_test.go
@@ -435,6 +435,23 @@ var _ = Describe("BuildResponseTree defensive guard", func() {
 			"response.m{}.bad"),
 	)
 
+	It("retains a parser-supplied reason when an unsupported node fails one artifact", func() {
+		tree, _, err := BuildResponseTree(objSchema(map[string]*Schema{
+			"choice": {
+				Kind:              SchemaKindUnsupported,
+				UnsupportedReason: `parser: oneOf at "response.choice" has colliding variant name "object"`,
+			},
+		}))
+		Expect(tree).To(BeNil())
+
+		var unsupported *UnsupportedKindError
+		Expect(errors.As(err, &unsupported)).To(BeTrue())
+		Expect(unsupported.Path).To(Equal("response.choice"))
+		Expect(unsupported.Kind).To(Equal(SchemaKindUnsupported))
+		Expect(unsupported.Reason).To(ContainSubstring("colliding variant name"))
+		Expect(err.Error()).To(ContainSubstring(`oneOf at "response.choice"`))
+	})
+
 	It("returns the type-mapping error for a non-object root that cannot be mapped (array-of-array)", func() {
 		tree, _, err := BuildResponseTree(arrSchema(arrSchema(primSchema("string"))))
 		Expect(tree).To(BeNil())

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -47,9 +47,9 @@ const (
 	SchemaKindRefCycle    SchemaKind = "ref_cycle"   // $ref cycle or beyond --max-depth
 	SchemaKindUnsupported SchemaKind = "unsupported" // no representable type/structure, or anyOf; always rejected
 
-	// SchemaKindVariant is the legacy parser name for SchemaKindOneOf. It stays
-	// as an alias until the parser migration populates Schema.OneOf directly.
-	// New model code should use SchemaKindOneOf.
+	// SchemaKindVariant is retained as a source-compatibility alias for code
+	// written before the parser populated Schema.OneOf directly. New code should
+	// use SchemaKindOneOf.
 	SchemaKindVariant = SchemaKindOneOf
 )
 
@@ -173,7 +173,7 @@ type Schema struct {
 	// required to bind those alternatives to the generated SDK wrapper.
 	OneOf *OneOfSpec
 	// Variants is the parser's legacy oneOf representation. It remains only as a
-	// compatibility bridge until normalization constructs OneOfSpec; new model
+	// source-compatibility bridge; NormalizeSchemas leaves it empty and new model
 	// and emit code must consume OneOf instead.
 	//
 	// Deprecated: use OneOf.Variants.

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -188,6 +188,11 @@ type Schema struct {
 	Sensitive bool
 	// Description is the OpenAPI description, populated during NormalizeSchemas.
 	Description string
+	// UnsupportedReason explains why a node with Kind == SchemaKindUnsupported
+	// cannot be represented. It is retained so the affected artifact can fail
+	// with the parser's actionable local diagnostic without aborting spec loading
+	// or preventing unrelated artifacts from being generated.
+	UnsupportedReason string
 }
 
 // OneOfSpec is the normalized representation of an OpenAPI oneOf. The envelope

--- a/.generator-v2/internal/parser/schema.go
+++ b/.generator-v2/internal/parser/schema.go
@@ -521,7 +521,6 @@ func (n *schemaNormalizer) normalizeOneOf(s *base.Schema, depth int, ctx schemaC
 		Discriminator: normalizeDiscriminator(s.Discriminator),
 	}
 
-	seenNames := make(map[string]struct{}, len(s.OneOf))
 	for _, proxy := range s.OneOf {
 		source, err := n.inspectOneOfVariants(proxy, depth)
 		if err != nil {
@@ -535,11 +534,6 @@ func (n *schemaNormalizer) normalizeOneOf(s *base.Schema, depth int, ctx schemaC
 		}
 
 		tfName := oneOfVariantName(s.Discriminator, proxy, source)
-		if _, exists := seenNames[tfName]; exists {
-			return nil, fmt.Errorf("parser: oneOf at %q has colliding variant name %q", ctx.path, tfName)
-		}
-		seenNames[tfName] = struct{}{}
-
 		variantPath := childPath(ctx.path, tfName)
 		variantSchema, err := n.normalizeProxyAt(proxy, depth, schemaContext{
 			path:     variantPath,
@@ -569,6 +563,9 @@ func (n *schemaNormalizer) normalizeOneOf(s *base.Schema, depth int, ctx schemaC
 	sort.Slice(union.Variants, func(i, j int) bool {
 		return union.Variants[i].TFName < union.Variants[j].TFName
 	})
+	if err := model.ValidateOneOfVariantNames(ctx.path, union.Variants); err != nil {
+		return nil, fmt.Errorf("parser: %w", err)
+	}
 	return union, nil
 }
 
@@ -624,29 +621,19 @@ func normalizeDiscriminator(discriminator *base.Discriminator) *model.OneOfDiscr
 }
 
 func oneOfVariantName(discriminator *base.Discriminator, proxy *base.SchemaProxy, source oneOfAlternativeSource) string {
-	candidate := discriminatorNameForRef(discriminator, source.ref, source.refName)
-	if candidate == "" {
-		candidate = source.refName
+	candidates := model.OneOfVariantNameCandidates{
+		DiscriminatorKey: discriminatorNameForRef(discriminator, source.ref, source.refName),
+		RefName:          source.refName,
 	}
-	if candidate == "" && source.schema != nil && isRepresentablePrimitive(source.schema) {
-		candidate = firstType(source.schema)
-		if candidate != "" && source.schema.Format != "" {
-			candidate += "_" + source.schema.Format
+	if source.schema != nil {
+		if isRepresentablePrimitive(source.schema) {
+			candidates.PrimitiveType = firstType(source.schema)
+			candidates.PrimitiveFormat = source.schema.Format
 		}
 	}
-	if candidate == "" {
-		sum := sha256.Sum256([]byte(schemaProxySignature(proxy)))
-		candidate = fmt.Sprintf("variant_%x", sum[:4])
-	}
-	candidate = model.SnakeCase(candidate)
-	candidate = strings.Trim(candidate, "_")
-	if candidate == "" {
-		candidate = "variant"
-	}
-	if candidate[0] >= '0' && candidate[0] <= '9' {
-		candidate = "variant_" + candidate
-	}
-	return candidate
+	sum := sha256.Sum256([]byte(schemaProxySignature(proxy)))
+	candidates.ShaSum = fmt.Sprintf("%x", sum[:4])
+	return model.ResolveOneOfVariantName(candidates)
 }
 
 func discriminatorNameForRef(discriminator *base.Discriminator, ref, refName string) string {

--- a/.generator-v2/internal/parser/schema.go
+++ b/.generator-v2/internal/parser/schema.go
@@ -81,7 +81,9 @@ func backtickedToken(s string) (string, bool) {
 // application/json body of the lowest-numbered 2xx code that has one. A missing
 // body leaves the field nil. $refs resolve through spec.Components up to maxDepth
 // edges, beyond which a node is SchemaKindRefCycle; a missing target yields
-// *UnresolvableRefError. Untracked, ungrouped operations are left untouched.
+// *UnresolvableRefError. Local oneOf naming failures become
+// SchemaKindUnsupported nodes carrying their reason so unrelated operations can
+// still normalize. Untracked, ungrouped operations are left untouched.
 func NormalizeSchemas(spec *model.Spec, rawOps map[*model.Operation]*v3.Operation, maxDepth int, trackingFieldName string) error {
 	if spec == nil {
 		return nil
@@ -493,12 +495,26 @@ func (n *schemaNormalizer) normalizeSchema(s *base.Schema, depth int, ctx schema
 	case model.SchemaKindOneOf:
 		union, err := n.normalizeOneOf(s, depth, ctx)
 		if err != nil {
+			if isLocalOneOfNamingError(err) {
+				out.Kind = model.SchemaKindUnsupported
+				out.UnsupportedReason = err.Error()
+				return out, nil
+			}
 			return nil, err
 		}
 		out.OneOf = union
 	}
 
 	return out, nil
+}
+
+func isLocalOneOfNamingError(err error) bool {
+	var unresolved *model.OneOfVariantNameResolutionError
+	if errors.As(err, &unresolved) {
+		return true
+	}
+	var collision *model.OneOfVariantNameCollisionError
+	return errors.As(err, &collision)
 }
 
 type oneOfAlternativeSource struct {
@@ -682,7 +698,29 @@ func (n *schemaNormalizer) mergeOneOfSiblings(
 	if err != nil {
 		return nil, err
 	}
+	// A type:object sibling carrying only required names is a constraint
+	// carrier, not a standalone Terraform object. General schema normalization
+	// correctly classifies an object with no properties as Unsupported, but
+	// retaining that sentinel here would cause mergeNormalizedSchemas to discard
+	// the required constraint. Give this merge-only schema an empty object shape
+	// so its required names are applied to every object alternative.
+	if common.Kind == model.SchemaKindUnsupported && isRequiredOnlyObjectConstraint(commonRaw) {
+		common.Kind = model.SchemaKindObject
+		common.Properties = make(map[string]*model.Schema)
+		common.Required = sortedRequired(commonRaw)
+	}
 	return mergeNormalizedSchemas(variant, common), nil
+}
+
+func isRequiredOnlyObjectConstraint(s *base.Schema) bool {
+	return s != nil &&
+		hasType(s, "object") &&
+		len(s.Required) > 0 &&
+		(s.Properties == nil || orderedmap.Len(s.Properties) == 0) &&
+		s.Items == nil &&
+		s.AdditionalProperties == nil &&
+		len(s.Enum) == 0 &&
+		s.Format == ""
 }
 
 func oneOfSiblingSchema(s *base.Schema) (*base.Schema, bool) {
@@ -725,6 +763,9 @@ func mergeNormalizedSchemas(variant, common *model.Schema) *model.Schema {
 		return variant
 	}
 	if variant.Kind == model.SchemaKindUnsupported {
+		if variant.UnsupportedReason != "" {
+			return variant
+		}
 		if common.Description == "" {
 			common.Description = variant.Description
 		}

--- a/.generator-v2/internal/parser/schema.go
+++ b/.generator-v2/internal/parser/schema.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"slices"
@@ -158,6 +159,15 @@ type schemaNormalizer struct {
 	trackingFieldName string
 }
 
+// schemaContext carries information that is not available after a SchemaProxy
+// has been resolved. oneOf normalization needs all three values to retain
+// component identity and to give inline/nested unions deterministic paths.
+type schemaContext struct {
+	path     string
+	required bool
+	refName  string
+}
+
 // fillOperation normalizes raw's request and 2xx response bodies into op,
 // leaving a field nil when its body is absent. It also captures query
 // parameters, pagination, and the list element type, which feed the plural
@@ -167,7 +177,11 @@ func (n *schemaNormalizer) fillOperation(op *model.Operation, raw *v3.Operation)
 		return nil
 	}
 	if reqProxy := requestBodySchemaProxy(raw); reqProxy != nil {
-		req, err := n.normalizeProxy(reqProxy, 0)
+		required := raw.RequestBody.Required != nil && *raw.RequestBody.Required
+		req, err := n.normalizeProxyAt(reqProxy, 0, schemaContext{
+			path:     "request",
+			required: required,
+		})
 		if err != nil {
 			return err
 		}
@@ -189,7 +203,7 @@ func (n *schemaNormalizer) fillOperation(op *model.Operation, raw *v3.Operation)
 	if respProxy.IsReference() {
 		op.ResponseRefName = lastRefSegment(respProxy.GetReference())
 	}
-	resp, err := n.normalizeProxy(respProxy, 0)
+	resp, err := n.normalizeProxyAt(respProxy, 0, schemaContext{path: "response", required: true})
 	if err != nil {
 		return err
 	}
@@ -212,7 +226,10 @@ func (n *schemaNormalizer) fillQueryParams(op *model.Operation, raw *v3.Operatio
 		if p == nil || p.In != "query" || p.Name == "" {
 			continue
 		}
-		schema, err := n.normalizeProxy(p.Schema, 0)
+		schema, err := n.normalizeProxyAt(p.Schema, 0, schemaContext{
+			path:     "query." + p.Name,
+			required: p.Required != nil && *p.Required,
+		})
 		if err != nil {
 			return err
 		}
@@ -365,14 +382,18 @@ func responseBodySchemaProxy(op *v3.Operation) *base.SchemaProxy {
 	return nil
 }
 
-// normalizeProxy normalizes one schema proxy, resolving a $ref through the
-// component set and counting it against the depth budget. At the boundary the
-// node is classified SchemaKindRefCycle rather than expanded.
-func (n *schemaNormalizer) normalizeProxy(proxy *base.SchemaProxy, depth int) (*model.Schema, error) {
+// normalizeProxyAt normalizes one schema proxy, resolving a $ref through the
+// component set and counting it against the depth budget. The first component
+// name is retained in ctx before resolution, since libopenapi's resolved schema
+// no longer identifies the component that supplied a oneOf envelope.
+func (n *schemaNormalizer) normalizeProxyAt(proxy *base.SchemaProxy, depth int, ctx schemaContext) (*model.Schema, error) {
 	if proxy == nil {
 		return nil, nil
 	}
 	if proxy.IsReference() {
+		if ctx.refName == "" {
+			ctx.refName = lastRefSegment(proxy.GetReference())
+		}
 		// depth counts $ref edges already followed; the >= bound matches cycles.go.
 		if n.maxDepth > 0 && depth >= n.maxDepth {
 			return &model.Schema{Kind: model.SchemaKindRefCycle}, nil
@@ -381,9 +402,9 @@ func (n *schemaNormalizer) normalizeProxy(proxy *base.SchemaProxy, depth int) (*
 		if err != nil {
 			return nil, err
 		}
-		return n.normalizeProxy(target, depth+1)
+		return n.normalizeProxyAt(target, depth+1, ctx)
 	}
-	return n.normalizeSchema(proxy.Schema(), depth)
+	return n.normalizeSchema(proxy.Schema(), depth, ctx)
 }
 
 // resolveRef returns the proxy a "#/components/schemas/<name>" ref points to, or
@@ -406,7 +427,7 @@ func (n *schemaNormalizer) resolveRef(ref string) (*base.SchemaProxy, error) {
 // normalizeSchema converts a resolved *base.Schema into a model.Schema:
 // classifying its kind from structure and carrying Type, Format, Enum, Required
 // and Sensitive. Children recurse at the same depth — only $refs cost depth.
-func (n *schemaNormalizer) normalizeSchema(s *base.Schema, depth int) (*model.Schema, error) {
+func (n *schemaNormalizer) normalizeSchema(s *base.Schema, depth int, ctx schemaContext) (*model.Schema, error) {
 	if s == nil {
 		return nil, nil
 	}
@@ -428,7 +449,10 @@ func (n *schemaNormalizer) normalizeSchema(s *base.Schema, depth int) (*model.Sc
 		out.Properties = make(map[string]*model.Schema)
 		// Sorted iteration keeps recursion (and any surfaced error) deterministic.
 		for _, key := range sortedPropertyKeys(s) {
-			child, err := n.normalizeProxy(s.Properties.GetOrZero(key), depth)
+			child, err := n.normalizeProxyAt(s.Properties.GetOrZero(key), depth, schemaContext{
+				path:     childPath(ctx.path, key),
+				required: slices.Contains(s.Required, key),
+			})
 			if err != nil {
 				return nil, err
 			}
@@ -439,7 +463,10 @@ func (n *schemaNormalizer) normalizeSchema(s *base.Schema, depth int) (*model.Sc
 	case model.SchemaKindArray:
 		// Array: a single element schema, carried in out.Items.
 		if s.Items != nil && s.Items.IsA() {
-			item, err := n.normalizeProxy(s.Items.A, depth)
+			item, err := n.normalizeProxyAt(s.Items.A, depth, schemaContext{
+				path:     childPath(ctx.path, "[]"),
+				required: true,
+			})
 			if err != nil {
 				return nil, err
 			}
@@ -452,7 +479,10 @@ func (n *schemaNormalizer) normalizeSchema(s *base.Schema, depth int) (*model.Sc
 		// no value schema — its values are unconstrained, which TF cannot
 		// represent, so carry an Unsupported sentinel for the check to reject.
 		if s.AdditionalProperties != nil && s.AdditionalProperties.IsA() {
-			value, err := n.normalizeProxy(s.AdditionalProperties.A, depth)
+			value, err := n.normalizeProxyAt(s.AdditionalProperties.A, depth, schemaContext{
+				path:     childPath(ctx.path, "{}"),
+				required: true,
+			})
 			if err != nil {
 				return nil, err
 			}
@@ -461,38 +491,446 @@ func (n *schemaNormalizer) normalizeSchema(s *base.Schema, depth int) (*model.Sc
 			out.Items = &model.Schema{Kind: model.SchemaKindUnsupported}
 		}
 
-	case model.SchemaKindVariant:
-		// Variant: one of several alternative oneOf shapes (anyOf is classified
-		// unsupported). Every alternative is normalized into out.Variants.
-		for _, variant := range s.OneOf {
-			v, err := n.normalizeProxy(variant, depth)
-			if err != nil {
-				return nil, err
-			}
-			out.Variants = append(out.Variants, v)
+	case model.SchemaKindOneOf:
+		union, err := n.normalizeOneOf(s, depth, ctx)
+		if err != nil {
+			return nil, err
 		}
+		out.OneOf = union
 	}
 
 	return out, nil
 }
 
+type oneOfAlternativeSource struct {
+	schema  *base.Schema
+	ref     string
+	refName string
+}
+
+// normalizeOneOf builds the parser-facing union model while the raw OpenAPI
+// proxies are still available. This is the only point at which component
+// references, discriminator mappings and sibling constraints can all be
+// associated with the same alternative without guessing downstream.
+func (n *schemaNormalizer) normalizeOneOf(s *base.Schema, depth int, ctx schemaContext) (*model.OneOfSpec, error) {
+	union := &model.OneOfSpec{
+		Name:          oneOfEnvelopeName(ctx),
+		Path:          ctx.path,
+		Optional:      !ctx.required,
+		Nullable:      schemaAllowsNull(s),
+		Discriminator: normalizeDiscriminator(s.Discriminator),
+	}
+
+	seenNames := make(map[string]struct{}, len(s.OneOf))
+	for _, proxy := range s.OneOf {
+		source, err := n.inspectOneOfVariants(proxy, depth)
+		if err != nil {
+			return nil, err
+		}
+		if source.schema != nil && schemaAllowsNull(source.schema) {
+			union.Nullable = true
+		}
+		if source.schema != nil && isNullOnlySchema(source.schema) {
+			continue
+		}
+
+		tfName := oneOfVariantName(s.Discriminator, proxy, source)
+		if _, exists := seenNames[tfName]; exists {
+			return nil, fmt.Errorf("parser: oneOf at %q has colliding variant name %q", ctx.path, tfName)
+		}
+		seenNames[tfName] = struct{}{}
+
+		variantPath := childPath(ctx.path, tfName)
+		variantSchema, err := n.normalizeProxyAt(proxy, depth, schemaContext{
+			path:     variantPath,
+			required: true,
+			refName:  source.refName,
+		})
+		if err != nil {
+			return nil, err
+		}
+		variantSchema, err = n.mergeOneOfSiblings(s, variantSchema, depth, schemaContext{path: variantPath})
+		if err != nil {
+			return nil, err
+		}
+		if variantSchema == nil {
+			variantSchema = &model.Schema{Kind: model.SchemaKindUnsupported}
+		}
+
+		union.Variants = append(union.Variants, model.OneOfVariant{
+			TFName:       tfName,
+			GoName:       model.SdkName(tfName),
+			Schema:       variantSchema,
+			RefName:      source.refName,
+			ValueWrapped: oneOfValueWrapped(variantSchema),
+		})
+	}
+
+	sort.Slice(union.Variants, func(i, j int) bool {
+		return union.Variants[i].TFName < union.Variants[j].TFName
+	})
+	return union, nil
+}
+
+// inspectOneOfVariants follows reference chains only far enough to retain
+// the outer component name and inspect naming/nullability metadata. The normal
+// normalization pass still owns depth handling and schema conversion.
+func (n *schemaNormalizer) inspectOneOfVariants(proxy *base.SchemaProxy, depth int) (oneOfAlternativeSource, error) {
+	var source oneOfAlternativeSource
+	for proxy != nil && proxy.IsReference() {
+		if source.ref == "" {
+			source.ref = proxy.GetReference()
+			source.refName = lastRefSegment(source.ref)
+		}
+		if n.maxDepth > 0 && depth >= n.maxDepth {
+			return source, nil
+		}
+		target, err := n.resolveRef(proxy.GetReference())
+		if err != nil {
+			return source, err
+		}
+		proxy = target
+		depth++
+	}
+	if proxy != nil {
+		source.schema = proxy.Schema()
+	}
+	return source, nil
+}
+
+func oneOfEnvelopeName(ctx schemaContext) string {
+	if ctx.refName != "" {
+		return ctx.refName
+	}
+	name := model.SdkName(ctx.path)
+	if name == "" {
+		name = "Inline"
+	}
+	return name + "OneOf"
+}
+
+func normalizeDiscriminator(discriminator *base.Discriminator) *model.OneOfDiscriminator {
+	if discriminator == nil {
+		return nil
+	}
+	out := &model.OneOfDiscriminator{PropertyName: discriminator.PropertyName}
+	if discriminator.Mapping != nil && orderedmap.Len(discriminator.Mapping) > 0 {
+		out.Mapping = make(map[string]string, orderedmap.Len(discriminator.Mapping))
+		for key, value := range discriminator.Mapping.FromOldest() {
+			out.Mapping[key] = value
+		}
+	}
+	return out
+}
+
+func oneOfVariantName(discriminator *base.Discriminator, proxy *base.SchemaProxy, source oneOfAlternativeSource) string {
+	candidate := discriminatorNameForRef(discriminator, source.ref, source.refName)
+	if candidate == "" {
+		candidate = source.refName
+	}
+	if candidate == "" && source.schema != nil && isRepresentablePrimitive(source.schema) {
+		candidate = firstType(source.schema)
+		if candidate != "" && source.schema.Format != "" {
+			candidate += "_" + source.schema.Format
+		}
+	}
+	if candidate == "" {
+		sum := sha256.Sum256([]byte(schemaProxySignature(proxy)))
+		candidate = fmt.Sprintf("variant_%x", sum[:4])
+	}
+	candidate = model.SnakeCase(candidate)
+	candidate = strings.Trim(candidate, "_")
+	if candidate == "" {
+		candidate = "variant"
+	}
+	if candidate[0] >= '0' && candidate[0] <= '9' {
+		candidate = "variant_" + candidate
+	}
+	return candidate
+}
+
+func discriminatorNameForRef(discriminator *base.Discriminator, ref, refName string) string {
+	if discriminator == nil || discriminator.Mapping == nil || (ref == "" && refName == "") {
+		return ""
+	}
+	keys := make([]string, 0, orderedmap.Len(discriminator.Mapping))
+	for key := range discriminator.Mapping.KeysFromOldest() {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		mapped := discriminator.Mapping.GetOrZero(key)
+		if mapped == ref || (refName != "" && lastRefSegment(mapped) == refName) {
+			return key
+		}
+	}
+	return ""
+}
+
+// schemaProxySignature is deliberately independent of oneOf source order and
+// OpenAPI map insertion order. It is only the final naming fallback for inline,
+// non-primitive alternatives.
+func schemaProxySignature(proxy *base.SchemaProxy) string {
+	if proxy == nil {
+		return "nil"
+	}
+	if proxy.IsReference() {
+		return "ref:" + proxy.GetReference()
+	}
+	s := proxy.Schema()
+	if s == nil {
+		return "empty"
+	}
+
+	var parts []string
+	types := append([]string(nil), s.Type...)
+	sort.Strings(types)
+	parts = append(parts, "type="+strings.Join(types, ","), "format="+s.Format)
+
+	required := append([]string(nil), s.Required...)
+	sort.Strings(required)
+	parts = append(parts, "required="+strings.Join(required, ","))
+
+	for _, key := range sortedPropertyKeys(s) {
+		parts = append(parts, "property:"+key+"="+schemaProxySignature(s.Properties.GetOrZero(key)))
+	}
+	if s.Items != nil && s.Items.IsA() {
+		parts = append(parts, "items="+schemaProxySignature(s.Items.A))
+	}
+	if s.AdditionalProperties != nil {
+		switch {
+		case s.AdditionalProperties.IsA():
+			parts = append(parts, "additional="+schemaProxySignature(s.AdditionalProperties.A))
+		case s.AdditionalProperties.IsB():
+			parts = append(parts, fmt.Sprintf("additional=%t", s.AdditionalProperties.B))
+		}
+	}
+
+	oneOf := make([]string, 0, len(s.OneOf))
+	for _, child := range s.OneOf {
+		oneOf = append(oneOf, schemaProxySignature(child))
+	}
+	sort.Strings(oneOf)
+	parts = append(parts, "oneOf="+strings.Join(oneOf, "|"))
+
+	enum := enumValues(s)
+	sort.Strings(enum)
+	parts = append(parts, "enum="+strings.Join(enum, ","))
+	return strings.Join(parts, ";")
+}
+
+// mergeOneOfSiblings applies the constraints adjacent to oneOf to an
+// alternative. Normalizing a shallow copy without oneOf lets the existing
+// object/array/map/primitive code process those siblings using the variant's
+// canonical path.
+func (n *schemaNormalizer) mergeOneOfSiblings(
+	parent *base.Schema,
+	variant *model.Schema,
+	depth int,
+	ctx schemaContext,
+) (*model.Schema, error) {
+	commonRaw, ok := oneOfSiblingSchema(parent)
+	if !ok {
+		return variant, nil
+	}
+	common, err := n.normalizeSchema(commonRaw, depth, ctx)
+	if err != nil {
+		return nil, err
+	}
+	return mergeNormalizedSchemas(variant, common), nil
+}
+
+func oneOfSiblingSchema(s *base.Schema) (*base.Schema, bool) {
+	if s == nil {
+		return nil, false
+	}
+	common := *s
+	common.OneOf = nil
+	common.AnyOf = nil
+	common.Discriminator = nil
+	common.Nullable = nil
+	common.Description = ""
+	common.Type = nonNullTypes(s.Type)
+
+	hasConstraints := len(common.Type) > 0 ||
+		(common.Properties != nil && orderedmap.Len(common.Properties) > 0) ||
+		len(common.Required) > 0 ||
+		common.Items != nil ||
+		common.AdditionalProperties != nil ||
+		len(common.Enum) > 0 ||
+		common.Format != ""
+	return &common, hasConstraints
+}
+
+// mergeNormalizedSchemas intersects the subset of OpenAPI constraints retained
+// by model.Schema. A kind mismatch remains present as an Unsupported variant so
+// later validation can report that precise alternative instead of dropping it.
+func mergeNormalizedSchemas(variant, common *model.Schema) *model.Schema {
+	if variant == nil {
+		return common
+	}
+	if common == nil || common.Kind == model.SchemaKindUnsupported {
+		return variant
+	}
+	if variant.Kind == model.SchemaKindOneOf && variant.OneOf != nil {
+		for i := range variant.OneOf.Variants {
+			variant.OneOf.Variants[i].Schema = mergeNormalizedSchemas(variant.OneOf.Variants[i].Schema, common)
+			variant.OneOf.Variants[i].ValueWrapped = oneOfValueWrapped(variant.OneOf.Variants[i].Schema)
+		}
+		return variant
+	}
+	if variant.Kind == model.SchemaKindUnsupported {
+		if common.Description == "" {
+			common.Description = variant.Description
+		}
+		return common
+	}
+	if variant.Kind != common.Kind {
+		return &model.Schema{
+			Kind:        model.SchemaKindUnsupported,
+			Description: variant.Description,
+		}
+	}
+
+	switch variant.Kind {
+	case model.SchemaKindObject:
+		if variant.Properties == nil {
+			variant.Properties = make(map[string]*model.Schema)
+		}
+		for key, commonProperty := range common.Properties {
+			if property, exists := variant.Properties[key]; exists {
+				variant.Properties[key] = mergeNormalizedSchemas(property, commonProperty)
+			} else {
+				variant.Properties[key] = commonProperty
+			}
+		}
+		variant.Required = sortedUniqueStrings(append(variant.Required, common.Required...))
+	case model.SchemaKindArray, model.SchemaKindMap:
+		variant.Items = mergeNormalizedSchemas(variant.Items, common.Items)
+	case model.SchemaKindPrimitive:
+		if variant.Type != "" && common.Type != "" && variant.Type != common.Type {
+			return &model.Schema{
+				Kind:        model.SchemaKindUnsupported,
+				Description: variant.Description,
+			}
+		}
+		if variant.Type == "" {
+			variant.Type = common.Type
+		}
+		if variant.Format != "" && common.Format != "" && variant.Format != common.Format {
+			return &model.Schema{
+				Kind:        model.SchemaKindUnsupported,
+				Description: variant.Description,
+			}
+		}
+		if variant.Format == "" {
+			variant.Format = common.Format
+		}
+		switch {
+		case len(variant.Enum) == 0:
+			variant.Enum = append([]string(nil), common.Enum...)
+		case len(common.Enum) > 0:
+			intersection := intersectStrings(variant.Enum, common.Enum)
+			if len(intersection) == 0 {
+				return &model.Schema{
+					Kind:        model.SchemaKindUnsupported,
+					Description: variant.Description,
+				}
+			}
+			variant.Enum = intersection
+		}
+	}
+	variant.Sensitive = variant.Sensitive || common.Sensitive
+	return variant
+}
+
+func oneOfValueWrapped(schema *model.Schema) bool {
+	if schema == nil {
+		return false
+	}
+	switch schema.Kind {
+	case model.SchemaKindPrimitive, model.SchemaKindArray, model.SchemaKindMap:
+		return true
+	default:
+		return false
+	}
+}
+
+func schemaAllowsNull(s *base.Schema) bool {
+	return s != nil && ((s.Nullable != nil && *s.Nullable) || hasType(s, "null"))
+}
+
+func isNullOnlySchema(s *base.Schema) bool {
+	if !schemaAllowsNull(s) {
+		return false
+	}
+	return len(nonNullTypes(s.Type)) == 0 &&
+		len(s.AllOf) == 0 &&
+		len(s.OneOf) == 0 &&
+		len(s.AnyOf) == 0 &&
+		(s.Properties == nil || orderedmap.Len(s.Properties) == 0) &&
+		s.Items == nil &&
+		s.AdditionalProperties == nil
+}
+
+func nonNullTypes(types []string) []string {
+	out := make([]string, 0, len(types))
+	for _, typ := range types {
+		if typ != "null" {
+			out = append(out, typ)
+		}
+	}
+	return out
+}
+
+func childPath(parent, child string) string {
+	if parent == "" {
+		return child
+	}
+	if child == "[]" || child == "{}" {
+		return parent + child
+	}
+	return parent + "." + child
+}
+
+func sortedUniqueStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	sort.Strings(values)
+	return slices.Compact(values)
+}
+
+func intersectStrings(left, right []string) []string {
+	allowed := make(map[string]struct{}, len(right))
+	for _, value := range right {
+		allowed[value] = struct{}{}
+	}
+	var intersection []string
+	for _, value := range left {
+		if _, ok := allowed[value]; ok {
+			intersection = append(intersection, value)
+		}
+	}
+	return sortedUniqueStrings(intersection)
+}
+
 // classifyKind derives the SchemaKind from structure, not type alone. Precedence
 // (first match wins, since a node can satisfy several at once):
-// anyOf → unsupported; oneOf → variant; properties → object; type:array+items →
+// anyOf → unsupported; oneOf → one_of; properties → object; type:array+items →
 // array; additionalProperties → map; a concrete scalar type → primitive; anything
 // else (free-form/empty object, typeless leaf, itemless array) → unsupported.
 //
-// oneOf and anyOf are handled differently downstream: a oneOf variant is dropped
-// from the attribute tree, while an anyOf — which we never expect and have not
-// validated — is classified unsupported so its artifact fails rather than guessing.
+// oneOf and anyOf are intentionally distinct: oneOf is normalized into a typed
+// envelope, while anyOf remains unsupported so its artifact fails rather than
+// inheriting oneOf's exactly-one semantics.
 func classifyKind(s *base.Schema) model.SchemaKind {
 	switch {
 	case len(s.AnyOf) > 0:
 		// anyOf has no Terraform equivalent; reject rather than drop or guess.
 		return model.SchemaKindUnsupported
 	case len(s.OneOf) > 0:
-		// "one of several shapes"; the attribute-tree builder drops it.
-		return model.SchemaKindVariant
+		return model.SchemaKindOneOf
 	case s.Properties != nil && orderedmap.Len(s.Properties) > 0:
 		// Declared named fields → object, regardless of the type keyword.
 		return model.SchemaKindObject
@@ -560,10 +998,14 @@ func isRepresentablePrimitive(s *base.Schema) bool {
 	}
 }
 
-// firstType returns the schema's first declared type, or "" when untyped.
+// firstType returns the schema's first non-null declared type, or "" when the
+// schema is untyped/null-only. Nullability is represented on OneOfSpec rather
+// than as a primitive alternative.
 func firstType(s *base.Schema) string {
-	if len(s.Type) > 0 {
-		return s.Type[0]
+	for _, typ := range s.Type {
+		if typ != "null" {
+			return typ
+		}
 	}
 	return ""
 }

--- a/.generator-v2/internal/parser/schema.go
+++ b/.generator-v2/internal/parser/schema.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"slices"
@@ -521,7 +520,7 @@ func (n *schemaNormalizer) normalizeOneOf(s *base.Schema, depth int, ctx schemaC
 		Discriminator: normalizeDiscriminator(s.Discriminator),
 	}
 
-	for _, proxy := range s.OneOf {
+	for alternativeIndex, proxy := range s.OneOf {
 		source, err := n.inspectOneOfVariants(proxy, depth)
 		if err != nil {
 			return nil, err
@@ -533,7 +532,15 @@ func (n *schemaNormalizer) normalizeOneOf(s *base.Schema, depth int, ctx schemaC
 			continue
 		}
 
-		tfName := oneOfVariantName(s.Discriminator, proxy, source)
+		tfName, err := oneOfVariantName(
+			s.Discriminator,
+			source,
+			ctx.path,
+			alternativeIndex+1,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("parser: %w", err)
+		}
 		variantPath := childPath(ctx.path, tfName)
 		variantSchema, err := n.normalizeProxyAt(proxy, depth, schemaContext{
 			path:     variantPath,
@@ -620,7 +627,12 @@ func normalizeDiscriminator(discriminator *base.Discriminator) *model.OneOfDiscr
 	return out
 }
 
-func oneOfVariantName(discriminator *base.Discriminator, proxy *base.SchemaProxy, source oneOfAlternativeSource) string {
+func oneOfVariantName(
+	discriminator *base.Discriminator,
+	source oneOfAlternativeSource,
+	path string,
+	alternative int,
+) (string, error) {
 	candidates := model.OneOfVariantNameCandidates{
 		DiscriminatorKey: discriminatorNameForRef(discriminator, source.ref, source.refName),
 		RefName:          source.refName,
@@ -631,9 +643,7 @@ func oneOfVariantName(discriminator *base.Discriminator, proxy *base.SchemaProxy
 			candidates.PrimitiveFormat = source.schema.Format
 		}
 	}
-	sum := sha256.Sum256([]byte(schemaProxySignature(proxy)))
-	candidates.ShaSum = fmt.Sprintf("%x", sum[:4])
-	return model.ResolveOneOfVariantName(candidates)
+	return model.ResolveOneOfVariantName(path, alternative, candidates)
 }
 
 func discriminatorNameForRef(discriminator *base.Discriminator, ref, refName string) string {
@@ -652,58 +662,6 @@ func discriminatorNameForRef(discriminator *base.Discriminator, ref, refName str
 		}
 	}
 	return ""
-}
-
-// schemaProxySignature is deliberately independent of oneOf source order and
-// OpenAPI map insertion order. It is only the final naming fallback for inline,
-// non-primitive alternatives.
-func schemaProxySignature(proxy *base.SchemaProxy) string {
-	if proxy == nil {
-		return "nil"
-	}
-	if proxy.IsReference() {
-		return "ref:" + proxy.GetReference()
-	}
-	s := proxy.Schema()
-	if s == nil {
-		return "empty"
-	}
-
-	var parts []string
-	types := append([]string(nil), s.Type...)
-	sort.Strings(types)
-	parts = append(parts, "type="+strings.Join(types, ","), "format="+s.Format)
-
-	required := append([]string(nil), s.Required...)
-	sort.Strings(required)
-	parts = append(parts, "required="+strings.Join(required, ","))
-
-	for _, key := range sortedPropertyKeys(s) {
-		parts = append(parts, "property:"+key+"="+schemaProxySignature(s.Properties.GetOrZero(key)))
-	}
-	if s.Items != nil && s.Items.IsA() {
-		parts = append(parts, "items="+schemaProxySignature(s.Items.A))
-	}
-	if s.AdditionalProperties != nil {
-		switch {
-		case s.AdditionalProperties.IsA():
-			parts = append(parts, "additional="+schemaProxySignature(s.AdditionalProperties.A))
-		case s.AdditionalProperties.IsB():
-			parts = append(parts, fmt.Sprintf("additional=%t", s.AdditionalProperties.B))
-		}
-	}
-
-	oneOf := make([]string, 0, len(s.OneOf))
-	for _, child := range s.OneOf {
-		oneOf = append(oneOf, schemaProxySignature(child))
-	}
-	sort.Strings(oneOf)
-	parts = append(parts, "oneOf="+strings.Join(oneOf, "|"))
-
-	enum := enumValues(s)
-	sort.Strings(enum)
-	parts = append(parts, "enum="+strings.Join(enum, ","))
-	return strings.Join(parts, ";")
 }
 
 // mergeOneOfSiblings applies the constraints adjacent to oneOf to an

--- a/.generator-v2/internal/parser/schema_test.go
+++ b/.generator-v2/internal/parser/schema_test.go
@@ -214,16 +214,7 @@ var _ = Describe("NormalizeSchemas field carrying", func() {
 //  Normalized oneOf metadata
 // -------------------------------------------------------------------
 
-// Pending: these specs describe the normalized oneOf metadata the parser does not
-// populate yet -- they assert Schema.OneOf where the parser still writes the
-// legacy Schema.Variants. Written ahead of the implementation on purpose, but a
-// red suite cannot be merged and this stack merges bottom-up, so PDescribe reports
-// them as pending rather than failing.
-//
-// The commit that updates the parser to populate Schema.OneOf turns this back into
-// Describe; all six specs must pass at that point, which is what makes them a
-// check on that commit.
-var _ = PDescribe("NormalizeSchemas oneOf metadata", func() {
+var _ = Describe("NormalizeSchemas oneOf metadata", func() {
 
 	var spec *model.Spec
 
@@ -377,6 +368,24 @@ var _ = PDescribe("NormalizeSchemas oneOf metadata", func() {
 		))
 	})
 
+	It("retains a required-only object constraint adjacent to oneOf", func() {
+		union := oneOfFor("CreateOneOfWithRequiredOnlySibling")
+		Expect(union.Variants).To(HaveLen(2))
+
+		Expect(union.Variants).To(ConsistOf(
+			SatisfyAll(
+				HaveField("Schema.Properties", HaveKey("kind")),
+				HaveField("Schema.Properties", HaveKey("alpha")),
+				HaveField("Schema.Required", ConsistOf("alpha", "kind")),
+			),
+			SatisfyAll(
+				HaveField("Schema.Properties", HaveKey("kind")),
+				HaveField("Schema.Properties", HaveKey("beta")),
+				HaveField("Schema.Required", ConsistOf("beta", "kind")),
+			),
+		))
+	})
+
 	It("produces stable names and sorted variants across independent loads", func() {
 		first := oneOfFor("CreateInlineOneOf")
 		secondSpec := loadSpecMust("schema_normalize_oneof.yaml")
@@ -400,28 +409,44 @@ var _ = PDescribe("NormalizeSchemas oneOf metadata", func() {
 
 var _ = Describe("NormalizeSchemas oneOf naming failures", func() {
 
-	It("rejects an anonymous non-primitive alternative instead of exposing a content-derived name", func() {
-		_, err := LoadSpec(filepath.Join("../testdata/parser", "schema_normalize_oneof_unnamed.yaml"))
-		Expect(err).To(HaveOccurred())
+	It("marks an anonymous non-primitive alternative unsupported without aborting spec loading", func() {
+		spec, err := LoadSpec(filepath.Join("../testdata/parser", "schema_normalize_oneof_unnamed.yaml"))
+		Expect(err).NotTo(HaveOccurred())
 
-		var unresolved *model.OneOfVariantNameResolutionError
-		Expect(errors.As(err, &unresolved)).To(BeTrue())
-		Expect(unresolved.Path).To(Equal("request"))
-		Expect(unresolved.Alternative).To(Equal(2))
-		Expect(err.Error()).To(Equal(
+		schema := opByID(spec, "CreateUnnamedOneOf").RequestSchema
+		Expect(schema.Kind).To(Equal(model.SchemaKindUnsupported))
+		Expect(schema.UnsupportedReason).To(Equal(
 			`parser: oneOf at "request" alternative 2 has no stable Terraform variant name; use a discriminator mapping key or a named schema reference`,
 		))
 	})
 
-	It("rejects variant names that collide after normalization", func() {
-		_, err := LoadSpec(filepath.Join("../testdata/parser", "schema_normalize_oneof_collision.yaml"))
-		Expect(err).To(HaveOccurred())
+	It("marks a colliding union unsupported without aborting spec loading", func() {
+		spec, err := LoadSpec(filepath.Join("../testdata/parser", "schema_normalize_oneof_collision.yaml"))
+		Expect(err).NotTo(HaveOccurred())
 
-		var collision *model.OneOfVariantNameCollisionError
-		Expect(errors.As(err, &collision)).To(BeTrue())
-		Expect(collision.Path).To(Equal("request"))
-		Expect(collision.Name).To(Equal("foo_bar"))
-		Expect(err.Error()).To(ContainSubstring(`parser: oneOf at "request" has colliding variant name "foo_bar"`))
+		schema := opByID(spec, "CreateCollidingOneOf").RequestSchema
+		Expect(schema.Kind).To(Equal(model.SchemaKindUnsupported))
+		Expect(schema.UnsupportedReason).To(Equal(
+			`parser: oneOf at "request" has colliding variant name "foo_bar"`,
+		))
+
+		healthy := opByID(spec, "CreateHealthyAfterCollision").RequestSchema
+		Expect(healthy.Kind).To(Equal(model.SchemaKindPrimitive))
+		Expect(healthy.Type).To(Equal("string"))
+	})
+
+	It("does not replace a local naming failure with outer sibling constraints", func() {
+		unsupported := &model.Schema{
+			Kind:              model.SchemaKindUnsupported,
+			UnsupportedReason: `parser: oneOf at "request.choice" has colliding variant name "object"`,
+		}
+		common := &model.Schema{
+			Kind:       model.SchemaKindObject,
+			Properties: map[string]*model.Schema{"shared": {Kind: model.SchemaKindPrimitive, Type: "string"}},
+		}
+
+		Expect(mergeNormalizedSchemas(unsupported, common)).To(BeIdenticalTo(unsupported))
+		Expect(unsupported.UnsupportedReason).To(ContainSubstring("colliding variant name"))
 	})
 })
 

--- a/.generator-v2/internal/parser/schema_test.go
+++ b/.generator-v2/internal/parser/schema_test.go
@@ -195,14 +195,17 @@ var _ = Describe("NormalizeSchemas field carrying", func() {
 		Expect(op.RequestSchema.Sensitive).To(BeFalse())
 	})
 
-	It("populates Variants for oneOf schemas and does not drop them", func() {
+	It("populates the normalized OneOf model and leaves the legacy Variants bridge empty", func() {
 		op := opByID(spec, "CreateVariantOneOf")
-		Expect(op.RequestSchema.Variants).To(HaveLen(2))
+		Expect(op.RequestSchema.OneOf).NotTo(BeNil())
+		Expect(op.RequestSchema.OneOf.Variants).To(HaveLen(2))
+		Expect(op.RequestSchema.Variants).To(BeEmpty())
 	})
 
-	It("classifies anyOf as unsupported and carries no Variants", func() {
+	It("classifies anyOf as unsupported and never treats it as a oneOf", func() {
 		op := opByID(spec, "CreateVariantAnyOf")
 		Expect(op.RequestSchema.Kind).To(Equal(model.SchemaKindUnsupported))
+		Expect(op.RequestSchema.OneOf).To(BeNil())
 		Expect(op.RequestSchema.Variants).To(BeEmpty())
 	})
 })
@@ -287,6 +290,25 @@ var _ = PDescribe("NormalizeSchemas oneOf metadata", func() {
 			HaveField("RefName", "Dog"),
 			HaveField("Schema.Kind", model.SchemaKindObject),
 			HaveField("ValueWrapped", false),
+		))
+	})
+
+	It("retains the same normalized metadata for a response oneOf", func() {
+		op := opByID(spec, "CreateAnimal")
+		Expect(op.ResponseRefName).To(Equal("AnimalUnion"))
+		Expect(op.ResponseSchema).NotTo(BeNil())
+		Expect(op.ResponseSchema.Kind).To(Equal(model.SchemaKindOneOf))
+		Expect(op.ResponseSchema.Variants).To(BeEmpty())
+
+		union := op.ResponseSchema.OneOf
+		Expect(union).NotTo(BeNil())
+		Expect(union.Name).To(Equal("AnimalUnion"))
+		Expect(union.Path).To(Equal("response"))
+		Expect(union.Optional).To(BeFalse())
+		Expect(union.Variants).To(HaveLen(2))
+		Expect(union.Variants).To(ConsistOf(
+			SatisfyAll(HaveField("TFName", "cat"), HaveField("RefName", "Cat")),
+			SatisfyAll(HaveField("TFName", "dog"), HaveField("RefName", "Dog")),
 		))
 	})
 

--- a/.generator-v2/internal/parser/schema_test.go
+++ b/.generator-v2/internal/parser/schema_test.go
@@ -400,6 +400,19 @@ var _ = PDescribe("NormalizeSchemas oneOf metadata", func() {
 
 var _ = Describe("NormalizeSchemas oneOf naming failures", func() {
 
+	It("rejects an anonymous non-primitive alternative instead of exposing a content-derived name", func() {
+		_, err := LoadSpec(filepath.Join("../testdata/parser", "schema_normalize_oneof_unnamed.yaml"))
+		Expect(err).To(HaveOccurred())
+
+		var unresolved *model.OneOfVariantNameResolutionError
+		Expect(errors.As(err, &unresolved)).To(BeTrue())
+		Expect(unresolved.Path).To(Equal("request"))
+		Expect(unresolved.Alternative).To(Equal(2))
+		Expect(err.Error()).To(Equal(
+			`parser: oneOf at "request" alternative 2 has no stable Terraform variant name; use a discriminator mapping key or a named schema reference`,
+		))
+	})
+
 	It("rejects variant names that collide after normalization", func() {
 		_, err := LoadSpec(filepath.Join("../testdata/parser", "schema_normalize_oneof_collision.yaml"))
 		Expect(err).To(HaveOccurred())

--- a/.generator-v2/internal/parser/schema_test.go
+++ b/.generator-v2/internal/parser/schema_test.go
@@ -387,6 +387,29 @@ var _ = PDescribe("NormalizeSchemas oneOf metadata", func() {
 		Expect(second.Variants).To(Equal(first.Variants))
 		Expect([]string{first.Variants[0].TFName, first.Variants[1].TFName}).To(Equal([]string{"boolean", "string"}))
 	})
+
+	It("produces the same sorted names when oneOf alternatives are reordered", func() {
+		first := oneOfFor("CreateInlineOneOf")
+		reordered := oneOfFor("CreateReorderedInlineOneOf")
+
+		Expect([]string{reordered.Variants[0].TFName, reordered.Variants[1].TFName}).To(
+			Equal([]string{first.Variants[0].TFName, first.Variants[1].TFName}),
+		)
+	})
+})
+
+var _ = Describe("NormalizeSchemas oneOf naming failures", func() {
+
+	It("rejects variant names that collide after normalization", func() {
+		_, err := LoadSpec(filepath.Join("../testdata/parser", "schema_normalize_oneof_collision.yaml"))
+		Expect(err).To(HaveOccurred())
+
+		var collision *model.OneOfVariantNameCollisionError
+		Expect(errors.As(err, &collision)).To(BeTrue())
+		Expect(collision.Path).To(Equal("request"))
+		Expect(collision.Name).To(Equal("foo_bar"))
+		Expect(err.Error()).To(ContainSubstring(`parser: oneOf at "request" has colliding variant name "foo_bar"`))
+	})
 })
 
 // -------------------------------------------------------------------

--- a/.generator-v2/internal/testdata/parser/schema_normalize_oneof.yaml
+++ b/.generator-v2/internal/testdata/parser/schema_normalize_oneof.yaml
@@ -111,12 +111,7 @@ paths:
                 recursive:
                   oneOf:
                     - type: string
-                    - type: object
-                      properties:
-                        nested:
-                          oneOf:
-                            - type: boolean
-                            - type: string
+                    - $ref: "#/components/schemas/RecursiveVariant"
       responses:
         "204":
           description: no content
@@ -141,21 +136,32 @@ paths:
                 shared:
                   type: string
               oneOf:
-                - type: object
-                  required: [alpha]
-                  properties:
-                    alpha:
-                      type: boolean
-                - type: object
-                  required: [beta]
-                  properties:
-                    beta:
-                      type: integer
+                - $ref: "#/components/schemas/AlphaVariant"
+                - $ref: "#/components/schemas/BetaVariant"
       responses:
         "204":
           description: no content
 components:
   schemas:
+    RecursiveVariant:
+      type: object
+      properties:
+        nested:
+          oneOf:
+            - type: boolean
+            - type: string
+    AlphaVariant:
+      type: object
+      required: [alpha]
+      properties:
+        alpha:
+          type: boolean
+    BetaVariant:
+      type: object
+      required: [beta]
+      properties:
+        beta:
+          type: integer
     AnimalUnion:
       discriminator:
         propertyName: kind

--- a/.generator-v2/internal/testdata/parser/schema_normalize_oneof.yaml
+++ b/.generator-v2/internal/testdata/parser/schema_normalize_oneof.yaml
@@ -141,6 +141,29 @@ paths:
       responses:
         "204":
           description: no content
+  /required-only-sibling:
+    post:
+      operationId: CreateOneOfWithRequiredOnlySibling
+      tags: [OneOf]
+      x-datadog-tf-generator:
+        artifact_kind: resource
+        artifact_name: oneof_with_required_only_sibling
+        group:
+          create: CreateOneOfWithRequiredOnlySibling
+          read: CreateOneOfWithRequiredOnlySibling
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [kind]
+              oneOf:
+                - $ref: "#/components/schemas/AlphaVariant"
+                - $ref: "#/components/schemas/BetaVariant"
+      responses:
+        "204":
+          description: no content
 components:
   schemas:
     RecursiveVariant:
@@ -154,12 +177,16 @@ components:
       type: object
       required: [alpha]
       properties:
+        kind:
+          type: string
         alpha:
           type: boolean
     BetaVariant:
       type: object
       required: [beta]
       properties:
+        kind:
+          type: string
         beta:
           type: integer
     AnimalUnion:

--- a/.generator-v2/internal/testdata/parser/schema_normalize_oneof.yaml
+++ b/.generator-v2/internal/testdata/parser/schema_normalize_oneof.yaml
@@ -25,6 +25,28 @@ paths:
       responses:
         "204":
           description: no content
+  /inline-reordered:
+    post:
+      operationId: CreateReorderedInlineOneOf
+      tags: [OneOf]
+      x-datadog-tf-generator:
+        artifact_kind: resource
+        artifact_name: reordered_inline_oneof
+        group:
+          create: CreateReorderedInlineOneOf
+          read: CreateReorderedInlineOneOf
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - nullable: true
+                - type: boolean
+                - type: string
+      responses:
+        "204":
+          description: no content
   /animals:
     post:
       operationId: CreateAnimal

--- a/.generator-v2/internal/testdata/parser/schema_normalize_oneof.yaml
+++ b/.generator-v2/internal/testdata/parser/schema_normalize_oneof.yaml
@@ -18,10 +18,10 @@ paths:
         content:
           application/json:
             schema:
-              nullable: true
               oneOf:
                 - type: string
                 - type: boolean
+                - nullable: true
       responses:
         "204":
           description: no content
@@ -42,8 +42,12 @@ paths:
             schema:
               $ref: "#/components/schemas/AnimalUnion"
       responses:
-        "204":
-          description: no content
+        "200":
+          description: animal
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AnimalUnion"
   /nested:
     post:
       operationId: CreateNestedOneOf

--- a/.generator-v2/internal/testdata/parser/schema_normalize_oneof_collision.yaml
+++ b/.generator-v2/internal/testdata/parser/schema_normalize_oneof_collision.yaml
@@ -29,6 +29,25 @@ paths:
       responses:
         "204":
           description: no content
+  /healthy:
+    post:
+      operationId: CreateHealthyAfterCollision
+      tags: [OneOf]
+      x-datadog-tf-generator:
+        artifact_kind: resource
+        artifact_name: healthy_after_collision
+        group:
+          create: CreateHealthyAfterCollision
+          read: CreateHealthyAfterCollision
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        "204":
+          description: no content
 components:
   schemas:
     Alpha:

--- a/.generator-v2/internal/testdata/parser/schema_normalize_oneof_collision.yaml
+++ b/.generator-v2/internal/testdata/parser/schema_normalize_oneof_collision.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.0
+info:
+  title: normalized oneOf collision fixture
+  version: 1.0.0
+paths:
+  /collision:
+    post:
+      operationId: CreateCollidingOneOf
+      tags: [OneOf]
+      x-datadog-tf-generator:
+        artifact_kind: resource
+        artifact_name: colliding_oneof
+        group:
+          create: CreateCollidingOneOf
+          read: CreateCollidingOneOf
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              discriminator:
+                propertyName: kind
+                mapping:
+                  Foo Bar: "#/components/schemas/Alpha"
+                  foo_bar: "#/components/schemas/Beta"
+              oneOf:
+                - $ref: "#/components/schemas/Alpha"
+                - $ref: "#/components/schemas/Beta"
+      responses:
+        "204":
+          description: no content
+components:
+  schemas:
+    Alpha:
+      type: object
+      properties:
+        alpha:
+          type: string
+    Beta:
+      type: object
+      properties:
+        beta:
+          type: boolean

--- a/.generator-v2/internal/testdata/parser/schema_normalize_oneof_unnamed.yaml
+++ b/.generator-v2/internal/testdata/parser/schema_normalize_oneof_unnamed.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+  title: normalized unnamed oneOf fixture
+  version: 1.0.0
+paths:
+  /unnamed:
+    post:
+      operationId: CreateUnnamedOneOf
+      tags: [OneOf]
+      x-datadog-tf-generator:
+        artifact_kind: resource
+        artifact_name: unnamed_oneof
+        group:
+          create: CreateUnnamedOneOf
+          read: CreateUnnamedOneOf
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - type: string
+                - type: object
+                  properties:
+                    enabled:
+                      type: boolean
+      responses:
+        "204":
+          description: no content


### PR DESCRIPTION
## Motivation

The normalized OneOf model exists, but OpenAPI parsing still populated the legacy `Schema.Variants` representation and discarded what typed envelopes need: component references, nullability, discriminator metadata, sibling constraints, canonical paths, and stable variant identities. OneOf projection cannot be implemented until parsing retains them.

## Changes

- Populate `Schema.OneOf` during normalization and leave the legacy `Schema.Variants` bridge empty.
- Thread canonical schema paths, requiredness, and component `$ref` names through request, response, query, object, array, and map normalization.
- Retain per-union metadata: envelope name, path, optionality, nullability, and discriminator mapping. Null-only alternatives fold into `Nullable` instead of becoming variants.
- Merge the constraints adjacent to `oneOf` into every alternative; conflicting kinds, types, formats, or enums become unsupported rather than being silently widened.
- Normalize a `oneOf` nested inside an alternative recursively.
- Resolve variant names from a compatibility-stable precedence — discriminator mapping key, referenced schema name, then primitive type and format — normalized to Terraform-safe snake case, with a `variant_` prefix for digit-leading names.
- Reject anonymous non-primitive alternatives instead of naming them from a content or source-order fingerprint, which would rename a public Terraform block whenever the spec changes shape.
- Sort variants by name so source order cannot affect output, and reject names that collide after normalization.
- Contain both naming failures locally: the node becomes unsupported and carries its reason, so only the affected artifact fails instead of aborting spec loading for every artifact.
- Continue classifying `anyOf` as unsupported instead of treating it as OneOf.
- Add parser and model coverage for inline, referenced, nullable, discriminated, nested, collection, sibling-constraint, response, reordered, unnamed, and colliding unions.

## Testing

- `make fmtcheck`
- `make tfgen-test` — green. The six `NormalizeSchemas oneOf metadata` specs that #4043 left pending are un-pended here and pass: parser goes from `98 passed | 6 pending` to `110 passed | 0 pending`.
- The 11 `internal/model` AttributeTree projection specs remain pending (`110 passed | 11 pending`); #4095 un-pends them when it lands the projection.

