### PR TITLE
[Tfgen] Fixed envelope flattening issues

### DIFF
--- a/.generator-v2/internal/cli/generate.go
+++ b/.generator-v2/internal/cli/generate.go
@@ -253,9 +253,10 @@ func generateArtifact(op *model.Operation, outputRoot, testsOutputRoot, examples
 	// Correct APIAccessor to the name the provider's helper actually exposes,
 	// which diverges from the derived name for a few acronym/aliased APIs.
 	emit.ApplyAPIAccessor(&view, accessors)
-	// Members the emit flattener dropped (e.g. relationships) ride along as info.
-	for _, msg := range view.Dropped {
-		entry.Diagnostics = append(entry.Diagnostics, model.Diagnostic{Severity: model.SeverityInfo, Message: msg})
+	// Members the emit flattener dropped (e.g. relationships) ride along at the
+	// severity the drop warrants.
+	for _, d := range view.Dropped {
+		entry.Diagnostics = append(entry.Diagnostics, model.Diagnostic{Severity: d.Severity, Message: d.Message})
 	}
 
 	src, err := emit.RenderDataSource(view)

--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -254,6 +254,12 @@ func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrat
 			b.dropped = append(b.dropped, droppedAuditField(child.Path))
 			continue
 		}
+		// The envelope id is surfaced unconditionally below, so an id under
+		// attributes always collides with it.
+		if tfNameOf(child.Path) == "id" {
+			b.dropped = append(b.dropped, droppedIDCollision(child.Path))
+			continue
+		}
 		if !isLeafType(child.TfType) && !isArrayType(child.TfType) && !isObjectType(child.TfType) {
 			b.unsupported = append(b.unsupported, UnsupportedNode{
 				Path:   child.Path,
@@ -302,20 +308,37 @@ type dataSourceBuilder struct {
 	models      []ModelStructView
 	unsupported []UnsupportedNode
 	// dropped notes envelope members skipped from the attributes-only view
-	// (e.g. relationships), surfaced as info diagnostics rather than failures.
-	dropped []string
+	// (e.g. relationships), surfaced as diagnostics rather than failures.
+	dropped []DroppedMember
 }
 
 // droppedEnvelopeMember is the info-diagnostic note for a JSON:API response
 // member skipped from the attributes-only view, e.g. relationships.
-func droppedEnvelopeMember(path string) string {
-	return fmt.Sprintf("dropped %q: not part of the surfaced {id, type, attributes} envelope", path)
+func droppedEnvelopeMember(path string) DroppedMember {
+	return DroppedMember{
+		Message:  fmt.Sprintf("dropped %q: not part of the surfaced {id, type, attributes} envelope", path),
+		Severity: model.SeverityInfo,
+	}
 }
 
 // droppedAuditField is the info-diagnostic note for a top-level audit attribute
 // omitted from a generated data source.
-func droppedAuditField(path string) string {
-	return fmt.Sprintf("dropped %q: server-managed audit field", path)
+func droppedAuditField(path string) DroppedMember {
+	return DroppedMember{
+		Message:  fmt.Sprintf("dropped %q: server-managed audit field", path),
+		Severity: model.SeverityInfo,
+	}
+}
+
+// droppedIDCollision is the warning-diagnostic note for a member promoted out of
+// attributes whose name is already claimed by the envelope id. Flattening would
+// emit two attributes named "id"; the envelope id wins because it carries the
+// data source's Terraform identity.
+func droppedIDCollision(path string) DroppedMember {
+	return DroppedMember{
+		Message:  fmt.Sprintf("dropped %q: collides with the envelope id surfaced as \"id\"", path),
+		Severity: model.SeverityWarning,
+	}
 }
 
 // walk processes one struct's worth of attributes in tree order, reserving the
@@ -597,7 +620,7 @@ func unsupportedReason(tfType string) string {
 // *UnsupportedEmitError, in which case the view is discarded.
 func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 	var unsupported []UnsupportedNode
-	var dropped []string
+	var dropped []DroppedMember
 
 	var call *model.SDKCall
 	if a.Lifecycle != nil {
@@ -796,9 +819,17 @@ type itemElementLeaf struct {
 // "attributes" off item.Attributes, and "type" is dropped. Members outside
 // {id, type, attributes} (e.g. relationships) are dropped with a note on dropped;
 // non-leaf id/attributes still append to unsupported. Leaves are sorted by TF name.
-func flattenItemElement(block *model.Attribute, unsupported *[]UnsupportedNode, dropped *[]string) (scalars []itemElementLeaf, nonScalars []*model.Attribute) {
+func flattenItemElement(block *model.Attribute, unsupported *[]UnsupportedNode, dropped *[]DroppedMember) (scalars []itemElementLeaf, nonScalars []*model.Attribute) {
 	if block == nil {
 		return nil, nil
+	}
+	// Children are name-sorted, so "attributes" is walked before "id". Look the
+	// envelope id up first so a colliding id under attributes can be dropped.
+	envelopeHasID := false
+	for _, child := range block.Children {
+		if tfNameOf(child.Path) == "id" {
+			envelopeHasID = true
+		}
 	}
 	for _, child := range block.Children {
 		switch tfNameOf(child.Path) {
@@ -818,6 +849,10 @@ func flattenItemElement(block *model.Attribute, unsupported *[]UnsupportedNode, 
 			for _, leaf := range child.Children {
 				if isAuditField(tfNameOf(leaf.Path)) {
 					*dropped = append(*dropped, droppedAuditField(leaf.Path))
+					continue
+				}
+				if envelopeHasID && tfNameOf(leaf.Path) == "id" {
+					*dropped = append(*dropped, droppedIDCollision(leaf.Path))
 					continue
 				}
 				switch {

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -1,6 +1,7 @@
 package emit
 
 import (
+	"bytes"
 	"errors"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -124,7 +125,107 @@ var _ = Describe("BuildDataSourceView", func() {
 
 		view, err := BuildDataSourceView(art)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(view.Dropped).To(ContainElement(ContainSubstring("relationships")))
+		Expect(view.Dropped).To(ContainElement(And(
+			HaveField("Message", ContainSubstring("relationships")),
+			HaveField("Severity", model.SeverityInfo),
+		)))
+	})
+})
+
+var _ = Describe("BuildDataSourceView envelope id collision", func() {
+	It("drops an id under singular attributes in favour of the envelope id and warns", func() {
+		op := incidentTypeOperation()
+		op.ResponseSchema.Properties["data"].Properties["attributes"].
+			Properties["id"] = prim("string", "The incident type's config ID.")
+		view := mustView(op)
+
+		Expect(view.Models).To(HaveLen(1))
+		var fields []string
+		for _, f := range view.Models[0].Fields {
+			fields = append(fields, f.TFName)
+		}
+		Expect(fields).To(Equal([]string{"id", "description", "is_default", "name"}))
+		Expect(view.Dropped).To(ContainElement(And(
+			HaveField("Message", ContainSubstring("attributes.id")),
+			HaveField("Message", ContainSubstring(`collides with the envelope id`)),
+			HaveField("Severity", model.SeverityWarning),
+		)))
+	})
+
+	It("drops an id under plural item attributes in favour of the item's envelope id and warns", func() {
+		op := datastoresOperation()
+		op.ResponseSchema.Properties["data"].Items.
+			Properties["attributes"].Properties["id"] = prim("string", "The datastore's config ID.")
+		view := mustView(op)
+
+		var itemAttrs []string
+		for _, b := range view.Schema.Blocks {
+			for _, a := range b.Attributes {
+				itemAttrs = append(itemAttrs, a.TFName)
+			}
+		}
+		Expect(itemAttrs).To(Equal([]string{
+			"creator_user_id", "creator_user_uuid", "description", "id", "name",
+			"org_id", "primary_column_name", "primary_key_generation_strategy",
+		}))
+		Expect(view.Dropped).To(ContainElement(And(
+			HaveField("Message", ContainSubstring("attributes.id")),
+			HaveField("Severity", model.SeverityWarning),
+		)))
+	})
+
+	It("keeps an id under attributes when the envelope has no id of its own", func() {
+		op := datastoresOperation()
+		items := op.ResponseSchema.Properties["data"].Items
+		delete(items.Properties, "id")
+		items.Properties["attributes"].Properties["id"] = prim("string", "The datastore's config ID.")
+		view := mustView(op)
+
+		var itemAttrs []string
+		for _, b := range view.Schema.Blocks {
+			for _, a := range b.Attributes {
+				itemAttrs = append(itemAttrs, a.TFName)
+			}
+		}
+		Expect(itemAttrs).To(Equal([]string{
+			"creator_user_id", "creator_user_uuid", "description", "id", "name",
+			"org_id", "primary_column_name", "primary_key_generation_strategy",
+		}))
+		Expect(view.Dropped).NotTo(ContainElement(
+			HaveField("Message", ContainSubstring("collides with the envelope id"))))
+	})
+
+	It("renders a colliding singular envelope to compiling Go with a single id attribute", func() {
+		op := incidentTypeOperation()
+		op.ResponseSchema.Properties["data"].Properties["attributes"].
+			Properties["id"] = prim("string", "The incident type's config ID.")
+
+		src, err := RenderDataSource(mustView(op))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bytes.Count(src, []byte("`tfsdk:\"id\"`"))).To(Equal(1))
+	})
+
+	It("produces byte-identical output across two runs of the same input", func() {
+		build := func() []byte {
+			op := datastoresOperation()
+			op.ResponseSchema.Properties["data"].Items.
+				Properties["attributes"].Properties["id"] = prim("string", "The datastore's config ID.")
+			src, err := RenderDataSource(mustView(op))
+			Expect(err).NotTo(HaveOccurred())
+			return src
+		}
+		Expect(build()).To(Equal(build()))
+	})
+})
+
+var _ = Describe("RenderDataSource duplicate field guard", func() {
+	It("fails instead of writing a model that declares the same tfsdk tag twice", func() {
+		view := mustView(incidentTypeOperation())
+		view.Models[0].Fields = append(view.Models[0].Fields,
+			ModelFieldView{GoField: "ID", GoType: "types.String", TFName: "id"})
+
+		_, err := RenderDataSource(view)
+		Expect(err).To(MatchError(ContainSubstring(`declares tfsdk:"id" twice`)))
 	})
 })
 
@@ -140,7 +241,10 @@ var _ = Describe("BuildDataSourceView audit fields", func() {
 		for _, a := range view.Schema.Attributes {
 			Expect(a.TFName).NotTo(BeElementOf("created_at", "updated_at", "created_by", "updated_by", "modified_at"))
 		}
-		Expect(view.Dropped).To(ContainElement(ContainSubstring("created_at")))
+		Expect(view.Dropped).To(ContainElement(And(
+			HaveField("Message", ContainSubstring("created_at")),
+			HaveField("Severity", model.SeverityInfo),
+		)))
 	})
 
 	It("keeps an audit-named field nested inside an object", func() {

--- a/.generator-v2/internal/emit/render.go
+++ b/.generator-v2/internal/emit/render.go
@@ -53,6 +53,10 @@ var dataSourceTemplates = template.Must(
 // NOTE: this is a minimal execution harness so the templates are runnable and
 // testable on their own.
 func RenderDataSource(v DataSourceView) ([]byte, error) {
+	if err := checkDuplicateFields(v.Models); err != nil {
+		return nil, fmt.Errorf("emit: data source %q: %w", v.TypeName, err)
+	}
+
 	name := "data_source_singular"
 	if v.Cardinality == Plural {
 		name = "data_source_plural"
@@ -68,6 +72,24 @@ func RenderDataSource(v DataSourceView) ([]byte, error) {
 		return nil, fmt.Errorf("emit: gofmt of generated data source %q: %w\n--- raw output ---\n%s", v.TypeName, err, buf.String())
 	}
 	return dropBlankLineAfterBrace(formatted), nil
+}
+
+// checkDuplicateFields rejects a model struct that declares the same Terraform
+// name twice. Such a struct renders three ways that do not compile — a
+// redeclared Go field, a duplicate tfsdk tag, and a duplicate key in the schema
+// attribute map — so failing here keeps a broken artifact from being written and
+// reported as created.
+func checkDuplicateFields(models []ModelStructView) error {
+	for _, m := range models {
+		seen := make(map[string]bool, len(m.Fields))
+		for _, f := range m.Fields {
+			if seen[f.TFName] {
+				return fmt.Errorf("model %s declares tfsdk:%q twice", m.Name, f.TFName)
+			}
+			seen[f.TFName] = true
+		}
+	}
+	return nil
 }
 
 // dropBlankLineAfterBrace removes blank lines that immediately follow a line

--- a/.generator-v2/internal/emit/view.go
+++ b/.generator-v2/internal/emit/view.go
@@ -10,6 +10,8 @@
 // fiddly logic in code that unit tests can pin down.
 package emit
 
+import "github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+
 // Cardinality selects which data-source template renders an artifact. A
 // singular data source resolves exactly one item whereas a plural
 // data source returns a filtered list of items.
@@ -76,9 +78,18 @@ type DataSourceView struct {
 	State StateView
 
 	// Dropped lists response members skipped from the rendered view (e.g.
-	// relationships), surfaced as info diagnostics in the run report. It does
-	// not affect rendering.
-	Dropped []string
+	// relationships), surfaced as diagnostics in the run report. It does not
+	// affect rendering.
+	Dropped []DroppedMember
+}
+
+// DroppedMember is one response member omitted from the rendered view, carrying
+// the severity its omission warrants in the run report. A member with no
+// Terraform representation is informational; one dropped to resolve a name
+// collision is a warning, because data the API exposes is not surfaced.
+type DroppedMember struct {
+	Message  string
+	Severity model.DiagnosticSeverity
 }
 
 // SDKReadView describes the datadog-api-client-go call that backs Read.


### PR DESCRIPTION
### Motivation

When a JSON:API response carries an `id` under `data.attributes` alongside the
envelope's own `data.id`, envelope flattening hoisted both into the same struct
and emitted two attributes named `id`. That renders three ways that don't
compile — a redeclared Go field, a duplicate `tfsdk` tag, and a duplicate key in
the schema attribute map — yet the artifact was still written and reported as
`created`. The original plan assumed this case was already covered by the
unsupported `data.attributes.id` id-strategy, but the two are independent: the
strategy can stay the default `data.id` while the response still exposes a
second `id`, so nothing failed.

Separately, every dropped response member was reported at `info` severity, so a
drop that silently loses data the API exposes was indistinguishable from
dropping `type`.

### Changes

- **Envelope id collision** (`internal/emit/builder.go`)
  - `flattenEnvelope` drops a child under `attributes` whose Terraform name is
    `id`. The envelope id is surfaced unconditionally, so such a child always
    collides.
  - `flattenItemElement` does the same for the plural item element. Because
    children are name-sorted, `attributes` is walked before `id`, so it
    pre-scans for an envelope `id` (`envelopeHasID`) and only drops the
    colliding leaf when one exists — an item with no envelope `id` of its own
    keeps its `attributes.id`.
  - New `droppedIDCollision` note, emitted at **warning** severity; the envelope
    id wins because it carries the data source's Terraform identity.

- **Drop notes carry severity** (`internal/emit/view.go`, `builder.go`,
  `internal/cli/generate.go`)
  - New `DroppedMember{Message, Severity}`; `DataSourceView.Dropped` and
    `dataSourceBuilder.dropped` change from `[]string` to `[]DroppedMember`.
    `view.go` now imports `internal/model` for `DiagnosticSeverity`.
  - `droppedEnvelopeMember` and `droppedAuditField` return `DroppedMember` at
    `model.SeverityInfo`, preserving today's behaviour for members with no
    Terraform representation.
  - `buildPluralView`'s local `dropped` and `flattenItemElement`'s parameter
    change type accordingly.
  - `generateArtifact` reports each drop at `d.Severity` instead of hardcoding
    `SeverityInfo`.

- **Duplicate-field backstop** (`internal/emit/render.go`)
  - `RenderDataSource` runs a new `checkDuplicateFields(v.Models)` before
    selecting a template and fails with the data source's type name in the
    error, so a model declaring the same `tfsdk` name twice can never be written
    and reported as created.

- **Tests** (`internal/emit/builder_test.go`)
  - Existing `Dropped` assertions updated from substring matches on strings to
    `HaveField("Message", …)` + `HaveField("Severity", …)`, pinning
    `relationships` and `created_at` drops as `SeverityInfo`.
  - New `BuildDataSourceView envelope id collision` suite: drops and warns for a
    colliding `id` under singular `attributes`; same for plural item
    `attributes`; keeps `attributes.id` when the envelope has no `id`; renders a
    colliding singular envelope to Go containing exactly one `tfsdk:"id"`;
    produces byte-identical output across two runs of the same input.
  - New `RenderDataSource duplicate field guard` suite: a model with a
    hand-appended duplicate `id` field fails to render.

### Test

`make tfgen-test` passes across all generator packages, with `internal/emit`
coverage at 87.0%.

Six new Ginkgo specs cover the change directly: the singular and plural drop
paths, the negative case where no envelope `id` exists, the rendered output
containing a single `tfsdk:"id"`, run-to-run byte-identical output, and the
duplicate-field guard rejecting a model rather than writing it.

No acceptance tests, cassettes, or `make build` verification are included. Per
this repo's convention, generated code is not exercised by the generation flow —
cassettes and acceptance tests are recorded separately by a human.