### PR TITLE
[datadog_incident_notification_rule] fix inconsistent result after apply on renotify_on

### DIFF
--- a/datadog/fwprovider/resource_datadog_incident_notification_rule.go
+++ b/datadog/fwprovider/resource_datadog_incident_notification_rule.go
@@ -266,6 +266,9 @@ func (r *incidentNotificationRuleResource) Create(ctx context.Context, request r
 	}
 
 	var state incidentNotificationRuleModel
+	// Seed the configured renotify_on so the flatten preserves the practitioner's
+	// null-vs-empty choice when the API echoes back an empty list (see updateStateFromResponse).
+	state.RenotifyOn = plan.RenotifyOn
 	r.updateStateFromResponse(&state, &resp)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
@@ -489,7 +492,12 @@ func (r *incidentNotificationRuleResource) updateStateFromResponse(state *incide
 			}
 		}
 
-		if renotifyOn, renotifyOnOk := attributes.GetRenotifyOnOk(); renotifyOnOk && renotifyOn != nil {
+		// renotify_on is Optional (not Computed), so the applied state must equal the
+		// planned value. The API always echoes it back as a (possibly empty) list, which
+		// erases the null-vs-empty distinction the practitioner configured. Only overwrite
+		// from the API when it returns a non-empty list; an empty response keeps the
+		// incoming value (null when omitted, [] when set explicitly).
+		if renotifyOn, renotifyOnOk := attributes.GetRenotifyOnOk(); renotifyOnOk && renotifyOn != nil && len(*renotifyOn) > 0 {
 			state.RenotifyOn = make([]types.String, len(*renotifyOn))
 			for i, item := range *renotifyOn {
 				state.RenotifyOn[i] = types.StringValue(item)

--- a/datadog/fwprovider/resource_datadog_incident_notification_rule_test.go
+++ b/datadog/fwprovider/resource_datadog_incident_notification_rule_test.go
@@ -1,0 +1,63 @@
+package fwprovider
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// newIncidentNotificationRuleResponse builds a minimal API response whose
+// renotify_on attribute is set to renotifyOn (which may be an empty slice to
+// mimic the API echoing back "renotify_on": []).
+func newIncidentNotificationRuleResponse(renotifyOn []string) *datadogV2.IncidentNotificationRule {
+	attrs := datadogV2.NewIncidentNotificationRuleAttributesWithDefaults()
+	attrs.SetTrigger("incident_created_trigger")
+	attrs.SetRenotifyOn(renotifyOn)
+
+	data := datadogV2.NewIncidentNotificationRuleResponseData(
+		uuid.Nil,
+		datadogV2.INCIDENTNOTIFICATIONRULETYPE_INCIDENT_NOTIFICATION_RULES,
+	)
+	data.SetAttributes(*attrs)
+
+	return datadogV2.NewIncidentNotificationRule(*data)
+}
+
+// TestIncidentNotificationRuleRenotifyOnPreservesNullVsEmpty guards the fix for
+// the "inconsistent result after apply" error: renotify_on is Optional (not
+// Computed), so the flatten must not turn the API's empty list into an empty
+// value when the practitioner left the attribute null.
+func TestIncidentNotificationRuleRenotifyOnPreservesNullVsEmpty(t *testing.T) {
+	r := &incidentNotificationRuleResource{}
+
+	// Attribute omitted in config -> incoming state is nil -> must stay nil (null),
+	// even though the API echoes back an empty list.
+	t.Run("null stays null", func(t *testing.T) {
+		state := incidentNotificationRuleModel{RenotifyOn: nil}
+		r.updateStateFromResponse(&state, newIncidentNotificationRuleResponse([]string{}))
+		if state.RenotifyOn != nil {
+			t.Fatalf("expected renotify_on to stay nil (null), got %#v", state.RenotifyOn)
+		}
+	})
+
+	// Attribute set to [] in config -> incoming state is a non-nil empty slice ->
+	// must stay an empty (non-null) list.
+	t.Run("explicit empty stays empty", func(t *testing.T) {
+		state := incidentNotificationRuleModel{RenotifyOn: []types.String{}}
+		r.updateStateFromResponse(&state, newIncidentNotificationRuleResponse([]string{}))
+		if state.RenotifyOn == nil || len(state.RenotifyOn) != 0 {
+			t.Fatalf("expected renotify_on to stay empty (non-null), got %#v", state.RenotifyOn)
+		}
+	})
+
+	// A non-empty API list is authoritative and overwrites the incoming value.
+	t.Run("non-empty overwrites", func(t *testing.T) {
+		state := incidentNotificationRuleModel{RenotifyOn: nil}
+		r.updateStateFromResponse(&state, newIncidentNotificationRuleResponse([]string{"status", "severity"}))
+		if len(state.RenotifyOn) != 2 || state.RenotifyOn[0].ValueString() != "status" || state.RenotifyOn[1].ValueString() != "severity" {
+			t.Fatalf("expected renotify_on = [status severity], got %#v", state.RenotifyOn)
+		}
+	})
+}


### PR DESCRIPTION
### What does this PR do?

Fixes a create-time failure on `datadog_incident_notification_rule` when the optional `renotify_on` attribute is omitted:

```
Error: Provider produced inconsistent result after apply
When applying changes to datadog_incident_notification_rule.X, provider
produced an unexpected new value: .renotify_on: was null, but now
cty.ListValEmpty(cty.String).
```

### Root cause

`renotify_on` is `Optional` (not `Computed`), so its applied state must equal the planned value. The API always echoes the attribute back as a (possibly empty) list, and `updateStateFromResponse` mapped that empty list to an empty framework value — overwriting the practitioner's `null` with `[]`. Terraform's post-apply consistency check then rejects the `null` → `[]` change.

### Fix

Preserve the null-vs-empty distinction the practitioner configured:

- `updateStateFromResponse` only populates `renotify_on` from the API when it returns a **non-empty** list; an empty response keeps the incoming value.
- `Create` seeds the model with the planned `renotify_on` first, so an explicitly configured `[]` stays `[]` instead of being reset to `null`.

Result:
- omitted → stays `null` (the reported bug)
- `renotify_on = []` → stays `[]` (no regression for the current explicit-empty workaround)
- `renotify_on = ["status", ...]` → API value is authoritative

### Minimal reproduction

```hcl
resource "datadog_incident_type" "t" { name = "Critical" }

resource "datadog_incident_notification_rule" "r" {
  incident_type = datadog_incident_type.t.id
  trigger       = "incident_created_trigger"
  enabled       = true
  handles       = ["@webhook-something"]

  conditions {
    field  = "severity"
    values = ["SEV-1"]
  }
  # renotify_on intentionally omitted
}
```

### Test coverage

Added `TestIncidentNotificationRuleRenotifyOnPreservesNullVsEmpty` (unit, `datadog/fwprovider`) covering all three cases above. It fails on `master` (`null` → `[]`) and passes with the fix. `make fmtcheck`, `make docs`/`check-docs` (no doc changes), `go vet`, and the `fwprovider` package tests are green.

Suggested changelog label: `changelog/bugfix`.
