### PR TITLE
[APIR-3166] Fix datadog_restriction_policy test — ExpectError regex broken by wrapped diagnostic

### DIFF
--- a/datadog/tests/resource_datadog_restriction_policy_test.go
+++ b/datadog/tests/resource_datadog_restriction_policy_test.go
@@ -69,8 +69,10 @@ func TestAccRestrictionPolicyInvalidInput(t *testing.T) {
 	resourceType := "security-rule"
 	invalidResourceType := "security_rule"
 
-	invalidResourceTypeError, _ := regexp.Compile("Invalid resource type")
-	invalidPrincipalError, _ := regexp.Compile("PrincipalTypeInvalidForRelation")
+	// Terraform hard-wraps diagnostic text, so the message may contain
+	// newlines between the words.
+	invalidResourceTypeError := regexp.MustCompile(`Invalid\s+resource\s+type`)
+	invalidPrincipalError := regexp.MustCompile(`PrincipalTypeInvalidForRelation`)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: accProviders,


### PR DESCRIPTION
## Motivation

`TestAccRestrictionPolicyInvalidInput` has failed on every nightly master integration run:

```
Step 1/2, expected an error with pattern, no match on: ...
400 Bad Request: {"errors":[{"title":"Generic Error","detail":"Invalid resource type:
'security_rule' does not support restriction policies"}]}
```

The API behaviour has not changed — it still rejects `security_rule` exactly as the test intends. The message simply grew long enough that Terraform's diagnostic hard-wrapping now breaks the line inside the phrase the `ExpectError` regex matches, so `Invalid resource type` no longer matches `Invalid\nresource type`.

Same defect as 6ad68a62d, which fixed a wrapped error regex in the dataset test.

Jira: [APIR-3166](https://datadoghq.atlassian.net/browse/APIR-3166)

## Overview of changes

Match `\s+` instead of a literal space, so the assertion tolerates wrapping without becoming any less specific. The second step's assertion is a single token that wrapping cannot split, so it is unchanged.

## Validation

- The whole restriction policy family passes against the live API with `RECORD=none`; before the change the pre-fix run reproduced CI exactly, including the wrapped `Invalid\nresource type` text.
- Cassette replay passes with `RECORD=false`; no re-recording needed since no request changed.


[APIR-3166]: https://datadoghq.atlassian.net/browse/APIR-3166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ