### PR TITLE
[TFgen] (oneOf) Map SDK oneOf wrappers back into Terraform state

### DIFF
--- a/.generator-v2/internal/cli/generate.go
+++ b/.generator-v2/internal/cli/generate.go
@@ -259,11 +259,6 @@ func generateArtifact(op *model.Operation, outputRoot, testsOutputRoot, examples
 	for _, d := range view.Dropped {
 		entry.Diagnostics = append(entry.Diagnostics, model.Diagnostic{Severity: d.Severity, Message: d.Message})
 	}
-	// Caveats about what the artifact does contain ride along as warnings, so a
-	// generated-but-incomplete artifact cannot report as unqualified success.
-	for _, msg := range view.Warnings {
-		entry.Diagnostics = append(entry.Diagnostics, model.Diagnostic{Severity: model.SeverityWarning, Message: msg})
-	}
 
 	src, err := emit.RenderDataSource(view)
 	if err != nil {

--- a/.generator-v2/internal/cli/generate.go
+++ b/.generator-v2/internal/cli/generate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/emit"
 	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
 	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/parser"
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/sdkbind"
 )
 
 // errCheckFailed signals that --check found files that would change.
@@ -235,6 +236,14 @@ func generateArtifact(op *model.Operation, outputRoot, testsOutputRoot, examples
 			Message:  fmt.Sprintf("resource generation not yet supported (kind=%s)", op.Tracking.ArtifactKind),
 		}}
 		return entry, nil, nil, nil
+	}
+
+	// Resolve the SDK oneOf wrapper, members and constructors before the schema is
+	// projected, since the projection carries those bindings onto each envelope
+	// rather than deriving them. Binding is per operation, so an unresolvable union
+	// fails only this artifact.
+	if err := sdkbind.BindOperation(op); err != nil {
+		return failEntry(entry, err), nil, nil, nil
 	}
 
 	artifact, err := model.BuildArtifact(op)

--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -55,24 +55,30 @@ func (b *dataSourceBuilder) oneOfEnvelope(a *model.Attribute) oneOfRender {
 		return cached
 	}
 
+	// The model layer names an envelope and its variants without knowing which
+	// artifact will render them — a reusable union has no single owner — so emit
+	// applies the artifact scope here, at the one point that does know.
+	envModel := b.namer.qualify(env.GoModel)
+
 	// Reserve the envelope's struct slot before walking the variants so it precedes
 	// their structs in Models, matching how walk orders a parent before its children.
 	envIdx := len(b.models)
-	b.models = append(b.models, ModelStructView{Name: env.GoModel})
+	b.models = append(b.models, ModelStructView{Name: envModel})
 
-	render := oneOfRender{goModel: env.GoModel}
+	render := oneOfRender{goModel: envModel}
 	envFields := make([]ModelFieldView, 0, len(env.Variants))
 
 	for _, v := range env.Variants {
 		sdkVar := lowerFirst(v.GoField) + "Variant"
 		modelVar := lowerFirst(v.GoField) + "Model"
+		variantModel := b.namer.qualify(v.GoModel)
 
 		assign := OneOfVariantAssignment{
 			SDKField:   v.SDKField,
 			SDKVar:     sdkVar,
 			SDKPointer: v.SDKPointer,
 			GoField:    v.GoField,
-			GoModel:    v.GoModel,
+			GoModel:    variantModel,
 			ModelVar:   modelVar,
 		}
 
@@ -81,11 +87,11 @@ func (b *dataSourceBuilder) oneOfEnvelope(a *model.Attribute) oneOfRender {
 			// The SDK member of a non-object alternative *is* the value — a *string,
 			// not a struct with getters — so its single "value" field is assigned by
 			// dereferencing the member rather than reading through Get<Field>Ok.
-			attrs, blocks = b.oneOfValueVariant(env, v, sdkVar, modelVar, &assign)
+			attrs, blocks = b.oneOfValueVariant(env, v, variantModel, sdkVar, modelVar, &assign)
 		} else {
 			var scalars []StateAssignment
 			var lists []ListAssignment
-			attrs, blocks, scalars, lists = b.walk(v.GoModel, sdkVar, modelVar, v.Attribute.Children)
+			attrs, blocks, scalars, lists = b.walk(variantModel, stemOf(v.GoModel), sdkVar, modelVar, v.Attribute.Children)
 			assign.Scalars, assign.Lists = scalars, lists
 		}
 
@@ -101,7 +107,7 @@ func (b *dataSourceBuilder) oneOfEnvelope(a *model.Attribute) oneOfRender {
 		})
 		envFields = append(envFields, ModelFieldView{
 			GoField: v.GoField,
-			GoType:  "*" + v.GoModel,
+			GoType:  "*" + variantModel,
 			TFName:  v.TFName,
 		})
 		render.variants = append(render.variants, assign)
@@ -126,6 +132,7 @@ func (b *dataSourceBuilder) oneOfEnvelope(a *model.Attribute) oneOfRender {
 func (b *dataSourceBuilder) oneOfValueVariant(
 	env *model.OneOfEnvelope,
 	v model.OneOfEnvelopeVariant,
+	variantModel string,
 	sdkVar, modelVar string,
 	assign *OneOfVariantAssignment,
 ) (attrs, blocks []AttrView) {
@@ -164,7 +171,7 @@ func (b *dataSourceBuilder) oneOfValueVariant(
 	// The variant still needs its own one-field model struct; walk would normally
 	// have appended it, and the envelope's field points at it either way.
 	b.models = append(b.models, ModelStructView{
-		Name:   v.GoModel,
+		Name:   variantModel,
 		Fields: []ModelFieldView{{GoField: goField, GoType: value.GoType, TFName: tfName}},
 	})
 	assign.Value = &StateAssignment{
@@ -263,7 +270,7 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 		return buildPluralView(a)
 	}
 
-	b := &dataSourceBuilder{receiver: envelopeReceiver}
+	b := &dataSourceBuilder{receiver: envelopeReceiver, namer: modelNamer{base: dsGoName(a.Name)}}
 
 	// Resolve the SDK calls. read backs the by-id lookup, search the list; the
 	// presence of each selects the resolution shape (read-only / search / both).
@@ -315,7 +322,7 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 		}
 	}
 
-	rootStruct := dsGoName(a.Name) + "DataSourceModel"
+	rootStruct := b.namer.qualify("DataSourceModel")
 	env := b.flattenEnvelope(topLevel, idStrategy, rootExpr)
 
 	if len(b.unsupported) > 0 {
@@ -324,7 +331,9 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 
 	// env is non-nil here: flattenEnvelope records an unsupported node (caught
 	// above) on every failure path. Walk the hoisted leaves into the root struct.
-	recordAttrs, recordBlocks, recordScalars, recordLists := b.walk(rootStruct, b.receiver, "state", env.leaves)
+	// The root's stem is empty: its inline children accumulate from the artifact base
+	// alone, so a top-level "foo" object becomes <base>FooModel.
+	recordAttrs, recordBlocks, recordScalars, recordLists := b.walk(rootStruct, "", b.receiver, "state", env.leaves)
 	leafFields := b.models[0].Fields
 
 	// Search filters: one Optional attribute + model field + param binding each.
@@ -341,6 +350,11 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 	}
 	fields := append([]ModelFieldView{idField}, filterFields...)
 	b.models[0].Fields = append(fields, leafFields...)
+
+	models, conflicts := dedupeModels(b.models)
+	if len(conflicts) > 0 {
+		return DataSourceView{}, &UnsupportedEmitError{Nodes: conflicts}
+	}
 
 	assignments := append([]StateAssignment{env.idAssign}, recordScalars...)
 
@@ -370,7 +384,7 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 		Searchable:  searchable,
 		Read:        readView,
 		Search:      searchView,
-		Models:      b.models,
+		Models:      models,
 		Schema:      SchemaView{Attributes: append(filterAttrs, recordAttrs...), Blocks: recordBlocks},
 		State: StateView{
 			ParamName:   paramName,
@@ -535,7 +549,10 @@ func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrat
 // unsupported-node collector. receiver is the getter root the state-mapper reads
 // leaves off (e.g. "attributes" for the flattened envelope).
 type dataSourceBuilder struct {
-	receiver    string
+	receiver string
+	// namer scopes every model struct name to this artifact and derives nested
+	// names from their OpenAPI component. See modelname.go.
+	namer       modelNamer
 	models      []ModelStructView
 	unsupported []UnsupportedNode
 	// dropped notes envelope members skipped from the attributes-only view
@@ -585,7 +602,16 @@ func droppedIDCollision(path string) DroppedMember {
 // the per-element accumulator). It returns the schema attr/block views plus the
 // scalar and list state assignments for the caller to place, recursing through
 // nested blocks.
-func (b *dataSourceBuilder) walk(structName, receiver, lhsPrefix string, attrs []*model.Attribute) (attrViews, blockViews []AttrView, scalars []StateAssignment, lists []ListAssignment) {
+//
+// stem is this struct's own naming stem, which its children accumulate from when
+// their schema is inline (modelname.go). It is separate from structName because
+// structName is already qualified and suffixed, and a stem must be neither.
+//
+// The same struct may be reserved twice when one OpenAPI component is reached from
+// two properties: each site needs its own assignments, which are expressed against
+// site-specific receivers and LHS prefixes, so both walks run. dedupeModels
+// collapses the duplicate declarations afterwards.
+func (b *dataSourceBuilder) walk(structName, stem, receiver, lhsPrefix string, attrs []*model.Attribute) (attrViews, blockViews []AttrView, scalars []StateAssignment, lists []ListAssignment) {
 	idx := len(b.models)
 	b.models = append(b.models, ModelStructView{Name: structName})
 	var fields []ModelFieldView
@@ -664,11 +690,11 @@ func (b *dataSourceBuilder) walk(structName, receiver, lhsPrefix string, attrs [
 			})
 
 		case "schema.ListNestedBlock":
-			elemStruct := field + "Model"
+			elemStruct, childStem := b.namer.nested(stem, a)
 			base := lowerFirst(field)
 			loopVar, elemVar := base+"Item", base+"Model"
 			fields = append(fields, ModelFieldView{GoField: field, GoType: "[]*" + elemStruct, TFName: tfName})
-			childAttrs, childBlocks, childScalars, childLists := b.walk(elemStruct, loopVar, elemVar, a.Children)
+			childAttrs, childBlocks, childScalars, childLists := b.walk(elemStruct, childStem, loopVar, elemVar, a.Children)
 			blockViews = append(blockViews, AttrView{
 				TFName:      tfName,
 				Description: a.Description,
@@ -694,11 +720,11 @@ func (b *dataSourceBuilder) walk(structName, receiver, lhsPrefix string, attrs [
 			})
 
 		case "schema.SingleNestedBlock":
-			childStruct := field + "Model"
+			childStruct, childStem := b.namer.nested(stem, a)
 			objVar := leafVar(tfName)
 			elemVar := lowerFirst(field) + "Model"
 			fields = append(fields, ModelFieldView{GoField: field, GoType: "*" + childStruct, TFName: tfName})
-			childAttrs, childBlocks, childScalars, childLists := b.walk(childStruct, objVar, elemVar, a.Children)
+			childAttrs, childBlocks, childScalars, childLists := b.walk(childStruct, childStem, objVar, elemVar, a.Children)
 			blockViews = append(blockViews, AttrView{
 				TFName:      tfName,
 				Description: a.Description,
@@ -944,8 +970,21 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 	}
 
 	// b hosts walk so list-of-object item fields generate their element structs.
-	b := &dataSourceBuilder{}
+	b := &dataSourceBuilder{namer: modelNamer{base: dsGoName(a.Name)}}
 	scalarLeaves, nonScalars := flattenItemElement(itemsBlock, &unsupported, &dropped)
+
+	// The item element's own stem. call.ItemType is the response element's component
+	// name, so it plays the same role here that ModelRefName plays under walk: the
+	// item struct is named after its component, and the item's inline children
+	// accumulate from it.
+	// Verbatim, like any other component name: ItemType is already a Go type name
+	// (it is spelled as call.GoPackage + "." + call.ItemType elsewhere), so SdkName
+	// would only mangle its acronyms.
+	var itemStem string
+	if call != nil {
+		itemStem = call.ItemType
+	}
+	itemStruct := b.namer.qualify(itemStem + "Model")
 
 	// Scalar leaves project into the item struct literal, unguarded, off the loop
 	// variable "item".
@@ -1010,10 +1049,12 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 				Kind: "primitive", LHS: "r." + field, GetterOk: getter, Var: leafVar(tfName), ElementType: n.ElementType,
 			})
 		case "schema.ListNestedBlock":
-			elemStruct := model.SdkName(tfName) + "Model"
+			// itemStem, not "": these hang off the item element, so an inline child
+			// accumulates from the item struct the same way it would under walk.
+			elemStruct, childStem := b.namer.nested(itemStem, n)
 			base := lowerFirst(model.SdkName(tfName))
 			loopVar, elemVar := base+"Item", base+"Model"
-			childAttrs, childBlocks, childScalars, childLists := b.walk(elemStruct, loopVar, elemVar, n.Children)
+			childAttrs, childBlocks, childScalars, childLists := b.walk(elemStruct, childStem, loopVar, elemVar, n.Children)
 			itemBlocks = append(itemBlocks, AttrView{
 				TFName: tfName, Description: n.Description,
 				IsBlock: true, ListBlock: true, Attributes: childAttrs, Blocks: childBlocks,
@@ -1025,10 +1066,10 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 				Scalars: childScalars, Lists: childLists,
 			})
 		case "schema.SingleNestedBlock":
-			elemStruct := model.SdkName(tfName) + "Model"
+			elemStruct, childStem := b.namer.nested(itemStem, n)
 			objVar := leafVar(tfName)
 			elemVar := lowerFirst(model.SdkName(tfName)) + "Model"
-			childAttrs, childBlocks, childScalars, childLists := b.walk(elemStruct, objVar, elemVar, n.Children)
+			childAttrs, childBlocks, childScalars, childLists := b.walk(elemStruct, childStem, objVar, elemVar, n.Children)
 			itemBlocks = append(itemBlocks, AttrView{
 				TFName: tfName, Description: n.Description,
 				IsBlock: true, ListBlock: false, Attributes: childAttrs, Blocks: childBlocks,
@@ -1053,7 +1094,6 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 		return DataSourceView{}, &UnsupportedEmitError{Nodes: unsupported}
 	}
 
-	itemStruct := model.SdkName(call.ItemType) + "Model"
 	itemField := model.SdkName(a.Name)
 	goName := dsGoName(a.Name)
 
@@ -1066,10 +1106,14 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 	// Models: parent, the item struct, then any element structs walked for
 	// list-of-object item fields.
 	models := []ModelStructView{
-		{Name: goName + "DataSourceModel", Fields: parentFields},
+		{Name: b.namer.qualify("DataSourceModel"), Fields: parentFields},
 		{Name: itemStruct, Fields: itemFields},
 	}
 	models = append(models, b.models...)
+	models, conflicts := dedupeModels(models)
+	if len(conflicts) > 0 {
+		return DataSourceView{}, &UnsupportedEmitError{Nodes: conflicts}
+	}
 
 	return DataSourceView{
 		Cardinality: Plural,

--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -49,10 +49,10 @@ const envelopeReceiver = "attributes"
 // what produces its model struct and its field assignments. The assignments are
 // carried on the returned OneOfVariantView rather than placed here: the mapper has
 // to unwrap the SDK member before they can run, and that lands separately.
-func (b *dataSourceBuilder) oneOfEnvelope(a *model.Attribute) (variantBlocks []AttrView, envelopeModel string) {
+func (b *dataSourceBuilder) oneOfEnvelope(a *model.Attribute) oneOfRender {
 	env := a.OneOf
-	if cached, ok := b.oneOfBlocks[env.Name]; ok {
-		return cached, env.GoModel
+	if cached, ok := b.oneOfRenders[env.Name]; ok {
+		return cached
 	}
 
 	// Reserve the envelope's struct slot before walking the variants so it precedes
@@ -60,21 +60,36 @@ func (b *dataSourceBuilder) oneOfEnvelope(a *model.Attribute) (variantBlocks []A
 	envIdx := len(b.models)
 	b.models = append(b.models, ModelStructView{Name: env.GoModel})
 
-	view := OneOfEnvelopeView{
-		Name:     env.Name,
-		GoModel:  env.GoModel,
-		SDKType:  env.SDKType,
-		Path:     env.Path,
-		Optional: env.Optional,
-	}
+	render := oneOfRender{goModel: env.GoModel}
 	envFields := make([]ModelFieldView, 0, len(env.Variants))
 
 	for _, v := range env.Variants {
 		sdkVar := lowerFirst(v.GoField) + "Variant"
 		modelVar := lowerFirst(v.GoField) + "Model"
 
-		attrs, blocks, scalars, lists := b.walk(v.GoModel, sdkVar, modelVar, v.Attribute.Children)
-		variantBlocks = append(variantBlocks, AttrView{
+		assign := OneOfVariantAssignment{
+			SDKField:   v.SDKField,
+			SDKVar:     sdkVar,
+			SDKPointer: v.SDKPointer,
+			GoField:    v.GoField,
+			GoModel:    v.GoModel,
+			ModelVar:   modelVar,
+		}
+
+		var attrs, blocks []AttrView
+		if v.ValueWrapped {
+			// The SDK member of a non-object alternative *is* the value — a *string,
+			// not a struct with getters — so its single "value" field is assigned by
+			// dereferencing the member rather than reading through Get<Field>Ok.
+			attrs, blocks = b.oneOfValueVariant(env, v, sdkVar, modelVar, &assign)
+		} else {
+			var scalars []StateAssignment
+			var lists []ListAssignment
+			attrs, blocks, scalars, lists = b.walk(v.GoModel, sdkVar, modelVar, v.Attribute.Children)
+			assign.Scalars, assign.Lists = scalars, lists
+		}
+
+		render.blocks = append(render.blocks, AttrView{
 			TFName:      v.TFName,
 			Description: v.Attribute.Description,
 			Optional:    v.Attribute.Optional,
@@ -89,29 +104,115 @@ func (b *dataSourceBuilder) oneOfEnvelope(a *model.Attribute) (variantBlocks []A
 			GoType:  "*" + v.GoModel,
 			TFName:  v.TFName,
 		})
-		view.Variants = append(view.Variants, OneOfVariantView{
-			TFName:         v.TFName,
-			GoField:        v.GoField,
-			GoModel:        v.GoModel,
-			SDKField:       v.SDKField,
-			SDKConstructor: v.SDKConstructor,
-			SDKPointer:     v.SDKPointer,
-			ValueWrapped:   v.ValueWrapped,
-			SDKVar:         sdkVar,
-			ModelVar:       modelVar,
-			Scalars:        scalars,
-			Lists:          lists,
-		})
+		render.variants = append(render.variants, assign)
 	}
 
 	b.models[envIdx].Fields = envFields
-	if b.oneOfBlocks == nil {
-		b.oneOfBlocks = make(map[string][]AttrView)
+	if b.oneOfRenders == nil {
+		b.oneOfRenders = make(map[string]oneOfRender)
 	}
-	b.oneOfBlocks[env.Name] = variantBlocks
-	b.envelopes = append(b.envelopes, view)
-	b.warnings = append(b.warnings, pendingOneOfMapping(env))
-	return variantBlocks, env.GoModel
+	b.oneOfRenders[env.Name] = render
+	return render
+}
+
+// oneOfValueVariant handles a value-wrapped alternative: the variant model has a
+// single "value" field, and the SDK member it comes from is the value itself.
+//
+// The walk cannot serve this case — it would emit SDKVar.GetValueOk(), and a
+// *string has no methods — so the schema attribute is built here and the
+// assignment dereferences the member directly. A value-wrapped alternative whose
+// value is not a scalar (a list or map alternative) has no such dereference and is
+// recorded unsupported rather than mis-assigned.
+func (b *dataSourceBuilder) oneOfValueVariant(
+	env *model.OneOfEnvelope,
+	v model.OneOfEnvelopeVariant,
+	sdkVar, modelVar string,
+	assign *OneOfVariantAssignment,
+) (attrs, blocks []AttrView) {
+	if len(v.Attribute.Children) != 1 {
+		b.unsupported = append(b.unsupported, UnsupportedNode{
+			Path:   env.Path,
+			Reason: fmt.Sprintf("oneOf envelope %q variant %q is value-wrapped but has %d children, expected exactly one", env.Name, v.TFName, len(v.Attribute.Children)),
+		})
+		return nil, nil
+	}
+	value := v.Attribute.Children[0]
+	if !isLeafType(value.TfType) {
+		b.unsupported = append(b.unsupported, UnsupportedNode{
+			Path: env.Path,
+			Reason: fmt.Sprintf(
+				"oneOf envelope %q variant %q wraps a %s, and the emit path can only read a scalar "+
+					"straight off an SDK oneOf member; give the alternative a named schema component "+
+					"so it becomes an object variant",
+				env.Name, v.TFName, value.TfType),
+		})
+		return nil, nil
+	}
+
+	tfName := tfNameOf(value.Path)
+	goField := model.SdkName(tfName)
+
+	attrs = []AttrView{{
+		TFName:      tfName,
+		TFType:      value.TfType,
+		Description: value.Description,
+		Required:    value.Required,
+		Optional:    value.Optional,
+		Computed:    value.Computed,
+		Sensitive:   value.Sensitive,
+	}}
+	// The variant still needs its own one-field model struct; walk would normally
+	// have appended it, and the envelope's field points at it either way.
+	b.models = append(b.models, ModelStructView{
+		Name:   v.GoModel,
+		Fields: []ModelFieldView{{GoField: goField, GoType: value.GoType, TFName: tfName}},
+	})
+	assign.Value = &StateAssignment{
+		LHS: modelVar + "." + goField,
+		RHS: guardedValue(value, sdkVar),
+	}
+	return attrs, nil
+}
+
+// oneOfRender is one envelope's render-ready output, cached per envelope name.
+// Both halves are a function of the envelope alone: the schema blocks because the
+// variants are shared, and the variant assignments because they are expressed
+// against variant-derived locals and carry GoField rather than a site-specific LHS.
+type oneOfRender struct {
+	blocks   []AttrView
+	variants []OneOfVariantAssignment
+	goModel  string
+}
+
+// oneOfListAssignment builds the site-specific assignment that unwraps an
+// envelope's SDK wrapper into its model, given the render shared across use sites.
+func oneOfListAssignment(
+	env *model.OneOfEnvelope,
+	render oneOfRender,
+	tfName, receiver, lhs string,
+	collection bool,
+) ListAssignment {
+	outer := leafVar(tfName)
+	assignment := &OneOfAssignment{
+		Path:       env.Path,
+		SDKType:    env.SDKType,
+		GoModel:    render.goModel,
+		LHS:        lhs,
+		GetterOk:   getterOk(receiver, tfName),
+		Var:        outer,
+		Receiver:   outer,
+		ModelVar:   outer + "Envelope",
+		MatchVar:   outer + "Matches",
+		Optional:   env.Optional,
+		Collection: collection,
+		Variants:   render.variants,
+	}
+	if collection {
+		// The members are read off each element, not off the slice pointer.
+		assignment.LoopVar = outer + "Item"
+		assignment.Receiver = assignment.LoopVar
+	}
+	return ListAssignment{Kind: "oneof", LHS: lhs, GetterOk: assignment.GetterOk, Var: outer, OneOf: assignment}
 }
 
 // oneOfFieldType returns the Go type of the model field holding an envelope,
@@ -130,18 +231,10 @@ func oneOfFieldType(tfType, envelopeModel string) (string, bool) {
 	}
 }
 
-// pendingOneOfMapping is the warning carried by every artifact containing an
-// envelope while the response mapper is unimplemented. The envelope's schema
-// and models are emitted, so the union is not dropped, but nothing
-// assigns into it yet and the block would read as permanently null. Saying so in the
-// run report is the difference between an increment and a silent lie; the mapper removes
-// this together with the gap it describes.
-func pendingOneOfMapping(env *model.OneOfEnvelope) string {
-	return fmt.Sprintf(
-		"oneOf envelope %q at %q: schema and models are emitted but response mapping is not, "+
-			"so this block stays null until the SDK oneOf wrapper mapping lands",
-		env.Name, env.Path,
-	)
+// isCollectionForm reports whether an envelope-carrying attribute is the
+// collection rather than the union itself, so each element is one envelope.
+func isCollectionForm(tfType string) bool {
+	return tfType == "schema.ListNestedBlock" || tfType == "schema.ListNestedAttribute"
 }
 
 // unsupportedOneOfPlacement explains a union the emit path cannot place yet, named
@@ -286,10 +379,8 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 			Assignments: assignments,
 			Lists:       recordLists,
 		},
-		UsesFmt:        !searchable,
-		OneOfEnvelopes: b.envelopes,
-		Dropped:        b.dropped,
-		Warnings:       b.warnings,
+		UsesFmt: !searchable || len(b.oneOfRenders) > 0,
+		Dropped: b.dropped,
 	}, nil
 }
 
@@ -454,11 +545,7 @@ type dataSourceBuilder struct {
 	// keyed on the parser's envelope Name, and doubles as the "already emitted its
 	// models" marker. envelopes accumulates one view per distinct envelope in first-use
 	// order, for the state mapper to walk.
-	oneOfBlocks map[string][]AttrView
-	envelopes   []OneOfEnvelopeView
-	// warnings notes things the generated artifact contains that a reader needs to
-	// know about, as opposed to dropped's omissions.
-	warnings []string
+	oneOfRenders map[string]oneOfRender
 }
 
 // droppedEnvelopeMember is the info-diagnostic note for a JSON:API response
@@ -511,12 +598,13 @@ func (b *dataSourceBuilder) walk(structName, receiver, lhsPrefix string, attrs [
 		// same schema.SingleNestedBlock as an ordinary nested object, and walking it
 		// as one would emit Get<Variant>Ok getters the SDK oneOf wrapper does not have.
 		if a.OneOf != nil {
-			variantBlocks, envelopeModel := b.oneOfEnvelope(a)
-			goType, ok := oneOfFieldType(a.TfType, envelopeModel)
+			render := b.oneOfEnvelope(a)
+			goType, ok := oneOfFieldType(a.TfType, render.goModel)
 			if !ok {
 				b.unsupported = append(b.unsupported, unsupportedOneOfPlacement(a.OneOf, a.TfType))
 				continue
 			}
+			collection := isCollectionForm(a.TfType)
 			fields = append(fields, ModelFieldView{GoField: field, GoType: goType, TFName: tfName})
 			blockViews = append(blockViews, AttrView{
 				TFName:      tfName,
@@ -526,9 +614,11 @@ func (b *dataSourceBuilder) walk(structName, receiver, lhsPrefix string, attrs [
 				Computed:    a.Computed,
 				Sensitive:   a.Sensitive,
 				IsBlock:     true,
-				ListBlock:   a.TfType == "schema.ListNestedBlock" || a.TfType == "schema.ListNestedAttribute",
-				Blocks:      variantBlocks,
+				ListBlock:   collection,
+				Blocks:      render.blocks,
 			})
+			lists = append(lists, oneOfListAssignment(
+				a.OneOf, render, tfName, receiver, lhsPrefix+"."+field, collection))
 			continue
 		}
 
@@ -887,6 +977,29 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 		field := goFieldName(tfName)
 		getter := getterOk("item.Attributes", tfName)
 
+		// Same rule as walk: a union is keyed on OneOf, never on TfType.
+		if n.OneOf != nil {
+			render := b.oneOfEnvelope(n)
+			goType, ok := oneOfFieldType(n.TfType, render.goModel)
+			if !ok {
+				unsupported = append(unsupported, unsupportedOneOfPlacement(n.OneOf, n.TfType))
+				continue
+			}
+			collection := isCollectionForm(n.TfType)
+			itemFields = append(itemFields, ModelFieldView{GoField: field, GoType: goType, TFName: tfName})
+			itemBlocks = append(itemBlocks, AttrView{
+				TFName:      tfName,
+				Description: n.Description,
+				Computed:    true,
+				IsBlock:     true,
+				ListBlock:   collection,
+				Blocks:      render.blocks,
+			})
+			itemLists = append(itemLists, oneOfListAssignment(
+				n.OneOf, render, tfName, "item.Attributes", "r."+field, collection))
+			continue
+		}
+
 		switch n.TfType {
 		case "schema.ListAttribute":
 			itemAttrs = append(itemAttrs, AttrView{
@@ -991,10 +1104,8 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 			ItemFields: itemAssigns,
 			ItemLists:  itemLists,
 		},
-		UsesFmt:        len(filterParams) > 0,
-		OneOfEnvelopes: b.envelopes,
-		Dropped:        dropped,
-		Warnings:       b.warnings,
+		UsesFmt: len(filterParams) > 0 || len(b.oneOfRenders) > 0,
+		Dropped: dropped,
 	}, nil
 }
 

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -251,6 +251,36 @@ var _ = Describe("RenderDataSource duplicate field guard", func() {
 			Items: obj(map[string]*model.Schema{"handle": prim("string", "")}),
 		}),
 	)
+
+	It("drops included, keeping its element union out of the view entirely", func() {
+		// The real shape: included is an array whose element is a oneOf, since it
+		// sideloads more than one resource type (User | LeakedKey for an API key).
+		op := incidentTypeOperation()
+		op.ResponseSchema.Properties["included"] = &model.Schema{
+			Kind: model.SchemaKindArray,
+			Items: &model.Schema{
+				Kind: model.SchemaKindOneOf,
+				OneOf: &model.OneOfSpec{
+					Name: "IncidentTypeResponseIncludedItem",
+					Path: "response.included[]",
+					Variants: []model.OneOfVariant{{
+						TFName: "user",
+						GoName: "User",
+						Schema: obj(map[string]*model.Schema{"handle": prim("string", "")}),
+					}},
+				},
+			},
+		}
+		art, err := model.BuildArtifact(op)
+		Expect(err).NotTo(HaveOccurred())
+		// The model still projects the union faithfully; only the view drops it.
+		Expect(art.Schema.Attributes).To(ContainElement(HaveField("Path", "response.included")))
+
+		view, err := BuildDataSourceView(art)
+		Expect(err).NotTo(HaveOccurred(), "a union under a dropped member must not fail the artifact")
+		Expect(view.Dropped).To(HaveLen(1))
+		Expect(view.Dropped[0].Message).To(ContainSubstring("dropped \"response.included\": not part of the surfaced {id, type, attributes} envelope"))
+	})
 })
 
 var _ = Describe("BuildDataSourceView audit fields", func() {

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -643,7 +643,7 @@ var _ = Describe("BuildDataSourceView singular nested arrays", func() {
 		for _, m := range view.Models {
 			names = append(names, m.Name)
 		}
-		Expect(names).To(Equal([]string{"datadogCostBudgetDataSourceModel", "EntriesModel", "TagFiltersModel"}))
+		Expect(names).To(Equal([]string{"datadogCostBudgetDataSourceModel", "datadogCostBudgetEntriesModel", "datadogCostBudgetEntriesTagFiltersModel"}))
 	})
 
 	It("maps each element through a guarded loop, recursing for nested arrays", func() {
@@ -657,7 +657,7 @@ var _ = Describe("BuildDataSourceView singular nested arrays", func() {
 		Expect(entries.GetterOk).To(Equal("attributes.GetEntriesOk()"))
 		Expect(entries.LoopVar).To(Equal("entriesItem"))
 		Expect(entries.ElemVar).To(Equal("entriesModel"))
-		Expect(entries.ElemStruct).To(Equal("EntriesModel"))
+		Expect(entries.ElemStruct).To(Equal("datadogCostBudgetEntriesModel"))
 		Expect(entries.Scalars).To(ContainElement(StateAssignment{
 			Var: "amount", GetterOk: "entriesItem.GetAmountOk()",
 			LHS: "entriesModel.Amount", RHS: "types.Float64Value(*amount)",
@@ -669,7 +669,7 @@ var _ = Describe("BuildDataSourceView singular nested arrays", func() {
 		Expect(tagFilters.LHS).To(Equal("entriesModel.TagFilters"))
 		Expect(tagFilters.GetterOk).To(Equal("entriesItem.GetTagFiltersOk()"))
 		Expect(tagFilters.LoopVar).To(Equal("tagFiltersItem"))
-		Expect(tagFilters.ElemStruct).To(Equal("TagFiltersModel"))
+		Expect(tagFilters.ElemStruct).To(Equal("datadogCostBudgetEntriesTagFiltersModel"))
 	})
 
 	It("produces a deeply-equal view across two runs", func() {
@@ -949,7 +949,7 @@ var _ = Describe("BuildDataSourceView plural nested arrays", func() {
 		for _, m := range view.Models {
 			names = append(names, m.Name)
 		}
-		Expect(names).To(Equal([]string{"datadogWidgetsDataSourceModel", "WidgetModel", "PartsModel"}))
+		Expect(names).To(Equal([]string{"datadogWidgetsDataSourceModel", "datadogWidgetsWidgetModel", "datadogWidgetsWidgetPartsModel"}))
 	})
 
 	It("maps the object array off item.Attributes into the item accumulator", func() {
@@ -962,7 +962,7 @@ var _ = Describe("BuildDataSourceView plural nested arrays", func() {
 		Expect(parts.LHS).To(Equal("r.Parts"))
 		Expect(parts.GetterOk).To(Equal("item.Attributes.GetPartsOk()"))
 		Expect(parts.LoopVar).To(Equal("partsItem"))
-		Expect(parts.ElemStruct).To(Equal("PartsModel"))
+		Expect(parts.ElemStruct).To(Equal("datadogWidgetsWidgetPartsModel"))
 		Expect(parts.Scalars).To(ContainElement(StateAssignment{
 			Var: "label", GetterOk: "partsItem.GetLabelOk()",
 			LHS: "partsModel.Label", RHS: "types.StringValue(*label)",
@@ -1037,7 +1037,7 @@ var _ = Describe("BuildDataSourceView singular nested objects", func() {
 		for _, m := range view.Models {
 			names = append(names, m.Name)
 		}
-		Expect(names).To(Equal([]string{"datadogApmRetentionFilterDataSourceModel", "FilterModel", "MetadataModel"}))
+		Expect(names).To(Equal([]string{"datadogApmRetentionFilterDataSourceModel", "datadogApmRetentionFilterFilterModel", "datadogApmRetentionFilterFilterMetadataModel"}))
 	})
 
 	It("maps the object through a guarded assignment, recursing into the nested object", func() {
@@ -1054,7 +1054,7 @@ var _ = Describe("BuildDataSourceView singular nested objects", func() {
 		Expect(filter.GetterOk).To(Equal("attributes.GetFilterOk()"))
 		Expect(filter.Var).To(Equal("filter"))
 		Expect(filter.ElemVar).To(Equal("filterModel"))
-		Expect(filter.ElemStruct).To(Equal("FilterModel"))
+		Expect(filter.ElemStruct).To(Equal("datadogApmRetentionFilterFilterModel"))
 		Expect(filter.Scalars).To(ContainElement(StateAssignment{
 			Var: "query", GetterOk: "filter.GetQueryOk()",
 			LHS: "filterModel.Query", RHS: "types.StringValue(*query)",
@@ -1068,7 +1068,7 @@ var _ = Describe("BuildDataSourceView singular nested objects", func() {
 		}
 		Expect(metadata.LHS).To(Equal("filterModel.Metadata"))
 		Expect(metadata.GetterOk).To(Equal("filter.GetMetadataOk()"))
-		Expect(metadata.ElemStruct).To(Equal("MetadataModel"))
+		Expect(metadata.ElemStruct).To(Equal("datadogApmRetentionFilterFilterMetadataModel"))
 	})
 
 	It("renders the guarded object block and the recursive assignment in updateState", func() {
@@ -1149,7 +1149,7 @@ var _ = Describe("BuildDataSourceView plural nested objects", func() {
 		for _, m := range view.Models {
 			names = append(names, m.Name)
 		}
-		Expect(names).To(Equal([]string{"datadogGizmosDataSourceModel", "GizmoModel", "SpecModel"}))
+		Expect(names).To(Equal([]string{"datadogGizmosDataSourceModel", "datadogGizmosGizmoModel", "datadogGizmosGizmoSpecModel"}))
 	})
 
 	It("maps the object off item.Attributes into the item accumulator", func() {
@@ -1162,7 +1162,7 @@ var _ = Describe("BuildDataSourceView plural nested objects", func() {
 		Expect(spec.LHS).To(Equal("r.Spec"))
 		Expect(spec.GetterOk).To(Equal("item.Attributes.GetSpecOk()"))
 		Expect(spec.Var).To(Equal("spec"))
-		Expect(spec.ElemStruct).To(Equal("SpecModel"))
+		Expect(spec.ElemStruct).To(Equal("datadogGizmosGizmoSpecModel"))
 		Expect(spec.Scalars).To(ContainElement(StateAssignment{
 			Var: "shape", GetterOk: "spec.GetShapeOk()",
 			LHS: "specModel.Shape", RHS: "types.StringValue(*shape)",

--- a/.generator-v2/internal/emit/modelname.go
+++ b/.generator-v2/internal/emit/modelname.go
@@ -1,0 +1,148 @@
+package emit
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+)
+
+// modelNamer is the single authority for the Go struct name of every model a
+// generated artifact declares. Every name is built the same way:
+//
+//	<artifact base><stem>Model
+//
+// Both halves are load-bearing, and each closes a distinct collision scope.
+//
+// The **artifact base** (dsGoName, e.g. "datadogActionConnection") closes the
+// cross-artifact scope. Every generated data source lands in package fwprovider, so
+// two artifacts that share an OpenAPI component would otherwise each declare the
+// same struct and neither could be compiled alongside the other. That is not
+// hypothetical: 54 of the components in the mini-OAS corpus appear in more than one
+// slice (GoogleMeetConfigurationReference and IncidentTypeAttributes in three
+// each). Prefixing also makes nested models unexported, which is the provider's own
+// convention for data-source models — hostListMetadataModel, rowModel — so this
+// moves toward the hand-written set rather than away from it.
+//
+// The **stem** closes the within-file scope. It prefers the OpenAPI component name
+// that supplied the object schema (Attribute.ModelRefName) and falls back to the
+// enclosing stem plus the property name when that schema was inline. This is the
+// rule the SDK generator's child_models() applies — get_name(schema) or
+// alternative_name, restarting at every $ref — and the rule oneOf envelope naming
+// already applies through OneOfSpec.Name. Deriving from the property name alone is
+// what produced two different TagFiltersModel structs in one file and made
+// integration_aws_external_id uncompilable.
+//
+// A component-derived stem also makes two uses of one component in one artifact
+// converge on a single struct, which dedupeModels then collapses.
+type modelNamer struct {
+	// base is the artifact's Go name stem, already lowerCamel (dsGoName).
+	base string
+}
+
+// qualify scopes an unqualified model name to the artifact. It is the one place an
+// artifact prefix is applied, so the model layer's OneOfEnvelope.GoModel can stay
+// artifact-agnostic: the model layer does not know which artifact is rendering a
+// reusable union, and emit does.
+func (n modelNamer) qualify(unqualified string) string {
+	return n.base + upperFirst(unqualified)
+}
+
+// nested returns the qualified struct name for the model backing a, plus the stem
+// its own children accumulate from. stem is the enclosing model's stem ("" at the
+// artifact root).
+func (n modelNamer) nested(stem string, a *model.Attribute) (name, childStem string) {
+	childStem = nestedStem(stem, a)
+	return n.qualify(childStem + "Model"), childStem
+}
+
+// nestedStem derives the stem of a's model: the component that supplied its object
+// schema when there is one — restarting the accumulation, exactly as child_models()
+// prefers a $ref name over the parent-derived one — else the enclosing stem plus
+// this attribute's property name.
+//
+// The two branches are spelled differently on purpose. A component name is already
+// a Go-style identifier (it is what the SDK names its own struct), so it is taken
+// verbatim, which is also what the oneOf envelope path does with OneOfSpec.Name.
+// Running it through model.SdkName would mangle acronyms and do so inconsistently —
+// AWSLogSourceTagFilter becomes AwsLogSourceTagFilter while XRayServicesList
+// survives — for no gain. A property name, by contrast, arrives as snake_case and
+// must be converted.
+func nestedStem(stem string, a *model.Attribute) string {
+	if a.ModelRefName != "" {
+		return a.ModelRefName
+	}
+	return stem + model.SdkName(tfNameOf(a.Path))
+}
+
+// stemOf recovers the naming stem from an unqualified model name produced by the
+// model layer (model.oneOfModelName appends "Model" to the envelope or variant
+// identity). Children of that struct accumulate inline names from the stem, so they
+// must not inherit the suffix.
+func stemOf(unqualifiedModel string) string {
+	return strings.TrimSuffix(unqualifiedModel, "Model")
+}
+
+// dedupeModels collapses model structs that share a name, and fails when two of
+// them disagree about their fields.
+//
+// Convergence is expected and correct: one OpenAPI component reached from two
+// properties in the same artifact yields one stem, so it must yield one declaration
+// rather than a redeclaration. Divergence means the naming rule produced one name
+// for two shapes, which is the defect this guards against — fail the artifact
+// naming both, because the alternatives are emitting code that cannot compile or
+// silently dropping one shape's fields, and the silent option is not acceptable.
+func dedupeModels(models []ModelStructView) ([]ModelStructView, []UnsupportedNode) {
+	var out []ModelStructView
+	seen := make(map[string]ModelStructView, len(models))
+	var conflicts []UnsupportedNode
+
+	for _, m := range models {
+		prev, ok := seen[m.Name]
+		if !ok {
+			seen[m.Name] = m
+			out = append(out, m)
+			continue
+		}
+		if fieldsEqual(prev.Fields, m.Fields) {
+			continue
+		}
+		conflicts = append(conflicts, UnsupportedNode{
+			Path: m.Name,
+			Reason: fmt.Sprintf(
+				"two different object shapes both derive the model struct %q (%s vs %s); "+
+					"the generated file would redeclare the type. Give the schemas distinct "+
+					"OpenAPI components so each names its own model",
+				m.Name, fieldList(prev.Fields), fieldList(m.Fields)),
+		})
+	}
+
+	sort.SliceStable(conflicts, func(i, j int) bool { return conflicts[i].Path < conflicts[j].Path })
+	return out, conflicts
+}
+
+func fieldsEqual(a, b []ModelFieldView) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].GoField != b[i].GoField || a[i].GoType != b[i].GoType || a[i].TFName != b[i].TFName {
+			return false
+		}
+	}
+	return true
+}
+
+// fieldList renders a model's fields for a collision diagnostic, so the message
+// shows which two shapes collided rather than only that they did.
+func fieldList(fields []ModelFieldView) string {
+	if len(fields) == 0 {
+		return "{}"
+	}
+	parts := make([]string, len(fields))
+	for i, f := range fields {
+		parts[i] = f.GoField + " " + f.GoType
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}

--- a/.generator-v2/internal/emit/modelname_test.go
+++ b/.generator-v2/internal/emit/modelname_test.go
@@ -1,0 +1,263 @@
+package emit
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+)
+
+// component wraps an object schema with the OpenAPI component name that supplied
+// it, which is what the parser records as Schema.RefName.
+func component(name string, props map[string]*model.Schema) *model.Schema {
+	s := obj(props)
+	s.RefName = name
+	return s
+}
+
+// twoTagFiltersOperation reduces the shape that made integration_aws_external_id
+// uncompilable: two differently-shaped objects, each reachable under a property
+// named "tag_filters", one nested a level deeper than the other. Deriving a model
+// name from the property alone gave both TagFiltersModel.
+func twoTagFiltersOperation() *model.Operation {
+	return &model.Operation{
+		Path:            "/api/v2/integration/aws/accounts/{aws_account_config_id}",
+		Method:          "GET",
+		OperationId:     "GetAWSAccount",
+		Tag:             "AWS Integration",
+		ResponseRefName: "AWSAccountResponse",
+		Tracking: &model.TrackingFieldMetadata{
+			ArtifactKind: model.ArtifactKindDataSource,
+			ArtifactName: "integration_aws_account",
+			IdStrategy:   model.IdStrategyDataID,
+			Group:        &model.OperationGroup{Read: "GetAWSAccount"},
+		},
+		ResponseSchema: obj(map[string]*model.Schema{
+			"data": obj(map[string]*model.Schema{
+				"id":   prim("string", "The account's identifier."),
+				"type": prim("string", "Resource type."),
+				"attributes": obj(map[string]*model.Schema{
+					"logs_config": component("AWSLogsConfig", map[string]*model.Schema{
+						"log_source_config": component("AWSLogSourceConfig", map[string]*model.Schema{
+							"tag_filters": {
+								Kind:        model.SchemaKindArray,
+								Description: "Log source tag filters.",
+								Items: component("AWSLogSourceTagFilter", map[string]*model.Schema{
+									"source": prim("string", "The log source."),
+								}),
+							},
+						}),
+					}),
+					"metrics_config": component("AWSMetricsConfig", map[string]*model.Schema{
+						"tag_filters": {
+							Kind:        model.SchemaKindArray,
+							Description: "Metrics namespace tag filters.",
+							Items: component("AWSNamespaceTagFilter", map[string]*model.Schema{
+								"namespace": prim("string", "The AWS namespace."),
+							}),
+						},
+					}),
+				}),
+			}),
+		}),
+	}
+}
+
+// sharedComponentOperation reaches one component from two properties in one
+// artifact. Both sites must converge on a single declaration rather than
+// redeclaring the type. The properties deliberately avoid created_by/updated_by,
+// which flattenEnvelope drops as server-managed audit fields.
+func sharedComponentOperation() *model.Operation {
+	creator := func() *model.Schema {
+		return component("Creator", map[string]*model.Schema{
+			"email": prim("string", "The creator's email."),
+			"name":  prim("string", "The creator's name."),
+		})
+	}
+	return &model.Operation{
+		Path:            "/api/v2/widgets/{widget_id}",
+		Method:          "GET",
+		OperationId:     "GetWidget",
+		Tag:             "Widgets",
+		ResponseRefName: "WidgetResponse",
+		Tracking: &model.TrackingFieldMetadata{
+			ArtifactKind: model.ArtifactKindDataSource,
+			ArtifactName: "widget",
+			IdStrategy:   model.IdStrategyDataID,
+			Group:        &model.OperationGroup{Read: "GetWidget"},
+		},
+		ResponseSchema: obj(map[string]*model.Schema{
+			"data": obj(map[string]*model.Schema{
+				"id":   prim("string", "The widget's identifier."),
+				"type": prim("string", "Resource type."),
+				"attributes": obj(map[string]*model.Schema{
+					"primary_contact":   creator(),
+					"secondary_contact": creator(),
+				}),
+			}),
+		}),
+	}
+}
+
+func modelNames(view DataSourceView) []string {
+	names := make([]string, 0, len(view.Models))
+	for _, m := range view.Models {
+		names = append(names, m.Name)
+	}
+	return names
+}
+
+var _ = Describe("generated model naming", func() {
+
+	Context("two objects under one property name", func() {
+		It("names each after its own component instead of colliding", func() {
+			view, err := BuildDataSourceView(mustArtifact(twoTagFiltersOperation()))
+			Expect(err).NotTo(HaveOccurred())
+
+			names := modelNames(view)
+			Expect(names).To(ContainElement("datadogIntegrationAwsAccountAWSLogSourceTagFilterModel"))
+			Expect(names).To(ContainElement("datadogIntegrationAwsAccountAWSNamespaceTagFilterModel"))
+		})
+
+		It("declares every model exactly once", func() {
+			view, err := BuildDataSourceView(mustArtifact(twoTagFiltersOperation()))
+			Expect(err).NotTo(HaveOccurred())
+
+			seen := map[string]int{}
+			for _, n := range modelNames(view) {
+				seen[n]++
+			}
+			for name, count := range seen {
+				Expect(count).To(Equal(1), "%s is declared %d times; the file would not compile", name, count)
+			}
+		})
+
+		It("points each tag_filters field at its own struct", func() {
+			view, err := BuildDataSourceView(mustArtifact(twoTagFiltersOperation()))
+			Expect(err).NotTo(HaveOccurred())
+
+			logSource := modelByName(view, "datadogIntegrationAwsAccountAWSLogSourceConfigModel")
+			Expect(logSource.Fields).To(Equal([]ModelFieldView{
+				{GoField: "TagFilters", GoType: "[]*datadogIntegrationAwsAccountAWSLogSourceTagFilterModel", TFName: "tag_filters"},
+			}))
+
+			metrics := modelByName(view, "datadogIntegrationAwsAccountAWSMetricsConfigModel")
+			Expect(metrics.Fields).To(Equal([]ModelFieldView{
+				{GoField: "TagFilters", GoType: "[]*datadogIntegrationAwsAccountAWSNamespaceTagFilterModel", TFName: "tag_filters"},
+			}))
+		})
+
+		It("renders gofmt-clean Go", func() {
+			view, err := BuildDataSourceView(mustArtifact(twoTagFiltersOperation()))
+			Expect(err).NotTo(HaveOccurred())
+			// RenderDataSource runs format.Source, so a duplicate declaration or a
+			// mangled identifier fails here rather than at the provider's build.
+			_, err = RenderDataSource(view)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("scoping to the artifact", func() {
+		It("prefixes every model with the artifact base", func() {
+			// Two data sources sharing a component must not each declare it: they land
+			// in one package, so an unprefixed name is a redeclaration across files.
+			// 54 components in the mini-OAS corpus appear in more than one slice.
+			view, err := BuildDataSourceView(mustArtifact(twoTagFiltersOperation()))
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, n := range modelNames(view) {
+				Expect(n).To(HavePrefix("datadogIntegrationAwsAccount"),
+					"%s is not scoped to its artifact", n)
+			}
+		})
+
+		It("keeps nested models unexported, as the hand-written data sources do", func() {
+			view, err := BuildDataSourceView(mustArtifact(twoTagFiltersOperation()))
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, n := range modelNames(view) {
+				Expect(n[:1]).To(Equal(strings.ToLower(n[:1])), "%s is exported", n)
+			}
+		})
+	})
+
+	Context("one component reached twice", func() {
+		It("collapses to a single declaration both sites point at", func() {
+			view, err := BuildDataSourceView(mustArtifact(sharedComponentOperation()))
+			Expect(err).NotTo(HaveOccurred())
+
+			var creators int
+			for _, n := range modelNames(view) {
+				if n == "datadogWidgetCreatorModel" {
+					creators++
+				}
+			}
+			Expect(creators).To(Equal(1))
+
+			root := modelByName(view, "datadogWidgetDataSourceModel")
+			var types []string
+			for _, f := range root.Fields {
+				if f.TFName == "primary_contact" || f.TFName == "secondary_contact" {
+					types = append(types, f.GoType)
+				}
+			}
+			Expect(types).To(Equal([]string{"*datadogWidgetCreatorModel", "*datadogWidgetCreatorModel"}))
+		})
+	})
+
+	DescribeTable("nestedStem",
+		func(stem string, a *model.Attribute, want string) {
+			Expect(nestedStem(stem, a)).To(Equal(want))
+		},
+		Entry("prefers the component name, verbatim",
+			"Parent", &model.Attribute{Path: "response.tag_filters", ModelRefName: "AWSLogSourceTagFilter"},
+			"AWSLogSourceTagFilter"),
+		Entry("restarts the accumulation at the component, ignoring the enclosing stem",
+			"LogsConfigLogSourceConfig", &model.Attribute{Path: "response.tag_filters", ModelRefName: "AWSNamespaceTagFilter"},
+			"AWSNamespaceTagFilter"),
+		Entry("accumulates from the enclosing stem for an inline schema",
+			"LogSourceConfig", &model.Attribute{Path: "response.logs.log_source_config.tag_filters"},
+			"LogSourceConfigTagFilters"),
+		Entry("converts a snake_case property, since only a component name is already Go-style",
+			"", &model.Attribute{Path: "response.http_token_auth"},
+			"HttpTokenAuth"),
+	)
+
+	Describe("dedupeModels", func() {
+		It("collapses identical declarations without complaint", func() {
+			fields := []ModelFieldView{{GoField: "Name", GoType: "types.String", TFName: "name"}}
+			out, conflicts := dedupeModels([]ModelStructView{
+				{Name: "aModel", Fields: fields},
+				{Name: "aModel", Fields: fields},
+			})
+			Expect(conflicts).To(BeEmpty())
+			Expect(out).To(HaveLen(1))
+		})
+
+		It("preserves first-use order", func() {
+			out, conflicts := dedupeModels([]ModelStructView{
+				{Name: "rootModel"}, {Name: "aModel"}, {Name: "rootModel"}, {Name: "bModel"},
+			})
+			Expect(conflicts).To(BeEmpty())
+			Expect([]string{out[0].Name, out[1].Name, out[2].Name}).To(Equal([]string{"rootModel", "aModel", "bModel"}))
+		})
+
+		It("fails when one name covers two shapes, naming both", func() {
+			// The guard applied to artifact names has no counterpart at the Go
+			// identifier level, so this is the emitter's own defence: emitting the
+			// redeclaration or silently dropping one shape are both worse.
+			out, conflicts := dedupeModels([]ModelStructView{
+				{Name: "tagFiltersModel", Fields: []ModelFieldView{{GoField: "Source", GoType: "types.String", TFName: "source"}}},
+				{Name: "tagFiltersModel", Fields: []ModelFieldView{{GoField: "Namespace", GoType: "types.String", TFName: "namespace"}}},
+			})
+			Expect(out).To(HaveLen(1))
+			Expect(conflicts).To(HaveLen(1))
+			Expect(conflicts[0].Path).To(Equal("tagFiltersModel"))
+			Expect(conflicts[0].Reason).To(ContainSubstring("Source types.String"))
+			Expect(conflicts[0].Reason).To(ContainSubstring("Namespace types.String"))
+			Expect(conflicts[0].Reason).To(ContainSubstring("redeclare"))
+		})
+	})
+})

--- a/.generator-v2/internal/emit/oneof_test.go
+++ b/.generator-v2/internal/emit/oneof_test.go
@@ -84,6 +84,50 @@ func modelByName(view DataSourceView, name string) ModelStructView {
 	return ModelStructView{}
 }
 
+// oneOfAssignmentAt finds the oneOf assignment for the union at path, searching
+// the state mapper's assignments and recursing through variants.
+func oneOfAssignmentAt(view DataSourceView, path string) *OneOfAssignment {
+	GinkgoHelper()
+	var find func(lists []ListAssignment) *OneOfAssignment
+	find = func(lists []ListAssignment) *OneOfAssignment {
+		for _, l := range lists {
+			if l.Kind == "oneof" && l.OneOf != nil {
+				if l.OneOf.Path == path {
+					return l.OneOf
+				}
+				for _, v := range l.OneOf.Variants {
+					if got := find(v.Lists); got != nil {
+						return got
+					}
+				}
+				continue
+			}
+			if got := find(l.Lists); got != nil {
+				return got
+			}
+		}
+		return nil
+	}
+	got := find(view.State.Lists)
+	if got == nil {
+		got = find(view.State.ItemLists)
+	}
+	Expect(got).NotTo(BeNil(), "no oneOf assignment at %q", path)
+	return got
+}
+
+// variantAssignment returns the alternative selected by the given SDK member.
+func variantAssignment(assign *OneOfAssignment, sdkField string) OneOfVariantAssignment {
+	GinkgoHelper()
+	for _, v := range assign.Variants {
+		if v.SDKField == sdkField {
+			return v
+		}
+	}
+	Fail("no variant bound to SDK member " + sdkField)
+	return OneOfVariantAssignment{}
+}
+
 // blockByName returns the named block from a block list.
 func blockByName(blocks []AttrView, name string) AttrView {
 	GinkgoHelper()
@@ -205,59 +249,68 @@ var _ = Describe("oneOf envelope emission", func() {
 			}
 			Expect(envelopeModels).To(Equal(1), "the component yielded one model per use site")
 
-			Expect(view.OneOfEnvelopes).To(HaveLen(1))
 			Expect(blockByName(view.Schema.Blocks, "primary").Blocks).
 				To(Equal(blockByName(view.Schema.Blocks, "secondary").Blocks))
+
+			// The two sites share the variant bodies but not the outer locals, so
+			// each unwraps into its own envelope model without colliding.
+			primary := oneOfAssignmentAt(view, "response.data.attributes.primary")
+			secondary := oneOfAssignmentAt(view, "response.data.attributes.secondary")
+			Expect(primary.Variants).To(Equal(secondary.Variants))
+			Expect(primary.ModelVar).NotTo(Equal(secondary.ModelVar))
+			Expect(primary.LHS).To(Equal("state.Primary"))
+			Expect(secondary.LHS).To(Equal("state.Secondary"))
 		})
 	})
 
-	Context("the envelope view handed to the mapper", func() {
-		It("carries both identities plus the per-variant SDK binding", func() {
+	Context("the assignment handed to the template", func() {
+		It("unwraps the wrapper through an ordinary getter and counts every member", func() {
 			view := unionView(unionOperation())
-			Expect(view.OneOfEnvelopes).To(HaveLen(1))
-			env := view.OneOfEnvelopes[0]
+			assign := oneOfAssignmentAt(view, "response.data.attributes.notification")
 
-			Expect(env.Name).To(Equal("IncidentNotification"))
-			Expect(env.GoModel).To(Equal("IncidentNotificationModel"))
-			Expect(env.SDKType).To(Equal("IncidentNotification"))
-			Expect(env.Path).To(Equal("response.data.attributes.notification"))
+			Expect(assign.SDKType).To(Equal("IncidentNotification"))
+			Expect(assign.GoModel).To(Equal("IncidentNotificationModel"))
+			Expect(assign.LHS).To(Equal("state.Notification"))
+			// The wrapper itself is a normal field on its parent; only its members
+			// lack getters.
+			Expect(assign.GetterOk).To(Equal("attributes.GetNotificationOk()"))
+			Expect(assign.Receiver).To(Equal(assign.Var))
+			Expect(assign.MatchVar).NotTo(BeEmpty())
+			Expect(assign.Collection).To(BeFalse())
+			Expect(assign.Variants).To(HaveLen(2))
+		})
 
-			byName := map[string]OneOfVariantView{}
-			for _, v := range env.Variants {
-				byName[v.TFName] = v
-			}
+		It("reads an object alternative's fields through the SDK member's getters", func() {
+			view := unionView(unionOperation())
+			webhook := variantAssignment(
+				oneOfAssignmentAt(view, "response.data.attributes.notification"), "WebhookNotification")
 
-			webhook := byName["webhook_notification"]
 			Expect(webhook.GoField).To(Equal("WebhookNotification"))
-			Expect(webhook.SDKField).To(Equal("WebhookNotification"))
-			Expect(webhook.SDKConstructor).To(Equal("WebhookNotificationAsIncidentNotification"))
-			Expect(webhook.SDKPointer).To(BeTrue())
-			Expect(webhook.ValueWrapped).To(BeFalse())
-			// The field assignments are derived against the mapper's own locals.
 			Expect(webhook.SDKVar).To(Equal("webhookNotificationVariant"))
 			Expect(webhook.ModelVar).To(Equal("webhookNotificationModel"))
+			Expect(webhook.SDKPointer).To(BeTrue())
+			Expect(webhook.Value).To(BeNil())
 			Expect(webhook.Scalars).To(ContainElement(StateAssignment{
 				Var:      "url",
 				GetterOk: "webhookNotificationVariant.GetUrlOk()",
 				LHS:      "webhookNotificationModel.Url",
 				RHS:      "types.StringValue(*url)",
 			}))
-
-			scalar := byName["string"]
-			Expect(scalar.SDKField).To(Equal("String"))
-			Expect(scalar.SDKConstructor).To(Equal("StringAsIncidentNotification"))
-			Expect(scalar.ValueWrapped).To(BeTrue())
 		})
-	})
 
-	Context("honesty of the run report", func() {
-		It("warns that the envelope is emitted but not yet populated", func() {
-			// While the mapper is unimplemented the block reads as permanently null.
-			// Reporting that is what separates an increment from a silent lie.
+		It("dereferences a scalar alternative instead of calling a getter on it", func() {
+			// The SDK member of a value-wrapped alternative is a *string, which has no
+			// GetValueOk; reading through one would not compile.
 			view := unionView(unionOperation())
-			Expect(view.Warnings).To(HaveLen(1))
-			Expect(view.Warnings[0]).To(ContainSubstring("IncidentNotification"))
-			Expect(view.Warnings[0]).To(ContainSubstring("response mapping is not"))
+			scalar := variantAssignment(
+				oneOfAssignmentAt(view, "response.data.attributes.notification"), "String")
+
+			Expect(scalar.Scalars).To(BeEmpty())
+			Expect(scalar.Value).NotTo(BeNil())
+			Expect(*scalar.Value).To(Equal(StateAssignment{
+				LHS: "stringModel.Value",
+				RHS: "types.StringValue(*stringVariant)",
+			}))
 		})
 	})
 
@@ -387,3 +440,82 @@ var _ = Describe("oneOf envelope in a collection", func() {
 // templates_test.go, covering a union at its own position and one as a list element.
 func oneOfEnvelopeView() DataSourceView     { return unionView(unionOperation()) }
 func oneOfEnvelopeListView() DataSourceView { return unionView(unionListOperation()) }
+
+var _ = Describe("oneOf response mapping", func() {
+	It("inspects every member rather than taking the first non-nil one", func() {
+		// The SDK's own MarshalJSON and GetActualInstance are first-match; the
+		// generated mapper deliberately is not.
+		src := string(mustRender(unionOperation()))
+		Expect(src).To(ContainSubstring("if stringVariant := notification.String; stringVariant != nil {"))
+		Expect(src).To(ContainSubstring("if webhookNotificationVariant := notification.WebhookNotification; webhookNotificationVariant != nil {"))
+		Expect(src).To(ContainSubstring("notificationMatches++"))
+	})
+
+	It("reports an unparsed payload at the union's schema path", func() {
+		src := string(mustRender(unionOperation()))
+		Expect(src).To(ContainSubstring("case notification.UnparsedObject != nil:"))
+		Expect(src).To(ContainSubstring("response.data.attributes.notification: the Datadog API returned a value none of the IncidentNotification alternatives could parse"))
+	})
+
+	It("reports multiple populated members instead of choosing one", func() {
+		src := string(mustRender(unionOperation()))
+		Expect(src).To(ContainSubstring("case notificationMatches > 1:"))
+		Expect(src).To(ContainSubstring("alternatives, expected exactly one"))
+	})
+
+	It("assigns the envelope only when exactly one member matched", func() {
+		src := string(mustRender(unionOperation()))
+		Expect(src).To(ContainSubstring("case notificationMatches == 1:\n\t\t\tstate.Notification = notificationEnvelope"))
+	})
+
+	It("errors on zero members when the union is required", func() {
+		op := unionOperation()
+		attrs := op.ResponseSchema.Properties["data"].Properties["attributes"]
+		attrs.Required = []string{"notification"}
+
+		src := string(mustRender(op))
+		Expect(src).To(ContainSubstring("matched none of the IncidentNotification alternatives, and the field is not optional"))
+	})
+
+	It("accepts zero members when the union is optional", func() {
+		// Zero populated members may represent an absent nullable value, so
+		// an optional envelope must not raise — it simply stays nil.
+		op := unionOperation()
+		attrs := op.ResponseSchema.Properties["data"].Properties["attributes"]
+		attrs.Properties["notification"].OneOf.Optional = true
+
+		src := string(mustRender(op))
+		Expect(src).NotTo(ContainSubstring("matched none of the IncidentNotification alternatives"))
+		Expect(src).To(ContainSubstring("case notificationMatches == 1:"))
+	})
+
+	It("maps a union nested inside another union's alternative", func() {
+		op := unionOperation()
+		webhook := op.ResponseSchema.Properties["data"].
+			Properties["attributes"].Properties["notification"].OneOf.Variants[1].Schema
+		webhook.Properties["target"] = unionSchema(
+			"response.data.attributes.notification.webhook_notification.target", "NotificationTarget")
+
+		src := string(mustRender(op))
+		// The inner wrapper is reached with an ordinary getter off the outer variant.
+		Expect(src).To(ContainSubstring("if target, ok := webhookNotificationVariant.GetTargetOk(); ok && target != nil {"))
+		Expect(src).To(ContainSubstring("targetEnvelope := &NotificationTargetModel{}"))
+		Expect(src).To(ContainSubstring("targetMatches++"))
+	})
+
+	It("imports fmt, which the ambiguous-match diagnostic needs", func() {
+		// go/format does not prune imports, so an under-estimate here is a compile
+		// error and an over-estimate is an unused import.
+		view := unionView(unionOperation())
+		Expect(view.UsesFmt).To(BeTrue())
+		Expect(string(mustRender(unionOperation()))).To(ContainSubstring("\"fmt\""))
+	})
+})
+
+// mustRender renders op's data source, asserting every stage succeeded.
+func mustRender(op *model.Operation) []byte {
+	GinkgoHelper()
+	src, err := RenderDataSource(unionView(op))
+	Expect(err).NotTo(HaveOccurred())
+	return src
+}

--- a/.generator-v2/internal/emit/oneof_test.go
+++ b/.generator-v2/internal/emit/oneof_test.go
@@ -145,11 +145,11 @@ var _ = Describe("oneOf envelope emission", func() {
 	Context("the envelope model", func() {
 		It("holds one pointer field per variant, keyed on the Terraform variant name", func() {
 			view := unionView(unionOperation())
-			envelope := modelByName(view, "IncidentNotificationModel")
+			envelope := modelByName(view, "datadogIncidentTypeIncidentNotificationModel")
 
 			Expect(envelope.Fields).To(Equal([]ModelFieldView{
-				{GoField: "String", GoType: "*IncidentNotificationStringModel", TFName: "string"},
-				{GoField: "WebhookNotification", GoType: "*IncidentNotificationWebhookNotificationModel", TFName: "webhook_notification"},
+				{GoField: "String", GoType: "*datadogIncidentTypeIncidentNotificationStringModel", TFName: "string"},
+				{GoField: "WebhookNotification", GoType: "*datadogIncidentTypeIncidentNotificationWebhookNotificationModel", TFName: "webhook_notification"},
 			}))
 		})
 
@@ -166,17 +166,17 @@ var _ = Describe("oneOf envelope emission", func() {
 				}
 			}
 			Expect(field.GoField).To(Equal("Notification"))
-			Expect(field.GoType).To(Equal("*IncidentNotificationModel"))
+			Expect(field.GoType).To(Equal("*datadogIncidentTypeIncidentNotificationModel"))
 		})
 
 		It("gives an object variant its own fields and a scalar variant a single value field", func() {
 			view := unionView(unionOperation())
 
-			Expect(modelByName(view, "IncidentNotificationWebhookNotificationModel").Fields).To(Equal([]ModelFieldView{
+			Expect(modelByName(view, "datadogIncidentTypeIncidentNotificationWebhookNotificationModel").Fields).To(Equal([]ModelFieldView{
 				{GoField: "Enabled", GoType: "types.Bool", TFName: "enabled"},
 				{GoField: "Url", GoType: "types.String", TFName: "url"},
 			}))
-			Expect(modelByName(view, "IncidentNotificationStringModel").Fields).To(Equal([]ModelFieldView{
+			Expect(modelByName(view, "datadogIncidentTypeIncidentNotificationStringModel").Fields).To(Equal([]ModelFieldView{
 				{GoField: "Value", GoType: "types.String", TFName: "value"},
 			}))
 		})
@@ -186,9 +186,9 @@ var _ = Describe("oneOf envelope emission", func() {
 			var envelopeAt, variantAt = -1, -1
 			for i, m := range view.Models {
 				switch m.Name {
-				case "IncidentNotificationModel":
+				case "datadogIncidentTypeIncidentNotificationModel":
 					envelopeAt = i
-				case "IncidentNotificationWebhookNotificationModel":
+				case "datadogIncidentTypeIncidentNotificationWebhookNotificationModel":
 					variantAt = i
 				}
 			}
@@ -243,7 +243,7 @@ var _ = Describe("oneOf envelope emission", func() {
 
 			var envelopeModels int
 			for _, m := range view.Models {
-				if m.Name == "IncidentNotificationModel" {
+				if m.Name == "datadogIncidentTypeIncidentNotificationModel" {
 					envelopeModels++
 				}
 			}
@@ -269,7 +269,7 @@ var _ = Describe("oneOf envelope emission", func() {
 			assign := oneOfAssignmentAt(view, "response.data.attributes.notification")
 
 			Expect(assign.SDKType).To(Equal("IncidentNotification"))
-			Expect(assign.GoModel).To(Equal("IncidentNotificationModel"))
+			Expect(assign.GoModel).To(Equal("datadogIncidentTypeIncidentNotificationModel"))
 			Expect(assign.LHS).To(Equal("state.Notification"))
 			// The wrapper itself is a normal field on its parent; only its members
 			// lack getters.
@@ -377,8 +377,8 @@ var _ = Describe("oneOf envelope emission", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			out := string(src)
-			Expect(out).To(ContainSubstring("type IncidentNotificationModel struct {"))
-			Expect(out).To(ContainSubstring("WebhookNotification *IncidentNotificationWebhookNotificationModel `tfsdk:\"webhook_notification\"`"))
+			Expect(out).To(ContainSubstring("type datadogIncidentTypeIncidentNotificationModel struct {"))
+			Expect(out).To(ContainSubstring("WebhookNotification *datadogIncidentTypeIncidentNotificationWebhookNotificationModel `tfsdk:\"webhook_notification\"`"))
 			Expect(out).To(ContainSubstring(`"notification": schema.SingleNestedBlock{`))
 			Expect(out).To(ContainSubstring(`"webhook_notification": schema.SingleNestedBlock{`))
 		})
@@ -417,7 +417,7 @@ var _ = Describe("oneOf envelope in a collection", func() {
 				field = f
 			}
 		}
-		Expect(field.GoType).To(Equal("[]*IncidentNotificationModel"),
+		Expect(field.GoType).To(Equal("[]*datadogIncidentTypeIncidentNotificationModel"),
 			"each element of the list is one envelope")
 
 		block := blockByName(view.Schema.Blocks, "notifications")
@@ -499,7 +499,7 @@ var _ = Describe("oneOf response mapping", func() {
 		src := string(mustRender(op))
 		// The inner wrapper is reached with an ordinary getter off the outer variant.
 		Expect(src).To(ContainSubstring("if target, ok := webhookNotificationVariant.GetTargetOk(); ok && target != nil {"))
-		Expect(src).To(ContainSubstring("targetEnvelope := &NotificationTargetModel{}"))
+		Expect(src).To(ContainSubstring("targetEnvelope := &datadogIncidentTypeNotificationTargetModel{}"))
 		Expect(src).To(ContainSubstring("targetMatches++"))
 	})
 

--- a/.generator-v2/internal/emit/templates/data_source_common.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_common.go.tmpl
@@ -127,7 +127,81 @@ if {{ .Var }}, ok := {{ .GetterOk }}; ok && {{ .Var }} != nil {
 {{- end }}
 	{{ .LHS }} = {{ .ElemVar }}
 }
+{{- else if eq .Kind "oneof" -}}
+{{ template "renderOneOf" .OneOf }}
 {{- end }}
+{{- end -}}
+
+{{/*
+  renderOneOf unwraps one SDK oneOf wrapper into its Terraform envelope model.
+
+  Every member is inspected and the matches counted; the envelope is only assigned
+  when exactly one matched. This is deliberately not the SDK's own behaviour —
+  MarshalJSON and GetActualInstance both return the first non-nil member — because
+  the contract requires zero, multiple, or an unparsed payload to be reported at the
+  union's schema path rather than silently resolving to one branch.
+
+  The wrapper itself is reached through an ordinary Ok-getter; only its members are
+  plain fields, which is why they are read with `:=` rather than Get<Field>Ok.
+*/}}
+{{- define "renderOneOf" -}}
+if {{ .Var }}, ok := {{ .GetterOk }}; ok && {{ .Var }} != nil {
+{{- if .Collection }}
+	for _, {{ .LoopVar }} := range *{{ .Var }} {
+		{{ template "oneOfBody" . }}
+	}
+{{- else }}
+	{{ template "oneOfBody" . }}
+{{- end }}
+}
+{{- end -}}
+
+{{/*
+  oneOfBody selects at most one variant off .Receiver and reports anything
+  ambiguous. Split from renderOneOf so the collection and single forms share it.
+*/}}
+{{- define "oneOfBody" -}}
+{{ .ModelVar }} := &{{ .GoModel }}{}
+{{ .MatchVar }} := 0
+{{- range .Variants }}
+if {{ .SDKVar }} := {{ $.Receiver }}.{{ .SDKField }}; {{ .SDKVar }} != nil {
+	{{ .ModelVar }} := &{{ .GoModel }}{}
+{{- with .Value }}
+	{{ .LHS }} = {{ .RHS }}
+{{- end }}
+{{- range .Scalars }}
+	if {{ .Var }}, ok := {{ .GetterOk }}; ok && {{ .Var }} != nil {
+		{{ .LHS }} = {{ .RHS }}
+	}
+{{- end }}
+{{- range .Lists }}
+	{{ template "renderList" . }}
+{{- end }}
+	{{ $.ModelVar }}.{{ .GoField }} = {{ .ModelVar }}
+	{{ $.MatchVar }}++
+}
+{{- end }}
+switch {
+case {{ .Receiver }}.UnparsedObject != nil:
+	diags.AddError(
+		"unexpected {{ .SDKType }} in the API response",
+		"{{ .Path }}: the Datadog API returned a value none of the {{ .SDKType }} alternatives could parse",
+	)
+case {{ .MatchVar }} > 1:
+	diags.AddError(
+		"ambiguous {{ .SDKType }} in the API response",
+		fmt.Sprintf("{{ .Path }}: the Datadog API response matched %d {{ .SDKType }} alternatives, expected exactly one", {{ .MatchVar }}),
+	)
+case {{ .MatchVar }} == 1:
+	{{ if .Collection }}{{ .LHS }} = append({{ .LHS }}, {{ .ModelVar }}){{ else }}{{ .LHS }} = {{ .ModelVar }}{{ end }}
+{{- if not .Optional }}
+default:
+	diags.AddError(
+		"missing {{ .SDKType }} in the API response",
+		"{{ .Path }}: the Datadog API response matched none of the {{ .SDKType }} alternatives, and the field is not optional",
+	)
+{{- end }}
+}
 {{- end -}}
 
 {{/* boilerplate renders the data-source struct, constructor, Configure, Metadata. */}}

--- a/.generator-v2/internal/emit/templates_test.go
+++ b/.generator-v2/internal/emit/templates_test.go
@@ -182,8 +182,8 @@ func pluralFixture() DataSourceView {
 	return DataSourceView{
 		Cardinality: Plural,
 		TypeName:    "teams",
-		// Hand-built views set UsesFmt themselves; the builder computes it for every
-		// view it produces. This fixture's filter hash reaches fmt.Sprintf.
+		// Hand-built views must set UsesFmt themselves; the builder computes it for
+		// every view it produces. This fixture's filter hash reaches fmt.Sprintf.
 		UsesFmt:     true,
 		GoName:      "datadogTeams",
 		Description: "Use this data source to retrieve information about existing teams for use in other resources.",

--- a/.generator-v2/internal/emit/templates_test.go
+++ b/.generator-v2/internal/emit/templates_test.go
@@ -207,11 +207,11 @@ func pluralFixture() DataSourceView {
 					{Comment: "Query Parameters", GoField: "FilterKeyword", GoType: "types.String", TFName: "filter_keyword"},
 					{GoField: "FilterMe", GoType: "types.Bool", TFName: "filter_me"},
 					{Comment: "Results", GoField: "ID", GoType: "types.String", TFName: "id"},
-					{GoField: "Teams", GoType: "[]*TeamModel", TFName: "teams"},
+					{GoField: "Teams", GoType: "[]*datadogTeamsTeamModel", TFName: "teams"},
 				},
 			},
 			{
-				Name: "TeamModel",
+				Name: "datadogTeamsTeamModel",
 				Fields: []ModelFieldView{
 					{GoField: "Description", GoType: "types.String", TFName: "description"},
 					{GoField: "Handle", GoType: "types.String", TFName: "handle"},
@@ -251,7 +251,7 @@ func pluralFixture() DataSourceView {
 			},
 		},
 		State: StateView{
-			ItemStruct: "TeamModel",
+			ItemStruct: "datadogTeamsTeamModel",
 			ItemField:  "Teams",
 			ItemFields: []StateAssignment{
 				{LHS: "Description", RHS: "types.StringValue(item.Attributes.GetDescription())"},

--- a/.generator-v2/internal/emit/view.go
+++ b/.generator-v2/internal/emit/view.go
@@ -77,30 +77,16 @@ type DataSourceView struct {
 	// State holds what updateState assigns back into the model.
 	State StateView
 
-	// UsesFmt selects the "fmt" import. The template is no longer in a position to
-	// decide this: fmt is reached from the by-id not-found message and from a plural
-	// filter hash today, and go/format does not prune an unused import, so an over-
-	// or under-estimate is a compile error either way. Deciding it in Go keeps the
-	// rule in one place as more call sites appear.
+	// UsesFmt selects the "fmt" import. The template cannot decide this: fmt is
+	// reached from the by-id not-found message, from a plural filter hash, and from
+	// a oneOf's ambiguous-match diagnostic, and go/format does not prune an unused
+	// import — so an over- or under-estimate here is a compile error either way.
 	UsesFmt bool
-
-	// OneOfEnvelopes are the generated oneOf envelopes this artifact contains, one
-	// entry per distinct envelope regardless of how many places use it, ordered by
-	// first use. Their schema blocks and model structs are already folded into
-	// Schema and Models; this slice is what the state mapper walks to unwrap the
-	// SDK wrapper.
-	OneOfEnvelopes []OneOfEnvelopeView
 
 	// Dropped lists response members skipped from the rendered view (e.g.
 	// relationships), surfaced as diagnostics in the run report. It does not
 	// affect rendering.
 	Dropped []DroppedMember
-
-	// Warnings lists things a reader of the generated artifact needs to know that
-	// are not omissions — surfaced as warning diagnostics in the run report. Unlike
-	// Dropped, an entry here concerns something the artifact does contain. It does
-	// not affect rendering.
-	Warnings []string
 }
 
 // OneOfEnvelopeView is one generated oneOf envelope: the Terraform model that
@@ -326,16 +312,23 @@ type StateAssignment struct {
 	GetterOk string
 }
 
-// ListAssignment is a nested-state assignment rendered by the updateState
-// "renderList" partial. A primitive list maps the SDK slice into a types.List via
+// ListAssignment is one non-scalar state assignment rendered by the updateState
+// "renderList" partial. Despite the name it covers every shape that is not a bare
+// leaf: a primitive list maps the SDK slice into a types.List via
 // types.ListValueFrom; an object list loops the SDK elements into a generated
 // nested model slice, recursing through Scalars (the element's leaf fields) and
 // Lists (its nested list fields); an object_single maps one nested object into a
-// generated model pointer, assigned once instead of looped. All forms are guarded
-// by an Ok-getter so an absent field stays null.
+// generated model pointer, assigned once instead of looped; and a oneof unwraps an
+// SDK oneOf wrapper through OneOf. All forms are guarded by an Ok-getter so an
+// absent field stays null.
+//
+// A oneOf envelope rides this type rather than a parallel one because it needs
+// exactly the same placement plumbing — it can appear at the top level, inside a
+// nested object, inside a list element, or inside another envelope's variant — and
+// duplicating that composition for one extra shape would be the larger cost.
 type ListAssignment struct {
-	// Kind is "primitive", "object", or "object_single" (a single nested object,
-	// assigned once rather than appended in a loop).
+	// Kind is "primitive", "object", "object_single" (a single nested object,
+	// assigned once rather than appended in a loop), or "oneof" (see OneOf).
 	Kind string
 	// LHS is the assignment target, e.g. "state.VisibleModules" (top level) or
 	// "entriesModel.TagFilters" (nested element field).
@@ -361,4 +354,81 @@ type ListAssignment struct {
 	Scalars []StateAssignment
 	// Lists are the element's nested list fields (recursion).
 	Lists []ListAssignment
+
+	// OneOf backs Kind == "oneof" and is nil otherwise.
+	OneOf *OneOfAssignment
+}
+
+// OneOfAssignment maps one Datadog go-sdk oneOf wrapper into one generated
+// Terraform envelope model.
+//
+// The generated code inspects *every* wrapper member rather than taking the first
+// non-nil one: the SDK's own MarshalJSON and GetActualInstance are first-match, and
+// the contract requires zero, multiple, or unparsed to be reported at the union's schema
+// path instead of silently resolving to one branch. Exactly one populated member
+// assigns the envelope; anything else either leaves it absent (permitted only when
+// Optional) or raises a diagnostic.
+type OneOfAssignment struct {
+	// Path is the union's schema path, named in every diagnostic this emits.
+	Path string
+	// SDKType is the wrapper struct, named in diagnostics so a reader can find it
+	// in the SDK.
+	SDKType string
+	// GoModel is the generated envelope struct, and LHS where it is stored, e.g.
+	// "state.Integration". For Collection, LHS is appended to.
+	GoModel string
+	LHS     string
+	// GetterOk is the ordinary optional getter that yields the wrapper off its
+	// parent, e.g. "attributes.GetIntegrationOk()". Only the wrapper's *members*
+	// lack getters; the wrapper itself is a normal field on its parent.
+	GetterOk string
+	// Var is the local bound from GetterOk.
+	Var string
+	// Receiver is the expression the members are read off: Var for a single
+	// envelope, LoopVar inside a collection.
+	Receiver string
+	// ModelVar is the local accumulating the envelope model, MatchVar the local
+	// counting populated members.
+	ModelVar string
+	MatchVar string
+	// Optional permits zero populated members, which is how an absent nullable
+	// union arrives. When false, zero members is an error.
+	Optional bool
+	// Collection marks a list whose element is an envelope; LoopVar is then the
+	// per-element local.
+	Collection bool
+	LoopVar    string
+	// Variants are the alternatives, ordered by Terraform variant name.
+	Variants []OneOfVariantAssignment
+}
+
+// OneOfVariantAssignment unwraps one alternative of a OneOfAssignment.
+//
+// Every field here is a function of the envelope alone, never of the site using it,
+// so one reusable oneOf component's variant bodies are computed once and shared.
+// That is why the envelope-model target is carried as GoField and composed with the
+// enclosing OneOfAssignment.ModelVar at render time rather than being a
+// precomputed LHS: the model var differs per use site, the field does not.
+type OneOfVariantAssignment struct {
+	// SDKField is the wrapper member whose non-nil-ness selects this alternative,
+	// and SDKVar the local bound to it. SDKPointer is false only for a free-form
+	// object, which the SDK emits as a bare, already-nil-able map.
+	SDKField   string
+	SDKVar     string
+	SDKPointer bool
+	// GoField is the envelope-model field this variant assigns, e.g.
+	// "AwsIntegration"; GoModel is its generated struct and ModelVar the local
+	// accumulating it.
+	GoField  string
+	GoModel  string
+	ModelVar string
+	// Value is set for a value-wrapped (non-object) alternative, whose SDK member is
+	// the scalar itself and therefore has no getters to read fields through: the
+	// single "value" field is assigned by dereferencing SDKVar directly.
+	Value *StateAssignment
+	// Scalars are this alternative's leaf fields and Lists its non-scalar ones,
+	// expressed against SDKVar and ModelVar. A union nested inside this alternative
+	// arrives in Lists with Kind "oneof", so recursion needs no extra channel.
+	Scalars []StateAssignment
+	Lists   []ListAssignment
 }

--- a/.generator-v2/internal/model/schema.go
+++ b/.generator-v2/internal/model/schema.go
@@ -203,7 +203,7 @@ func (b *treeBuilder) attribute(s *Schema, path string, mode nestingMode, requir
 		if err != nil {
 			return nil, err
 		}
-		attr.Children = children
+		attr.Children, attr.ModelRefName = children, s.RefName
 
 	case SchemaKindArray:
 		switch s.Items.Kind {
@@ -212,7 +212,8 @@ func (b *treeBuilder) attribute(s *Schema, path string, mode nestingMode, requir
 			if err != nil {
 				return nil, err
 			}
-			attr.Children = children
+			// The element supplies the struct, so the element's component names it.
+			attr.Children, attr.ModelRefName = children, s.Items.RefName
 		case SchemaKindOneOf:
 			// The list itself carries the envelope: its elements are variant
 			// blocks, so no attribute stands at the element path.
@@ -238,7 +239,7 @@ func (b *treeBuilder) attribute(s *Schema, path string, mode nestingMode, requir
 			if err != nil {
 				return nil, err
 			}
-			attr.Children = children
+			attr.Children, attr.ModelRefName = children, s.Items.RefName
 		case SchemaKindOneOf:
 			variants, envelope, err := b.oneOfVariants(s.Items, path+"{}", nestAttribute)
 			if err != nil {

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -352,6 +352,18 @@ type Attribute struct {
 	Description string
 	// Children holds nested attributes for nested blocks.
 	Children []*Attribute
+	// ModelRefName is the OpenAPI component name that supplied the *object* schema
+	// backing this attribute's generated model struct: the node's own schema for an
+	// object, its element schema for an array or map of objects. Empty when that
+	// schema was inline, and empty for a leaf, which has no struct.
+	//
+	// It exists so emit can name a nested model after its component rather than
+	// after the property that happens to point at it — the same preference the SDK
+	// generator's child_models() applies (get_name(schema) or alternative_name) and
+	// that oneOf envelope naming already applies via OneOfSpec.Name. Without it, two
+	// differently-shaped objects reachable under the same property name produce one
+	// struct name and the artifact cannot compile.
+	ModelRefName string
 	// OneOf is non-nil when this attribute carries a synthetic oneOf envelope:
 	// either the envelope itself (a union at the root or an object property) or
 	// the collection whose element is a union. Children then holds the variant

--- a/.generator-v2/internal/sdkbind/bind.go
+++ b/.generator-v2/internal/sdkbind/bind.go
@@ -1,0 +1,279 @@
+// Package sdkbind resolves the Datadog go-sdk bindings for every OpenAPI oneOf
+// reachable from a normalized operation: the generated wrapper struct, and for
+// each alternative the wrapper member that selects it plus the convenience
+// constructor that builds it.
+//
+// It runs after parser normalization and before the Terraform projection, and it
+// writes only into OneOfSpec.SDKType and OneOfVariant.SDKField/SDKConstructor/
+// SDKPointer. The fields model.BuildResponseTree carries through onto each
+// OneOfEnvelope.
+//
+// Method of record : every name here is **re-derived** by reimplementing the go-sdk
+// generator's own logic over the same OpenAPI input. gotype.go holds the naming rules;
+// this file holds the walk that decides which generated model a union lives in.
+//
+// The walk exists because a wrapper's identity is positional, not local. The SDK
+// generator's child_models() names a model after its $ref component when it has
+// one, and otherwise after the accumulated path from the enclosing named model,
+// parent name plus camel_case(property), plus "Item" per array step. A Terraform
+// envelope name must never stand in for that: an inline union's envelope name is
+// path-derived for generated-model stability and names no SDK struct.
+package sdkbind
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+)
+
+// BindOperation resolves the SDK oneOf bindings for every union reachable from
+// op's request and response schemas, mutating the normalized schemas in place. It
+// is idempotent: re-running it over an already-bound operation recomputes the same
+// values.
+//
+// Failures are collected rather than returned on first sight, and the returned
+// *UnresolvedBindingError names the artifact, the operation, and every union path
+// and alternative it could not bind. Because binding is per operation, one
+// artifact's unresolvable union cannot stop another artifact from generating.
+//
+// A position whose SDK model name cannot be determined is walked *past*, not
+// abandoned: only a union actually standing at such a position fails, so an
+// unnameable branch holding no union costs nothing.
+func BindOperation(op *model.Operation) error {
+	if op == nil {
+		return nil
+	}
+	b := &binder{visited: make(map[visitKey]bool)}
+	// Each body root is the SDK type the operation's method signature names, which
+	// is where the SDK generator's own naming starts too.
+	b.walk(op.RequestSchema, op.RequestRefName, "request")
+	b.walk(op.ResponseSchema, op.ResponseRefName, "response")
+
+	if len(b.failures) == 0 {
+		return nil
+	}
+	return &UnresolvedBindingError{
+		Artifact:  artifactName(op),
+		Operation: op.OperationId,
+		Failures:  b.failures,
+	}
+}
+
+// BindSpec binds every operation in spec, returning one error per operation that
+// had an unresolvable union, keyed by operation. It exists for callers that want
+// to bind the whole spec up front; the generate path binds per artifact so a
+// failure lands on that artifact's report entry.
+func BindSpec(spec *model.Spec) map[*model.Operation]error {
+	if spec == nil {
+		return nil
+	}
+	var failed map[*model.Operation]error
+	for _, op := range spec.Operations {
+		if err := BindOperation(op); err != nil {
+			if failed == nil {
+				failed = make(map[*model.Operation]error)
+			}
+			failed[op] = err
+		}
+	}
+	return failed
+}
+
+type binder struct {
+	failures []Failure
+	// visited guards termination over the normalized graph, which is a DAG rather
+	// than a tree: mergeOneOfSiblings shares one sibling-constraint node across
+	// every alternative it was merged into. Keying on (node, SDK name) rather than
+	// on the node alone keeps a shared node bound correctly when two positions give
+	// it two different SDK names, instead of letting whichever position was walked
+	// first decide for both.
+	visited map[visitKey]bool
+}
+
+type visitKey struct {
+	schema  *model.Schema
+	sdkName string
+}
+
+// walk descends s, carrying the name of the generated SDK model this node lives
+// in. sdkName is empty at a position whose model the rules cannot name; the walk
+// continues so that only a union standing there fails.
+//
+// This mirrors openapi.child_models: a $ref restarts the name, an object property
+// appends camel_case(key), and an array element appends "Item".
+func (b *binder) walk(s *model.Schema, sdkName, path string) {
+	if s == nil {
+		return
+	}
+	// get_name(schema) or alternative_name: a component name always wins over the
+	// name accumulated from the parent.
+	if s.RefName != "" {
+		sdkName = s.RefName
+	}
+
+	key := visitKey{schema: s, sdkName: sdkName}
+	if b.visited[key] {
+		return
+	}
+	b.visited[key] = true
+
+	switch s.Kind {
+	case model.SchemaKindOneOf:
+		b.bindUnion(s.OneOf, sdkName, path)
+
+	case model.SchemaKindObject:
+		for _, name := range sortedKeys(s.Properties) {
+			b.walk(s.Properties[name], childModelName(sdkName, model.SdkName(name)), childPath(path, name))
+		}
+
+	case model.SchemaKindArray:
+		b.walk(s.Items, childModelName(sdkName, "Item"), childPath(path, "[]"))
+
+	case model.SchemaKindMap:
+		// child_models only recurses into additionalProperties when the value is a
+		// $ref, so a map value is nameable through its own component name or not at
+		// all: pass no accumulated name and let the $ref rule above supply one.
+		b.walk(s.Items, "", childPath(path, "{}"))
+	}
+}
+
+// bindUnion resolves one union's wrapper and members. The wrapper is the generated
+// model the union node itself became: its component name when it has one, else the
+// name the walk accumulated (model_oneof.j2's `name`).
+func (b *binder) bindUnion(spec *model.OneOfSpec, sdkName, path string) {
+	if spec == nil {
+		return
+	}
+	// Prefer the union's own component name over the accumulated one. They agree
+	// wherever both exist — the walk sets sdkName from the same RefName — but the
+	// spec's copy is the identity the parser recorded, so read it directly.
+	wrapper := spec.RefName
+	if wrapper == "" {
+		wrapper = sdkName
+	}
+	unionPath := spec.Path
+	if unionPath == "" {
+		unionPath = path
+	}
+
+	if wrapper == "" {
+		b.failures = append(b.failures, Failure{
+			Path: unionPath,
+			Reason: "inline union sits at a position with no generated SDK model to name its " +
+				"wrapper (the go-sdk names an inline model after the enclosing model plus the " +
+				"property path, which does not resolve here); replace the inline oneOf with a " +
+				"$ref to a named schema component",
+		})
+		// Still bind the members below: their names do not depend on the wrapper, and
+		// reporting one wrapper failure is more useful than also reporting every
+		// alternative as unbound.
+	}
+	spec.SDKType = wrapper
+
+	for i := range spec.Variants {
+		v := &spec.Variants[i]
+		member, pointer, err := memberBinding(*v)
+		if err != nil {
+			b.failures = append(b.failures, Failure{
+				Path:    unionPath,
+				Variant: v.TFName,
+				Reason:  err.Error(),
+			})
+			v.SDKField, v.SDKConstructor, v.SDKPointer = "", "", false
+			continue
+		}
+		v.SDKField = member
+		v.SDKPointer = pointer
+		// model_oneof.j2 emits `<Member>As<Union>` for every alternative,
+		// unconditionally — so this is never optional, and an empty wrapper name
+		// leaves it empty rather than half-formed.
+		if wrapper != "" {
+			v.SDKConstructor = member + "As" + wrapper
+		} else {
+			v.SDKConstructor = ""
+		}
+
+		// An alternative may itself be a union, or contain one.
+		b.walk(v.Schema, v.RefName, childPath(unionPath, v.TFName))
+	}
+}
+
+// childModelName appends one path step to an accumulated SDK model name. An empty
+// parent stays empty: child_models has no name to build on either, so the child is
+// unnameable rather than named after the step alone.
+func childModelName(parent, step string) string {
+	if parent == "" {
+		return ""
+	}
+	return parent + step
+}
+
+// childPath mirrors the parser's path spelling so a binding diagnostic points at
+// the same node a normalization diagnostic would.
+func childPath(parent, child string) string {
+	if parent == "" {
+		return child
+	}
+	if child == "[]" || child == "{}" {
+		return parent + child
+	}
+	return parent + "." + child
+}
+
+func sortedKeys(m map[string]*model.Schema) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func artifactName(op *model.Operation) string {
+	if op.Tracking != nil {
+		return op.Tracking.ArtifactName
+	}
+	return ""
+}
+
+// Failure is one union (or one of its alternatives) the derivation could not bind.
+type Failure struct {
+	// Path is the union's schema path, e.g. "response.data.attributes.integration".
+	Path string
+	// Variant is the Terraform variant name when the failure is specific to one
+	// alternative, empty when it concerns the wrapper itself.
+	Variant string
+	// Reason states what could not be derived and what the maintainer can do.
+	Reason string
+}
+
+// UnresolvedBindingError reports every SDK oneOf binding an operation could not
+// resolve. It names the artifact, operation, union path and alternative so the
+// diagnostic is actionable without reading the specification.
+type UnresolvedBindingError struct {
+	Artifact  string
+	Operation string
+	Failures  []Failure
+}
+
+func (e *UnresolvedBindingError) Error() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "sdkbind: artifact %q operation %q: %d unresolved SDK oneOf binding(s):",
+		e.Artifact, e.Operation, len(e.Failures))
+	for _, f := range e.Failures {
+		b.WriteString("\n  ")
+		b.WriteString(f.Path)
+		if f.Variant != "" {
+			b.WriteString(" variant ")
+			b.WriteString(f.Variant)
+		}
+		b.WriteString(": ")
+		b.WriteString(f.Reason)
+	}
+	return b.String()
+}

--- a/.generator-v2/internal/sdkbind/bind_test.go
+++ b/.generator-v2/internal/sdkbind/bind_test.go
@@ -1,0 +1,262 @@
+package sdkbind
+
+import (
+	"errors"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/parser"
+)
+
+var placementSpec = filepath.Join("../testdata/sdkbind", "bind_placement.yaml")
+
+// loadBound loads the placement fixture and binds every operation, returning the
+// operations keyed by operationId together with each one's binding error.
+func loadBound() (map[string]*model.Operation, map[string]error) {
+	GinkgoHelper()
+	spec, err := parser.LoadSpec(placementSpec)
+	Expect(err).To(Succeed())
+
+	ops := make(map[string]*model.Operation, len(spec.Operations))
+	errs := make(map[string]error, len(spec.Operations))
+	for _, op := range spec.Operations {
+		ops[op.OperationId] = op
+		if bindErr := BindOperation(op); bindErr != nil {
+			errs[op.OperationId] = bindErr
+		}
+	}
+	return ops, errs
+}
+
+// unionAt walks a normalized schema down a slash-delimited path of steps, where a
+// step is a property name, "[]" for an array element, or "{}" for a map value, and
+// returns the OneOfSpec it lands on.
+func unionAt(root *model.Schema, steps ...string) *model.OneOfSpec {
+	GinkgoHelper()
+	node := root
+	for _, step := range steps {
+		Expect(node).NotTo(BeNil(), "walked off the tree before %q", step)
+		switch step {
+		case "[]", "{}":
+			node = node.Items
+		default:
+			Expect(node.Properties).To(HaveKey(step))
+			node = node.Properties[step]
+		}
+	}
+	Expect(node).NotTo(BeNil())
+	Expect(node.Kind).To(Equal(model.SchemaKindOneOf), "node is %s, not a union", node.Kind)
+	Expect(node.OneOf).NotTo(BeNil())
+	return node.OneOf
+}
+
+// variant returns the named alternative of a union.
+func variant(spec *model.OneOfSpec, tfName string) model.OneOfVariant {
+	GinkgoHelper()
+	for _, v := range spec.Variants {
+		if v.TFName == tfName {
+			return v
+		}
+	}
+	Fail("union " + spec.Path + " has no variant " + tfName)
+	return model.OneOfVariant{}
+}
+
+var _ = Describe("BindOperation", func() {
+
+	Context("wrapper placement", func() {
+		It("binds a component-backed union to its own component name", func() {
+			ops, errs := loadBound()
+			Expect(errs).NotTo(HaveKey("GetWidget"))
+
+			union := unionAt(ops["GetWidget"].ResponseSchema, "data", "attributes", "integration")
+			Expect(union.SDKType).To(Equal("WidgetIntegration"))
+			Expect(union.RefName).To(Equal("WidgetIntegration"))
+		})
+
+		It("binds an inline union to the enclosing model plus the property name", func() {
+			// child_models names an inline model <parent><CamelProperty>, so the union
+			// at WidgetAttributes.inline_choice is WidgetAttributesInlineChoice — a name
+			// the Terraform envelope identity (path-derived) would never produce.
+			ops, _ := loadBound()
+			union := unionAt(ops["GetWidget"].ResponseSchema, "data", "attributes", "inline_choice")
+			Expect(union.SDKType).To(Equal("WidgetAttributesInlineChoice"))
+			Expect(union.RefName).To(BeEmpty())
+			Expect(union.Name).NotTo(Equal(union.SDKType),
+				"the Terraform envelope name must not be reused as the SDK wrapper")
+		})
+
+		It("appends Item for an inline union in a list", func() {
+			ops, _ := loadBound()
+			union := unionAt(ops["GetWidget"].ResponseSchema, "data", "attributes", "choices", "[]")
+			Expect(union.SDKType).To(Equal("WidgetAttributesChoicesItem"))
+		})
+
+		It("binds a union at the response root to the response type", func() {
+			ops, errs := loadBound()
+			Expect(errs).NotTo(HaveKey("GetRoot"))
+
+			root := ops["GetRoot"].ResponseSchema
+			Expect(root.Kind).To(Equal(model.SchemaKindOneOf))
+			Expect(root.OneOf.SDKType).To(Equal("RootUnion"))
+		})
+
+		It("binds a union nested inside another union's alternative", func() {
+			ops, _ := loadBound()
+			outer := unionAt(ops["GetWidget"].ResponseSchema, "data", "attributes", "integration")
+			aws := variant(outer, "aws_integration")
+			inner := unionAt(aws.Schema, "credentials")
+			Expect(inner.SDKType).To(Equal("AWSCredentials"))
+		})
+
+		It("binds a union on the request side from the request root", func() {
+			ops, errs := loadBound()
+			Expect(errs).NotTo(HaveKey("CreateWidget"))
+
+			op := ops["CreateWidget"]
+			Expect(op.RequestRefName).To(Equal("WidgetCreateRequest"),
+				"the request $ref name is the SDK root the request-side walk starts from")
+			union := unionAt(op.RequestSchema, "data", "attributes", "payload")
+			Expect(union.SDKType).To(Equal("WidgetCreateAttributesPayload"))
+		})
+	})
+
+	Context("members and constructors", func() {
+		It("binds each referenced alternative to its component member and constructor", func() {
+			ops, _ := loadBound()
+			union := unionAt(ops["GetWidget"].ResponseSchema, "data", "attributes", "integration")
+
+			aws := variant(union, "aws_integration")
+			Expect(aws.SDKField).To(Equal("AWSIntegration"))
+			Expect(aws.SDKConstructor).To(Equal("AWSIntegrationAsWidgetIntegration"))
+			Expect(aws.SDKPointer).To(BeTrue())
+
+			http := variant(union, "http_integration")
+			Expect(http.SDKField).To(Equal("HTTPIntegration"))
+			Expect(http.SDKConstructor).To(Equal("HTTPIntegrationAsWidgetIntegration"))
+		})
+
+		It("binds a primitive alternative to its upperfirst Go spelling", func() {
+			ops, _ := loadBound()
+			union := unionAt(ops["GetWidget"].ResponseSchema, "data", "attributes", "inline_choice")
+
+			str := variant(union, "string")
+			Expect(str.SDKField).To(Equal("String"))
+			Expect(str.SDKConstructor).To(Equal("StringAsWidgetAttributesInlineChoice"))
+
+			b := variant(union, "boolean")
+			Expect(b.SDKField).To(Equal("Bool"))
+			Expect(b.SDKConstructor).To(Equal("BoolAsWidgetAttributesInlineChoice"))
+		})
+
+		It("emits a constructor for every alternative, never only some", func() {
+			// model_oneof.j2 emits <Member>As<Union> unconditionally; treating it as
+			// optional silently degrades request mapping to direct member assignment.
+			ops, _ := loadBound()
+			for _, union := range []*model.OneOfSpec{
+				unionAt(ops["GetWidget"].ResponseSchema, "data", "attributes", "integration"),
+				unionAt(ops["GetWidget"].ResponseSchema, "data", "attributes", "inline_choice"),
+				unionAt(ops["GetWidget"].ResponseSchema, "data", "attributes", "choices", "[]"),
+				unionAt(ops["CreateWidget"].RequestSchema, "data", "attributes", "payload"),
+			} {
+				Expect(union.Variants).NotTo(BeEmpty())
+				for _, v := range union.Variants {
+					Expect(v.SDKConstructor).To(Equal(v.SDKField+"As"+union.SDKType),
+						"union %s variant %s", union.Path, v.TFName)
+				}
+			}
+		})
+
+		It("binds an integer alternative to Int32, not Int64", func() {
+			ops, _ := loadBound()
+			union := unionAt(ops["CreateWidget"].RequestSchema, "data", "attributes", "payload")
+			Expect(variant(union, "integer").SDKField).To(Equal("Int32"))
+		})
+	})
+
+	Context("unresolvable positions", func() {
+		It("fails the union whose position no SDK model names", func() {
+			_, errs := loadBound()
+
+			err := errs["GetWidgetUnnamed"]
+			Expect(err).To(HaveOccurred())
+
+			var unresolved *UnresolvedBindingError
+			Expect(errors.As(err, &unresolved)).To(BeTrue())
+			Expect(unresolved.Artifact).To(Equal("widget_unnamed"))
+			Expect(unresolved.Operation).To(Equal("GetWidgetUnnamed"))
+			Expect(unresolved.Failures).To(HaveLen(1))
+			Expect(unresolved.Failures[0].Path).To(Equal("response.by_key{}"))
+			Expect(unresolved.Failures[0].Reason).To(ContainSubstring("$ref"))
+		})
+
+		It("does not fail an unrelated artifact for it", func() {
+			// Binding is per operation, so one artifact's unnameable union leaves the
+			// others generable.
+			_, errs := loadBound()
+			Expect(errs).NotTo(HaveKey("GetWidget"))
+			Expect(errs).NotTo(HaveKey("CreateWidget"))
+			Expect(errs).NotTo(HaveKey("GetRoot"))
+		})
+
+		It("names the artifact, operation and union path in its diagnostic", func() {
+			_, errs := loadBound()
+			msg := errs["GetWidgetUnnamed"].Error()
+			Expect(msg).To(ContainSubstring("widget_unnamed"))
+			Expect(msg).To(ContainSubstring("GetWidgetUnnamed"))
+			Expect(msg).To(ContainSubstring("response.by_key{}"))
+		})
+
+		It("leaves no half-formed constructor on an unbound union", func() {
+			ops, _ := loadBound()
+			union := unionAt(ops["GetWidgetUnnamed"].ResponseSchema, "by_key", "{}")
+			Expect(union.SDKType).To(BeEmpty())
+			Expect(union.Variants).NotTo(BeEmpty())
+			for _, v := range union.Variants {
+				Expect(v.SDKConstructor).To(BeEmpty(),
+					"variant %s got a constructor without a wrapper to build", v.TFName)
+			}
+		})
+	})
+
+	Context("contract", func() {
+		It("is idempotent", func() {
+			ops, _ := loadBound()
+			op := ops["GetWidget"]
+			union := unionAt(op.ResponseSchema, "data", "attributes", "integration")
+			before := *union
+
+			Expect(BindOperation(op)).To(Succeed())
+			after := unionAt(op.ResponseSchema, "data", "attributes", "integration")
+			Expect(after.SDKType).To(Equal(before.SDKType))
+			Expect(after.Variants).To(Equal(before.Variants))
+		})
+
+		It("tolerates a nil operation and empty schemas", func() {
+			Expect(BindOperation(nil)).To(Succeed())
+			Expect(BindOperation(&model.Operation{OperationId: "Empty"})).To(Succeed())
+		})
+
+		It("binds every operation of a spec through BindSpec", func() {
+			spec, err := parser.LoadSpec(placementSpec)
+			Expect(err).To(Succeed())
+
+			failed := BindSpec(spec)
+			var failedIDs []string
+			for op := range failed {
+				failedIDs = append(failedIDs, op.OperationId)
+			}
+			Expect(failedIDs).To(ConsistOf("GetWidgetUnnamed"))
+
+			for _, op := range spec.Operations {
+				if op.OperationId != "GetRoot" {
+					continue
+				}
+				Expect(op.ResponseSchema.OneOf.SDKType).To(Equal("RootUnion"))
+			}
+		})
+	})
+})

--- a/.generator-v2/internal/sdkbind/corroborate_test.go
+++ b/.generator-v2/internal/sdkbind/corroborate_test.go
@@ -1,0 +1,339 @@
+//go:build integration
+
+// This test corroborates the derivation in bind.go/gotype.go against the pinned
+// datadog-api-client-go, and is the one place in this package that reads generated
+// SDK source. It exists because a derivation fails differently from a lookup: a
+// lookup that misses returns nothing, while a wrong derivation returns a plausible
+// name for a symbol that does not exist,
+//
+// It is corroboration, never the source of a name and it reads declarations with
+// go/ast only.
+//
+// Behind -tags=integration because it shells out to `go list -m` and parses a few
+// thousand generated files, neither of which belongs in the default unit run.
+package sdkbind
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.yaml.in/yaml/v4"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+	tfparser "github.com/terraform-providers/terraform-provider-datadog/generator/internal/parser"
+)
+
+// corpusDir holds the checked-in mini-OAS slices: real Datadog response shapes,
+// unannotated, which this test annotates in memory to opt each read operation in.
+const corpusDir = "../testdata/mini-oas"
+
+// providerRoot is the provider module, whose go.mod pins the SDK this generator's
+// output must compile against.
+const providerRoot = "../../.."
+
+// packageDecls is what one generated SDK package declares, read from source.
+type packageDecls struct {
+	// structFields maps a struct type name to its field names.
+	structFields map[string][]string
+	// funcs holds every top-level function name.
+	funcs map[string]bool
+}
+
+func (d packageDecls) hasField(structName, field string) bool {
+	for _, f := range d.structFields[structName] {
+		if f == field {
+			return true
+		}
+	}
+	return false
+}
+
+// sdkPackageDecls parses <sdk>/api/<pkg> and returns its declarations. It reads
+// only exported declarations' names, never types, so nothing here depends on the
+// SDK being linkable.
+func sdkPackageDecls(pkg string) (packageDecls, error) {
+	sdkDir, err := sdkModuleDir()
+	if err != nil {
+		return packageDecls{}, err
+	}
+	dir := filepath.Join(sdkDir, "api", pkg)
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, dir, nil, parser.SkipObjectResolution)
+	if err != nil {
+		return packageDecls{}, err
+	}
+
+	decls := packageDecls{
+		structFields: make(map[string][]string),
+		funcs:        make(map[string]bool),
+	}
+	for _, p := range pkgs {
+		for _, file := range p.Files {
+			for _, d := range file.Decls {
+				switch decl := d.(type) {
+				case *ast.FuncDecl:
+					if decl.Recv == nil {
+						decls.funcs[decl.Name.Name] = true
+					}
+				case *ast.GenDecl:
+					for _, spec := range decl.Specs {
+						ts, ok := spec.(*ast.TypeSpec)
+						if !ok {
+							continue
+						}
+						st, ok := ts.Type.(*ast.StructType)
+						if !ok {
+							continue
+						}
+						var fields []string
+						for _, f := range st.Fields.List {
+							for _, name := range f.Names {
+								fields = append(fields, name.Name)
+							}
+						}
+						decls.structFields[ts.Name.Name] = fields
+					}
+				}
+			}
+		}
+	}
+	return decls, nil
+}
+
+// sdkModuleDir resolves the pinned SDK's module directory through the provider
+// module, so the version read is exactly the one the provider builds against.
+func sdkModuleDir() (string, error) {
+	cmd := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", "github.com/DataDog/datadog-api-client-go/v2")
+	cmd.Dir = providerRoot
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// annotatedCorpus loads every mini-OAS slice with its by-id (else first) GET
+// annotated as a singular data source, and binds it. It returns the operations
+// that carry at least one union, keyed by "<artifact>:<operationId>".
+func annotatedCorpus() map[string]*model.Operation {
+	GinkgoHelper()
+	entries, err := os.ReadDir(corpusDir)
+	Expect(err).To(Succeed())
+
+	tmp := GinkgoT().TempDir()
+	withUnions := make(map[string]*model.Operation)
+
+	for _, e := range entries {
+		name, ok := strings.CutPrefix(e.Name(), "mini-datadog_")
+		if !ok || !strings.HasSuffix(name, ".yaml") {
+			continue
+		}
+		artifact := strings.TrimSuffix(name, ".yaml")
+
+		annotated, ok := annotateReadOp(filepath.Join(corpusDir, e.Name()), artifact, tmp)
+		if !ok {
+			continue
+		}
+		spec, err := tfparser.LoadSpec(annotated)
+		if err != nil {
+			// A slice the parser rejects outright (e.g. a $ref cycle) has no bindings
+			// to corroborate; the corpus-level failures are tracked as their own tasks.
+			continue
+		}
+		for _, op := range spec.Operations {
+			if op.Tracking == nil {
+				continue
+			}
+			_ = BindOperation(op) // failures are asserted separately; bound unions still count
+			if len(collectUnions(op)) > 0 {
+				withUnions[artifact+":"+op.OperationId] = op
+			}
+		}
+	}
+	return withUnions
+}
+
+// annotateReadOp writes a copy of the slice at src with its read operation opted
+// in, and returns the copy's path. It mirrors the README's documented annotation.
+func annotateReadOp(src, artifact, tmpDir string) (string, bool) {
+	GinkgoHelper()
+	raw, err := os.ReadFile(src)
+	Expect(err).To(Succeed())
+
+	var doc yaml.Node
+	Expect(yaml.Unmarshal(raw, &doc)).To(Succeed())
+
+	var spec map[string]any
+	Expect(yaml.Unmarshal(raw, &spec)).To(Succeed())
+
+	paths, ok := spec["paths"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	// Prefer a by-id GET (a path with a {param}); that is the singular read.
+	var chosenPath string
+	var chosenOp map[string]any
+	for _, p := range sortedMapKeys(paths) {
+		item, ok := paths[p].(map[string]any)
+		if !ok {
+			continue
+		}
+		get, ok := item["get"].(map[string]any)
+		if !ok || get["operationId"] == nil {
+			continue
+		}
+		if chosenOp == nil || (!strings.Contains(chosenPath, "{") && strings.Contains(p, "{")) {
+			chosenPath, chosenOp = p, get
+		}
+	}
+	if chosenOp == nil {
+		return "", false
+	}
+	chosenOp["x-datadog-tf-generator"] = map[string]any{
+		"artifact_kind": "data_source",
+		"artifact_name": artifact,
+		"group":         map[string]any{"read": chosenOp["operationId"]},
+	}
+
+	out, err := yaml.Marshal(spec)
+	Expect(err).To(Succeed())
+	dst := filepath.Join(tmpDir, artifact+".yaml")
+	Expect(os.WriteFile(dst, out, 0o600)).To(Succeed())
+	return dst, true
+}
+
+func sortedMapKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// collectUnions returns every union reachable from op's request and response
+// schemas, keyed by schema path.
+func collectUnions(op *model.Operation) map[string]*model.OneOfSpec {
+	found := make(map[string]*model.OneOfSpec)
+	seen := make(map[*model.Schema]bool)
+	var walk func(s *model.Schema)
+	walk = func(s *model.Schema) {
+		if s == nil || seen[s] {
+			return
+		}
+		seen[s] = true
+		if s.Kind == model.SchemaKindOneOf && s.OneOf != nil {
+			found[s.OneOf.Path] = s.OneOf
+			for _, v := range s.OneOf.Variants {
+				walk(v.Schema)
+			}
+			return
+		}
+		for _, child := range s.Properties {
+			walk(child)
+		}
+		walk(s.Items)
+	}
+	walk(op.RequestSchema)
+	walk(op.ResponseSchema)
+	return found
+}
+
+var _ = Describe("SDK oneOf binding, corroborated against the pinned SDK", func() {
+
+	It("resolves every union in the mini-OAS corpus to a wrapper, member and constructor that exist", func() {
+		corpus := annotatedCorpus()
+		Expect(corpus).NotTo(BeEmpty(), "no corpus slice produced a union to corroborate")
+
+		declsByPackage := make(map[string]packageDecls)
+		var problems []string
+		var checked int
+
+		for key, op := range corpus {
+			pkg := model.SDKPackageForPath(op.Path)
+			decls, ok := declsByPackage[pkg]
+			if !ok {
+				var err error
+				decls, err = sdkPackageDecls(pkg)
+				Expect(err).To(Succeed(), "reading SDK package %s", pkg)
+				declsByPackage[pkg] = decls
+			}
+
+			for path, union := range collectUnions(op) {
+				if union.SDKType == "" {
+					// An unresolved union is reported by BindOperation as a diagnostic, not
+					// a wrong name; it is out of scope for a name-existence check.
+					continue
+				}
+				checked++
+				if _, exists := decls.structFields[union.SDKType]; !exists {
+					problems = append(problems, key+" "+path+
+						": derived wrapper "+pkg+"."+union.SDKType+" is not declared in the SDK")
+					continue
+				}
+				if !decls.hasField(union.SDKType, "UnparsedObject") {
+					problems = append(problems, key+" "+path+
+						": derived wrapper "+union.SDKType+" is not a oneOf wrapper (no UnparsedObject member)")
+				}
+				for _, v := range union.Variants {
+					if v.SDKField == "" {
+						continue
+					}
+					if !decls.hasField(union.SDKType, v.SDKField) {
+						problems = append(problems, key+" "+path+" variant "+v.TFName+
+							": derived member "+union.SDKType+"."+v.SDKField+" is not declared")
+					}
+					if !decls.funcs[v.SDKConstructor] {
+						problems = append(problems, key+" "+path+" variant "+v.TFName+
+							": derived constructor "+pkg+"."+v.SDKConstructor+" is not declared")
+					}
+				}
+			}
+		}
+
+		// Reported so a shrinking corpus is visible rather than silently vacuous: a
+		// corroboration that checks nothing passes just as loudly as one that checks
+		// everything.
+		AddReportEntry("unions corroborated", checked)
+		AddReportEntry("corpus operations with unions", len(corpus))
+
+		Expect(checked).To(BeNumerically(">", 0), "no bound union was corroborated")
+		Expect(problems).To(BeEmpty(), "derived SDK bindings that do not exist in the pinned SDK")
+	})
+
+	It("binds every alternative of action_connection's integration union", func() {
+		// The acceptance bar: 25 unions, and every outer alternative
+		// resolving both a member and a constructor.
+		corpus := annotatedCorpus()
+		var op *model.Operation
+		for key, candidate := range corpus {
+			if strings.HasPrefix(key, "action_connection:") {
+				op = candidate
+				break
+			}
+		}
+		Expect(op).NotTo(BeNil(), "action_connection produced no union")
+
+		unions := collectUnions(op)
+		Expect(len(unions)).To(BeNumerically(">=", 25),
+			"expected the integration union plus one credentials union per integration variant")
+
+		integration := unions["response.data.attributes.integration"]
+		Expect(integration).NotTo(BeNil())
+		Expect(integration.SDKType).To(Equal("ActionConnectionIntegration"))
+		Expect(integration.Variants).To(HaveLen(24))
+		for _, v := range integration.Variants {
+			Expect(v.SDKField).NotTo(BeEmpty(), "variant %s bound no SDK member", v.TFName)
+			Expect(v.SDKConstructor).To(Equal(v.SDKField+"AsActionConnectionIntegration"),
+				"variant %s", v.TFName)
+		}
+	})
+})

--- a/.generator-v2/internal/snapshots/data_source_plural.golden
+++ b/.generator-v2/internal/snapshots/data_source_plural.golden
@@ -24,11 +24,11 @@ type datadogTeamsDataSourceModel struct {
 	FilterMe      types.Bool   `tfsdk:"filter_me"`
 
 	// Results
-	ID    types.String `tfsdk:"id"`
-	Teams []*TeamModel `tfsdk:"teams"`
+	ID    types.String             `tfsdk:"id"`
+	Teams []*datadogTeamsTeamModel `tfsdk:"teams"`
 }
 
-type TeamModel struct {
+type datadogTeamsTeamModel struct {
 	Description    types.String `tfsdk:"description"`
 	Handle         types.String `tfsdk:"handle"`
 	ID             types.String `tfsdk:"id"`
@@ -158,9 +158,9 @@ func (d *datadogTeamsDataSource) Read(ctx context.Context, request datasource.Re
 
 func (d *datadogTeamsDataSource) updateState(ctx context.Context, state *datadogTeamsDataSourceModel, data *[]datadogV2.Team) diag.Diagnostics {
 	var diags diag.Diagnostics
-	results := make([]*TeamModel, 0, len(*data))
+	results := make([]*datadogTeamsTeamModel, 0, len(*data))
 	for _, item := range *data {
-		r := TeamModel{
+		r := datadogTeamsTeamModel{
 			Description: types.StringValue(item.Attributes.GetDescription()),
 			Handle:      types.StringValue(item.Attributes.GetHandle()),
 			ID:          types.StringValue(item.GetId()),

--- a/.generator-v2/internal/snapshots/data_source_plural_nested.golden
+++ b/.generator-v2/internal/snapshots/data_source_plural_nested.golden
@@ -19,17 +19,17 @@ var (
 
 type datadogWidgetsDataSourceModel struct {
 	// Results
-	ID      types.String   `tfsdk:"id"`
-	Widgets []*WidgetModel `tfsdk:"widgets"`
+	ID      types.String                 `tfsdk:"id"`
+	Widgets []*datadogWidgetsWidgetModel `tfsdk:"widgets"`
 }
 
-type WidgetModel struct {
-	ID    types.String  `tfsdk:"id"`
-	Name  types.String  `tfsdk:"name"`
-	Parts []*PartsModel `tfsdk:"parts"`
+type datadogWidgetsWidgetModel struct {
+	ID    types.String                      `tfsdk:"id"`
+	Name  types.String                      `tfsdk:"name"`
+	Parts []*datadogWidgetsWidgetPartsModel `tfsdk:"parts"`
 }
 
-type PartsModel struct {
+type datadogWidgetsWidgetPartsModel struct {
 	Label    types.String `tfsdk:"label"`
 	Quantity types.Int64  `tfsdk:"quantity"`
 }
@@ -120,15 +120,15 @@ func (d *datadogWidgetsDataSource) Read(ctx context.Context, request datasource.
 
 func (d *datadogWidgetsDataSource) updateState(ctx context.Context, state *datadogWidgetsDataSourceModel, data *[]datadogV2.Widget) diag.Diagnostics {
 	var diags diag.Diagnostics
-	results := make([]*WidgetModel, 0, len(*data))
+	results := make([]*datadogWidgetsWidgetModel, 0, len(*data))
 	for _, item := range *data {
-		r := WidgetModel{
+		r := datadogWidgetsWidgetModel{
 			ID:   types.StringValue(item.GetId()),
 			Name: types.StringValue(item.Attributes.GetName()),
 		}
 		if parts, ok := item.Attributes.GetPartsOk(); ok && parts != nil {
 			for _, partsItem := range *parts {
-				partsModel := &PartsModel{}
+				partsModel := &datadogWidgetsWidgetPartsModel{}
 				if label, ok := partsItem.GetLabelOk(); ok && label != nil {
 					partsModel.Label = types.StringValue(*label)
 				}

--- a/.generator-v2/internal/snapshots/data_source_plural_no_params.golden
+++ b/.generator-v2/internal/snapshots/data_source_plural_no_params.golden
@@ -19,11 +19,11 @@ var (
 
 type datadogDatastoresDataSourceModel struct {
 	// Results
-	ID         types.String          `tfsdk:"id"`
-	Datastores []*DatastoreDataModel `tfsdk:"datastores"`
+	ID         types.String                           `tfsdk:"id"`
+	Datastores []*datadogDatastoresDatastoreDataModel `tfsdk:"datastores"`
 }
 
-type DatastoreDataModel struct {
+type datadogDatastoresDatastoreDataModel struct {
 	CreatorUserId                types.Int64  `tfsdk:"creator_user_id"`
 	CreatorUserUuid              types.String `tfsdk:"creator_user_uuid"`
 	Description                  types.String `tfsdk:"description"`
@@ -127,9 +127,9 @@ func (d *datadogDatastoresDataSource) Read(ctx context.Context, request datasour
 
 func (d *datadogDatastoresDataSource) updateState(ctx context.Context, state *datadogDatastoresDataSourceModel, data *[]datadogV2.DatastoreData) diag.Diagnostics {
 	var diags diag.Diagnostics
-	results := make([]*DatastoreDataModel, 0, len(*data))
+	results := make([]*datadogDatastoresDatastoreDataModel, 0, len(*data))
 	for _, item := range *data {
-		r := DatastoreDataModel{
+		r := datadogDatastoresDatastoreDataModel{
 			CreatorUserId:                types.Int64Value(int64(item.Attributes.GetCreatorUserId())),
 			CreatorUserUuid:              types.StringValue(item.Attributes.GetCreatorUserUuid()),
 			Description:                  types.StringValue(item.Attributes.GetDescription()),

--- a/.generator-v2/internal/snapshots/data_source_plural_object.golden
+++ b/.generator-v2/internal/snapshots/data_source_plural_object.golden
@@ -19,17 +19,17 @@ var (
 
 type datadogGizmosDataSourceModel struct {
 	// Results
-	ID     types.String  `tfsdk:"id"`
-	Gizmos []*GizmoModel `tfsdk:"gizmos"`
+	ID     types.String               `tfsdk:"id"`
+	Gizmos []*datadogGizmosGizmoModel `tfsdk:"gizmos"`
 }
 
-type GizmoModel struct {
-	ID   types.String `tfsdk:"id"`
-	Name types.String `tfsdk:"name"`
-	Spec *SpecModel   `tfsdk:"spec"`
+type datadogGizmosGizmoModel struct {
+	ID   types.String                 `tfsdk:"id"`
+	Name types.String                 `tfsdk:"name"`
+	Spec *datadogGizmosGizmoSpecModel `tfsdk:"spec"`
 }
 
-type SpecModel struct {
+type datadogGizmosGizmoSpecModel struct {
 	Shape types.String `tfsdk:"shape"`
 	Size  types.Int64  `tfsdk:"size"`
 }
@@ -119,14 +119,14 @@ func (d *datadogGizmosDataSource) Read(ctx context.Context, request datasource.R
 
 func (d *datadogGizmosDataSource) updateState(ctx context.Context, state *datadogGizmosDataSourceModel, data *[]datadogV2.Gizmo) diag.Diagnostics {
 	var diags diag.Diagnostics
-	results := make([]*GizmoModel, 0, len(*data))
+	results := make([]*datadogGizmosGizmoModel, 0, len(*data))
 	for _, item := range *data {
-		r := GizmoModel{
+		r := datadogGizmosGizmoModel{
 			ID:   types.StringValue(item.GetId()),
 			Name: types.StringValue(item.Attributes.GetName()),
 		}
 		if spec, ok := item.Attributes.GetSpecOk(); ok && spec != nil {
-			specModel := &SpecModel{}
+			specModel := &datadogGizmosGizmoSpecModel{}
 			if shape, ok := spec.GetShapeOk(); ok && shape != nil {
 				specModel.Shape = types.StringValue(*shape)
 			}

--- a/.generator-v2/internal/snapshots/data_source_singular_nested.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular_nested.golden
@@ -17,18 +17,18 @@ var (
 )
 
 type datadogCostBudgetDataSourceModel struct {
-	ID      types.String    `tfsdk:"id"`
-	Entries []*EntriesModel `tfsdk:"entries"`
-	Name    types.String    `tfsdk:"name"`
+	ID      types.String                     `tfsdk:"id"`
+	Entries []*datadogCostBudgetEntriesModel `tfsdk:"entries"`
+	Name    types.String                     `tfsdk:"name"`
 }
 
-type EntriesModel struct {
-	Amount     types.Float64      `tfsdk:"amount"`
-	Month      types.Int64        `tfsdk:"month"`
-	TagFilters []*TagFiltersModel `tfsdk:"tag_filters"`
+type datadogCostBudgetEntriesModel struct {
+	Amount     types.Float64                              `tfsdk:"amount"`
+	Month      types.Int64                                `tfsdk:"month"`
+	TagFilters []*datadogCostBudgetEntriesTagFiltersModel `tfsdk:"tag_filters"`
 }
 
-type TagFiltersModel struct {
+type datadogCostBudgetEntriesTagFiltersModel struct {
 	TagKey   types.String `tfsdk:"tag_key"`
 	TagValue types.String `tfsdk:"tag_value"`
 }
@@ -144,7 +144,7 @@ func (d *datadogCostBudgetDataSource) updateState(ctx context.Context, state *da
 	}
 	if entries, ok := attributes.GetEntriesOk(); ok && entries != nil {
 		for _, entriesItem := range *entries {
-			entriesModel := &EntriesModel{}
+			entriesModel := &datadogCostBudgetEntriesModel{}
 			if amount, ok := entriesItem.GetAmountOk(); ok && amount != nil {
 				entriesModel.Amount = types.Float64Value(*amount)
 			}
@@ -153,7 +153,7 @@ func (d *datadogCostBudgetDataSource) updateState(ctx context.Context, state *da
 			}
 			if tagFilters, ok := entriesItem.GetTagFiltersOk(); ok && tagFilters != nil {
 				for _, tagFiltersItem := range *tagFilters {
-					tagFiltersModel := &TagFiltersModel{}
+					tagFiltersModel := &datadogCostBudgetEntriesTagFiltersModel{}
 					if tagKey, ok := tagFiltersItem.GetTagKeyOk(); ok && tagKey != nil {
 						tagFiltersModel.TagKey = types.StringValue(*tagKey)
 					}

--- a/.generator-v2/internal/snapshots/data_source_singular_object.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular_object.golden
@@ -17,19 +17,19 @@ var (
 )
 
 type datadogApmRetentionFilterDataSourceModel struct {
-	ID      types.String `tfsdk:"id"`
-	Enabled types.Bool   `tfsdk:"enabled"`
-	Filter  *FilterModel `tfsdk:"filter"`
-	Name    types.String `tfsdk:"name"`
+	ID      types.String                          `tfsdk:"id"`
+	Enabled types.Bool                            `tfsdk:"enabled"`
+	Filter  *datadogApmRetentionFilterFilterModel `tfsdk:"filter"`
+	Name    types.String                          `tfsdk:"name"`
 }
 
-type FilterModel struct {
-	Metadata *MetadataModel `tfsdk:"metadata"`
-	Query    types.String   `tfsdk:"query"`
-	Tags     types.List     `tfsdk:"tags"`
+type datadogApmRetentionFilterFilterModel struct {
+	Metadata *datadogApmRetentionFilterFilterMetadataModel `tfsdk:"metadata"`
+	Query    types.String                                  `tfsdk:"query"`
+	Tags     types.List                                    `tfsdk:"tags"`
 }
 
-type MetadataModel struct {
+type datadogApmRetentionFilterFilterMetadataModel struct {
 	CreatedBy types.String `tfsdk:"created_by"`
 }
 
@@ -145,12 +145,12 @@ func (d *datadogApmRetentionFilterDataSource) updateState(ctx context.Context, s
 		state.Name = types.StringValue(*name)
 	}
 	if filter, ok := attributes.GetFilterOk(); ok && filter != nil {
-		filterModel := &FilterModel{}
+		filterModel := &datadogApmRetentionFilterFilterModel{}
 		if query, ok := filter.GetQueryOk(); ok && query != nil {
 			filterModel.Query = types.StringValue(*query)
 		}
 		if metadata, ok := filter.GetMetadataOk(); ok && metadata != nil {
-			metadataModel := &MetadataModel{}
+			metadataModel := &datadogApmRetentionFilterFilterMetadataModel{}
 			if createdBy, ok := metadata.GetCreatedByOk(); ok && createdBy != nil {
 				metadataModel.CreatedBy = types.StringValue(*createdBy)
 			}

--- a/.generator-v2/internal/snapshots/data_source_singular_oneof.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular_oneof.golden
@@ -17,23 +17,23 @@ var (
 )
 
 type datadogIncidentTypeDataSourceModel struct {
-	ID           types.String               `tfsdk:"id"`
-	Description  types.String               `tfsdk:"description"`
-	IsDefault    types.Bool                 `tfsdk:"is_default"`
-	Name         types.String               `tfsdk:"name"`
-	Notification *IncidentNotificationModel `tfsdk:"notification"`
+	ID           types.String                                  `tfsdk:"id"`
+	Description  types.String                                  `tfsdk:"description"`
+	IsDefault    types.Bool                                    `tfsdk:"is_default"`
+	Name         types.String                                  `tfsdk:"name"`
+	Notification *datadogIncidentTypeIncidentNotificationModel `tfsdk:"notification"`
 }
 
-type IncidentNotificationModel struct {
-	String              *IncidentNotificationStringModel              `tfsdk:"string"`
-	WebhookNotification *IncidentNotificationWebhookNotificationModel `tfsdk:"webhook_notification"`
+type datadogIncidentTypeIncidentNotificationModel struct {
+	String              *datadogIncidentTypeIncidentNotificationStringModel              `tfsdk:"string"`
+	WebhookNotification *datadogIncidentTypeIncidentNotificationWebhookNotificationModel `tfsdk:"webhook_notification"`
 }
 
-type IncidentNotificationStringModel struct {
+type datadogIncidentTypeIncidentNotificationStringModel struct {
 	Value types.String `tfsdk:"value"`
 }
 
-type IncidentNotificationWebhookNotificationModel struct {
+type datadogIncidentTypeIncidentNotificationWebhookNotificationModel struct {
 	Enabled types.Bool   `tfsdk:"enabled"`
 	Url     types.String `tfsdk:"url"`
 }
@@ -161,16 +161,16 @@ func (d *datadogIncidentTypeDataSource) updateState(ctx context.Context, state *
 		state.Name = types.StringValue(*name)
 	}
 	if notification, ok := attributes.GetNotificationOk(); ok && notification != nil {
-		notificationEnvelope := &IncidentNotificationModel{}
+		notificationEnvelope := &datadogIncidentTypeIncidentNotificationModel{}
 		notificationMatches := 0
 		if stringVariant := notification.String; stringVariant != nil {
-			stringModel := &IncidentNotificationStringModel{}
+			stringModel := &datadogIncidentTypeIncidentNotificationStringModel{}
 			stringModel.Value = types.StringValue(*stringVariant)
 			notificationEnvelope.String = stringModel
 			notificationMatches++
 		}
 		if webhookNotificationVariant := notification.WebhookNotification; webhookNotificationVariant != nil {
-			webhookNotificationModel := &IncidentNotificationWebhookNotificationModel{}
+			webhookNotificationModel := &datadogIncidentTypeIncidentNotificationWebhookNotificationModel{}
 			if enabled, ok := webhookNotificationVariant.GetEnabledOk(); ok && enabled != nil {
 				webhookNotificationModel.Enabled = types.BoolValue(*enabled)
 			}

--- a/.generator-v2/internal/snapshots/data_source_singular_oneof.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular_oneof.golden
@@ -160,5 +160,45 @@ func (d *datadogIncidentTypeDataSource) updateState(ctx context.Context, state *
 	if name, ok := attributes.GetNameOk(); ok && name != nil {
 		state.Name = types.StringValue(*name)
 	}
+	if notification, ok := attributes.GetNotificationOk(); ok && notification != nil {
+		notificationEnvelope := &IncidentNotificationModel{}
+		notificationMatches := 0
+		if stringVariant := notification.String; stringVariant != nil {
+			stringModel := &IncidentNotificationStringModel{}
+			stringModel.Value = types.StringValue(*stringVariant)
+			notificationEnvelope.String = stringModel
+			notificationMatches++
+		}
+		if webhookNotificationVariant := notification.WebhookNotification; webhookNotificationVariant != nil {
+			webhookNotificationModel := &IncidentNotificationWebhookNotificationModel{}
+			if enabled, ok := webhookNotificationVariant.GetEnabledOk(); ok && enabled != nil {
+				webhookNotificationModel.Enabled = types.BoolValue(*enabled)
+			}
+			if url, ok := webhookNotificationVariant.GetUrlOk(); ok && url != nil {
+				webhookNotificationModel.Url = types.StringValue(*url)
+			}
+			notificationEnvelope.WebhookNotification = webhookNotificationModel
+			notificationMatches++
+		}
+		switch {
+		case notification.UnparsedObject != nil:
+			diags.AddError(
+				"unexpected IncidentNotification in the API response",
+				"response.data.attributes.notification: the Datadog API returned a value none of the IncidentNotification alternatives could parse",
+			)
+		case notificationMatches > 1:
+			diags.AddError(
+				"ambiguous IncidentNotification in the API response",
+				fmt.Sprintf("response.data.attributes.notification: the Datadog API response matched %d IncidentNotification alternatives, expected exactly one", notificationMatches),
+			)
+		case notificationMatches == 1:
+			state.Notification = notificationEnvelope
+		default:
+			diags.AddError(
+				"missing IncidentNotification in the API response",
+				"response.data.attributes.notification: the Datadog API response matched none of the IncidentNotification alternatives, and the field is not optional",
+			)
+		}
+	}
 	return diags
 }

--- a/.generator-v2/internal/snapshots/data_source_singular_oneof_list.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular_oneof_list.golden
@@ -161,5 +161,47 @@ func (d *datadogIncidentTypeDataSource) updateState(ctx context.Context, state *
 	if name, ok := attributes.GetNameOk(); ok && name != nil {
 		state.Name = types.StringValue(*name)
 	}
+	if notifications, ok := attributes.GetNotificationsOk(); ok && notifications != nil {
+		for _, notificationsItem := range *notifications {
+			notificationsEnvelope := &IncidentNotificationModel{}
+			notificationsMatches := 0
+			if stringVariant := notificationsItem.String; stringVariant != nil {
+				stringModel := &IncidentNotificationStringModel{}
+				stringModel.Value = types.StringValue(*stringVariant)
+				notificationsEnvelope.String = stringModel
+				notificationsMatches++
+			}
+			if webhookNotificationVariant := notificationsItem.WebhookNotification; webhookNotificationVariant != nil {
+				webhookNotificationModel := &IncidentNotificationWebhookNotificationModel{}
+				if enabled, ok := webhookNotificationVariant.GetEnabledOk(); ok && enabled != nil {
+					webhookNotificationModel.Enabled = types.BoolValue(*enabled)
+				}
+				if url, ok := webhookNotificationVariant.GetUrlOk(); ok && url != nil {
+					webhookNotificationModel.Url = types.StringValue(*url)
+				}
+				notificationsEnvelope.WebhookNotification = webhookNotificationModel
+				notificationsMatches++
+			}
+			switch {
+			case notificationsItem.UnparsedObject != nil:
+				diags.AddError(
+					"unexpected IncidentNotification in the API response",
+					"response.data.attributes.notifications[]: the Datadog API returned a value none of the IncidentNotification alternatives could parse",
+				)
+			case notificationsMatches > 1:
+				diags.AddError(
+					"ambiguous IncidentNotification in the API response",
+					fmt.Sprintf("response.data.attributes.notifications[]: the Datadog API response matched %d IncidentNotification alternatives, expected exactly one", notificationsMatches),
+				)
+			case notificationsMatches == 1:
+				state.Notifications = append(state.Notifications, notificationsEnvelope)
+			default:
+				diags.AddError(
+					"missing IncidentNotification in the API response",
+					"response.data.attributes.notifications[]: the Datadog API response matched none of the IncidentNotification alternatives, and the field is not optional",
+				)
+			}
+		}
+	}
 	return diags
 }

--- a/.generator-v2/internal/snapshots/data_source_singular_oneof_list.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular_oneof_list.golden
@@ -17,23 +17,23 @@ var (
 )
 
 type datadogIncidentTypeDataSourceModel struct {
-	ID            types.String                 `tfsdk:"id"`
-	Description   types.String                 `tfsdk:"description"`
-	IsDefault     types.Bool                   `tfsdk:"is_default"`
-	Name          types.String                 `tfsdk:"name"`
-	Notifications []*IncidentNotificationModel `tfsdk:"notifications"`
+	ID            types.String                                    `tfsdk:"id"`
+	Description   types.String                                    `tfsdk:"description"`
+	IsDefault     types.Bool                                      `tfsdk:"is_default"`
+	Name          types.String                                    `tfsdk:"name"`
+	Notifications []*datadogIncidentTypeIncidentNotificationModel `tfsdk:"notifications"`
 }
 
-type IncidentNotificationModel struct {
-	String              *IncidentNotificationStringModel              `tfsdk:"string"`
-	WebhookNotification *IncidentNotificationWebhookNotificationModel `tfsdk:"webhook_notification"`
+type datadogIncidentTypeIncidentNotificationModel struct {
+	String              *datadogIncidentTypeIncidentNotificationStringModel              `tfsdk:"string"`
+	WebhookNotification *datadogIncidentTypeIncidentNotificationWebhookNotificationModel `tfsdk:"webhook_notification"`
 }
 
-type IncidentNotificationStringModel struct {
+type datadogIncidentTypeIncidentNotificationStringModel struct {
 	Value types.String `tfsdk:"value"`
 }
 
-type IncidentNotificationWebhookNotificationModel struct {
+type datadogIncidentTypeIncidentNotificationWebhookNotificationModel struct {
 	Enabled types.Bool   `tfsdk:"enabled"`
 	Url     types.String `tfsdk:"url"`
 }
@@ -163,16 +163,16 @@ func (d *datadogIncidentTypeDataSource) updateState(ctx context.Context, state *
 	}
 	if notifications, ok := attributes.GetNotificationsOk(); ok && notifications != nil {
 		for _, notificationsItem := range *notifications {
-			notificationsEnvelope := &IncidentNotificationModel{}
+			notificationsEnvelope := &datadogIncidentTypeIncidentNotificationModel{}
 			notificationsMatches := 0
 			if stringVariant := notificationsItem.String; stringVariant != nil {
-				stringModel := &IncidentNotificationStringModel{}
+				stringModel := &datadogIncidentTypeIncidentNotificationStringModel{}
 				stringModel.Value = types.StringValue(*stringVariant)
 				notificationsEnvelope.String = stringModel
 				notificationsMatches++
 			}
 			if webhookNotificationVariant := notificationsItem.WebhookNotification; webhookNotificationVariant != nil {
-				webhookNotificationModel := &IncidentNotificationWebhookNotificationModel{}
+				webhookNotificationModel := &datadogIncidentTypeIncidentNotificationWebhookNotificationModel{}
 				if enabled, ok := webhookNotificationVariant.GetEnabledOk(); ok && enabled != nil {
 					webhookNotificationModel.Enabled = types.BoolValue(*enabled)
 				}

--- a/.generator-v2/internal/testdata/sdkbind/bind_placement.yaml
+++ b/.generator-v2/internal/testdata/sdkbind/bind_placement.yaml
@@ -1,0 +1,210 @@
+# Fixture for internal/sdkbind: every position a oneOf can occupy relative to the
+# Datadog go-sdk's generated models, so the binding walk is exercised against the
+# real parser rather than hand-built model structs.
+#
+# Expected SDK wrapper per union (derived per child_models):
+#   response.data.attributes.integration          → WidgetIntegration   ($ref)
+#   response.data.attributes.inline_choice        → WidgetAttributesInlineChoice
+#   response.data.attributes.choices[]            → WidgetAttributesChoicesItem
+#   …integration.aws_integration.credentials      → AWSCredentials       ($ref)
+#   request.data.attributes.payload               → WidgetCreateAttributesPayload
+#   response (root)                               → RootUnion           ($ref)
+#
+# GetWidgetUnnamed is the one operation expected to fail, and it is kept separate
+# so every other operation binds cleanly: its union sits at a map value, a position
+# child_models only descends into through a $ref, so no generated model names it.
+#   response.by_key{}                             → (none)
+openapi: 3.0.0
+info:
+  title: sdkbind placement fixture
+  version: "1.0"
+paths:
+  /api/v2/widgets/{widget_id}:
+    get:
+      operationId: GetWidget
+      tags:
+        - Widgets
+      x-datadog-tf-generator:
+        artifact_kind: data_source
+        artifact_name: widget
+        group:
+          read: GetWidget
+      parameters:
+        - name: widget_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WidgetResponse'
+  /api/v2/widgets:
+    post:
+      operationId: CreateWidget
+      tags:
+        - Widgets
+      x-datadog-tf-generator:
+        artifact_kind: resource
+        artifact_name: widget_create
+        group:
+          # read is required by the tracking-field contract (a group must name a
+          # read or a search); only the create half matters to this fixture.
+          create: CreateWidget
+          read: GetWidget
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WidgetCreateRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WidgetCreateResponse'
+  /api/v2/unnamed/{widget_id}:
+    get:
+      operationId: GetWidgetUnnamed
+      tags:
+        - Widgets
+      x-datadog-tf-generator:
+        artifact_kind: data_source
+        artifact_name: widget_unnamed
+        group:
+          read: GetWidgetUnnamed
+      parameters:
+        - name: widget_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WidgetUnnamedResponse'
+  /api/v2/roots:
+    get:
+      operationId: GetRoot
+      tags:
+        - Widgets
+      x-datadog-tf-generator:
+        artifact_kind: data_source
+        artifact_name: root
+        group:
+          read: GetRoot
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RootUnion'
+components:
+  schemas:
+    WidgetResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/Widget'
+    Widget:
+      type: object
+      properties:
+        id:
+          type: string
+        attributes:
+          $ref: '#/components/schemas/WidgetAttributes'
+    WidgetAttributes:
+      type: object
+      description: The definition of `WidgetAttributes` object.
+      properties:
+        integration:
+          $ref: '#/components/schemas/WidgetIntegration'
+        inline_choice:
+          description: An inline union, named after the enclosing model plus the property.
+          oneOf:
+            - type: string
+            - type: boolean
+        choices:
+          type: array
+          description: A list whose element is an inline union.
+          items:
+            oneOf:
+              - type: string
+              - $ref: '#/components/schemas/WidgetSetting'
+    WidgetIntegration:
+      description: The definition of `WidgetIntegration` object.
+      oneOf:
+        - $ref: '#/components/schemas/AWSIntegration'
+        - $ref: '#/components/schemas/HTTPIntegration'
+    AWSIntegration:
+      type: object
+      properties:
+        credentials:
+          $ref: '#/components/schemas/AWSCredentials'
+    AWSCredentials:
+      description: A union nested inside another union's alternative.
+      oneOf:
+        - $ref: '#/components/schemas/AWSAssumeRole'
+    AWSAssumeRole:
+      type: object
+      properties:
+        role_name:
+          type: string
+    HTTPIntegration:
+      type: object
+      properties:
+        base_url:
+          type: string
+    WidgetSetting:
+      type: object
+      properties:
+        name:
+          type: string
+    RootUnion:
+      description: A union at the response root.
+      oneOf:
+        - $ref: '#/components/schemas/WidgetSetting'
+        - type: string
+    WidgetCreateRequest:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/WidgetCreateData'
+    WidgetCreateData:
+      type: object
+      properties:
+        attributes:
+          $ref: '#/components/schemas/WidgetCreateAttributes'
+    WidgetCreateAttributes:
+      type: object
+      properties:
+        payload:
+          description: An inline union on the request side.
+          oneOf:
+            - type: string
+            - type: integer
+    WidgetCreateResponse:
+      type: object
+      description: Kept union-free so the create operation exercises only the request walk.
+      properties:
+        data:
+          $ref: '#/components/schemas/WidgetSetting'
+    WidgetUnnamedResponse:
+      type: object
+      properties:
+        by_key:
+          type: object
+          description: A map whose value is an inline union — no SDK model names it.
+          additionalProperties:
+            oneOf:
+              - type: string
+              - type: boolean


### PR DESCRIPTION
## Motivation

Populate the envelope #4100 emits. Until now it generated a struct that stayed empty.

> **Note:** this PR was the original 14-commit oneOf branch. It has been split into #4091–#4101 and now carries only the SDK-wrapper state mapping; the title changed accordingly.

## Changes

The SDK's oneOf wrapper exposes one plain pointer member per alternative rather than the `Get<Field>Ok` getters the rest of the mapper is built on, so the generated code tests each member for non-nil, builds the matching Terraform variant model, and counts how many matched.

Counting is the point: **zero** matches is an error unless the envelope is optional or nullable, and **more than one** is always an error, because either case means the state we would write does not describe the response. Both surface as diagnostics naming the union's path rather than silently writing a half-populated object — which is why `UsesFmt` now also accounts for the ambiguous-match message.

- A value-wrapped alternative dereferences its member directly, since a `*string` has no getters.
- Collection placements unwrap per element.
- The envelope render is cached per envelope name, so one reusable oneOf component reached from several places yields a single generated model and one mapper shape rather than a copy per use site.
- With the mapper in place the `Warnings` channel #4100 added has nothing left to say, so it goes: the envelope is now populated, and the honest signal is the generated diagnostics rather than a note in the run report.

## Testing

`go build ./...` and `go test ./...` green. `oneof_test.go` extended for the match-counting and value-wrapped paths; both oneOf goldens updated with the populated mapper.



