### PR TITLE
[datadog_dashboard_v2] Validate widgets during plan

### DIFF
--- a/datadog/dashboardmapping/engine.go
+++ b/datadog/dashboardmapping/engine.go
@@ -1846,6 +1846,19 @@ func WidgetErrorPathToHCL(widgetType, jsonPath string) string {
 }
 
 func normalizeValidationJSONPath(path string) string {
+	path = strings.TrimSpace(path)
+	if strings.HasPrefix(path, "[") && strings.HasSuffix(path, "]") {
+		path = strings.TrimSuffix(strings.TrimPrefix(path, "["), "]")
+		parts := strings.Split(path, ",")
+		tokens := make([]string, 0, len(parts))
+		for _, part := range parts {
+			token := strings.Trim(strings.TrimSpace(part), "'\"")
+			if token != "" {
+				tokens = append(tokens, token)
+			}
+		}
+		return strings.Join(tokens, ".")
+	}
 	path = strings.ReplaceAll(path, "[", ".")
 	path = strings.ReplaceAll(path, "]", "")
 	return strings.Trim(path, ".")

--- a/datadog/dashboardmapping/engine.go
+++ b/datadog/dashboardmapping/engine.go
@@ -1811,6 +1811,104 @@ func BuildWidgetEngineJSONFromMap(widget map[string]interface{}) map[string]inte
 	return buildWidgetEngineJSONFromMap(widget)
 }
 
+// WidgetDefinitionHCLKey returns the Terraform block name for a widget JSON
+// type. Validation APIs speak in JSON paths, while provider errors must point
+// users to the corresponding HCL configuration.
+func WidgetDefinitionHCLKey(widgetType string) string {
+	for _, spec := range allWidgetSpecs {
+		if spec.JSONType == widgetType {
+			return spec.HCLKey
+		}
+	}
+	return "unknown_definition"
+}
+
+// WidgetErrorPathToHCL translates a widget-definition JSON error path, such as
+// "requests.0.q", to its FieldSpec-backed Terraform path, such as
+// "request.0.q". Unknown path segments are preserved so backend errors never
+// lose useful location information.
+func WidgetErrorPathToHCL(widgetType, jsonPath string) string {
+	var fields []FieldSpec
+	for _, spec := range allWidgetSpecs {
+		if spec.JSONType == widgetType {
+			fields = make([]FieldSpec, 0, len(CommonWidgetFields)+len(spec.Fields))
+			fields = append(fields, CommonWidgetFields...)
+			fields = append(fields, spec.Fields...)
+			break
+		}
+	}
+	if len(fields) == 0 {
+		return normalizeValidationJSONPath(jsonPath)
+	}
+
+	tokens := strings.Split(normalizeValidationJSONPath(jsonPath), ".")
+	return strings.Join(fieldSpecJSONPathToHCL(fields, tokens), ".")
+}
+
+func normalizeValidationJSONPath(path string) string {
+	path = strings.ReplaceAll(path, "[", ".")
+	path = strings.ReplaceAll(path, "]", "")
+	return strings.Trim(path, ".")
+}
+
+func fieldSpecJSONPathToHCL(fields []FieldSpec, tokens []string) []string {
+	if len(tokens) == 0 {
+		return nil
+	}
+
+	for _, field := range fields {
+		jsonPath := field.effectiveJSONPath()
+		// Formula-and-function blocks use singular HCL names but are assembled
+		// into plural JSON arrays by the request post-processor.
+		if field.Type == TypeBlockList && field.JSONKey == "" && field.JSONPath == "" {
+			switch field.HCLKey {
+			case "query":
+				jsonPath = "queries"
+			case "formula":
+				jsonPath = "formulas"
+			}
+		}
+		jsonTokens := strings.Split(jsonPath, ".")
+		if !hasPathPrefix(tokens, jsonTokens) {
+			continue
+		}
+
+		result := []string{field.HCLKey}
+		rest := tokens[len(jsonTokens):]
+		switch field.Type {
+		case TypeBlock, TypeBlockList:
+			if len(rest) > 0 {
+				if _, err := strconv.Atoi(rest[0]); err == nil {
+					result = append(result, rest[0])
+					rest = rest[1:]
+				}
+			}
+			result = append(result, fieldSpecJSONPathToHCL(field.Children, rest)...)
+		case TypeOneOf:
+			// The selected HCL variant is not encoded in the JSON error path.
+			// Preserve the remaining backend path rather than inventing a block.
+			result = append(result, rest...)
+		default:
+			result = append(result, rest...)
+		}
+		return result
+	}
+
+	return tokens
+}
+
+func hasPathPrefix(path, prefix []string) bool {
+	if len(prefix) > len(path) {
+		return false
+	}
+	for i := range prefix {
+		if path[i] != prefix[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // buildWidgetEngineJSONFromMap builds the JSON for a single widget from a SDKv2 map.
 // Parallel to buildWidgetEngineJSON but reads from map[string]interface{}.
 func buildWidgetEngineJSONFromMap(widget map[string]interface{}) map[string]interface{} {

--- a/datadog/dashboardmapping/engine.go
+++ b/datadog/dashboardmapping/engine.go
@@ -1811,16 +1811,24 @@ func BuildWidgetEngineJSONFromMap(widget map[string]interface{}) map[string]inte
 	return buildWidgetEngineJSONFromMap(widget)
 }
 
+func widgetSpecForJSONType(widgetType string) *WidgetSpec {
+	for i := range allWidgetSpecs {
+		if allWidgetSpecs[i].JSONType == widgetType {
+			return &allWidgetSpecs[i]
+		}
+	}
+	return nil
+}
+
 // WidgetDefinitionHCLKey returns the Terraform block name for a widget JSON
 // type. Validation APIs speak in JSON paths, while provider errors must point
 // users to the corresponding HCL configuration.
 func WidgetDefinitionHCLKey(widgetType string) string {
-	for _, spec := range allWidgetSpecs {
-		if spec.JSONType == widgetType {
-			return spec.HCLKey
-		}
+	spec := widgetSpecForJSONType(widgetType)
+	if spec == nil {
+		return "unknown_definition"
 	}
-	return "unknown_definition"
+	return spec.HCLKey
 }
 
 // WidgetErrorPathToHCL translates a widget-definition JSON error path, such as
@@ -1828,18 +1836,13 @@ func WidgetDefinitionHCLKey(widgetType string) string {
 // "request.0.q". Unknown path segments are preserved so backend errors never
 // lose useful location information.
 func WidgetErrorPathToHCL(widgetType, jsonPath string) string {
-	var fields []FieldSpec
-	for _, spec := range allWidgetSpecs {
-		if spec.JSONType == widgetType {
-			fields = make([]FieldSpec, 0, len(CommonWidgetFields)+len(spec.Fields))
-			fields = append(fields, CommonWidgetFields...)
-			fields = append(fields, spec.Fields...)
-			break
-		}
-	}
-	if len(fields) == 0 {
+	spec := widgetSpecForJSONType(widgetType)
+	if spec == nil {
 		return normalizeValidationJSONPath(jsonPath)
 	}
+	fields := make([]FieldSpec, 0, len(CommonWidgetFields)+len(spec.Fields))
+	fields = append(fields, CommonWidgetFields...)
+	fields = append(fields, spec.Fields...)
 
 	tokens := strings.Split(normalizeValidationJSONPath(jsonPath), ".")
 	return strings.Join(fieldSpecJSONPathToHCL(fields, tokens), ".")

--- a/datadog/dashboardmapping/validation_path_test.go
+++ b/datadog/dashboardmapping/validation_path_test.go
@@ -1,0 +1,51 @@
+package dashboardmapping
+
+import "testing"
+
+func TestWidgetDefinitionHCLKey(t *testing.T) {
+	if got := WidgetDefinitionHCLKey("timeseries"); got != "timeseries_definition" {
+		t.Fatalf("expected timeseries_definition, got %q", got)
+	}
+}
+
+func TestWidgetErrorPathToHCL(t *testing.T) {
+	tests := []struct {
+		name       string
+		widgetType string
+		jsonPath   string
+		want       string
+	}{
+		{
+			name:       "legacy request query",
+			widgetType: "timeseries",
+			jsonPath:   "requests.0.q",
+			want:       "request.0.q",
+		},
+		{
+			name:       "bracket indexes",
+			widgetType: "timeseries",
+			jsonPath:   "requests[0].q",
+			want:       "request.0.q",
+		},
+		{
+			name:       "formula and function query",
+			widgetType: "timeseries",
+			jsonPath:   "requests.0.queries.1.query",
+			want:       "request.0.query.1.query",
+		},
+		{
+			name:       "unknown widget preserves backend path",
+			widgetType: "future_widget",
+			jsonPath:   "requests.0.q",
+			want:       "requests.0.q",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := WidgetErrorPathToHCL(test.widgetType, test.jsonPath); got != test.want {
+				t.Fatalf("expected %q, got %q", test.want, got)
+			}
+		})
+	}
+}

--- a/datadog/dashboardmapping/validation_path_test.go
+++ b/datadog/dashboardmapping/validation_path_test.go
@@ -28,6 +28,12 @@ func TestWidgetErrorPathToHCL(t *testing.T) {
 			want:       "request.0.q",
 		},
 		{
+			name:       "backend list representation",
+			widgetType: "timeseries",
+			jsonPath:   "['requests', 0, 'q']",
+			want:       "request.0.q",
+		},
+		{
 			name:       "formula and function query",
 			widgetType: "timeseries",
 			jsonPath:   "requests.0.queries.1.query",

--- a/datadog/resource_datadog_dashboard_v2.go
+++ b/datadog/resource_datadog_dashboard_v2.go
@@ -2,17 +2,24 @@ package datadog
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/dashboardmapping"
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 )
+
+const dashboardWidgetValidationPath = "/api/unstable/graphing/validate_dashboard_widgets_for_llm"
 
 // resourceDatadogDashboardV2 returns the SDKv2 resource for datadog_dashboard_v2.
 // It shares all FieldSpec/WidgetSpec declarations via the dashboardmapping package.
@@ -26,7 +33,7 @@ func resourceDatadogDashboardV2() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+		CustomizeDiff: func(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 			oldValue, newValue := diff.GetChange("dashboard_lists")
 			if !oldValue.(*schema.Set).Equal(newValue.(*schema.Set)) {
 				removed := oldValue.(*schema.Set).Difference(newValue.(*schema.Set))
@@ -45,7 +52,7 @@ func resourceDatadogDashboardV2() *schema.Resource {
 				return fmt.Errorf("%s", strings.Join(errs, "\n"))
 			}
 
-			return nil
+			return resourceDatadogDashboardV2ValidateWidgets(ctx, diff, meta)
 		},
 		SchemaFunc: buildDashboardV2Schema,
 	}
@@ -67,6 +74,15 @@ func buildDashboardV2Schema() map[string]*schema.Schema {
 			return true
 		},
 	}
+	topSchema["validate"] = &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "If set to `false`, skip dashboard widget validation during plan. Defaults to `true`.",
+		DiffSuppressFunc: func(_, _, _ string, _ *schema.ResourceData) bool {
+			// This provider-only setting is never sent to the backend.
+			return true
+		},
+	}
 
 	// Add widget block with all widget types
 	widgetSchema := dashboardmapping.AllWidgetSDKv2Schema(false)
@@ -80,6 +96,177 @@ func buildDashboardV2Schema() map[string]*schema.Schema {
 	}
 
 	return topSchema
+}
+
+type dashboardWidgetDefinition struct {
+	path       string
+	definition map[string]interface{}
+}
+
+type dashboardWidgetValidationResult struct {
+	IsValid      bool    `json:"is_valid"`
+	WidgetType   *string `json:"widget_type"`
+	ErrorMessage *string `json:"error_message"`
+	ErrorPath    *string `json:"error_path"`
+}
+
+// resourceDatadogDashboardV2ValidateWidgets validates fully known widget definitions
+// during planning. Like monitor validation, callers can explicitly opt out.
+func resourceDatadogDashboardV2ValidateWidgets(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+	if validate, ok := diff.GetOkExists("validate"); ok && !validate.(bool) {
+		return nil
+	}
+	widgets, ok := diff.GetOk("widget")
+	if !ok {
+		return nil
+	}
+	if !dashboardWidgetValuesKnown(diff) {
+		// Values that depend on other resources are not available during planning.
+		return nil
+	}
+	definitions := flattenDashboardWidgetDefinitions(widgets)
+	if len(definitions) == 0 {
+		return nil
+	}
+
+	providerConf := meta.(*ProviderConfiguration)
+	return validateDashboardWidgetDefinitions(
+		ctx,
+		providerConf.Auth,
+		providerConf.DatadogApiInstances.HttpClient,
+		definitions,
+	)
+}
+
+func dashboardWidgetValuesKnown(diff *schema.ResourceDiff) bool {
+	widgetConfig, diagnostics := diff.GetRawConfigAt(cty.GetAttrPath("widget"))
+	if diagnostics.HasError() {
+		// Resource.Diff-based unit tests do not populate RawConfig. Fall back to
+		// the parent availability check for that legacy-only SDK call path.
+		return diff.NewValueKnown("widget")
+	}
+	return dashboardWidgetConfigKnown(widgetConfig)
+}
+
+func dashboardWidgetConfigKnown(widgetConfig cty.Value) bool {
+	return widgetConfig.IsWhollyKnown()
+}
+
+// flattenDashboardWidgetDefinitions converts the SDKv2 widget representation to
+// API widget definitions. Group children are validated separately so errors point
+// to the specific nested widget.
+func flattenDashboardWidgetDefinitions(widgets interface{}) []dashboardWidgetDefinition {
+	widgetList, ok := widgets.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	definitions := make([]dashboardWidgetDefinition, 0, len(widgetList))
+	for i, rawWidget := range widgetList {
+		widget, ok := rawWidget.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		widgetJSON := dashboardmapping.BuildWidgetEngineJSONFromMap(widget)
+		definition, ok := widgetJSON["definition"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		appendDashboardWidgetDefinition(&definitions, fmt.Sprintf("widget %d", i+1), definition)
+	}
+	return definitions
+}
+
+func appendDashboardWidgetDefinition(definitions *[]dashboardWidgetDefinition, path string, definition map[string]interface{}) {
+	if definition["type"] != "group" {
+		*definitions = append(*definitions, dashboardWidgetDefinition{path: path, definition: definition})
+		return
+	}
+
+	groupDefinition := make(map[string]interface{}, len(definition))
+	for key, value := range definition {
+		groupDefinition[key] = value
+	}
+	groupDefinition["widgets"] = []interface{}{}
+	*definitions = append(*definitions, dashboardWidgetDefinition{path: path, definition: groupDefinition})
+
+	children, ok := definition["widgets"].([]interface{})
+	if !ok {
+		return
+	}
+	for i, rawChild := range children {
+		child, ok := rawChild.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		childDefinition, ok := child["definition"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		appendDashboardWidgetDefinition(definitions, fmt.Sprintf("%s > child %d", path, i+1), childDefinition)
+	}
+}
+
+func validateDashboardWidgetDefinitions(
+	ctx context.Context,
+	auth context.Context,
+	client *datadog.APIClient,
+	definitions []dashboardWidgetDefinition,
+) error {
+	widgetDefinitions := make([]map[string]interface{}, len(definitions))
+	for i, definition := range definitions {
+		widgetDefinitions[i] = definition.definition
+	}
+	body := map[string]interface{}{"widget_definitions": widgetDefinitions}
+
+	return retry.RetryContext(ctx, retryTimeout, func() *retry.RetryError {
+		responseBody, httpResponse, err := utils.SendRequest(auth, client, http.MethodPost, dashboardWidgetValidationPath, &body)
+		if err != nil {
+			translatedErr := utils.TranslateClientError(err, httpResponse, "error validating dashboard widgets")
+			if httpResponse != nil && (httpResponse.StatusCode == http.StatusBadGateway || httpResponse.StatusCode == http.StatusGatewayTimeout) {
+				return retry.RetryableError(translatedErr)
+			}
+			return retry.NonRetryableError(translatedErr)
+		}
+
+		var response struct {
+			Results []dashboardWidgetValidationResult `json:"results"`
+		}
+		if err := json.Unmarshal(responseBody, &response); err != nil {
+			return retry.NonRetryableError(fmt.Errorf("error parsing dashboard widget validation response: %w", err))
+		}
+		if len(response.Results) != len(definitions) {
+			return retry.NonRetryableError(fmt.Errorf(
+				"dashboard widget validation response contained %d results for %d widgets",
+				len(response.Results),
+				len(definitions),
+			))
+		}
+
+		failures := make([]string, 0)
+		for i, result := range response.Results {
+			if result.IsValid {
+				continue
+			}
+			message := "invalid widget definition"
+			if result.ErrorMessage != nil && *result.ErrorMessage != "" {
+				message = *result.ErrorMessage
+			}
+			if result.ErrorPath != nil && *result.ErrorPath != "" && !strings.Contains(message, *result.ErrorPath) {
+				message = fmt.Sprintf("%s: %s", *result.ErrorPath, message)
+			}
+			widgetType := "unknown"
+			if result.WidgetType != nil && *result.WidgetType != "" {
+				widgetType = *result.WidgetType
+			}
+			failures = append(failures, fmt.Sprintf("%s (%s): %s", definitions[i].path, widgetType, message))
+		}
+		if len(failures) > 0 {
+			return retry.NonRetryableError(fmt.Errorf("dashboard widget validation failed:\n%s", strings.Join(failures, "\n")))
+		}
+
+		return nil
+	})
 }
 
 // resourceDatadogDashboardV2Create creates a new dashboard via the Datadog API.

--- a/datadog/resource_datadog_dashboard_v2.go
+++ b/datadog/resource_datadog_dashboard_v2.go
@@ -76,7 +76,7 @@ func buildDashboardV2Schema() map[string]*schema.Schema {
 	topSchema["validate"] = &schema.Schema{
 		Type:        schema.TypeBool,
 		Optional:    true,
-		Description: "If set to `false`, skip dashboard widget validation during plan. Defaults to `true`.",
+		Description: "Whether to send widget definitions to the Datadog API to validate widget configuration and query values during `terraform plan`. Defaults to `true`. Setting this to `false` skips only the Datadog API validation; local Terraform schema and conflicting-field checks still run.",
 		DiffSuppressFunc: func(_, _, _ string, _ *schema.ResourceData) bool {
 			// This provider-only setting is never sent to the backend.
 			return true

--- a/datadog/resource_datadog_dashboard_v2.go
+++ b/datadog/resource_datadog_dashboard_v2.go
@@ -120,11 +120,12 @@ func resourceDatadogDashboardV2ValidateWidgets(ctx context.Context, diff *schema
 	if !ok {
 		return nil
 	}
-	if !dashboardWidgetValuesKnown(diff) {
-		// Values that depend on other resources are not available during planning.
+	widgetList, ok := widgets.([]interface{})
+	if !ok {
 		return nil
 	}
-	definitions := flattenDashboardWidgetDefinitions(widgets)
+	knownWidgetIndexes := dashboardKnownWidgetIndexes(diff, len(widgetList))
+	definitions := flattenDashboardWidgetDefinitionsAtIndexes(widgetList, knownWidgetIndexes)
 	if len(definitions) == 0 {
 		return nil
 	}
@@ -138,18 +139,41 @@ func resourceDatadogDashboardV2ValidateWidgets(ctx context.Context, diff *schema
 	)
 }
 
-func dashboardWidgetValuesKnown(diff *schema.ResourceDiff) bool {
+func dashboardKnownWidgetIndexes(diff *schema.ResourceDiff, widgetCount int) map[int]struct{} {
 	widgetConfig, diagnostics := diff.GetRawConfigAt(cty.GetAttrPath("widget"))
 	if diagnostics.HasError() {
 		// Resource.Diff-based unit tests do not populate RawConfig. Fall back to
 		// the parent availability check for that legacy-only SDK call path.
-		return diff.NewValueKnown("widget")
+		if !diff.NewValueKnown("widget") {
+			return nil
+		}
+		knownIndexes := make(map[int]struct{}, widgetCount)
+		for i := 0; i < widgetCount; i++ {
+			knownIndexes[i] = struct{}{}
+		}
+		return knownIndexes
 	}
-	return dashboardWidgetConfigKnown(widgetConfig)
+	return dashboardKnownWidgetIndexesFromConfig(widgetConfig)
 }
 
-func dashboardWidgetConfigKnown(widgetConfig cty.Value) bool {
-	return widgetConfig.IsWhollyKnown()
+func dashboardKnownWidgetIndexesFromConfig(widgetConfig cty.Value) map[int]struct{} {
+	knownIndexes := make(map[int]struct{})
+	widgetConfig, _ = widgetConfig.UnmarkDeep()
+	if !widgetConfig.IsKnown() || widgetConfig.IsNull() {
+		return knownIndexes
+	}
+	if !widgetConfig.CanIterateElements() {
+		return knownIndexes
+	}
+
+	iterator := widgetConfig.ElementIterator()
+	for i := 0; iterator.Next(); i++ {
+		_, widgetConfig := iterator.Element()
+		if widgetConfig.IsWhollyKnown() {
+			knownIndexes[i] = struct{}{}
+		}
+	}
+	return knownIndexes
 }
 
 // flattenDashboardWidgetDefinitions converts the SDKv2 widget representation to
@@ -160,9 +184,19 @@ func flattenDashboardWidgetDefinitions(widgets interface{}) []dashboardWidgetDef
 	if !ok {
 		return nil
 	}
+	knownWidgetIndexes := make(map[int]struct{}, len(widgetList))
+	for i := range widgetList {
+		knownWidgetIndexes[i] = struct{}{}
+	}
+	return flattenDashboardWidgetDefinitionsAtIndexes(widgetList, knownWidgetIndexes)
+}
 
+func flattenDashboardWidgetDefinitionsAtIndexes(widgetList []interface{}, knownWidgetIndexes map[int]struct{}) []dashboardWidgetDefinition {
 	definitions := make([]dashboardWidgetDefinition, 0, len(widgetList))
 	for i, rawWidget := range widgetList {
+		if _, known := knownWidgetIndexes[i]; !known {
+			continue
+		}
 		widget, ok := rawWidget.(map[string]interface{})
 		if !ok {
 			continue

--- a/datadog/resource_datadog_dashboard_v2.go
+++ b/datadog/resource_datadog_dashboard_v2.go
@@ -110,8 +110,7 @@ type dashboardWidgetValidationResult struct {
 	ErrorPath    *string `json:"error_path"`
 }
 
-// resourceDatadogDashboardV2ValidateWidgets validates widget definitions during
-// planning. Like monitor validation, callers can explicitly opt out.
+// resourceDatadogDashboardV2ValidateWidgets validates widget definitions during planning.
 func resourceDatadogDashboardV2ValidateWidgets(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 	if validate, ok := diff.GetOkExists("validate"); ok && !validate.(bool) {
 		return nil
@@ -228,6 +227,7 @@ func validateDashboardWidgets(
 	}
 
 	return retry.RetryContext(ctx, retryTimeout, func() *retry.RetryError {
+		// Use the raw request helper until this endpoint is available in the generated Datadog API client.
 		responseBody, httpResponse, err := utils.SendRequest(auth, client, http.MethodPost, dashboardWidgetValidationPath, &body)
 		if err != nil {
 			translatedErr := utils.TranslateClientError(err, httpResponse, "error validating dashboard widgets")

--- a/datadog/resource_datadog_dashboard_v2.go
+++ b/datadog/resource_datadog_dashboard_v2.go
@@ -18,8 +18,8 @@ import (
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 )
 
-// TODO: Replace this raw endpoint path with the generated Datadog API client method once the endpoint is published in the API spec and client.
-const dashboardWidgetValidationPath = "/api/v2/dashboard/widgets/validate"
+// TODO: Replace this raw endpoint path with the generated Datadog API client method once the unstable endpoint is published in the API spec and client.
+const dashboardWidgetValidationPath = "/api/unstable/dashboard/widgets/validate"
 
 // resourceDatadogDashboardV2 returns the SDKv2 resource for datadog_dashboard_v2.
 // It shares all FieldSpec/WidgetSpec declarations via the dashboardmapping package.
@@ -115,6 +115,12 @@ func resourceDatadogDashboardV2ValidateWidgets(ctx context.Context, diff *schema
 	if validate, ok := diff.GetOkExists("validate"); ok && !validate.(bool) {
 		return nil
 	}
+	widgetSchema := buildDashboardV2Schema()["widget"]
+	if !dashboardV2ConfigValueKnown(diff, "widget", widgetSchema) ||
+		!diff.NewValueKnown("layout_type") ||
+		!diff.NewValueKnown("reflow_type") {
+		return nil
+	}
 	widgets, ok := diff.GetOk("widget")
 	if !ok {
 		return nil
@@ -135,6 +141,50 @@ func resourceDatadogDashboardV2ValidateWidgets(ctx context.Context, diff *schema
 		layoutType,
 		reflowType,
 	)
+}
+
+// dashboardV2ConfigValueKnown reports whether every configurable value is
+// known. Computed fields are ignored because Terraform populates them with
+// unknown placeholders during planning even though they are not API inputs.
+func dashboardV2ConfigValueKnown(diff *schema.ResourceDiff, path string, fieldSchema *schema.Schema) bool {
+	if fieldSchema.Computed {
+		return true
+	}
+	if !diff.NewValueKnown(path) {
+		return false
+	}
+
+	if fieldSchema.Type != schema.TypeList {
+		return true
+	}
+	values, ok := diff.Get(path).([]interface{})
+	if !ok {
+		return true
+	}
+	for i := range values {
+		elementPath := fmt.Sprintf("%s.%d", path, i)
+		switch elementSchema := fieldSchema.Elem.(type) {
+		case *schema.Schema:
+			if !dashboardV2ConfigValueKnown(diff, elementPath, elementSchema) {
+				return false
+			}
+		case *schema.Resource:
+			if !dashboardV2ConfigObjectKnown(diff, elementPath, elementSchema.Schema) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+func dashboardV2ConfigObjectKnown(diff *schema.ResourceDiff, path string, objectSchema map[string]*schema.Schema) bool {
+	for name, fieldSchema := range objectSchema {
+		if !dashboardV2ConfigValueKnown(diff, path+"."+name, fieldSchema) {
+			return false
+		}
+	}
+	return true
 }
 
 // flattenDashboardWidgets converts the SDKv2 widget representation to API

--- a/datadog/resource_datadog_dashboard_v2.go
+++ b/datadog/resource_datadog_dashboard_v2.go
@@ -77,7 +77,7 @@ func buildDashboardV2Schema() map[string]*schema.Schema {
 	topSchema["validate"] = &schema.Schema{
 		Type:        schema.TypeBool,
 		Optional:    true,
-		Description: "Whether to send widgets to the Datadog API to validate widget configuration and query values during `terraform plan`. Defaults to `true`. Setting this to `false` skips only the Datadog API validation; local Terraform schema and conflicting-field checks still run.",
+		Description: "Whether to send widgets to the Datadog API to validate widget configuration and query values during `terraform plan`. Defaults to `true`. Setting this to `false` skips only the Datadog API validation; local Terraform schema and checks for conflicting fields still run.",
 		DiffSuppressFunc: func(_, _, _ string, _ *schema.ResourceData) bool {
 			// This provider-only setting is never sent to the backend.
 			return true

--- a/datadog/resource_datadog_dashboard_v2.go
+++ b/datadog/resource_datadog_dashboard_v2.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -99,8 +98,8 @@ func buildDashboardV2Schema() map[string]*schema.Schema {
 }
 
 type dashboardWidgetDefinition struct {
-	path       string
-	definition map[string]interface{}
+	terraformPath string
+	definition    map[string]interface{}
 }
 
 type dashboardWidgetValidationResult struct {
@@ -110,8 +109,8 @@ type dashboardWidgetValidationResult struct {
 	ErrorPath    *string `json:"error_path"`
 }
 
-// resourceDatadogDashboardV2ValidateWidgets validates fully known widget definitions
-// during planning. Like monitor validation, callers can explicitly opt out.
+// resourceDatadogDashboardV2ValidateWidgets validates widget definitions during
+// planning. Like monitor validation, callers can explicitly opt out.
 func resourceDatadogDashboardV2ValidateWidgets(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 	if validate, ok := diff.GetOkExists("validate"); ok && !validate.(bool) {
 		return nil
@@ -120,12 +119,7 @@ func resourceDatadogDashboardV2ValidateWidgets(ctx context.Context, diff *schema
 	if !ok {
 		return nil
 	}
-	widgetList, ok := widgets.([]interface{})
-	if !ok {
-		return nil
-	}
-	knownWidgetIndexes := dashboardKnownWidgetIndexes(diff, len(widgetList))
-	definitions := flattenDashboardWidgetDefinitionsAtIndexes(widgetList, knownWidgetIndexes)
+	definitions := flattenDashboardWidgetDefinitions(widgets)
 	if len(definitions) == 0 {
 		return nil
 	}
@@ -139,43 +133,6 @@ func resourceDatadogDashboardV2ValidateWidgets(ctx context.Context, diff *schema
 	)
 }
 
-func dashboardKnownWidgetIndexes(diff *schema.ResourceDiff, widgetCount int) map[int]struct{} {
-	widgetConfig, diagnostics := diff.GetRawConfigAt(cty.GetAttrPath("widget"))
-	if diagnostics.HasError() {
-		// Resource.Diff-based unit tests do not populate RawConfig. Fall back to
-		// the parent availability check for that legacy-only SDK call path.
-		if !diff.NewValueKnown("widget") {
-			return nil
-		}
-		knownIndexes := make(map[int]struct{}, widgetCount)
-		for i := 0; i < widgetCount; i++ {
-			knownIndexes[i] = struct{}{}
-		}
-		return knownIndexes
-	}
-	return dashboardKnownWidgetIndexesFromConfig(widgetConfig)
-}
-
-func dashboardKnownWidgetIndexesFromConfig(widgetConfig cty.Value) map[int]struct{} {
-	knownIndexes := make(map[int]struct{})
-	widgetConfig, _ = widgetConfig.UnmarkDeep()
-	if !widgetConfig.IsKnown() || widgetConfig.IsNull() {
-		return knownIndexes
-	}
-	if !widgetConfig.CanIterateElements() {
-		return knownIndexes
-	}
-
-	iterator := widgetConfig.ElementIterator()
-	for i := 0; iterator.Next(); i++ {
-		_, widgetConfig := iterator.Element()
-		if widgetConfig.IsWhollyKnown() {
-			knownIndexes[i] = struct{}{}
-		}
-	}
-	return knownIndexes
-}
-
 // flattenDashboardWidgetDefinitions converts the SDKv2 widget representation to
 // API widget definitions. Group children are validated separately so errors point
 // to the specific nested widget.
@@ -184,19 +141,8 @@ func flattenDashboardWidgetDefinitions(widgets interface{}) []dashboardWidgetDef
 	if !ok {
 		return nil
 	}
-	knownWidgetIndexes := make(map[int]struct{}, len(widgetList))
-	for i := range widgetList {
-		knownWidgetIndexes[i] = struct{}{}
-	}
-	return flattenDashboardWidgetDefinitionsAtIndexes(widgetList, knownWidgetIndexes)
-}
-
-func flattenDashboardWidgetDefinitionsAtIndexes(widgetList []interface{}, knownWidgetIndexes map[int]struct{}) []dashboardWidgetDefinition {
 	definitions := make([]dashboardWidgetDefinition, 0, len(widgetList))
 	for i, rawWidget := range widgetList {
-		if _, known := knownWidgetIndexes[i]; !known {
-			continue
-		}
 		widget, ok := rawWidget.(map[string]interface{})
 		if !ok {
 			continue
@@ -206,14 +152,17 @@ func flattenDashboardWidgetDefinitionsAtIndexes(widgetList []interface{}, knownW
 		if !ok {
 			continue
 		}
-		appendDashboardWidgetDefinition(&definitions, fmt.Sprintf("widget %d", i+1), definition)
+		widgetType, _ := definition["type"].(string)
+		definitionKey := dashboardmapping.WidgetDefinitionHCLKey(widgetType)
+		terraformPath := fmt.Sprintf("widget.%d.%s.0", i, definitionKey)
+		appendDashboardWidgetDefinition(&definitions, terraformPath, definition)
 	}
 	return definitions
 }
 
-func appendDashboardWidgetDefinition(definitions *[]dashboardWidgetDefinition, path string, definition map[string]interface{}) {
+func appendDashboardWidgetDefinition(definitions *[]dashboardWidgetDefinition, terraformPath string, definition map[string]interface{}) {
 	if definition["type"] != "group" {
-		*definitions = append(*definitions, dashboardWidgetDefinition{path: path, definition: definition})
+		*definitions = append(*definitions, dashboardWidgetDefinition{terraformPath: terraformPath, definition: definition})
 		return
 	}
 
@@ -222,7 +171,7 @@ func appendDashboardWidgetDefinition(definitions *[]dashboardWidgetDefinition, p
 		groupDefinition[key] = value
 	}
 	groupDefinition["widgets"] = []interface{}{}
-	*definitions = append(*definitions, dashboardWidgetDefinition{path: path, definition: groupDefinition})
+	*definitions = append(*definitions, dashboardWidgetDefinition{terraformPath: terraformPath, definition: groupDefinition})
 
 	children, ok := definition["widgets"].([]interface{})
 	if !ok {
@@ -237,7 +186,10 @@ func appendDashboardWidgetDefinition(definitions *[]dashboardWidgetDefinition, p
 		if !ok {
 			continue
 		}
-		appendDashboardWidgetDefinition(definitions, fmt.Sprintf("%s > child %d", path, i+1), childDefinition)
+		childType, _ := childDefinition["type"].(string)
+		childDefinitionKey := dashboardmapping.WidgetDefinitionHCLKey(childType)
+		childTerraformPath := fmt.Sprintf("%s.widget.%d.%s.0", terraformPath, i, childDefinitionKey)
+		appendDashboardWidgetDefinition(definitions, childTerraformPath, childDefinition)
 	}
 }
 
@@ -286,14 +238,18 @@ func validateDashboardWidgetDefinitions(
 			if result.ErrorMessage != nil && *result.ErrorMessage != "" {
 				message = *result.ErrorMessage
 			}
-			if result.ErrorPath != nil && *result.ErrorPath != "" && !strings.Contains(message, *result.ErrorPath) {
-				message = fmt.Sprintf("%s: %s", *result.ErrorPath, message)
-			}
 			widgetType := "unknown"
 			if result.WidgetType != nil && *result.WidgetType != "" {
 				widgetType = *result.WidgetType
 			}
-			failures = append(failures, fmt.Sprintf("%s (%s): %s", definitions[i].path, widgetType, message))
+			terraformPath := definitions[i].terraformPath
+			if result.ErrorPath != nil && *result.ErrorPath != "" {
+				mappedPath := dashboardmapping.WidgetErrorPathToHCL(widgetType, *result.ErrorPath)
+				if mappedPath != "" {
+					terraformPath += "." + mappedPath
+				}
+			}
+			failures = append(failures, fmt.Sprintf("%s (%s): %s", terraformPath, widgetType, message))
 		}
 		if len(failures) > 0 {
 			return retry.NonRetryableError(fmt.Errorf("dashboard widget validation failed:\n%s", strings.Join(failures, "\n")))

--- a/datadog/resource_datadog_dashboard_v2.go
+++ b/datadog/resource_datadog_dashboard_v2.go
@@ -18,7 +18,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 )
 
-const dashboardWidgetValidationPath = "/api/unstable/graphing/validate_dashboard_widgets_for_llm"
+const dashboardWidgetValidationPath = "/api/v1/dashboard/widgets/validate"
 
 // resourceDatadogDashboardV2 returns the SDKv2 resource for datadog_dashboard_v2.
 // It shares all FieldSpec/WidgetSpec declarations via the dashboardmapping package.
@@ -76,7 +76,7 @@ func buildDashboardV2Schema() map[string]*schema.Schema {
 	topSchema["validate"] = &schema.Schema{
 		Type:        schema.TypeBool,
 		Optional:    true,
-		Description: "Whether to send widget definitions to the Datadog API to validate widget configuration and query values during `terraform plan`. Defaults to `true`. Setting this to `false` skips only the Datadog API validation; local Terraform schema and conflicting-field checks still run.",
+		Description: "Whether to send widgets to the Datadog API to validate widget configuration and query values during `terraform plan`. Defaults to `true`. Setting this to `false` skips only the Datadog API validation; local Terraform schema and conflicting-field checks still run.",
 		DiffSuppressFunc: func(_, _, _ string, _ *schema.ResourceData) bool {
 			// This provider-only setting is never sent to the backend.
 			return true
@@ -97,9 +97,9 @@ func buildDashboardV2Schema() map[string]*schema.Schema {
 	return topSchema
 }
 
-type dashboardWidgetDefinition struct {
+type dashboardWidget struct {
 	terraformPath string
-	definition    map[string]interface{}
+	widget        map[string]interface{}
 }
 
 type dashboardWidgetValidationResult struct {
@@ -119,29 +119,33 @@ func resourceDatadogDashboardV2ValidateWidgets(ctx context.Context, diff *schema
 	if !ok {
 		return nil
 	}
-	definitions := flattenDashboardWidgetDefinitions(widgets)
-	if len(definitions) == 0 {
+	validationWidgets := flattenDashboardWidgets(widgets)
+	if len(validationWidgets) == 0 {
 		return nil
 	}
+	layoutType, _ := diff.Get("layout_type").(string)
+	reflowType, _ := diff.Get("reflow_type").(string)
 
 	providerConf := meta.(*ProviderConfiguration)
-	return validateDashboardWidgetDefinitions(
+	return validateDashboardWidgets(
 		ctx,
 		providerConf.Auth,
 		providerConf.DatadogApiInstances.HttpClient,
-		definitions,
+		validationWidgets,
+		layoutType,
+		reflowType,
 	)
 }
 
-// flattenDashboardWidgetDefinitions converts the SDKv2 widget representation to
-// API widget definitions. Group children are validated separately so errors point
-// to the specific nested widget.
-func flattenDashboardWidgetDefinitions(widgets interface{}) []dashboardWidgetDefinition {
+// flattenDashboardWidgets converts the SDKv2 widget representation to API
+// widgets. Group children are validated separately so errors point to the
+// specific nested widget.
+func flattenDashboardWidgets(widgets interface{}) []dashboardWidget {
 	widgetList, ok := widgets.([]interface{})
 	if !ok {
 		return nil
 	}
-	definitions := make([]dashboardWidgetDefinition, 0, len(widgetList))
+	validationWidgets := make([]dashboardWidget, 0, len(widgetList))
 	for i, rawWidget := range widgetList {
 		widget, ok := rawWidget.(map[string]interface{})
 		if !ok {
@@ -155,23 +159,32 @@ func flattenDashboardWidgetDefinitions(widgets interface{}) []dashboardWidgetDef
 		widgetType, _ := definition["type"].(string)
 		definitionKey := dashboardmapping.WidgetDefinitionHCLKey(widgetType)
 		terraformPath := fmt.Sprintf("widget.%d.%s.0", i, definitionKey)
-		appendDashboardWidgetDefinition(&definitions, terraformPath, definition)
+		appendDashboardWidget(&validationWidgets, terraformPath, widgetJSON)
 	}
-	return definitions
+	return validationWidgets
 }
 
-func appendDashboardWidgetDefinition(definitions *[]dashboardWidgetDefinition, terraformPath string, definition map[string]interface{}) {
+func appendDashboardWidget(widgets *[]dashboardWidget, terraformPath string, widget map[string]interface{}) {
+	definition, ok := widget["definition"].(map[string]interface{})
+	if !ok {
+		return
+	}
 	if definition["type"] != "group" {
-		*definitions = append(*definitions, dashboardWidgetDefinition{terraformPath: terraformPath, definition: definition})
+		*widgets = append(*widgets, dashboardWidget{terraformPath: terraformPath, widget: widget})
 		return
 	}
 
+	groupWidget := make(map[string]interface{}, len(widget))
+	for key, value := range widget {
+		groupWidget[key] = value
+	}
 	groupDefinition := make(map[string]interface{}, len(definition))
 	for key, value := range definition {
 		groupDefinition[key] = value
 	}
 	groupDefinition["widgets"] = []interface{}{}
-	*definitions = append(*definitions, dashboardWidgetDefinition{terraformPath: terraformPath, definition: groupDefinition})
+	groupWidget["definition"] = groupDefinition
+	*widgets = append(*widgets, dashboardWidget{terraformPath: terraformPath, widget: groupWidget})
 
 	children, ok := definition["widgets"].([]interface{})
 	if !ok {
@@ -189,21 +202,29 @@ func appendDashboardWidgetDefinition(definitions *[]dashboardWidgetDefinition, t
 		childType, _ := childDefinition["type"].(string)
 		childDefinitionKey := dashboardmapping.WidgetDefinitionHCLKey(childType)
 		childTerraformPath := fmt.Sprintf("%s.widget.%d.%s.0", terraformPath, i, childDefinitionKey)
-		appendDashboardWidgetDefinition(definitions, childTerraformPath, childDefinition)
+		appendDashboardWidget(widgets, childTerraformPath, child)
 	}
 }
 
-func validateDashboardWidgetDefinitions(
+func validateDashboardWidgets(
 	ctx context.Context,
 	auth context.Context,
 	client *datadog.APIClient,
-	definitions []dashboardWidgetDefinition,
+	validationWidgets []dashboardWidget,
+	layoutType string,
+	reflowType string,
 ) error {
-	widgetDefinitions := make([]map[string]interface{}, len(definitions))
-	for i, definition := range definitions {
-		widgetDefinitions[i] = definition.definition
+	widgets := make([]map[string]interface{}, len(validationWidgets))
+	for i, validationWidget := range validationWidgets {
+		widgets[i] = validationWidget.widget
 	}
-	body := map[string]interface{}{"widget_definitions": widgetDefinitions}
+	body := map[string]interface{}{
+		"widgets":     widgets,
+		"layout_type": layoutType,
+	}
+	if reflowType != "" {
+		body["reflow_type"] = reflowType
+	}
 
 	return retry.RetryContext(ctx, retryTimeout, func() *retry.RetryError {
 		responseBody, httpResponse, err := utils.SendRequest(auth, client, http.MethodPost, dashboardWidgetValidationPath, &body)
@@ -221,11 +242,11 @@ func validateDashboardWidgetDefinitions(
 		if err := json.Unmarshal(responseBody, &response); err != nil {
 			return retry.NonRetryableError(fmt.Errorf("error parsing dashboard widget validation response: %w", err))
 		}
-		if len(response.Results) != len(definitions) {
+		if len(response.Results) != len(validationWidgets) {
 			return retry.NonRetryableError(fmt.Errorf(
 				"dashboard widget validation response contained %d results for %d widgets",
 				len(response.Results),
-				len(definitions),
+				len(validationWidgets),
 			))
 		}
 
@@ -242,7 +263,7 @@ func validateDashboardWidgetDefinitions(
 			if result.WidgetType != nil && *result.WidgetType != "" {
 				widgetType = *result.WidgetType
 			}
-			terraformPath := definitions[i].terraformPath
+			terraformPath := validationWidgets[i].terraformPath
 			if result.ErrorPath != nil && *result.ErrorPath != "" {
 				mappedPath := dashboardmapping.WidgetErrorPathToHCL(widgetType, *result.ErrorPath)
 				if mappedPath != "" {

--- a/datadog/resource_datadog_dashboard_v2.go
+++ b/datadog/resource_datadog_dashboard_v2.go
@@ -18,7 +18,8 @@ import (
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 )
 
-const dashboardWidgetValidationPath = "/api/v1/dashboard/widgets/validate"
+// TODO: Replace this raw endpoint path with the generated Datadog API client method once the endpoint is published in the API spec and client.
+const dashboardWidgetValidationPath = "/api/v2/dashboard/widgets/validate"
 
 // resourceDatadogDashboardV2 returns the SDKv2 resource for datadog_dashboard_v2.
 // It shares all FieldSpec/WidgetSpec declarations via the dashboardmapping package.

--- a/datadog/resource_datadog_dashboard_v2_unit_test.go
+++ b/datadog/resource_datadog_dashboard_v2_unit_test.go
@@ -75,6 +75,20 @@ func TestFlattenDashboardWidgetDefinitions(t *testing.T) {
 	}
 }
 
+func TestFlattenDashboardWidgetDefinitionsAtIndexesPreservesPaths(t *testing.T) {
+	widgets := append(
+		dashboardV2TestTimeseriesWidgets("avg:system.load.1{*}"),
+		dashboardV2TestTimeseriesWidgets("avg:system.cpu.user{*}")...,
+	)
+	definitions := flattenDashboardWidgetDefinitionsAtIndexes(widgets, map[int]struct{}{1: {}})
+	if len(definitions) != 1 {
+		t.Fatalf("expected one known widget definition, got %d", len(definitions))
+	}
+	if got := definitions[0].path; got != "widget 2" {
+		t.Fatalf("expected original widget path to be preserved, got %q", got)
+	}
+}
+
 func TestDashboardV2PlanValidationCanBeDisabled(t *testing.T) {
 	config := map[string]interface{}{
 		"title":       "Plan-time validation test",
@@ -95,19 +109,23 @@ func TestDashboardV2PlanValidationCanBeDisabled(t *testing.T) {
 	}
 }
 
-func TestDashboardWidgetConfigKnown(t *testing.T) {
-	knownConfig := cty.ListVal([]cty.Value{
+func TestDashboardKnownWidgetIndexesFromConfig(t *testing.T) {
+	widgetConfig := cty.ListVal([]cty.Value{
 		cty.ObjectVal(map[string]cty.Value{"query": cty.StringVal("avg:system.load.1{*}")}),
-	})
-	if !dashboardWidgetConfigKnown(knownConfig) {
-		t.Fatal("expected literal widget config to be known")
-	}
-
-	unknownConfig := cty.ListVal([]cty.Value{
 		cty.ObjectVal(map[string]cty.Value{"query": cty.UnknownVal(cty.String)}),
+		cty.ObjectVal(map[string]cty.Value{"query": cty.StringVal("avg:system.cpu.user{*}")}),
 	})
-	if dashboardWidgetConfigKnown(unknownConfig) {
-		t.Fatal("expected interpolated widget query to remain unknown during plan")
+	knownIndexes := dashboardKnownWidgetIndexesFromConfig(widgetConfig)
+	if len(knownIndexes) != 2 {
+		t.Fatalf("expected two known widgets, got %#v", knownIndexes)
+	}
+	for _, index := range []int{0, 2} {
+		if _, ok := knownIndexes[index]; !ok {
+			t.Fatalf("expected widget %d to be known", index)
+		}
+	}
+	if _, ok := knownIndexes[1]; ok {
+		t.Fatal("expected interpolated widget to remain unknown during plan")
 	}
 }
 

--- a/datadog/resource_datadog_dashboard_v2_unit_test.go
+++ b/datadog/resource_datadog_dashboard_v2_unit_test.go
@@ -27,7 +27,7 @@ func TestBuildDashboardV2SchemaValidate(t *testing.T) {
 	}
 }
 
-func TestFlattenDashboardWidgetDefinitions(t *testing.T) {
+func TestFlattenDashboardWidgets(t *testing.T) {
 	widgets := []interface{}{
 		map[string]interface{}{
 			"group_definition": []interface{}{
@@ -46,6 +46,14 @@ func TestFlattenDashboardWidgetDefinitions(t *testing.T) {
 									},
 								},
 							},
+							"widget_layout": []interface{}{
+								map[string]interface{}{
+									"x":      0,
+									"y":      1,
+									"width":  4,
+									"height": 2,
+								},
+							},
 						},
 					},
 				},
@@ -53,24 +61,30 @@ func TestFlattenDashboardWidgetDefinitions(t *testing.T) {
 		},
 	}
 
-	definitions := flattenDashboardWidgetDefinitions(widgets)
-	if len(definitions) != 2 {
-		t.Fatalf("expected group and child definitions, got %d", len(definitions))
+	validationWidgets := flattenDashboardWidgets(widgets)
+	if len(validationWidgets) != 2 {
+		t.Fatalf("expected group and child widgets, got %d", len(validationWidgets))
 	}
-	if got := definitions[0].terraformPath; got != "widget.0.group_definition.0" {
+	if got := validationWidgets[0].terraformPath; got != "widget.0.group_definition.0" {
 		t.Fatalf("unexpected group path %q", got)
 	}
-	if got := definitions[0].definition["type"]; got != "group" {
+	groupDefinition := validationWidgets[0].widget["definition"].(map[string]interface{})
+	if got := groupDefinition["type"]; got != "group" {
 		t.Fatalf("unexpected group type %#v", got)
 	}
-	if children, ok := definitions[0].definition["widgets"].([]interface{}); !ok || len(children) != 0 {
-		t.Fatalf("group validation payload should not contain children, got %#v", definitions[0].definition["widgets"])
+	if children, ok := groupDefinition["widgets"].([]interface{}); !ok || len(children) != 0 {
+		t.Fatalf("group validation payload should not contain children, got %#v", groupDefinition["widgets"])
 	}
-	if got := definitions[1].terraformPath; got != "widget.0.group_definition.0.widget.0.timeseries_definition.0" {
+	if got := validationWidgets[1].terraformPath; got != "widget.0.group_definition.0.widget.0.timeseries_definition.0" {
 		t.Fatalf("unexpected child path %q", got)
 	}
-	if got := definitions[1].definition["type"]; got != "timeseries" {
+	childDefinition := validationWidgets[1].widget["definition"].(map[string]interface{})
+	if got := childDefinition["type"]; got != "timeseries" {
 		t.Fatalf("unexpected child type %#v", got)
+	}
+	childLayout := validationWidgets[1].widget["layout"].(map[string]interface{})
+	if childLayout["x"] != 0 || childLayout["y"] != 1 {
+		t.Fatalf("child validation payload should preserve its layout, got %#v", childLayout)
 	}
 }
 
@@ -98,7 +112,7 @@ func TestDashboardV2PlanValidationCallsEndpointByDefault(t *testing.T) {
 	called := false
 	client := dashboardValidationTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		called = true
-		assertDashboardValidationRequest(t, r, 1)
+		assertDashboardValidationRequest(t, r, 1, "ordered", "")
 		writeDashboardValidationResponse(t, w, map[string]interface{}{
 			"results": []interface{}{map[string]interface{}{"is_valid": true, "widget_type": "timeseries"}},
 		})
@@ -127,10 +141,11 @@ func TestDashboardV2PlanValidationRejectsMalformedQuery(t *testing.T) {
 	const malformedQuery = "sum:metric.name{env:test} by {service.ad_count()"
 
 	client := dashboardValidationTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		definitions := assertDashboardValidationRequest(t, r, 1)
-		requests, ok := definitions[0]["requests"].([]interface{})
+		widgets := assertDashboardValidationRequest(t, r, 1, "ordered", "")
+		definition := widgets[0]["definition"].(map[string]interface{})
+		requests, ok := definition["requests"].([]interface{})
 		if !ok || len(requests) != 1 {
-			t.Fatalf("expected one widget request, got %#v", definitions[0]["requests"])
+			t.Fatalf("expected one widget request, got %#v", definition["requests"])
 		}
 		request, ok := requests[0].(map[string]interface{})
 		if !ok || request["q"] != malformedQuery {
@@ -140,7 +155,7 @@ func TestDashboardV2PlanValidationRejectsMalformedQuery(t *testing.T) {
 			"results": []interface{}{map[string]interface{}{
 				"is_valid":      false,
 				"widget_type":   "timeseries",
-				"error_path":    "requests.0.q",
+				"error_path":    "['requests', 0, 'q']",
 				"error_message": "invalid metric query: missing closing brace",
 			}},
 		})
@@ -168,14 +183,16 @@ func TestDashboardV2PlanValidationRejectsMalformedQuery(t *testing.T) {
 	}
 }
 
-func TestValidateDashboardWidgetDefinitions(t *testing.T) {
-	definitions := []dashboardWidgetDefinition{
+func TestValidateDashboardWidgets(t *testing.T) {
+	validationWidgets := []dashboardWidget{
 		{
 			terraformPath: "widget.0.group_definition.0.widget.0.timeseries_definition.0",
-			definition: map[string]interface{}{
-				"type": "timeseries",
-				"requests": []interface{}{
-					map[string]interface{}{"q": "avg:system.load.1{*}", "display_type": "line"},
+			widget: map[string]interface{}{
+				"definition": map[string]interface{}{
+					"type": "timeseries",
+					"requests": []interface{}{
+						map[string]interface{}{"q": "avg:system.load.1{*}", "display_type": "line"},
+					},
 				},
 			},
 		},
@@ -183,13 +200,13 @@ func TestValidateDashboardWidgetDefinitions(t *testing.T) {
 
 	t.Run("valid", func(t *testing.T) {
 		client := dashboardValidationTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-			assertDashboardValidationRequest(t, r, 1)
+			assertDashboardValidationRequest(t, r, 1, "ordered", "fixed")
 			writeDashboardValidationResponse(t, w, map[string]interface{}{
 				"results": []interface{}{map[string]interface{}{"is_valid": true, "widget_type": "timeseries"}},
 			})
 		})
 
-		if err := validateDashboardWidgetDefinitions(context.Background(), context.Background(), client, definitions); err != nil {
+		if err := validateDashboardWidgets(context.Background(), context.Background(), client, validationWidgets, "ordered", "fixed"); err != nil {
 			t.Fatalf("unexpected validation error: %v", err)
 		}
 	})
@@ -200,13 +217,13 @@ func TestValidateDashboardWidgetDefinitions(t *testing.T) {
 				"results": []interface{}{map[string]interface{}{
 					"is_valid":      false,
 					"widget_type":   "timeseries",
-					"error_path":    "requests.0.q",
+					"error_path":    "['requests', 0, 'q']",
 					"error_message": "invalid metric query: missing closing brace",
 				}},
 			})
 		})
 
-		err := validateDashboardWidgetDefinitions(context.Background(), context.Background(), client, definitions)
+		err := validateDashboardWidgets(context.Background(), context.Background(), client, validationWidgets, "ordered", "")
 		if err == nil {
 			t.Fatal("expected validation error")
 		}
@@ -222,7 +239,7 @@ func TestValidateDashboardWidgetDefinitions(t *testing.T) {
 			writeDashboardValidationResponse(t, w, map[string]interface{}{"results": []interface{}{}})
 		})
 
-		err := validateDashboardWidgetDefinitions(context.Background(), context.Background(), client, definitions)
+		err := validateDashboardWidgets(context.Background(), context.Background(), client, validationWidgets, "ordered", "")
 		if err == nil || !strings.Contains(err.Error(), "0 results for 1 widgets") {
 			t.Fatalf("expected cardinality error, got %v", err)
 		}
@@ -234,7 +251,7 @@ func TestValidateDashboardWidgetDefinitions(t *testing.T) {
 			_, _ = w.Write([]byte(`{"errors":["invalid request"]}`))
 		})
 
-		err := validateDashboardWidgetDefinitions(context.Background(), context.Background(), client, definitions)
+		err := validateDashboardWidgets(context.Background(), context.Background(), client, validationWidgets, "ordered", "")
 		if err == nil || !strings.Contains(err.Error(), "error validating dashboard widgets") {
 			t.Fatalf("expected endpoint error, got %v", err)
 		}
@@ -252,7 +269,7 @@ func dashboardValidationTestClient(t *testing.T, handler http.HandlerFunc) *data
 	return datadog.NewAPIClient(configuration)
 }
 
-func assertDashboardValidationRequest(t *testing.T, request *http.Request, definitionCount int) []map[string]interface{} {
+func assertDashboardValidationRequest(t *testing.T, request *http.Request, widgetCount int, layoutType, reflowType string) []map[string]interface{} {
 	t.Helper()
 	if request.Method != http.MethodPost {
 		t.Fatalf("expected POST, got %s", request.Method)
@@ -261,15 +278,26 @@ func assertDashboardValidationRequest(t *testing.T, request *http.Request, defin
 		t.Fatalf("expected path %q, got %q", dashboardWidgetValidationPath, request.URL.Path)
 	}
 	var body struct {
-		WidgetDefinitions []map[string]interface{} `json:"widget_definitions"`
+		Widgets    []map[string]interface{} `json:"widgets"`
+		LayoutType string                   `json:"layout_type"`
+		ReflowType *string                  `json:"reflow_type"`
 	}
 	if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
 		t.Fatalf("decode request: %v", err)
 	}
-	if len(body.WidgetDefinitions) != definitionCount {
-		t.Fatalf("expected %d definitions, got %d", definitionCount, len(body.WidgetDefinitions))
+	if len(body.Widgets) != widgetCount {
+		t.Fatalf("expected %d widgets, got %d", widgetCount, len(body.Widgets))
 	}
-	return body.WidgetDefinitions
+	if body.LayoutType != layoutType {
+		t.Fatalf("expected layout type %q, got %q", layoutType, body.LayoutType)
+	}
+	if reflowType == "" && body.ReflowType != nil {
+		t.Fatalf("expected reflow type to be omitted, got %q", *body.ReflowType)
+	}
+	if reflowType != "" && (body.ReflowType == nil || *body.ReflowType != reflowType) {
+		t.Fatalf("expected reflow type %q, got %#v", reflowType, body.ReflowType)
+	}
+	return body.Widgets
 }
 
 func writeDashboardValidationResponse(t *testing.T, writer http.ResponseWriter, response interface{}) {

--- a/datadog/resource_datadog_dashboard_v2_unit_test.go
+++ b/datadog/resource_datadog_dashboard_v2_unit_test.go
@@ -1,0 +1,315 @@
+package datadog
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+)
+
+func TestBuildDashboardV2SchemaValidate(t *testing.T) {
+	validateSchema, ok := buildDashboardV2Schema()["validate"]
+	if !ok {
+		t.Fatal("validate schema is missing")
+	}
+	if !validateSchema.Optional || validateSchema.Type.String() != "TypeBool" {
+		t.Fatalf("validate schema should be an optional bool, got %#v", validateSchema)
+	}
+	if validateSchema.DiffSuppressFunc == nil || !validateSchema.DiffSuppressFunc("validate", "false", "true", nil) {
+		t.Fatal("validate must not create a persistent diff")
+	}
+}
+
+func TestFlattenDashboardWidgetDefinitions(t *testing.T) {
+	widgets := []interface{}{
+		map[string]interface{}{
+			"group_definition": []interface{}{
+				map[string]interface{}{
+					"layout_type": "ordered",
+					"title":       "Service overview",
+					"widget": []interface{}{
+						map[string]interface{}{
+							"timeseries_definition": []interface{}{
+								map[string]interface{}{
+									"request": []interface{}{
+										map[string]interface{}{
+											"display_type": "line",
+											"q":            "avg:system.load.1{*}",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	definitions := flattenDashboardWidgetDefinitions(widgets)
+	if len(definitions) != 2 {
+		t.Fatalf("expected group and child definitions, got %d", len(definitions))
+	}
+	if got := definitions[0].path; got != "widget 1" {
+		t.Fatalf("unexpected group path %q", got)
+	}
+	if got := definitions[0].definition["type"]; got != "group" {
+		t.Fatalf("unexpected group type %#v", got)
+	}
+	if children, ok := definitions[0].definition["widgets"].([]interface{}); !ok || len(children) != 0 {
+		t.Fatalf("group validation payload should not contain children, got %#v", definitions[0].definition["widgets"])
+	}
+	if got := definitions[1].path; got != "widget 1 > child 1" {
+		t.Fatalf("unexpected child path %q", got)
+	}
+	if got := definitions[1].definition["type"]; got != "timeseries" {
+		t.Fatalf("unexpected child type %#v", got)
+	}
+}
+
+func TestDashboardV2PlanValidationCanBeDisabled(t *testing.T) {
+	config := map[string]interface{}{
+		"title":       "Plan-time validation test",
+		"layout_type": "ordered",
+		"validate":    false,
+		"widget":      dashboardV2TestTimeseriesWidgets("avg:system.load.1{*}"),
+	}
+
+	// A nil provider configuration would panic if the validation HTTP call
+	// were reached, so a successful diff proves the call was skipped.
+	if _, err := resourceDatadogDashboardV2().Diff(
+		context.Background(),
+		nil,
+		terraform.NewResourceConfigRaw(config),
+		nil,
+	); err != nil {
+		t.Fatalf("unexpected diff error: %v", err)
+	}
+}
+
+func TestDashboardWidgetConfigKnown(t *testing.T) {
+	knownConfig := cty.ListVal([]cty.Value{
+		cty.ObjectVal(map[string]cty.Value{"query": cty.StringVal("avg:system.load.1{*}")}),
+	})
+	if !dashboardWidgetConfigKnown(knownConfig) {
+		t.Fatal("expected literal widget config to be known")
+	}
+
+	unknownConfig := cty.ListVal([]cty.Value{
+		cty.ObjectVal(map[string]cty.Value{"query": cty.UnknownVal(cty.String)}),
+	})
+	if dashboardWidgetConfigKnown(unknownConfig) {
+		t.Fatal("expected interpolated widget query to remain unknown during plan")
+	}
+}
+
+func TestDashboardV2PlanValidationCallsEndpointByDefault(t *testing.T) {
+	called := false
+	client := dashboardValidationTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		assertDashboardValidationRequest(t, r, 1)
+		writeDashboardValidationResponse(t, w, map[string]interface{}{
+			"results": []interface{}{map[string]interface{}{"is_valid": true, "widget_type": "timeseries"}},
+		})
+	})
+	providerConfig := &ProviderConfiguration{
+		Auth: context.Background(),
+		DatadogApiInstances: &utils.ApiInstances{
+			HttpClient: client,
+		},
+	}
+	config := terraform.NewResourceConfigRaw(map[string]interface{}{
+		"title":       "Plan-time validation test",
+		"layout_type": "ordered",
+		"widget":      dashboardV2TestTimeseriesWidgets("avg:system.load.1{*}"),
+	})
+
+	if _, err := resourceDatadogDashboardV2().Diff(context.Background(), nil, config, providerConfig); err != nil {
+		t.Fatalf("unexpected diff error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected plan-time validation endpoint to be called")
+	}
+}
+
+func TestDashboardV2PlanValidationRejectsMalformedQuery(t *testing.T) {
+	const malformedQuery = "sum:metric.name{env:test} by {service.ad_count()"
+
+	client := dashboardValidationTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		definitions := assertDashboardValidationRequest(t, r, 1)
+		requests, ok := definitions[0]["requests"].([]interface{})
+		if !ok || len(requests) != 1 {
+			t.Fatalf("expected one widget request, got %#v", definitions[0]["requests"])
+		}
+		request, ok := requests[0].(map[string]interface{})
+		if !ok || request["q"] != malformedQuery {
+			t.Fatalf("expected malformed query %q, got %#v", malformedQuery, requests[0])
+		}
+		writeDashboardValidationResponse(t, w, map[string]interface{}{
+			"results": []interface{}{map[string]interface{}{
+				"is_valid":      false,
+				"widget_type":   "timeseries",
+				"error_path":    "requests.0.q",
+				"error_message": "invalid metric query: missing closing brace",
+			}},
+		})
+	})
+	providerConfig := &ProviderConfiguration{
+		Auth: context.Background(),
+		DatadogApiInstances: &utils.ApiInstances{
+			HttpClient: client,
+		},
+	}
+	config := terraform.NewResourceConfigRaw(map[string]interface{}{
+		"title":       "Plan-time validation test",
+		"layout_type": "ordered",
+		"widget":      dashboardV2TestTimeseriesWidgets(malformedQuery),
+	})
+
+	_, err := resourceDatadogDashboardV2().Diff(context.Background(), nil, config, providerConfig)
+	if err == nil {
+		t.Fatal("expected malformed dashboard query to fail planning")
+	}
+	for _, expected := range []string{"widget 1", "timeseries", "requests.0.q", "missing closing brace"} {
+		if !strings.Contains(err.Error(), expected) {
+			t.Fatalf("expected error %q to contain %q", err, expected)
+		}
+	}
+}
+
+func TestValidateDashboardWidgetDefinitions(t *testing.T) {
+	definitions := []dashboardWidgetDefinition{
+		{
+			path: "widget 1 > child 1",
+			definition: map[string]interface{}{
+				"type": "timeseries",
+				"requests": []interface{}{
+					map[string]interface{}{"q": "avg:system.load.1{*}", "display_type": "line"},
+				},
+			},
+		},
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		client := dashboardValidationTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			assertDashboardValidationRequest(t, r, 1)
+			writeDashboardValidationResponse(t, w, map[string]interface{}{
+				"results": []interface{}{map[string]interface{}{"is_valid": true, "widget_type": "timeseries"}},
+			})
+		})
+
+		if err := validateDashboardWidgetDefinitions(context.Background(), context.Background(), client, definitions); err != nil {
+			t.Fatalf("unexpected validation error: %v", err)
+		}
+	})
+
+	t.Run("invalid query", func(t *testing.T) {
+		client := dashboardValidationTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+			writeDashboardValidationResponse(t, w, map[string]interface{}{
+				"results": []interface{}{map[string]interface{}{
+					"is_valid":      false,
+					"widget_type":   "timeseries",
+					"error_path":    "requests.0.q",
+					"error_message": "invalid metric query: missing closing brace",
+				}},
+			})
+		})
+
+		err := validateDashboardWidgetDefinitions(context.Background(), context.Background(), client, definitions)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+		for _, expected := range []string{"widget 1 > child 1", "timeseries", "requests.0.q", "missing closing brace"} {
+			if !strings.Contains(err.Error(), expected) {
+				t.Fatalf("expected error %q to contain %q", err, expected)
+			}
+		}
+	})
+
+	t.Run("response cardinality mismatch", func(t *testing.T) {
+		client := dashboardValidationTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+			writeDashboardValidationResponse(t, w, map[string]interface{}{"results": []interface{}{}})
+		})
+
+		err := validateDashboardWidgetDefinitions(context.Background(), context.Background(), client, definitions)
+		if err == nil || !strings.Contains(err.Error(), "0 results for 1 widgets") {
+			t.Fatalf("expected cardinality error, got %v", err)
+		}
+	})
+
+	t.Run("endpoint error", func(t *testing.T) {
+		client := dashboardValidationTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"errors":["invalid request"]}`))
+		})
+
+		err := validateDashboardWidgetDefinitions(context.Background(), context.Background(), client, definitions)
+		if err == nil || !strings.Contains(err.Error(), "error validating dashboard widgets") {
+			t.Fatalf("expected endpoint error, got %v", err)
+		}
+	})
+}
+
+func dashboardValidationTestClient(t *testing.T, handler http.HandlerFunc) *datadog.APIClient {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	configuration := datadog.NewConfiguration()
+	configuration.HTTPClient = server.Client()
+	configuration.Servers = datadog.ServerConfigurations{{URL: server.URL}}
+	return datadog.NewAPIClient(configuration)
+}
+
+func assertDashboardValidationRequest(t *testing.T, request *http.Request, definitionCount int) []map[string]interface{} {
+	t.Helper()
+	if request.Method != http.MethodPost {
+		t.Fatalf("expected POST, got %s", request.Method)
+	}
+	if request.URL.Path != dashboardWidgetValidationPath {
+		t.Fatalf("expected path %q, got %q", dashboardWidgetValidationPath, request.URL.Path)
+	}
+	var body struct {
+		WidgetDefinitions []map[string]interface{} `json:"widget_definitions"`
+	}
+	if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if len(body.WidgetDefinitions) != definitionCount {
+		t.Fatalf("expected %d definitions, got %d", definitionCount, len(body.WidgetDefinitions))
+	}
+	return body.WidgetDefinitions
+}
+
+func writeDashboardValidationResponse(t *testing.T, writer http.ResponseWriter, response interface{}) {
+	t.Helper()
+	writer.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(writer).Encode(response); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}
+
+func dashboardV2TestTimeseriesWidgets(query string) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"timeseries_definition": []interface{}{
+				map[string]interface{}{
+					"request": []interface{}{
+						map[string]interface{}{
+							"display_type": "line",
+							"q":            query,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/datadog/resource_datadog_dashboard_v2_unit_test.go
+++ b/datadog/resource_datadog_dashboard_v2_unit_test.go
@@ -108,6 +108,54 @@ func TestDashboardV2PlanValidationCanBeDisabled(t *testing.T) {
 	}
 }
 
+func TestDashboardV2PlanValidationSkipsUnknownInputValues(t *testing.T) {
+	// This is the SDKv2 sentinel accepted by terraform.NewResourceConfigRaw for
+	// values that will only become known after dependencies are resolved.
+	const unknownValue = "74D93920-ED26-11E3-AC10-0800200C9A66"
+
+	tests := map[string]map[string]interface{}{
+		"widget": {
+			"title":       "Plan-time validation test",
+			"layout_type": "ordered",
+			"widget":      dashboardV2TestTimeseriesWidgets(unknownValue),
+		},
+		"layout_type": {
+			"title":       "Plan-time validation test",
+			"layout_type": unknownValue,
+			"widget":      dashboardV2TestTimeseriesWidgets("avg:system.load.1{*}"),
+		},
+		"reflow_type": {
+			"title":       "Plan-time validation test",
+			"layout_type": "ordered",
+			"reflow_type": unknownValue,
+			"widget":      dashboardV2TestTimeseriesWidgets("avg:system.load.1{*}"),
+		},
+	}
+
+	for name, rawConfig := range tests {
+		t.Run(name, func(t *testing.T) {
+			called := false
+			client := dashboardValidationTestClient(t, func(http.ResponseWriter, *http.Request) {
+				called = true
+			})
+			providerConfig := &ProviderConfiguration{
+				Auth: context.Background(),
+				DatadogApiInstances: &utils.ApiInstances{
+					HttpClient: client,
+				},
+			}
+			config := terraform.NewResourceConfigRaw(rawConfig)
+
+			if _, err := resourceDatadogDashboardV2().Diff(context.Background(), nil, config, providerConfig); err != nil {
+				t.Fatalf("unexpected diff error: %v", err)
+			}
+			if called {
+				t.Fatal("validation endpoint must not be called while input values are unknown")
+			}
+		})
+	}
+}
+
 func TestDashboardV2PlanValidationCallsEndpointByDefault(t *testing.T) {
 	called := false
 	client := dashboardValidationTestClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/datadog/resource_datadog_dashboard_v2_unit_test.go
+++ b/datadog/resource_datadog_dashboard_v2_unit_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -58,7 +57,7 @@ func TestFlattenDashboardWidgetDefinitions(t *testing.T) {
 	if len(definitions) != 2 {
 		t.Fatalf("expected group and child definitions, got %d", len(definitions))
 	}
-	if got := definitions[0].path; got != "widget 1" {
+	if got := definitions[0].terraformPath; got != "widget.0.group_definition.0" {
 		t.Fatalf("unexpected group path %q", got)
 	}
 	if got := definitions[0].definition["type"]; got != "group" {
@@ -67,25 +66,11 @@ func TestFlattenDashboardWidgetDefinitions(t *testing.T) {
 	if children, ok := definitions[0].definition["widgets"].([]interface{}); !ok || len(children) != 0 {
 		t.Fatalf("group validation payload should not contain children, got %#v", definitions[0].definition["widgets"])
 	}
-	if got := definitions[1].path; got != "widget 1 > child 1" {
+	if got := definitions[1].terraformPath; got != "widget.0.group_definition.0.widget.0.timeseries_definition.0" {
 		t.Fatalf("unexpected child path %q", got)
 	}
 	if got := definitions[1].definition["type"]; got != "timeseries" {
 		t.Fatalf("unexpected child type %#v", got)
-	}
-}
-
-func TestFlattenDashboardWidgetDefinitionsAtIndexesPreservesPaths(t *testing.T) {
-	widgets := append(
-		dashboardV2TestTimeseriesWidgets("avg:system.load.1{*}"),
-		dashboardV2TestTimeseriesWidgets("avg:system.cpu.user{*}")...,
-	)
-	definitions := flattenDashboardWidgetDefinitionsAtIndexes(widgets, map[int]struct{}{1: {}})
-	if len(definitions) != 1 {
-		t.Fatalf("expected one known widget definition, got %d", len(definitions))
-	}
-	if got := definitions[0].path; got != "widget 2" {
-		t.Fatalf("expected original widget path to be preserved, got %q", got)
 	}
 }
 
@@ -106,26 +91,6 @@ func TestDashboardV2PlanValidationCanBeDisabled(t *testing.T) {
 		nil,
 	); err != nil {
 		t.Fatalf("unexpected diff error: %v", err)
-	}
-}
-
-func TestDashboardKnownWidgetIndexesFromConfig(t *testing.T) {
-	widgetConfig := cty.ListVal([]cty.Value{
-		cty.ObjectVal(map[string]cty.Value{"query": cty.StringVal("avg:system.load.1{*}")}),
-		cty.ObjectVal(map[string]cty.Value{"query": cty.UnknownVal(cty.String)}),
-		cty.ObjectVal(map[string]cty.Value{"query": cty.StringVal("avg:system.cpu.user{*}")}),
-	})
-	knownIndexes := dashboardKnownWidgetIndexesFromConfig(widgetConfig)
-	if len(knownIndexes) != 2 {
-		t.Fatalf("expected two known widgets, got %#v", knownIndexes)
-	}
-	for _, index := range []int{0, 2} {
-		if _, ok := knownIndexes[index]; !ok {
-			t.Fatalf("expected widget %d to be known", index)
-		}
-	}
-	if _, ok := knownIndexes[1]; ok {
-		t.Fatal("expected interpolated widget to remain unknown during plan")
 	}
 }
 
@@ -196,7 +161,7 @@ func TestDashboardV2PlanValidationRejectsMalformedQuery(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected malformed dashboard query to fail planning")
 	}
-	for _, expected := range []string{"widget 1", "timeseries", "requests.0.q", "missing closing brace"} {
+	for _, expected := range []string{"widget.0.timeseries_definition.0.request.0.q", "timeseries", "missing closing brace"} {
 		if !strings.Contains(err.Error(), expected) {
 			t.Fatalf("expected error %q to contain %q", err, expected)
 		}
@@ -206,7 +171,7 @@ func TestDashboardV2PlanValidationRejectsMalformedQuery(t *testing.T) {
 func TestValidateDashboardWidgetDefinitions(t *testing.T) {
 	definitions := []dashboardWidgetDefinition{
 		{
-			path: "widget 1 > child 1",
+			terraformPath: "widget.0.group_definition.0.widget.0.timeseries_definition.0",
 			definition: map[string]interface{}{
 				"type": "timeseries",
 				"requests": []interface{}{
@@ -245,7 +210,7 @@ func TestValidateDashboardWidgetDefinitions(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected validation error")
 		}
-		for _, expected := range []string{"widget 1 > child 1", "timeseries", "requests.0.q", "missing closing brace"} {
+		for _, expected := range []string{"widget.0.group_definition.0.widget.0.timeseries_definition.0.request.0.q", "timeseries", "missing closing brace"} {
 			if !strings.Contains(err.Error(), expected) {
 				t.Fatalf("expected error %q to contain %q", err, expected)
 			}

--- a/datadog/tests/resource_datadog_dashboard_test.go
+++ b/datadog/tests/resource_datadog_dashboard_test.go
@@ -1415,6 +1415,7 @@ func testAccDatadogDashboardV2WidgetUtil(t *testing.T, v1TestName string, config
 	uniq := withUniqueSurrounding(clockFromContext(ctx), v1TestName)
 	replacer := strings.NewReplacer("{{uniq}}", uniq)
 	config = replacer.Replace(config)
+	config = disableDashboardV2PlanValidation(config)
 	for i := range assertions {
 		assertions[i] = replacer.Replace(assertions[i])
 	}
@@ -1448,6 +1449,7 @@ func testAccDatadogDashboardV2WidgetUtilImport(t *testing.T, v1TestName string, 
 	uniq := withUniqueSurrounding(clockFromContext(ctx), v1TestName)
 	replacer := strings.NewReplacer("{{uniq}}", uniq)
 	config = replacer.Replace(config)
+	config = disableDashboardV2PlanValidation(config)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -1464,6 +1466,22 @@ func testAccDatadogDashboardV2WidgetUtilImport(t *testing.T, v1TestName string, 
 			},
 		},
 	})
+}
+
+// Existing v2 acceptance tests reuse v1 dashboard cassettes, which do not
+// contain plan-time validation calls. Dedicated validation tests cover that path.
+func disableDashboardV2PlanValidation(config string) string {
+	const resourceMarker = `resource "datadog_dashboard_v2"`
+	resourceStart := strings.Index(config, resourceMarker)
+	if resourceStart == -1 {
+		return config
+	}
+	openingBrace := strings.Index(config[resourceStart:], "{")
+	if openingBrace == -1 {
+		return config
+	}
+	insertAt := resourceStart + openingBrace + 1
+	return config[:insertAt] + "\n  validate = false" + config[insertAt:]
 }
 
 func datadogOpenDashboardConfig(uniqueDashboardName string) string {

--- a/datadog/tests/resource_datadog_dashboard_v2_tab_test.go
+++ b/datadog/tests/resource_datadog_dashboard_v2_tab_test.go
@@ -98,6 +98,9 @@ resource "datadog_dashboard_v2" "tab_dashboard" {
 		note_definition { content = "Widget 3" }
 	}
 }`)
+	configCreate = disableDashboardV2PlanValidation(configCreate)
+	configUpdate = disableDashboardV2PlanValidation(configUpdate)
+	configRemove = disableDashboardV2PlanValidation(configRemove)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },

--- a/docs/resources/dashboard_v2.md
+++ b/docs/resources/dashboard_v2.md
@@ -159,7 +159,7 @@ resource "datadog_dashboard_v2" "free_dashboard" {
 - `template_variable` (Block List) The list of template variables for this dashboard. (see [below for nested schema](#nestedblock--template_variable))
 - `template_variable_preset` (Block List) The list of selectable template variable presets for this dashboard. (see [below for nested schema](#nestedblock--template_variable_preset))
 - `url` (String) The URL of the dashboard.
-- `validate` (Boolean) Whether to send widget definitions to the Datadog API to validate widget configuration and query values during `terraform plan`. Defaults to `true`. Setting this to `false` skips only the Datadog API validation; local Terraform schema and conflicting-field checks still run.
+- `validate` (Boolean) Whether to send widgets to the Datadog API to validate widget configuration and query values during `terraform plan`. Defaults to `true`. Setting this to `false` skips only the Datadog API validation; local Terraform schema and conflicting-field checks still run.
 - `widget` (Block List) The list of widgets to display on the dashboard. (see [below for nested schema](#nestedblock--widget))
 
 ### Read-Only

--- a/docs/resources/dashboard_v2.md
+++ b/docs/resources/dashboard_v2.md
@@ -159,7 +159,7 @@ resource "datadog_dashboard_v2" "free_dashboard" {
 - `template_variable` (Block List) The list of template variables for this dashboard. (see [below for nested schema](#nestedblock--template_variable))
 - `template_variable_preset` (Block List) The list of selectable template variable presets for this dashboard. (see [below for nested schema](#nestedblock--template_variable_preset))
 - `url` (String) The URL of the dashboard.
-- `validate` (Boolean) Whether to send widgets to the Datadog API to validate widget configuration and query values during `terraform plan`. Defaults to `true`. Setting this to `false` skips only the Datadog API validation; local Terraform schema and conflicting-field checks still run.
+- `validate` (Boolean) Whether to send widgets to the Datadog API to validate widget configuration and query values during `terraform plan`. Defaults to `true`. Setting this to `false` skips only the Datadog API validation; local Terraform schema and checks for conflicting fields still run.
 - `widget` (Block List) The list of widgets to display on the dashboard. (see [below for nested schema](#nestedblock--widget))
 
 ### Read-Only

--- a/docs/resources/dashboard_v2.md
+++ b/docs/resources/dashboard_v2.md
@@ -159,6 +159,7 @@ resource "datadog_dashboard_v2" "free_dashboard" {
 - `template_variable` (Block List) The list of template variables for this dashboard. (see [below for nested schema](#nestedblock--template_variable))
 - `template_variable_preset` (Block List) The list of selectable template variable presets for this dashboard. (see [below for nested schema](#nestedblock--template_variable_preset))
 - `url` (String) The URL of the dashboard.
+- `validate` (Boolean) If set to `false`, skip dashboard widget validation during plan. Defaults to `true`.
 - `widget` (Block List) The list of widgets to display on the dashboard. (see [below for nested schema](#nestedblock--widget))
 
 ### Read-Only

--- a/docs/resources/dashboard_v2.md
+++ b/docs/resources/dashboard_v2.md
@@ -159,7 +159,7 @@ resource "datadog_dashboard_v2" "free_dashboard" {
 - `template_variable` (Block List) The list of template variables for this dashboard. (see [below for nested schema](#nestedblock--template_variable))
 - `template_variable_preset` (Block List) The list of selectable template variable presets for this dashboard. (see [below for nested schema](#nestedblock--template_variable_preset))
 - `url` (String) The URL of the dashboard.
-- `validate` (Boolean) If set to `false`, skip dashboard widget validation during plan. Defaults to `true`.
+- `validate` (Boolean) Whether to send widget definitions to the Datadog API to validate widget configuration and query values during `terraform plan`. Defaults to `true`. Setting this to `false` skips only the Datadog API validation; local Terraform schema and conflicting-field checks still run.
 - `widget` (Block List) The list of widgets to display on the dashboard. (see [below for nested schema](#nestedblock--widget))
 
 ### Read-Only


### PR DESCRIPTION
## Summary

Validates `datadog_dashboard_v2` widget configuration and query values during `terraform plan`, so malformed widgets fail before apply. Validation is enabled by default and can be disabled with `validate = false`; local Terraform schema validation and conflicting-field checks still run when API validation is disabled.

The provider now calls the dedicated bulk dashboard endpoint introduced by [dd-source #57147](https://github.com/ddoghq/dd-source/pull/57147)

## Endpoint contract

`POST /api/v2/dashboard/widgets/validate`

The request contains:

- `widgets`: complete dashboard widget objects
- `layout_type`: the dashboard layout type
- `reflow_type`: the optional ordered-dashboard reflow type

The response contains one ordered result per widget with `is_valid`, `widget_type`, `error_message`, and `error_path`. Group children are sent separately so validation errors can point to the exact nested Terraform block. Backend list-form error paths such as `['requests', 0, 'q']` are translated to Terraform paths such as `request.0.q`.

## Ticket

- [FRGRAPHING-5240](https://datadoghq.atlassian.net/browse/FRGRAPHING-5240)
- [DASHB-1048](https://datadoghq.atlassian.net/browse/DASHB-1048)

## Dependencies and API source

- Runtime endpoint: [dd-source #57147](https://github.com/ddoghq/dd-source/pull/57147) must merge and deploy before this provider change can be released.
- Provider baseline checked: `DataDog/terraform-provider-datadog` `origin/master` at `e48198deb2a2e735a294fd662c1ea5f808852cec`.
- OpenAPI snapshot checked: `DataDog/datadog-api-spec` at `057e344e1d8fc0a6c26d00d0d3fd96635635872f`. The new endpoint is not published in that snapshot yet; public API-spec/client publication is a follow-up dependency.

## Test plan

- [x] `make fmtcheck`
- [x] `make test` — 231 tests passed
- [x] `make vet`
- [x] `make docs`
- [x] `make check-docs`
- [x] Unit coverage for the endpoint path, full widget payload, `layout_type`, optional `reflow_type`, response cardinality, endpoint errors, nested group paths/layouts, malformed queries, and backend list-form error paths
- [ ] Live acceptance test — blocked until the dd-source endpoint is deployed

`make errcheck` reports only the repository's pre-existing unchecked-error backlog and no findings in the changed files. `make lint-new` could not load the Go context in this environment (`no go files to analyze`); it did not report a changed-code diagnostic.


[FRGRAPHING-5240]: https://datadoghq.atlassian.net/browse/FRGRAPHING-5240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
