### PR TITLE
[Tfgen] Change to relative path to fix accessor resolution

### DIFF
--- a/.generator-v2/internal/cli/generate.go
+++ b/.generator-v2/internal/cli/generate.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,10 +20,11 @@ import (
 // Execute translates this into exit code 3.
 var errCheckFailed = fmt.Errorf("check: one or more files would change")
 
-// apiInstancesHelperPath is the provider's ApiInstances helper, the source of
-// truth for SDK API accessor names. It is read relative to the working directory
-// (the repo root), like the other default paths.
-const apiInstancesHelperPath = "datadog/internal/utils/api_instances_helper.go"
+// apiInstancesHelperRelPath locates the provider's ApiInstances helper, the source
+// of truth for SDK API accessor names. It is resolved against --output-root rather
+// than the working directory, so it lands on the real file wherever tfgen is run
+// from.
+const apiInstancesHelperRelPath = "../internal/utils/api_instances_helper.go"
 
 func newGenerateCmd(flags *globalFlags) *cobra.Command {
 	var check bool
@@ -83,13 +83,12 @@ func newGenerateCmd(flags *globalFlags) *cobra.Command {
 				filter := parseInclude(include)
 
 				// Resolve the provider's SDK-accessor names, the source of truth for
-				// APIAccessor. A missing file is expected outside a full checkout; a parse
-				// failure is worth surfacing. Either way we fall back to derived names.
-				accessors, accErr := emit.ResolveAPIAccessors(apiInstancesHelperPath)
+				// APIAccessor. Always surface a failure: the fallback to derived names
+				// emits code that does not compile for the APIs whose accessor diverges
+				// from the struct name (RUM, APM, Observability Pipelines).
+				accessors, accErr := emit.ResolveAPIAccessors(filepath.Join(outputRoot, apiInstancesHelperRelPath))
 				if accErr != nil {
-					if !errors.Is(accErr, os.ErrNotExist) {
-						cmd.PrintErrln("tfgen: could not resolve API accessors, using derived names:", accErr)
-					}
+					cmd.PrintErrln("tfgen: could not resolve API accessors, using derived names:", accErr)
 					accessors = nil
 				}
 


### PR DESCRIPTION
### Motivation

`emit.ResolveAPIAccessors` parses the provider's `api_instances_helper.go` to
learn the accessor method that actually returns each V2 SDK API struct, because
three of them diverge from the derived `Get<Struct>V2` name:

| SDK struct | Real accessor | Derived |
|---|---|---|
| `RUMApi` | `GetRumApiV2` | `GetRUMApiV2` |
| `APMRetentionFiltersApi` | `GetApmRetentionFiltersApiV2` | `GetAPMRetentionFiltersApiV2` |
| `ObservabilityPipelinesApi` | `GetObsPipelinesV2` | `GetObservabilityPipelinesApiV2` |

That resolution has never run under the generation pipeline. The helper path was
a constant resolved against the process working directory, but the pipeline's
tfgen command `cd`s into `generated/terraform/.generator-v2` first, so it looked
for the file one directory below where it lives. The `os.ErrNotExist` branch then
suppressed the warning on the reasoning that a missing helper is expected outside
a full checkout, leaving `accessors` nil and every artifact falling back to the
derived name.

Inside a real checkout with the wrong working directory, that produces a clean
run report with `"failed": 0` while emitting code that does not compile —
`providerData.DatadogApiInstances.GetRUMApiV2 undefined (type *utils.ApiInstances
has no field or method GetRUMApiV2, but does have method GetRumApiV2)`, which is
what broke CI on the `rum_applications` artifact.

The bug is as old as the generator (`accessors.go` has a single commit,
`a1d260aa0`) and stayed latent because every artifact annotated before this batch
— `datastores`, `authn_mappings`, `api_keys`, `application_keys`,
`azure_uc_configs`, `downtimes` — derives its accessor correctly. Only 3 of the
helper's ~90 accessors diverge, and `rum_applications` is the first artifact to
touch one.

### Changes

`.generator-v2/internal/cli/generate.go` only.

- **Resolve the helper against `--output-root` instead of the working directory**
  - `apiInstancesHelperPath` (`datadog/internal/utils/api_instances_helper.go`)
    becomes `apiInstancesHelperRelPath` (`../internal/utils/api_instances_helper.go`),
    joined onto `outputRoot` at the call site via `filepath.Join`.
  - This lands on the real file from either working directory:
    `../datadog/fwprovider` → `../datadog/internal/utils/…` (pipeline), and
    `datadog/fwprovider` → `datadog/internal/utils/…` (repo root, `make` targets,
    `tfgen-split.yml`).
  - Consequently no change is needed to the tfgen command in
    `datadog-api-spec`'s `config/client_generator_config.yaml`, and no build/run
    split or new flag is introduced.
  - Doc comment updated; it previously documented the working-directory
    assumption that caused the bug.

- **Always surface a failed resolution**
  - Removed the `errors.Is(accErr, os.ErrNotExist)` suppression, so a missing,
    unreadable, or unparseable helper prints
    `tfgen: could not resolve API accessors, using derived names: …` instead of
    failing silently. Behaviour is otherwise unchanged — it still falls back to
    derived names rather than aborting the run.
  - Comment rewritten to state why the fallback is dangerous (non-compiling
    output for the three diverging APIs) rather than describing it as an expected
    condition.
  - `errors` import dropped; it had no other use.

### Test

Verified by replicating the pipeline invocation exactly — `cd .generator-v2`,
same flag shape as `client_generator_config.yaml` — against an `rum_applications`-annotated
copy of `internal/testdata/mini-oas/mini-datadog_rum_application.yaml`:

- the generated data source emits
  `providerData.DatadogApiInstances.GetRumApiV2()`
- `make build` passes with that artifact in the tree
- a second run of the same input reports `"unchanged": 1`
- pointing `--output-root` at a directory with no helper prints the warning
  instead of swallowing it

`make tfgen-test` passes across all generator packages. Those generated artifacts
were reverted and are **not** part of this PR, which is generator-only.

Not covered:

- **No automated test.** The regression guard for this class is the warning: a
  future path or working-directory mistake now reports itself on stderr instead
  of shipping non-compiling code under a clean report.
- **APM and Observability Pipelines are unverified end-to-end.** Neither has an
  annotated artifact in the spec, so there is nothing to generate; they share the
  same resolution path and map.
- The real `full_spec.terraform.yaml` could not be used, because it currently
  fails in the parser with
  `infinite circular reference detected: SummarizedSpan: SummarizedTrace -> SummarizedSpan -> SummarizedSpan`
  before reaching this code. Pre-existing and unrelated, but it blocks a full
  pipeline run.