### PR TITLE
[APIR-3168] Fix datadog_custom_allocation_rule test — API no longer increments version on in-place update

### DIFF
--- a/datadog/tests/resource_datadog_custom_allocation_rule_test.go
+++ b/datadog/tests/resource_datadog_custom_allocation_rule_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
@@ -104,17 +105,21 @@ func TestAccDatadogCustomAllocationRuleInPlaceUpdate(t *testing.T) {
 			},
 			{
 				// Change only costs_to_allocate (not rule_name) so this is an in-place
-				// PATCH, not a replacement. The API bumps `updated` and `version` on
-				// every update.
+				// PATCH, not a replacement. The API bumps `updated` on every update but
+				// keeps `version` at 1, so the plan action is what asserts the update
+				// happened in place.
 				Config: testAccCheckDatadogCustomAllocationRuleInPlaceUpdate(uniq),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("datadog_custom_allocation_rule.foo", plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatadogCustomAllocationRuleExists(providers.frameworkProvider),
 					resource.TestCheckResourceAttr(
 						"datadog_custom_allocation_rule.foo", "rule_name", fmt.Sprintf("tf-test-rule-%s", uniq)),
 					resource.TestCheckResourceAttr(
 						"datadog_custom_allocation_rule.foo", "costs_to_allocate.0.value", "AmazonS3"),
-					resource.TestCheckResourceAttr(
-						"datadog_custom_allocation_rule.foo", "version", "2"),
 				),
 			},
 		},


### PR DESCRIPTION
## Motivation

`TestAccDatadogCustomAllocationRuleInPlaceUpdate` has failed on every nightly master integration run:

```
Step 2/2 error: Check 4/4 error: datadog_custom_allocation_rule.foo:
Attribute 'version' expected "2", got "1"
```

The CCM `arbitrary_rule` API no longer increments `version` on an in-place PATCH. Verified directly with a throwaway rule: POST returns version 1, two successive PATCHes each move `updated` but leave `version` at 1, and a follow-up GET also returns 1. The provider is correct — it copies `version` straight from the response — so state faithfully held 1. The expectation of 2 was recorded in October 2025 when the API really did bump it, as the cassette still shows.

Jira: [APIR-3168](https://datadoghq.atlassian.net/browse/APIR-3168)

## Overview of changes

Drops the `version` assertion and instead asserts what the step actually exists to prove: that changing only `costs_to_allocate` plans as an in-place update rather than a replacement. That is checked directly on the plan action, so it no longer depends on a server-side counter, and it will keep holding if the API later starts incrementing `version` again.

## Validation

- Passes against the live API with `RECORD=none`; before the change it failed with the version mismatch on three consecutive runs.
- Cassette replay passes with `RECORD=false` across the whole resource family (14 tests).
- No provider code changed.

[APIR-3168]: https://datadoghq.atlassian.net/browse/APIR-3168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ