### PR TITLE
[REDRES-7396] Rename redapl-ingest to rp-ingest in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -71,7 +71,7 @@ datadog/**/*datadog_app_key_registration*        @DataDog/action-platform @DataD
 datadog/**/*datadog_api_key*                     @DataDog/credential-management
 datadog/**/*datadog_apm_retention_filter*        @DataDog/apm-trace-intake
 datadog/**/*datadog_application_key*             @DataDog/credential-management
-datadog/**/*datadog_hosts*                       @DataDog/redapl-storage @DataDog/redapl-ingest
+datadog/**/*datadog_hosts*                       @DataDog/redapl-storage @DataDog/rp-ingest
 datadog/**/*datadog_integration_aws*             @DataDog/aws-integrations
 datadog/**/*datadog_integration_azure*           @DataDog/azure-integrations
 datadog/**/*datadog_integration_cloudflare*      @DataDog/saas-integrations


### PR DESCRIPTION
Part of REDRES-7390 team rename from redapl-ingest to rp-ingest (RP-Ingest). Mirrors the same change done in REDRES-6000.