### PR TITLE
DASHB-1136: Prevent new dashboards from using the v1 resource

### DIFF
--- a/datadog/internal/utils/utils.go
+++ b/datadog/internal/utils/utils.go
@@ -630,6 +630,10 @@ func UseMonitorFrameworkProvider() bool {
 	return getEnv("TERRAFORM_MONITOR_FRAMEWORK_PROVIDER", "false") == "true"
 }
 
+func DisallowDashboardV1Create() bool {
+	return getEnv("DD_TERRAFORM_DISALLOW_DASHBOARD_V1_CREATE", "false") == "true"
+}
+
 func IsDatabricksIntegrationEnabled() bool {
 	return getEnv("DD_TERRAFORM_DATABRICKS_INTEGRATION_ENABLED", "false") == "true"
 }

--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -29,6 +29,11 @@ func resourceDatadogDashboard() *schema.Resource {
 		ReadContext:   resourceDatadogDashboardRead,
 		DeleteContext: resourceDatadogDashboardDelete,
 		CustomizeDiff: func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+			oldLayoutType, newLayoutType := diff.GetChange("layout_type")
+			if err := validateDashboardV1Operation(diff.Id(), oldLayoutType, newLayoutType); err != nil {
+				return err
+			}
+
 			oldValue, newValue := diff.GetChange("dashboard_lists")
 			if !oldValue.(*schema.Set).Equal(newValue.(*schema.Set)) {
 				// Only calculate removed when the list change, to no create useless diffs
@@ -178,7 +183,27 @@ func resourceDatadogDashboard() *schema.Resource {
 	}
 }
 
+func validateDashboardV1Operation(id string, oldLayoutType, newLayoutType interface{}) error {
+	if !utils.DisallowDashboardV1Create() {
+		return nil
+	}
+
+	if id == "" {
+		return fmt.Errorf("creating dashboards with datadog_dashboard is disabled; use datadog_dashboard_v2 instead")
+	}
+
+	if oldLayoutType != newLayoutType {
+		return fmt.Errorf("replacing dashboards managed with datadog_dashboard is disabled; migrate to datadog_dashboard_v2 before changing layout_type")
+	}
+
+	return nil
+}
+
 func resourceDatadogDashboardCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	if err := validateDashboardV1Operation("", nil, nil); err != nil {
+		return diag.FromErr(err)
+	}
+
 	providerConf := meta.(*ProviderConfiguration)
 	apiInstances := providerConf.DatadogApiInstances
 	auth := providerConf.Auth

--- a/datadog/resource_datadog_dashboard_create_guard_test.go
+++ b/datadog/resource_datadog_dashboard_create_guard_test.go
@@ -1,0 +1,58 @@
+package datadog
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
+)
+
+func TestResourceDatadogDashboardCreateDisallowed(t *testing.T) {
+	t.Setenv("DD_TERRAFORM_DISALLOW_DASHBOARD_V1_CREATE", "true")
+
+	diags := resourceDatadogDashboardCreate(context.Background(), nil, nil)
+	if !diags.HasError() {
+		t.Fatal("expected v1 dashboard creation to be rejected")
+	}
+
+	if got := diags[0].Summary; !strings.Contains(got, "use datadog_dashboard_v2 instead") {
+		t.Fatalf("unexpected error: %s", got)
+	}
+}
+
+func TestDisallowDashboardV1CreateDefaultsToFalse(t *testing.T) {
+	t.Setenv("DD_TERRAFORM_DISALLOW_DASHBOARD_V1_CREATE", "")
+
+	if utils.DisallowDashboardV1Create() {
+		t.Fatal("expected v1 dashboard creation to be allowed by default")
+	}
+}
+
+func TestDisallowDashboardV1CreateEnabled(t *testing.T) {
+	t.Setenv("DD_TERRAFORM_DISALLOW_DASHBOARD_V1_CREATE", "true")
+
+	if !utils.DisallowDashboardV1Create() {
+		t.Fatal("expected v1 dashboard creation to be disabled")
+	}
+}
+
+func TestValidateDashboardV1OperationAllowsExistingUpdate(t *testing.T) {
+	t.Setenv("DD_TERRAFORM_DISALLOW_DASHBOARD_V1_CREATE", "true")
+
+	if err := validateDashboardV1Operation("abc-123", "ordered", "ordered"); err != nil {
+		t.Fatalf("expected an existing v1 dashboard update to be allowed: %s", err)
+	}
+}
+
+func TestValidateDashboardV1OperationRejectsReplacement(t *testing.T) {
+	t.Setenv("DD_TERRAFORM_DISALLOW_DASHBOARD_V1_CREATE", "true")
+
+	err := validateDashboardV1Operation("abc-123", "ordered", "free")
+	if err == nil {
+		t.Fatal("expected a v1 dashboard replacement to be rejected")
+	}
+	if !strings.Contains(err.Error(), "migrate to datadog_dashboard_v2") {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}


### PR DESCRIPTION
## Summary
Adds an opt-in provider guard for the internal Dashboard v2 rollout. When DD_TERRAFORM_DISALLOW_DASHBOARD_V1_CREATE=true, Terraform rejects new datadog_dashboard resources and layout_type replacements while continuing to allow existing v1 dashboards to be refreshed, updated, imported, and deleted.

The guard defaults off, so the public provider behavior is unchanged until internal Terraform runners enable it.

## Ticket
https://datadoghq.atlassian.net/browse/DASHB-1136

## Related Docs
https://datadoghq.atlassian.net/wiki/spaces/~712020eec892ae2dd84589a031320009d839ec/pages/6291161503/Terraform+Dashboard+v2+and+Export+as+Terraform+-+Rollout+Plan

## Test Plan
- [x] make fmtcheck
- [x] make test
- [x] make vet
- [x] make check-docs
- [ ] Enable the guard in a staging Terraform runner and verify a new v1 dashboard plan is rejected
- [ ] Verify an existing v1 dashboard still produces a clean no-change plan

Note: make errcheck currently reports pre-existing unchecked errors outside this PR's changed files.

🤖 Generated with Claude Code