### PR TITLE
ci (APIR-3159): opt in to fork-head checkout for integration tests

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -42,6 +42,10 @@ jobs:
         with:
           # PR head for pull_request_target; the triggering ref for the schedule.
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # checkout v7 refuses fork-head checkouts under pull_request_target by
+          # default. Running the PR's code is intended here; fork runs are gated
+          # on the forks-prs environment declared above.
+          allow-unsafe-pr-checkout: true
       - name: Mint Datadog credentials
         id: dd-sts
         uses: DataDog/dd-sts-action@7d2d231c02fd54a3da912e582ff87cb995d1fd30 # v1.0.4

--- a/.github/workflows/test_pr_integration.yml
+++ b/.github/workflows/test_pr_integration.yml
@@ -104,6 +104,11 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          # checkout v7 refuses fork-head checkouts under workflow_run by
+          # default. Executing the PR's own code is the entire purpose of this
+          # job, so opt in explicitly; without it every fork PR fails here
+          # before a single test runs.
+          allow-unsafe-pr-checkout: true
       - name: Mint Datadog credentials
         id: dd-sts
         uses: DataDog/dd-sts-action@7d2d231c02fd54a3da912e582ff87cb995d1fd30 # v1.0.4


### PR DESCRIPTION
## Motivation

Integration tests silently stopped running for every pull request from a fork.

`actions/checkout` v7, adopted repo-wide in #4041, added a guard that refuses to check out fork pull request code when the workflow event is `pull_request_target` or `workflow_run`. Both credentialed integration paths do exactly that, so the job now dies on its first step.

Seen on #4004 (from `Cesarsk/terraform-provider-datadog`): the integration job failed two seconds in with `Refusing to check out fork pull request code from a 'workflow_run' workflow`. No tests ran, no results file was produced, the artifact upload no-opped, and the reporting job published `pr-integration-tests` as a failure titled "No test results". The PR looked like it had failed integration tests when none had executed.

The `pull_request_target` path is affected identically. It is only latent because it needs the `ci/integrations` label, so it would have surfaced on the next labelled fork PR.

## Overview of changes

Both fork-head checkout steps now set `allow-unsafe-pr-checkout: true`, restoring the pre-bump behaviour rather than reverting the action upgrade. Checking out and running the PR's own code against the live API is the entire purpose of these jobs, so the guard is flagging the intended design; the credentials involved are short-lived and scoped to the test org, and the fork path on the label-gated workflow keeps its `forks-prs` environment approval.

Same-repo PRs, master and scheduled runs were never affected — the guard only fires when the PR head repository differs from the base.

## Validation

CI on this PR cannot prove the fix. The branch lives in the base repository, so the guard never fires and `pr-integration-tests` will pass regardless.

Validating this needs a fork PR. After merge, re-run PR Test Selection on #4004 and confirm the downstream integration job gets past checkout, selects the organization settings tests and reports a real pass/fail conclusion instead of "No test results".
