### PR TITLE
[datadog_service_level_objective] Validate metric query data_source and stop panicking on invalid values

### DIFF
--- a/datadog/resource_datadog_service_level_objective.go
+++ b/datadog/resource_datadog_service_level_objective.go
@@ -59,10 +59,11 @@ func getTimeseriesQuerySchema() *schema.Schema {
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
 										"data_source": {
-											Type:        schema.TypeString,
-											Optional:    true,
-											Default:     "metrics",
-											Description: "The data source for metrics queries.",
+											Type:             schema.TypeString,
+											Optional:         true,
+											Default:          "metrics",
+											ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewFormulaAndFunctionMetricDataSourceFromValue),
+											Description:      "The data source for metrics queries.",
 										},
 										"query": {
 											Type:        schema.TypeString,
@@ -333,10 +334,11 @@ func resourceDatadogServiceLevelObjective() *schema.Resource {
 														Elem: &schema.Resource{
 															Schema: map[string]*schema.Schema{
 																"data_source": {
-																	Type:        schema.TypeString,
-																	Optional:    true,
-																	Default:     "metrics",
-																	Description: "The data source for metrics queries.",
+																	Type:             schema.TypeString,
+																	Optional:         true,
+																	Default:          "metrics",
+																	ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewFormulaAndFunctionMetricDataSourceFromValue),
+																	Description:      "The data source for metrics queries.",
 																},
 																"query": {
 																	Type:        schema.TypeString,
@@ -413,7 +415,7 @@ func resourceDatadogServiceLevelObjectiveCustomizeDiff(ctx context.Context, diff
 	return nil
 }
 
-func buildSLOTimeSliceQueryStruct(d []interface{}) *datadogV1.SLOTimeSliceQuery {
+func buildSLOTimeSliceQueryStruct(d []interface{}) (*datadogV1.SLOTimeSliceQuery, error) {
 	// only use the first defined query
 	ret := datadogV1.NewSLOTimeSliceQueryWithDefaults()
 	ret.Formulas = make([]datadogV1.SLOFormula, 0)
@@ -438,7 +440,10 @@ func buildSLOTimeSliceQueryStruct(d []interface{}) *datadogV1.SLOTimeSliceQuery 
 							name := rawMetricQuery["name"].(string)
 							query := rawMetricQuery["query"].(string)
 							rawDataSource := rawMetricQuery["data_source"].(string)
-							dataSource, _ := datadogV1.NewFormulaAndFunctionMetricDataSourceFromValue(rawDataSource)
+							dataSource, err := datadogV1.NewFormulaAndFunctionMetricDataSourceFromValue(rawDataSource)
+							if err != nil {
+								return nil, err
+							}
 							ret.Queries = append(ret.Queries,
 								datadogV1.FormulaAndFunctionMetricQueryDefinitionAsSLODataSourceQueryDefinition(
 									datadogV1.NewFormulaAndFunctionMetricQueryDefinition(*dataSource, name, query)))
@@ -448,16 +453,16 @@ func buildSLOTimeSliceQueryStruct(d []interface{}) *datadogV1.SLOTimeSliceQuery 
 			}
 		}
 	}
-	return ret
+	return ret, nil
 }
 
-func buildSLOCountSpec(d []interface{}) *datadogV1.SLOCountSpec {
+func buildSLOCountSpec(d []interface{}) (*datadogV1.SLOCountSpec, error) {
 	if len(d) == 0 {
-		return nil
+		return nil, nil
 	}
 	raw, ok := d[0].(map[string]interface{})
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	goodEventsFormula := *datadogV1.NewSLOFormula(raw["good_events_formula"].(string))
@@ -472,7 +477,10 @@ func buildSLOCountSpec(d []interface{}) *datadogV1.SLOCountSpec {
 					name := rawMetricQuery["name"].(string)
 					query := rawMetricQuery["query"].(string)
 					rawDataSource := rawMetricQuery["data_source"].(string)
-					dataSource, _ := datadogV1.NewFormulaAndFunctionMetricDataSourceFromValue(rawDataSource)
+					dataSource, err := datadogV1.NewFormulaAndFunctionMetricDataSourceFromValue(rawDataSource)
+					if err != nil {
+						return nil, err
+					}
 					queries = append(queries,
 						datadogV1.FormulaAndFunctionMetricQueryDefinitionAsSLODataSourceQueryDefinition(
 							datadogV1.NewFormulaAndFunctionMetricQueryDefinition(*dataSource, name, query)))
@@ -485,15 +493,15 @@ func buildSLOCountSpec(d []interface{}) *datadogV1.SLOCountSpec {
 		totalEventsFormula := *datadogV1.NewSLOFormula(totalEventsFormulaStr)
 		totalCountDef := datadogV1.NewSLOCountDefinitionWithTotalEventsFormula(goodEventsFormula, queries, totalEventsFormula)
 		countDef := datadogV1.SLOCountDefinitionWithTotalEventsFormulaAsSLOCountDefinition(totalCountDef)
-		return datadogV1.NewSLOCountSpec(countDef)
+		return datadogV1.NewSLOCountSpec(countDef), nil
 	} else if badEventsFormulaStr, ok := raw["bad_events_formula"].(string); ok && badEventsFormulaStr != "" {
 		badEventsFormula := *datadogV1.NewSLOFormula(badEventsFormulaStr)
 		badCountDef := datadogV1.NewSLOCountDefinitionWithBadEventsFormula(badEventsFormula, goodEventsFormula, queries)
 		countDef := datadogV1.SLOCountDefinitionWithBadEventsFormulaAsSLOCountDefinition(badCountDef)
-		return datadogV1.NewSLOCountSpec(countDef)
+		return datadogV1.NewSLOCountSpec(countDef), nil
 	}
 
-	return nil
+	return nil, nil
 }
 
 func buildServiceLevelObjectiveStructs(d *schema.ResourceData) (*datadogV1.ServiceLevelObjective, *datadogV1.ServiceLevelObjectiveRequest, error) {
@@ -545,7 +553,11 @@ func buildServiceLevelObjectiveStructs(d *schema.ResourceData) (*datadogV1.Servi
 					if len(rawTimeSliceConds) >= 1 {
 						rawTimeSliceCond := rawTimeSliceConds[0].(map[string]interface{})
 						if rawTimeSliceQuery, ok := rawTimeSliceCond["query"].([]interface{}); ok {
-							sliSpec.SLOTimeSliceSpec.TimeSlice.SetQuery(*buildSLOTimeSliceQueryStruct(rawTimeSliceQuery))
+							timeSliceQuery, err := buildSLOTimeSliceQueryStruct(rawTimeSliceQuery)
+							if err != nil {
+								return nil, nil, err
+							}
+							sliSpec.SLOTimeSliceSpec.TimeSlice.SetQuery(*timeSliceQuery)
 						}
 						if comparator, ok := rawTimeSliceCond["comparator"].(string); ok {
 							sliSpec.SLOTimeSliceSpec.TimeSlice.SetComparator(datadogV1.SLOTimeSliceComparator(comparator))
@@ -577,7 +589,10 @@ func buildServiceLevelObjectiveStructs(d *schema.ResourceData) (*datadogV1.Servi
 				if rawCountList, ok := rawSliSpec["count"]; ok {
 					rawCount := rawCountList.([]interface{})
 					if len(rawCount) >= 1 {
-						countSpec := buildSLOCountSpec(rawCount)
+						countSpec, err := buildSLOCountSpec(rawCount)
+						if err != nil {
+							return nil, nil, err
+						}
 						sliSpec := datadogV1.SLOCountSpecAsSLOSliSpec(countSpec)
 						slo.SetSliSpecification(sliSpec)
 						slor.SetSliSpecification(sliSpec)

--- a/datadog/resource_datadog_service_level_objective_unit_test.go
+++ b/datadog/resource_datadog_service_level_objective_unit_test.go
@@ -1,0 +1,76 @@
+package datadog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// metricQueryRaw mirrors the schema-decoded shape of a single time-slice /
+// count `query` block containing one `metric_query`.
+func metricQueryRaw(dataSource string) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"formula": []interface{}{
+				map[string]interface{}{"formula_expression": "query1"},
+			},
+			"query": []interface{}{
+				map[string]interface{}{
+					"metric_query": []interface{}{
+						map[string]interface{}{
+							"data_source": dataSource,
+							"name":        "query1",
+							"query":       "avg:system.cpu.user{*}",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestBuildSLOTimeSliceQueryStruct_InvalidDataSource guards against a
+// regression where an unsupported data_source (e.g. "rum") caused a nil
+// pointer dereference: NewFormulaAndFunctionMetricDataSourceFromValue returns
+// (nil, err) for anything other than "metrics", the error was discarded, and
+// dereferencing the nil pointer crashed the whole provider process at apply.
+func TestBuildSLOTimeSliceQueryStruct_InvalidDataSource(t *testing.T) {
+	require.NotPanics(t, func() {
+		_, err := buildSLOTimeSliceQueryStruct(metricQueryRaw("rum"))
+		assert.Error(t, err, "invalid data_source must return an error, not panic")
+	})
+}
+
+func TestBuildSLOTimeSliceQueryStruct_ValidDataSource(t *testing.T) {
+	q, err := buildSLOTimeSliceQueryStruct(metricQueryRaw("metrics"))
+	require.NoError(t, err)
+	require.NotNil(t, q)
+	require.Len(t, q.GetQueries(), 1)
+}
+
+// TestBuildSLOCountSpec_InvalidDataSource covers the same nil-deref pattern in
+// the count-SLI code path.
+func TestBuildSLOCountSpec_InvalidDataSource(t *testing.T) {
+	raw := []interface{}{
+		map[string]interface{}{
+			"good_events_formula":  "query1",
+			"total_events_formula": "query1",
+			"queries": []interface{}{
+				map[string]interface{}{
+					"metric_query": []interface{}{
+						map[string]interface{}{
+							"data_source": "rum",
+							"name":        "query1",
+							"query":       "avg:system.cpu.user{*}",
+						},
+					},
+				},
+			},
+		},
+	}
+	require.NotPanics(t, func() {
+		_, err := buildSLOCountSpec(raw)
+		assert.Error(t, err, "invalid data_source must return an error, not panic")
+	})
+}

--- a/docs/resources/service_level_objective.md
+++ b/docs/resources/service_level_objective.md
@@ -246,7 +246,7 @@ Required:
 
 Optional:
 
-- `data_source` (String) The data source for metrics queries. Defaults to `"metrics"`.
+- `data_source` (String) The data source for metrics queries. Valid values are `metrics`. Defaults to `"metrics"`.
 
 
 
@@ -297,7 +297,7 @@ Required:
 
 Optional:
 
-- `data_source` (String) The data source for metrics queries. Defaults to `"metrics"`.
+- `data_source` (String) The data source for metrics queries. Valid values are `metrics`. Defaults to `"metrics"`.
 
 ## Import
 


### PR DESCRIPTION
Fixes #4052

### What / why

An unsupported `data_source` (e.g. `"rum"`) in an SLO metric query crashes the
provider at apply time with a nil pointer dereference (SIGSEGV), taking down the
whole plugin process (surfaced to the user as `Error: Plugin did not respond`).

`NewFormulaAndFunctionMetricDataSourceFromValue` returns `(nil, err)` for any
value other than the only supported `"metrics"`; the error was discarded with
`_` and the nil pointer was then dereferenced
(`resource_datadog_service_level_objective.go:444`, and the same pattern in the
count SLI path). Because the `data_source` schema field had no validation, the
invalid value passed `plan`/`validate` cleanly and only failed — as a crash —
during `apply`. (`validate = false` does not help; the crash is at
request-build time, unrelated to that option.)

### Changes

- Add `ValidateDiagFunc: validators.ValidateEnumValue(datadogV1.NewFormulaAndFunctionMetricDataSourceFromValue)`
  to the `data_source` field of both the time-slice and count metric queries, so
  invalid values are rejected at plan time with a clear message
  (`invalid value '...' for FormulaAndFunctionMetricDataSource: valid values are [metrics]`).
- Propagate the error from `buildSLOTimeSliceQueryStruct` and `buildSLOCountSpec`
  instead of discarding it and dereferencing a nil pointer (defense in depth).
- Regenerate docs (`make docs`): the validator adds "Valid values are `metrics`."
  to the `data_source` description.
- Add unit tests covering the invalid-`data_source` regression.

### Testing

- `make fmtcheck`, `make vet`, `make test` pass.
- New unit tests: `TestBuildSLOTimeSliceQueryStruct_InvalidDataSource`,
  `TestBuildSLOTimeSliceQueryStruct_ValidDataSource`,
  `TestBuildSLOCountSpec_InvalidDataSource`.

### Changelog

Please apply the `changelog/bugfix` label.
