### PR TITLE
[datadog_dataset] Fix integration test error regex

### DIFF
--- a/datadog/tests/resource_datadog_dataset_test.go
+++ b/datadog/tests/resource_datadog_dataset_test.go
@@ -80,8 +80,10 @@ func TestAccDatadogDataset_InvalidInput(t *testing.T) {
 		ProtoV6ProviderFactories: accProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckDatadogDataset(datasetName, invalidProduct),
-				ExpectError: regexp.MustCompile("Invalid product"),
+				Config: testAccCheckDatadogDataset(datasetName, invalidProduct),
+				// Terraform hard-wraps diagnostic text, so the message may
+				// contain a newline between the two words.
+				ExpectError: regexp.MustCompile(`Invalid\s+product`),
 			},
 			{
 				Config:      testAccCheckDatadogDatasetInvalidPrincipal(datasetName, product),


### PR DESCRIPTION
<!-- dd-meta {"pullId":"72e4d1cf-0673-480d-9b7a-ad3051493066","source":"chat","resourceId":"47a1c9b6-153e-49f9-a384-66a73c2f0465","workflowId":"954bd011-2cd6-4245-ab32-a69600d999d9","codeChangeId":"954bd011-2cd6-4245-ab32-a69600d999d9","sourceType":"chat"} -->
## Summary

- **Failing test:** `TestAccDatadogDataset_InvalidInput` (step 1/3), failing in every scheduled `master` integration run since at least 2026-07-24.
- **Root cause:** the test asserted on the literal string `Invalid product`, but Terraform hard-wraps diagnostic detail text, so the live API error renders as `Invalid\nproduct: Datasets are not supported for ci-visibility` and the regex never matches.
- **Fix:** make the `ExpectError` regex whitespace-tolerant (`Invalid\s+product`).

## Changes

- `datadog/tests/resource_datadog_dataset_test.go`: replace the `Invalid product` `ExpectError` pattern with `Invalid\s+product` and note why.

## Testing

- CI log evidence: `resource_datadog_dataset_test.go:79: Step 1/3, expected an error with pattern, no match on: Error running apply: exit status 1`, with the wrapped API error `400 Bad Request: {"errors":[{"title":"Generic Error","detail":"Invalid` / `product: Datasets are not supported for ci-visibility"}]}`.
- `RECORD=false TESTARGS="-run TestAccDatadogDataset" make testacc` — all 4 dataset tests pass.
- `make fmtcheck` passes.
- [ ] Integration run in CI (triggered by the `ci/integrations` label) confirms the test passes against the live API.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/47a1c9b6-153e-49f9-a384-66a73c2f0465)

Comment @datadog to request changes