### PR TITLE
[APIR-3164] Fix datadog_api_key integration tests — quota exhaustion and revoked-key destroy check

### DIFF
--- a/datadog/tests/api_key_sweep_test.go
+++ b/datadog/tests/api_key_sweep_test.go
@@ -1,0 +1,191 @@
+package test
+
+import (
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+var apiKeySweepOnce sync.Once
+
+// apiKeyMinAge is how old a key must be before the sweeper considers it stale.
+// Keys younger than this may belong to a run in progress.
+const apiKeyMinAge = time.Hour
+
+// providerTestKeyName matches the names withUniqueSurrounding generates:
+// "tf-<TestName>-<buildID>-<unix ts>", where buildID is a CI build number or
+// the literal "local". Keys that do not match are left alone.
+var providerTestKeyName = regexp.MustCompile(`^tf-.+-(local|\d+)-\d{10}$`)
+
+// sweepingIsSafe reports whether the current RECORD mode may delete real API
+// keys. Replay must not reach the network, and recording runs skip the api key
+// tests, so only a live run sweeps.
+func sweepingIsSafe() bool {
+	return !isRecording() && !isReplaying()
+}
+
+// cleanupApiKeys removes stale API keys left behind by crashed or failed test
+// runs. The org caps API keys at 200, so leaked keys eventually make every api
+// key test fail with "You have exceeded the maximum number of permitted API
+// keys".
+//
+// Call this at the top of every api key test function, before t.Parallel().
+func cleanupApiKeys(t *testing.T) {
+	t.Helper()
+
+	if !sweepingIsSafe() {
+		return
+	}
+
+	apiKeySweepOnce.Do(func() {
+		doSweepApiKeys(t)
+	})
+}
+
+// TestSweepApiKeys is a standalone sweep test for CI / manual invocation via
+// `go test -run TestSweep` or `make sweep`.
+func TestSweepApiKeys(t *testing.T) {
+	if !sweepingIsSafe() {
+		t.Skip("sweeping deletes real API keys; not supported under RECORD=true or RECORD=false")
+	}
+	doSweepApiKeys(t)
+}
+
+func doSweepApiKeys(t *testing.T) {
+	t.Helper()
+
+	if !sweepingIsSafe() {
+		t.Log("API key sweep: refusing to delete keys in a cassette mode")
+		return
+	}
+
+	ctx, client := newSweepAPIClient(t)
+	if client == nil {
+		return
+	}
+
+	api := datadogV2.NewKeyManagementApi(client)
+
+	// Collect before deleting: deletions shift the pagination window.
+	type staleKey struct {
+		id   string
+		name string
+	}
+	var toDelete []staleKey
+	var totalSeen int
+	const pageSize int64 = 100
+	cutoff := time.Now().Add(-apiKeyMinAge)
+
+	for pageNumber := int64(0); ; pageNumber++ {
+		opts := datadogV2.NewListAPIKeysOptionalParameters().
+			WithPageSize(pageSize).
+			WithPageNumber(pageNumber)
+
+		resp, _, err := api.ListAPIKeys(ctx, *opts)
+		if err != nil {
+			t.Logf("API key sweep: failed to list keys (page %d): %v", pageNumber, err)
+			return
+		}
+
+		data := resp.GetData()
+		totalSeen += len(data)
+
+		for _, key := range data {
+			attrs := key.Attributes
+			if attrs == nil {
+				continue
+			}
+			name := attrs.GetName()
+			if !isTestApiKeyName(name) {
+				continue
+			}
+			createdAt, err := time.Parse(time.RFC3339Nano, attrs.GetCreatedAt())
+			if err != nil {
+				t.Logf("API key sweep: skipping %q, unparseable created_at %q", name, attrs.GetCreatedAt())
+				continue
+			}
+			if createdAt.After(cutoff) {
+				continue
+			}
+			toDelete = append(toDelete, staleKey{id: key.GetId(), name: name})
+		}
+
+		if int64(len(data)) < pageSize {
+			break
+		}
+	}
+
+	t.Logf("API key sweep: found %d keys, %d stale", totalSeen, len(toDelete))
+
+	var deleted int
+	for _, key := range toDelete {
+		httpResp, err := api.DeleteAPIKey(ctx, key.id)
+		if err != nil {
+			status := 0
+			if httpResp != nil {
+				status = httpResp.StatusCode
+			}
+			t.Logf("API key sweep: failed to delete %q (id=%s, status=%d): %v", key.name, key.id, status, err)
+			continue
+		}
+		deleted++
+	}
+
+	t.Logf("API key sweep: deleted %d stale keys", deleted)
+}
+
+func isTestApiKeyName(name string) bool {
+	return providerTestKeyName.MatchString(name)
+}
+
+func TestIsTestApiKeyName(t *testing.T) {
+	// Every "keep" case below is a name seen on a real key in the test org.
+	sweep := []string{
+		"tf-TestAccDatadogApiKeyDatasource_matchId-local-1785463711",
+		"tf-TestDatadogApiKey_import-2847193-1785463711",
+		"tf-TestAccDatadogApiKey_Update-local-1785463711",
+	}
+	for _, name := range sweep {
+		if !isTestApiKeyName(name) {
+			t.Errorf("expected %q to be swept, it was kept", name)
+		}
+	}
+
+	keep := []string{
+		"tf-prod-deploy",
+		"tf-terraform-cloud-runner",
+		"terraform",
+		"Test-Key",
+		"Datadog Agent",
+		"CI Runner 1785463711",
+		"my-tf-key-local-1785463711",
+		"Test-Go-Create-an-API-key-returns-OK-response-1785463711",
+		"Test-Python-List-API-keys-1785463711",
+		"test-go-something-1785463711",
+	}
+	for _, name := range keep {
+		if isTestApiKeyName(name) {
+			t.Errorf("expected %q to be kept, it would have been swept", name)
+		}
+	}
+}
+
+func TestSweepingIsSafe(t *testing.T) {
+	for _, tc := range []struct {
+		record string
+		want   bool
+	}{
+		{"false", false}, // replay
+		{"true", false},  // recording
+		{"none", true},   // live run
+		{"", true},       // unset behaves as a live run
+	} {
+		t.Setenv("RECORD", tc.record)
+		if got := sweepingIsSafe(); got != tc.want {
+			t.Errorf("RECORD=%q: sweepingIsSafe() = %v, want %v", tc.record, got, tc.want)
+		}
+	}
+}

--- a/datadog/tests/data_source_datadog_api_key_test.go
+++ b/datadog/tests/data_source_datadog_api_key_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccDatadogApiKeyDatasource_matchId(t *testing.T) {
+	cleanupApiKeys(t)
 	t.Parallel()
 	if isRecording() || isReplaying() {
 		t.Skip("This test doesn't support recording or replaying")
@@ -36,6 +37,7 @@ func TestAccDatadogApiKeyDatasource_matchId(t *testing.T) {
 }
 
 func TestAccDatadogApiKeyDatasource_matchName(t *testing.T) {
+	cleanupApiKeys(t)
 	t.Parallel()
 	if isRecording() || isReplaying() {
 		t.Skip("This test doesn't support recording or replaying")
@@ -62,6 +64,7 @@ func TestAccDatadogApiKeyDatasource_matchName(t *testing.T) {
 }
 
 func TestAccDatadogApiKeyDatasource_exactMatchName(t *testing.T) {
+	cleanupApiKeys(t)
 	t.Parallel()
 	if isRecording() || isReplaying() {
 		t.Skip("This test doesn't support recording or replaying")

--- a/datadog/tests/resource_datadog_api_key_test.go
+++ b/datadog/tests/resource_datadog_api_key_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -13,6 +14,7 @@ import (
 )
 
 func TestAccDatadogApiKey_Update(t *testing.T) {
+	cleanupApiKeys(t)
 	if isRecording() || isReplaying() {
 		t.Skip("This test doesn't support recording or replaying")
 	}
@@ -91,6 +93,7 @@ func TestAccDatadogApiKey_Update(t *testing.T) {
 }
 
 func TestDatadogApiKey_import(t *testing.T) {
+	cleanupApiKeys(t)
 	if isRecording() || isReplaying() {
 		t.Skip("This test doesn't support recording or replaying")
 	}
@@ -167,7 +170,7 @@ func datadogApiKeyDestroyHelper(ctx context.Context, s *terraform.State, apiInst
 		}
 
 		id := r.Primary.ID
-		_, httpResponse, err := apiInstances.GetKeyManagementApiV2().GetAPIKey(ctx, id)
+		resp, httpResponse, err := apiInstances.GetKeyManagementApiV2().GetAPIKey(ctx, id)
 
 		if err != nil {
 			if httpResponse.StatusCode == 404 {
@@ -176,10 +179,25 @@ func datadogApiKeyDestroyHelper(ctx context.Context, s *terraform.State, apiInst
 			return fmt.Errorf("received an error retrieving api key %s", err)
 		}
 
+		if datadogApiKeyRevoked(resp) {
+			continue
+		}
+
 		return fmt.Errorf("api key still exists")
 	}
 
 	return nil
+}
+
+// datadogApiKeyRevoked reports whether the api key has been revoked. Deleting an
+// api key revokes it: the key stops working and drops out of the org's key list,
+// but GET keeps returning it with a "revoked" status rather than a 404.
+func datadogApiKeyRevoked(resp datadogV2.APIKeyResponse) bool {
+	apiKey := resp.GetData()
+	attributes := apiKey.GetAttributes()
+	// The status attribute is not part of the API client model yet.
+	status, ok := attributes.AdditionalProperties["status"].(string)
+	return ok && status == "revoked"
 }
 
 func Ptr[T any](v T) *T {


### PR DESCRIPTION
## Motivation

All five `datadog_api_key` acceptance tests have failed on every nightly master integration run. The shared test org sat at 202 API keys against a hard cap of 200, so every create returned `400 You have exceeded the maximum number of permitted API keys`. Nothing reclaimed the keys that crashed or failed runs leave behind.

Clearing the quota exposed a second failure underneath it. Deleting an API key now revokes it rather than removing it: `DELETE` returns 204 and the key drops out of the list endpoint, but `GET /api/v2/api_keys/{id}` keeps returning 200 with `"status":"revoked"` indefinitely. `CheckDestroy` treated any non-404 as "still exists", so it could never pass.

Jira: [APIR-3164]

## Overview of changes

Adds an API key sweeper, following the existing sensitive-data-scanner sweeper, invoked once per test binary before the api key tests run. Because it deletes real credentials the matching is deliberately narrow: it matches only the full name shape the test helpers generate, `tf-<TestName>-<buildID>-<unix timestamp>`, so a human key such as `tf-prod-deploy` cannot match, and it skips anything created within the last hour so it can never race a live run. A unit test pins the keep/sweep boundary.

Keys leaked into the same org by the client library suites are deliberately left alone — this repo does not delete another team's credentials. That does mean the sweeper alone will not hold the org under the cap; see the caveat below.

`CheckDestroy` now treats a revoked key as destroyed, reading `status` from the response's additional properties since the field is not in the Go client model yet.

## Validation

- All five tests pass against the live API with `RECORD=none`; before the change all five failed with the quota error.
- `TestIsTestApiKeyName` covers the keep/sweep boundary, including `tf-prod-deploy`, `terraform`, `Test-Key` and the client library names.
- The matcher was dry-run against all 62 keys currently in the org: zero matches.
- These tests skip under both `RECORD=true` and `RECORD=false`, so there are no cassettes to re-record.

[APIR-3164]: https://datadoghq.atlassian.net/browse/APIR-3164