### PR TITLE
[tfgen] Bind scalar SDK arguments

### DIFF
--- a/.generator-v2/internal/cli/generate.go
+++ b/.generator-v2/internal/cli/generate.go
@@ -15,6 +15,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/emit"
 	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
 	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/parser"
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/sdkbinding"
 )
 
 // errCheckFailed signals that --check found files that would change.
@@ -94,16 +95,18 @@ func newGenerateCmd(flags *globalFlags) *cobra.Command {
 					accessors = nil
 				}
 
-				var constructors map[string]string
-				sdkPackageDir, sdkDirErr := resolveSDKPackageDir(outputRoot)
-				if sdkDirErr != nil {
-					cmd.PrintErrln("tfgen: could not locate pinned SDK API package; data sources without ApiInstances accessors will fail:", sdkDirErr)
-				} else {
-					constructors, err = emit.ResolveAPIConstructors(sdkPackageDir)
-					if err != nil {
-						cmd.PrintErrln("tfgen: could not resolve pinned SDK API constructors; data sources without ApiInstances accessors will fail:", err)
-						constructors = nil
-					}
+				sdkPackageDir, err := resolveSDKPackageDir(outputRoot)
+				if err != nil {
+					return fmt.Errorf("generate: resolve pinned SDK: %w", err)
+				}
+				constructors, constructorErr := emit.ResolveAPIConstructors(sdkPackageDir)
+				if constructorErr != nil {
+					cmd.PrintErrln("tfgen: could not resolve pinned SDK API constructors; data sources without ApiInstances accessors will fail:", constructorErr)
+					constructors = nil
+				}
+				sdkBindings, err := sdkbinding.Load(sdkPackageDir)
+				if err != nil {
+					return fmt.Errorf("generate: load pinned SDK bindings: %w", err)
 				}
 
 				var registrations []emit.GeneratedRegistration
@@ -135,7 +138,7 @@ func newGenerateCmd(flags *globalFlags) *cobra.Command {
 						continue
 					}
 
-					entry, testEntry, exampleEntry, reg := generateArtifact(op, outputRoot, testsOutputRoot, examplesOutputRoot, emitTests, check, accessors, constructors)
+					entry, testEntry, exampleEntry, reg := generateArtifact(op, outputRoot, testsOutputRoot, examplesOutputRoot, emitTests, check, accessors, constructors, sdkBindings)
 					runReport.Artifacts = append(runReport.Artifacts, entry)
 					if testEntry != nil {
 						runReport.Artifacts = append(runReport.Artifacts, *testEntry)
@@ -289,7 +292,7 @@ func findProviderModuleRoot(outputRoot string) (string, error) {
 // operation. On success it also returns the GeneratedRegistration the caller
 // uses to wire the data source into the provider; it is nil for a skipped or
 // failed artifact.
-func generateArtifact(op *model.Operation, outputRoot, testsOutputRoot, examplesOutputRoot string, emitTests, check bool, accessors, constructors map[string]string) (model.ArtifactReportEntry, *model.ArtifactReportEntry, *model.ArtifactReportEntry, *emit.GeneratedRegistration) {
+func generateArtifact(op *model.Operation, outputRoot, testsOutputRoot, examplesOutputRoot string, emitTests, check bool, accessors, constructors map[string]string, sdkBindings *sdkbinding.Inventory) (model.ArtifactReportEntry, *model.ArtifactReportEntry, *model.ArtifactReportEntry, *emit.GeneratedRegistration) {
 	entry := model.ArtifactReportEntry{
 		Name: op.Tracking.ArtifactName,
 		Kind: op.Tracking.ArtifactKind,
@@ -302,6 +305,15 @@ func generateArtifact(op *model.Operation, outputRoot, testsOutputRoot, examples
 			Message:  fmt.Sprintf("resource generation not yet supported (kind=%s)", op.Tracking.ArtifactKind),
 		}}
 		return entry, nil, nil, nil
+	}
+
+	if err := sdkBindings.Bind(op); err != nil {
+		return failEntry(entry, err), nil, nil, nil
+	}
+	if op.SearchOp != nil && op.SearchOp != op {
+		if err := sdkBindings.Bind(op.SearchOp); err != nil {
+			return failEntry(entry, err), nil, nil, nil
+		}
 	}
 
 	artifact, err := model.BuildArtifact(op)

--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -58,7 +58,8 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 		read, search = a.Lifecycle.Read, a.Lifecycle.Search
 		idStrategy = a.Lifecycle.IdStrategy
 	}
-	byID, searchable := read != nil, search != nil
+	hasRead, searchable := read != nil, search != nil
+	byID := hasRead && (!read.BindingResolved || callHasArgument(read, "id"))
 
 	// The primary call provides the SDK package/struct the data source binds to:
 	// the by-id call when present, otherwise the list call.
@@ -87,13 +88,16 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 		paramType = "*" + read.GoPackage + "." + read.GoResponseType
 	}
 
-	// Partition the schema: Optional leaves are the search filters, the lone
-	// envelope block is the record to flatten.
-	var topLevel, filterLeaves []*model.Attribute
+	// Partition the schema: required/optional leaves are SDK inputs, while the
+	// lone computed envelope block is the record to flatten.
+	var topLevel, inputLeaves, filterLeaves []*model.Attribute
 	if a.Schema != nil {
 		for _, attr := range a.Schema.Attributes {
-			if attr.Optional && isLeafType(attr.TfType) {
-				filterLeaves = append(filterLeaves, attr)
+			if (attr.Required || attr.Optional) && isLeafType(attr.TfType) {
+				inputLeaves = append(inputLeaves, attr)
+				if attr.Optional {
+					filterLeaves = append(filterLeaves, attr)
+				}
 			} else {
 				topLevel = append(topLevel, attr)
 			}
@@ -112,8 +116,13 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 	recordAttrs, recordBlocks, recordScalars, recordLists := b.walk(rootStruct, b.receiver, "state", env.leaves)
 	leafFields := b.models[0].Fields
 
-	// Search filters: one Optional attribute + model field + param binding each.
-	filterAttrs, filterFields, filterParams := buildSingularFilters(filterLeaves)
+	inputAttrs, inputFields := buildInputViews(inputLeaves)
+	filterParams := buildFilterParams(search, filterLeaves, &b.unsupported)
+	readArgs, readUUID := buildArgumentViews(read, &b.unsupported)
+	searchArgs, searchUUID := buildArgumentViews(search, &b.unsupported)
+	if len(b.unsupported) > 0 {
+		return DataSourceView{}, &UnsupportedEmitError{Nodes: b.unsupported}
+	}
 
 	// Parent model fields: the lookup id, then the search filters, then the record
 	// leaves. The group comments are only emitted for the search shapes.
@@ -124,14 +133,14 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 			leafFields[0].Comment = "Computed values"
 		}
 	}
-	fields := append([]ModelFieldView{idField}, filterFields...)
+	fields := append([]ModelFieldView{idField}, inputFields...)
 	b.models[0].Fields = append(fields, leafFields...)
 
 	assignments := append([]StateAssignment{env.idAssign}, recordScalars...)
 
 	var readView, searchView SDKReadView
-	if byID {
-		readView = SDKReadView{Method: read.GoMethod, ResponseType: read.GoResponseType}
+	if hasRead {
+		readView = SDKReadView{Method: read.GoMethod, ResponseType: read.GoResponseType, Arguments: readArgs}
 	}
 	if searchable {
 		searchView = SDKReadView{
@@ -140,6 +149,7 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 			ItemType:           search.ItemType,
 			OptionalParamsType: search.OptionalParamsType,
 			Filters:            filterParams,
+			Arguments:          searchArgs,
 		}
 	}
 
@@ -151,12 +161,13 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 		SDKPackage:  primary.GoPackage,
 		APIStruct:   primary.GoApiStruct,
 		APIAccessor: "Get" + primary.GoApiStruct + strings.TrimPrefix(primary.GoPackage, "datadog"),
+		UsesUUID:    readUUID || searchUUID,
 		ByID:        byID,
 		Searchable:  searchable,
 		Read:        readView,
 		Search:      searchView,
 		Models:      b.models,
-		Schema:      SchemaView{Attributes: append(filterAttrs, recordAttrs...), Blocks: recordBlocks},
+		Schema:      SchemaView{Attributes: append(inputAttrs, recordAttrs...), Blocks: recordBlocks},
 		State: StateView{
 			ParamName:   paramName,
 			ParamType:   paramType,
@@ -168,25 +179,150 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 	}, nil
 }
 
-// buildSingularFilters turns the Optional filter leaves of a search/both data
-// source into Terraform attributes, model fields, and the request-param bindings
-// that set the list call's optional parameters — mirroring the plural filter set.
-func buildSingularFilters(leaves []*model.Attribute) (attrs []AttrView, fields []ModelFieldView, params []FilterParamView) {
+// buildInputViews turns Terraform input leaves into schema attributes and model
+// fields shared by singular and plural data sources.
+func buildInputViews(leaves []*model.Attribute) (attrs []AttrView, fields []ModelFieldView) {
+	comment := "Query Parameters"
+	for _, leaf := range leaves {
+		if leaf.Required {
+			comment = "SDK call parameters"
+			break
+		}
+	}
 	for i, leaf := range leaves {
 		tfName := tfNameOf(leaf.Path)
-		attrs = append(attrs, AttrView{TFName: tfName, TFType: leaf.TfType, Description: leaf.Description, Optional: true})
+		attrs = append(attrs, AttrView{
+			TFName: tfName, TFType: leaf.TfType, Description: leaf.Description,
+			Required: leaf.Required, Optional: leaf.Optional,
+		})
 		field := ModelFieldView{GoField: model.SdkName(tfName), GoType: leaf.GoType, TFName: tfName}
 		if i == 0 {
-			field.Comment = "Query Parameters"
+			field.Comment = comment
 		}
 		fields = append(fields, field)
-		params = append(params, FilterParamView{
+	}
+	return attrs, fields
+}
+
+func buildHashInputs(leaves []*model.Attribute) []FilterParamView {
+	inputs := make([]FilterParamView, 0, len(leaves))
+	for _, leaf := range leaves {
+		tfName := tfNameOf(leaf.Path)
+		inputs = append(inputs, FilterParamView{
 			StateField: model.SdkName(tfName),
-			ParamField: model.SdkName(tfName),
 			ValueExpr:  pointerValueExpr(leaf.GoType),
 		})
 	}
-	return attrs, fields, params
+	return inputs
+}
+
+func callHasArgument(call *model.SDKCall, tfName string) bool {
+	if call == nil {
+		return false
+	}
+	for _, arg := range call.Arguments {
+		if arg.TFName == tfName {
+			return true
+		}
+	}
+	return false
+}
+
+func buildArgumentViews(call *model.SDKCall, unsupported *[]UnsupportedNode) ([]SDKArgumentView, bool) {
+	if call == nil || !call.BindingResolved {
+		return nil, false
+	}
+	var views []SDKArgumentView
+	usesUUID := false
+	for _, arg := range call.Arguments {
+		expr, uuidVar, uuidSource, reason := sdkArgumentExpression(call.GoPackage, arg)
+		if reason != "" {
+			*unsupported = append(*unsupported, UnsupportedNode{
+				Path: "sdk." + call.GoMethod + "." + arg.Name, Reason: reason,
+			})
+			continue
+		}
+		views = append(views, SDKArgumentView{
+			Expression: expr, UUIDVar: uuidVar, UUIDSource: uuidSource, TFName: arg.TFName,
+		})
+		usesUUID = usesUUID || uuidVar != ""
+	}
+	return views, usesUUID
+}
+
+func buildFilterParams(call *model.SDKCall, leaves []*model.Attribute, unsupported *[]UnsupportedNode) []FilterParamView {
+	if call == nil {
+		return nil
+	}
+	byName := map[string]model.SDKArgument{}
+	for _, arg := range call.OptionalArguments {
+		byName[arg.TFName] = arg
+	}
+	var params []FilterParamView
+	for _, leaf := range leaves {
+		tfName := tfNameOf(leaf.Path)
+		if !call.BindingResolved {
+			params = append(params, FilterParamView{
+				StateField: model.SdkName(tfName), ParamField: model.SdkName(tfName), ValueExpr: pointerValueExpr(leaf.GoType),
+			})
+			continue
+		}
+		arg, ok := byName[tfName]
+		if !ok {
+			*unsupported = append(*unsupported, UnsupportedNode{
+				Path:   "sdk." + call.GoMethod + "." + tfName,
+				Reason: "no matching optional-parameter setter in the pinned SDK",
+			})
+			continue
+		}
+		expr, uuidVar, _, reason := sdkArgumentExpression(call.GoPackage, arg)
+		if uuidVar != "" {
+			reason = "optional UUID arguments are not supported by scalar-first binding"
+		}
+		if reason != "" {
+			*unsupported = append(*unsupported, UnsupportedNode{Path: "sdk." + call.GoMethod + "." + arg.Name, Reason: reason})
+			continue
+		}
+		params = append(params, FilterParamView{
+			StateField: model.SdkName(tfName), ParamField: model.SdkName(tfName), ValueExpr: expr, Setter: arg.Setter,
+		})
+	}
+	return params
+}
+
+func sdkArgumentExpression(sdkPackage string, arg model.SDKArgument) (expr, uuidVar, uuidSource, reason string) {
+	if arg.Schema == nil || arg.Schema.Kind != model.SchemaKindPrimitive {
+		return "", "", "", fmt.Sprintf("SDK argument type %s is outside scalar-first support", arg.GoType)
+	}
+	field := goFieldName(arg.TFName)
+	source := "state." + field
+	var value string
+	switch arg.Schema.Type {
+	case "string":
+		value = source + ".ValueString()"
+	case "boolean":
+		value = source + ".ValueBool()"
+	case "integer":
+		value = source + ".ValueInt64()"
+	case "number":
+		value = source + ".ValueFloat64()"
+	default:
+		return "", "", "", fmt.Sprintf("OpenAPI scalar type %q is not supported", arg.Schema.Type)
+	}
+
+	switch arg.GoType {
+	case "string", "bool", "int64", "float64":
+		return value, "", "", ""
+	case "int", "int32", "float32":
+		return arg.GoType + "(" + value + ")", "", "", ""
+	case "uuid.UUID":
+		name := "parsed" + model.SdkName(arg.TFName)
+		return name, name, value, ""
+	}
+	if strings.ContainsAny(arg.GoType, "[]*{}.") || arg.GoType == "interface{}" {
+		return "", "", "", fmt.Sprintf("SDK argument type %s is outside scalar-first support", arg.GoType)
+	}
+	return sdkPackage + "." + arg.GoType + "(" + value + ")", "", "", ""
 }
 
 // flattenedEnvelope is the result of recognizing a singular JSON:API envelope:
@@ -216,12 +352,14 @@ func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrat
 	data := topLevel[0]
 
 	// data members must be a subset of {id, type, attributes}.
-	var attributes *model.Attribute
+	var id, attributes *model.Attribute
 	ok := true
 	for _, child := range data.Children {
 		switch tfNameOf(child.Path) {
-		case "id", "type":
-			// id is surfaced from id_strategy below; type is the discriminator, dropped.
+		case "id":
+			id = child
+		case "type":
+			// type is the discriminator and is not surfaced.
 		case "attributes":
 			attributes = child
 		default:
@@ -287,6 +425,10 @@ func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrat
 		return nil
 	}
 
+	idValueExpr := "*id"
+	if id != nil && id.IsEnum {
+		idValueExpr = "string(*id)"
+	}
 	return &flattenedEnvelope{
 		leaves:  leaves,
 		idField: ModelFieldView{GoField: "ID", GoType: "types.String", TFName: "id"},
@@ -294,7 +436,7 @@ func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrat
 			Var:      "id",
 			GetterOk: rootExpr + ".GetIdOk()",
 			LHS:      "state.ID",
-			RHS:      "types.StringValue(*id)",
+			RHS:      "types.StringValue(" + idValueExpr + ")",
 		},
 		preamble: []string{"attributes := " + rootExpr + ".GetAttributes()"},
 	}
@@ -635,18 +777,21 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 		unsupported = append(unsupported, UnsupportedNode{Path: "response", Reason: "missing list item type"})
 	}
 
-	// Partition the top-level schema: Optional leaves are filters, the lone
+	// Partition the top-level schema: required/optional leaves are SDK inputs, the lone
 	// ListNestedBlock is the items block (the model already dropped response
 	// metadata siblings, keeping only the results array).
-	var filterLeaves []*model.Attribute
+	var inputLeaves, filterLeaves []*model.Attribute
 	var itemsBlock *model.Attribute
 	if a.Schema != nil {
 		for _, attr := range a.Schema.Attributes {
 			switch {
 			case attr.TfType == "schema.ListNestedBlock":
 				itemsBlock = attr
-			case attr.Optional && isLeafType(attr.TfType):
-				filterLeaves = append(filterLeaves, attr)
+			case (attr.Required || attr.Optional) && isLeafType(attr.TfType):
+				inputLeaves = append(inputLeaves, attr)
+				if attr.Optional {
+					filterLeaves = append(filterLeaves, attr)
+				}
 			default:
 				unsupported = append(unsupported, UnsupportedNode{Path: attr.Path, Reason: unsupportedReason(attr.TfType)})
 			}
@@ -656,26 +801,9 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 		unsupported = append(unsupported, UnsupportedNode{Path: "response", Reason: "missing results array block"})
 	}
 
-	// Filters: one Optional attribute + model field + param binding each.
-	var filterAttrs []AttrView
-	var filterFields []ModelFieldView
-	var filterParams []FilterParamView
-	for i, leaf := range filterLeaves {
-		tfName := tfNameOf(leaf.Path)
-		filterAttrs = append(filterAttrs, AttrView{
-			TFName: tfName, TFType: leaf.TfType, Description: leaf.Description, Optional: true,
-		})
-		field := ModelFieldView{GoField: model.SdkName(tfName), GoType: leaf.GoType, TFName: tfName}
-		if i == 0 {
-			field.Comment = "Query Parameters"
-		}
-		filterFields = append(filterFields, field)
-		filterParams = append(filterParams, FilterParamView{
-			StateField: model.SdkName(tfName),
-			ParamField: model.SdkName(tfName),
-			ValueExpr:  pointerValueExpr(leaf.GoType),
-		})
-	}
+	inputAttrs, inputFields := buildInputViews(inputLeaves)
+	filterParams := buildFilterParams(call, filterLeaves, &unsupported)
+	callArgs, usesUUID := buildArgumentViews(call, &unsupported)
 
 	// b hosts walk so list-of-object item fields generate their element structs.
 	b := &dataSourceBuilder{}
@@ -761,7 +889,7 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 	itemField := model.SdkName(a.Name)
 	goName := dsGoName(a.Name)
 
-	parentFields := append([]ModelFieldView{}, filterFields...)
+	parentFields := append([]ModelFieldView{}, inputFields...)
 	parentFields = append(parentFields,
 		ModelFieldView{Comment: "Results", GoField: "ID", GoType: "types.String", TFName: "id"},
 		ModelFieldView{GoField: itemField, GoType: "[]*" + itemStruct, TFName: a.Name},
@@ -783,16 +911,19 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 		SDKPackage:  call.GoPackage,
 		APIStruct:   call.GoApiStruct,
 		APIAccessor: "Get" + call.GoApiStruct + strings.TrimPrefix(call.GoPackage, "datadog"),
+		UsesUUID:    usesUUID,
 		Read: SDKReadView{
 			Method:             call.GoMethod,
 			Paginated:          call.Paginated,
 			ItemType:           call.ItemType,
 			OptionalParamsType: call.OptionalParamsType,
 			Filters:            filterParams,
+			HashInputs:         buildHashInputs(inputLeaves),
+			Arguments:          callArgs,
 		},
 		Models: models,
 		Schema: SchemaView{
-			Attributes: filterAttrs,
+			Attributes: inputAttrs,
 			Blocks: []AttrView{{
 				TFName:      a.Name,
 				Description: itemsBlock.Description,

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -97,12 +97,63 @@ var _ = Describe("BuildDataSourceView", func() {
 		Expect(src).NotTo(ContainSubstring("if type, ok :="))
 	})
 
+	It("casts a named string envelope id before storing it in Terraform state", func() {
+		op := incidentTypeOperation()
+		op.ResponseSchema.Properties["data"].Properties["id"].Enum = []string{"permanent"}
+		view := mustView(op)
+		Expect(view.State.Assignments[0]).To(Equal(StateAssignment{
+			Var: "id", GetterOk: "resp.Data.GetIdOk()", LHS: "state.ID", RHS: "types.StringValue(string(*id))",
+		}))
+	})
+
 	It("produces a deeply-equal view across two runs", func() {
 		first, err := BuildDataSourceView(incidentTypeArtifact())
 		Expect(err).NotTo(HaveOccurred())
 		second, err := BuildDataSourceView(incidentTypeArtifact())
 		Expect(err).NotTo(HaveOccurred())
 		Expect(first).To(Equal(second))
+	})
+
+	It("renders resolved path arguments in SDK order, including UUID conversion", func() {
+		op := incidentTypeOperation()
+		op.Path = "/api/v2/accounts/{account_id}/incident-types/{incident_type_id}"
+		op.SDKBinding = &model.SDKOperationBinding{Required: []model.SDKArgument{
+			{Name: "account_id", GoName: "accountId", GoType: "int64", Location: "path", Schema: prim("integer", "The account ID.")},
+			{Name: "incident_type_id", GoName: "incidentTypeId", GoType: "uuid.UUID", Location: "path", Schema: &model.Schema{Kind: model.SchemaKindPrimitive, Type: "string", Format: "uuid"}},
+		}}
+
+		art, err := model.BuildArtifact(op)
+		Expect(err).NotTo(HaveOccurred())
+		view, err := BuildDataSourceView(art)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(view.UsesUUID).To(BeTrue())
+		Expect(view.Read.Arguments).To(Equal([]SDKArgumentView{
+			{Expression: "state.AccountId.ValueInt64()", TFName: "account_id"},
+			{Expression: "parsedId", UUIDVar: "parsedId", UUIDSource: "state.ID.ValueString()", TFName: "id"},
+		}))
+
+		rendered, err := RenderDataSource(view)
+		Expect(err).NotTo(HaveOccurred())
+		src := string(rendered)
+		Expect(src).To(ContainSubstring(`parsedId, err := uuid.Parse(state.ID.ValueString())`))
+		Expect(src).To(ContainSubstring(`GetIncidentType(d.Auth, state.AccountId.ValueInt64(), parsedId)`))
+	})
+
+	It("renders a resolved singleton call without inventing an id argument", func() {
+		op := incidentTypeOperation()
+		op.Path = "/api/v2/incidents/config/types/default"
+		op.SDKBinding = &model.SDKOperationBinding{}
+
+		art, err := model.BuildArtifact(op)
+		Expect(err).NotTo(HaveOccurred())
+		view, err := BuildDataSourceView(art)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(view.ByID).To(BeFalse())
+		Expect(view.Read.Arguments).To(BeEmpty())
+
+		rendered, err := RenderDataSource(view)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(rendered)).To(ContainSubstring(`GetIncidentType(d.Auth)`))
 	})
 
 	DescribeTable("fail-slows anything outside the recognized envelope",
@@ -770,6 +821,32 @@ var _ = Describe("BuildDataSourceView plural", func() {
 		Expect(view.Read.Filters).To(BeEmpty())
 		Expect(view.Read.OptionalParamsType).To(BeEmpty())
 		Expect(view.Schema.Attributes).To(BeEmpty())
+	})
+
+	It("includes required positional SDK inputs in the plural identity hash", func() {
+		op := teamsOperation()
+		op.Path = "/api/v2/accounts/{account_id}/team"
+		op.SDKBinding = &model.SDKOperationBinding{
+			Required: []model.SDKArgument{
+				{Name: "account_id", GoName: "accountId", GoType: "int64", Location: "path", Schema: prim("integer", "The account ID.")},
+			},
+			OptionalParamsType: "ListTeamsOptionalParameters",
+			Optional: []model.SDKArgument{
+				{Name: "filter[keyword]", GoName: "filterKeyword", GoType: "string", Location: "query", Schema: prim("string", ""), Setter: "WithFilterKeyword"},
+				{Name: "filter[me]", GoName: "filterMe", GoType: "bool", Location: "query", Schema: prim("boolean", ""), Setter: "WithFilterMe"},
+			},
+		}
+
+		view, err := BuildDataSourceView(mustArtifact(op))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(view.Read.HashInputs).To(Equal([]FilterParamView{
+			{StateField: "AccountId", ValueExpr: "ValueInt64Pointer()"},
+			{StateField: "FilterKeyword", ValueExpr: "ValueStringPointer()"},
+			{StateField: "FilterMe", ValueExpr: "ValueBoolPointer()"},
+		}))
+		rendered, err := RenderDataSource(view)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(rendered)).To(ContainSubstring(`fmt.Sprintf("%d:%s:%t", state.AccountId.ValueInt64(), state.FilterKeyword.ValueString(), state.FilterMe.ValueBool())`))
 	})
 
 	It("produces a deeply-equal plural view across two runs", func() {

--- a/.generator-v2/internal/emit/templates/data_source_plural.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_plural.go.tmpl
@@ -9,7 +9,7 @@ package fwprovider
 
 import (
 	"context"
-{{- if .Read.Filters }}
+{{- if .Read.HashInputs }}
 	"fmt"
 {{- end }}
 
@@ -17,6 +17,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+{{- if .UsesUUID }}
+	"github.com/google/uuid"
+{{- end }}
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 )
@@ -55,13 +58,26 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 	var optionalParams {{ .SDKPackage }}.{{ .Read.OptionalParamsType }}
 {{- range .Read.Filters }}
 	if !state.{{ .StateField }}.IsNull() {
+{{- if .Setter }}
+		optionalParams.{{ .Setter }}({{ .ValueExpr }})
+{{- else }}
 		optionalParams.{{ .ParamField }} = state.{{ .StateField }}.{{ .ValueExpr }}
+{{- end }}
 	}
 {{- end }}
 {{ end }}
+{{- range .Read.Arguments }}
+{{- if .UUIDVar }}
+	{{ .UUIDVar }}, err := uuid.Parse({{ .UUIDSource }})
+	if err != nil {
+		response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
+		return
+	}
+{{- end }}
+{{- end }}
 	var items []{{ .SDKPackage }}.{{ .Read.ItemType }}
 {{- if .Read.Paginated }}
-	result, cancel := d.Api.{{ .Read.Method }}WithPagination(d.Auth{{ if .Read.OptionalParamsType }}, optionalParams{{ end }})
+	result, cancel := d.Api.{{ .Read.Method }}WithPagination(d.Auth{{ range .Read.Arguments }}, {{ .Expression }}{{ end }}{{ if .Read.OptionalParamsType }}, optionalParams{{ end }})
 	defer cancel()
 	for paginationResult := range result {
 		if paginationResult.Error != nil {
@@ -71,7 +87,7 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 		items = append(items, paginationResult.Item)
 	}
 {{- else }}
-	resp, _, err := d.Api.{{ .Read.Method }}(d.Auth{{ if .Read.OptionalParamsType }}, optionalParams{{ end }})
+	resp, _, err := d.Api.{{ .Read.Method }}(d.Auth{{ range .Read.Arguments }}, {{ .Expression }}{{ end }}{{ if .Read.OptionalParamsType }}, optionalParams{{ end }})
 	if err != nil {
 		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "Error when calling `{{ .Read.Method }}`"))
 		return
@@ -96,8 +112,8 @@ func (d *{{ .GoName }}DataSource) updateState(state *{{ .GoName }}DataSourceMode
 {{- end }}
 		results = append(results, &r)
 	}
-{{ if .Read.Filters }}
-	hashingData := fmt.Sprintf("{{ range $i, $f := .Read.Filters }}{{ if $i }}:{{ end }}{{ fmtVerb $f.ValueExpr }}{{ end }}", {{- range .Read.Filters }} state.{{ .StateField }}.{{ hashExpr .ValueExpr }},{{ end }})
+{{ if .Read.HashInputs }}
+hashingData := fmt.Sprintf("{{ range $i, $f := .Read.HashInputs }}{{ if $i }}:{{ end }}{{ fmtVerb $f.ValueExpr }}{{ end }}", {{- range .Read.HashInputs }} state.{{ .StateField }}.{{ hashExpr .ValueExpr }},{{ end }})
 {{- else }}
 	hashingData := {{ printf "%q" .TypeName }}
 {{- end }}

--- a/.generator-v2/internal/emit/templates/data_source_singular.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_singular.go.tmpl
@@ -19,7 +19,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-{{- if .Searchable }}
+{{- if .UsesUUID }}
+	"github.com/google/uuid"
+{{- end }}
+{{- if or .Searchable (not .ByID) }}
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 {{- end }}
@@ -47,10 +50,14 @@ func (d *{{ .GoName }}DataSource) Schema(_ context.Context, _ datasource.SchemaR
 			"id": utils.ResourceIDAttribute(),
 {{- end }}
 {{- else }}
+{{- if .ByID }}
 			"id": schema.StringAttribute{
 				Description: {{ printf "%q" (printf "The ID of this %s data source." .TypeName) }},
 				Required:    true,
 			},
+{{- else }}
+			"id": utils.ResourceIDAttribute(),
+{{- end }}
 {{- end }}
 {{- range .Schema.Attributes }}
 {{ template "schemaAttribute" . }}
@@ -74,7 +81,16 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 	}
 {{- if not .Searchable }}
 
-	resp, httpResp, err := d.Api.{{ .Read.Method }}(d.Auth, state.ID.ValueString())
+{{ range .Read.Arguments }}
+{{- if .UUIDVar }}
+	{{ .UUIDVar }}, err := uuid.Parse({{ .UUIDSource }})
+	if err != nil {
+		response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
+		return
+	}
+{{- end }}
+{{- end }}
+	resp, httpResp, err := d.Api.{{ .Read.Method }}(d.Auth{{ range .Read.Arguments }}, {{ .Expression }}{{ end }}{{ if and .ByID (not .Read.Arguments) }}, state.ID.ValueString(){{ end }})
 	if err != nil {
 		if httpResp != nil && httpResp.StatusCode == 404 {
 			response.Diagnostics.AddError(
@@ -94,7 +110,16 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 {{- else if .ByID }}
 
 	if !state.ID.IsNull() {
-		resp, _, err := d.Api.{{ .Read.Method }}(d.Auth, state.ID.ValueString())
+{{ range .Read.Arguments }}
+{{- if .UUIDVar }}
+		{{ .UUIDVar }}, err := uuid.Parse({{ .UUIDSource }})
+		if err != nil {
+			response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
+			return
+		}
+{{- end }}
+{{- end }}
+		resp, _, err := d.Api.{{ .Read.Method }}(d.Auth{{ range .Read.Arguments }}, {{ .Expression }}{{ end }}{{ if not .Read.Arguments }}, state.ID.ValueString(){{ end }})
 		if err != nil {
 			response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error reading {{ .TypeName }}"))
 			return
@@ -138,13 +163,26 @@ func (d *{{ .GoName }}DataSource) updateState(state *{{ .GoName }}DataSourceMode
 	var optionalParams {{ .SDKPackage }}.{{ .Search.OptionalParamsType }}
 {{- range .Search.Filters }}
 	if !state.{{ .StateField }}.IsNull() {
+{{- if .Setter }}
+		optionalParams.{{ .Setter }}({{ .ValueExpr }})
+{{- else }}
 		optionalParams.{{ .ParamField }} = state.{{ .StateField }}.{{ .ValueExpr }}
+{{- end }}
 	}
 {{- end }}
 {{ end }}
+{{- range .Search.Arguments }}
+{{- if .UUIDVar }}
+	{{ .UUIDVar }}, err := uuid.Parse({{ .UUIDSource }})
+	if err != nil {
+		response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
+		return
+	}
+{{- end }}
+{{- end }}
 	var items []{{ .SDKPackage }}.{{ .Search.ItemType }}
 {{- if .Search.Paginated }}
-	result, cancel := d.Api.{{ .Search.Method }}WithPagination(d.Auth{{ if .Search.OptionalParamsType }}, optionalParams{{ end }})
+	result, cancel := d.Api.{{ .Search.Method }}WithPagination(d.Auth{{ range .Search.Arguments }}, {{ .Expression }}{{ end }}{{ if .Search.OptionalParamsType }}, optionalParams{{ end }})
 	defer cancel()
 	for paginationResult := range result {
 		if paginationResult.Error != nil {
@@ -154,7 +192,7 @@ func (d *{{ .GoName }}DataSource) updateState(state *{{ .GoName }}DataSourceMode
 		items = append(items, paginationResult.Item)
 	}
 {{- else }}
-	listResp, _, err := d.Api.{{ .Search.Method }}(d.Auth{{ if .Search.OptionalParamsType }}, optionalParams{{ end }})
+	listResp, _, err := d.Api.{{ .Search.Method }}(d.Auth{{ range .Search.Arguments }}, {{ .Expression }}{{ end }}{{ if .Search.OptionalParamsType }}, optionalParams{{ end }})
 	if err != nil {
 		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "Error when calling `{{ .Search.Method }}`"))
 		return

--- a/.generator-v2/internal/emit/templates_test.go
+++ b/.generator-v2/internal/emit/templates_test.go
@@ -228,6 +228,10 @@ func pluralFixture() DataSourceView {
 				{StateField: "FilterKeyword", ParamField: "FilterKeyword", ValueExpr: "ValueStringPointer()"},
 				{StateField: "FilterMe", ParamField: "FilterMe", ValueExpr: "ValueBoolPointer()"},
 			},
+			HashInputs: []FilterParamView{
+				{StateField: "FilterKeyword", ValueExpr: "ValueStringPointer()"},
+				{StateField: "FilterMe", ValueExpr: "ValueBoolPointer()"},
+			},
 		},
 		Models: []ModelStructView{
 			{

--- a/.generator-v2/internal/emit/test_render.go
+++ b/.generator-v2/internal/emit/test_render.go
@@ -59,7 +59,7 @@ func buildTestView(v DataSourceView) testView {
 		Plural:       v.Cardinality == Plural,
 		// A singular by-id data source resolves on the id; everything else
 		// (singular search/both, plural) resolves on optional filters.
-		LookupByID: v.Cardinality != Plural && !v.Searchable,
+		LookupByID: v.Cardinality != Plural && v.ByID && !v.Searchable,
 	}
 	tv.CassettePath = "datadog/tests/cassettes/" + tv.FuncName + ".yaml"
 

--- a/.generator-v2/internal/emit/view.go
+++ b/.generator-v2/internal/emit/view.go
@@ -56,6 +56,8 @@ type DataSourceView struct {
 	// not expose APIStruct, e.g. "NewCaseManagementApi". Exactly one of
 	// APIAccessor and APIConstructor is populated after accessor resolution.
 	APIConstructor string
+	// UsesUUID adds the google/uuid import and argument parsing blocks.
+	UsesUUID bool
 
 	// ByID and Searchable select how a singular data source resolves its one
 	// record, driving the Read body and the "id" attribute: ByID only → by-id
@@ -105,6 +107,8 @@ type SDKReadView struct {
 	// ResponseType is the SDK response type returned by a singular Method, e.g.
 	// "IncidentTypeResponse". It names the updateState receiver.
 	ResponseType string
+	// Arguments are required positional SDK call arguments in call order.
+	Arguments []SDKArgumentView
 
 	// The fields below are plural-only.
 
@@ -119,6 +123,19 @@ type SDKReadView struct {
 	// Filters maps each optional query parameter from the model onto the
 	// request's optional-parameters struct.
 	Filters []FilterParamView
+	// HashInputs includes every Terraform input that identifies the returned
+	// collection, both required positional arguments and optional filters.
+	HashInputs []FilterParamView
+}
+
+// SDKArgumentView is one rendered positional SDK call argument. UUID arguments
+// carry a preparation variable; all other scalar arguments render Expression
+// directly at the call site.
+type SDKArgumentView struct {
+	Expression string
+	UUIDVar    string
+	UUIDSource string
+	TFName     string
 }
 
 // FilterParamView maps one optional query parameter from the Terraform model
@@ -135,6 +152,9 @@ type FilterParamView struct {
 	// ValueExpr is the model accessor producing the SDK value, e.g.
 	// "ValueStringPointer()".
 	ValueExpr string
+	// Setter is the SDK With* method. Empty retains the legacy direct-field form
+	// used by parser-shaped unit fixtures without resolved SDK bindings.
+	Setter string
 }
 
 // SchemaView is the attribute/block split rendered into the Schema method. The

--- a/.generator-v2/internal/model/artifact.go
+++ b/.generator-v2/internal/model/artifact.go
@@ -45,6 +45,12 @@ func buildSingularByIdArtifact(op *Operation) (*Artifact, error) {
 	if err != nil {
 		return nil, err
 	}
+	read := readCall(op, true)
+	inputs, err := buildRequiredInputLeaves(read.Arguments)
+	if err != nil {
+		return nil, err
+	}
+	schema.Attributes = append(inputs, schema.Attributes...)
 	return &Artifact{
 		Name:        op.Tracking.ArtifactName,
 		Kind:        op.Tracking.ArtifactKind,
@@ -53,7 +59,7 @@ func buildSingularByIdArtifact(op *Operation) (*Artifact, error) {
 		Schema:      schema,
 		SourceFile:  sourceFileFor(op.Tracking.ArtifactName),
 		Lifecycle: &LifecycleBindings{
-			Read:       readCall(op),
+			Read:       read,
 			IdStrategy: op.Tracking.IdStrategy,
 		},
 		Diagnostics: diags,
@@ -74,6 +80,11 @@ func buildSingularSearchArtifact(op *Operation) (*Artifact, error) {
 	if err != nil {
 		return nil, err
 	}
+	search := listCall(op)
+	inputs, err := buildRequiredInputLeaves(search.Arguments)
+	if err != nil {
+		return nil, err
+	}
 	filters, diags := buildFilterLeaves(op)
 	diags = append(diags, recDiags...)
 	return &Artifact{
@@ -81,10 +92,10 @@ func buildSingularSearchArtifact(op *Operation) (*Artifact, error) {
 		Kind:        op.Tracking.ArtifactKind,
 		Cardinality: CardinalitySingular,
 		Description: op.Tracking.TfDescription,
-		Schema:      &AttributeTree{Attributes: append(filters, record.Attributes...)},
+		Schema:      &AttributeTree{Attributes: append(append(inputs, filters...), record.Attributes...)},
 		SourceFile:  sourceFileFor(op.Tracking.ArtifactName),
 		Lifecycle: &LifecycleBindings{
-			Search:     listCall(op),
+			Search:     search,
 			IdStrategy: op.Tracking.IdStrategy,
 		},
 		Diagnostics: diags,
@@ -127,6 +138,12 @@ func buildSingularBothArtifact(op *Operation) (*Artifact, error) {
 	if err != nil {
 		return nil, err
 	}
+	read := readCall(op, true)
+	search := listCall(searchOp)
+	inputs, err := mergeRequiredInputLeaves(read.Arguments, search.Arguments)
+	if err != nil {
+		return nil, err
+	}
 	filters, diags := buildFilterLeaves(searchOp)
 	diags = append(diags, recDiags...)
 	return &Artifact{
@@ -134,11 +151,11 @@ func buildSingularBothArtifact(op *Operation) (*Artifact, error) {
 		Kind:        op.Tracking.ArtifactKind,
 		Cardinality: CardinalitySingular,
 		Description: op.Tracking.TfDescription,
-		Schema:      &AttributeTree{Attributes: append(filters, record.Attributes...)},
+		Schema:      &AttributeTree{Attributes: append(append(inputs, filters...), record.Attributes...)},
 		SourceFile:  sourceFileFor(op.Tracking.ArtifactName),
 		Lifecycle: &LifecycleBindings{
-			Read:       readCall(op),
-			Search:     listCall(searchOp),
+			Read:       read,
+			Search:     search,
 			IdStrategy: op.Tracking.IdStrategy,
 		},
 		Diagnostics: diags,
@@ -188,14 +205,18 @@ func buildPluralArtifact(op *Operation) (*Artifact, error) {
 	if err != nil {
 		return nil, err
 	}
+	read := listCall(op)
+	inputs, err := buildRequiredInputLeaves(read.Arguments)
+	if err != nil {
+		return nil, err
+	}
 	filters, diags := buildFilterLeaves(op)
 	diags = append(diags, itemDiags...)
-	attrs := filters
+	attrs := append(inputs, filters...)
 	if itemsBlock != nil {
 		attrs = append(attrs, itemsBlock)
 	}
 
-	read := listCall(op)
 	name := op.Tracking.ArtifactName
 	return &Artifact{
 		Name:        name,
@@ -239,13 +260,15 @@ func buildItemsBlock(op *Operation) (*Attribute, []Diagnostic, error) {
 }
 
 // readCall resolves the datadog-api-client-go binding for op's read.
-func readCall(op *Operation) *SDKCall {
-	return &SDKCall{
+func readCall(op *Operation, aliasTerminalID bool) *SDKCall {
+	call := &SDKCall{
 		GoPackage:      "datadog" + strings.ToUpper(versionSegment(op.Path)),
 		GoApiStruct:    tagToClassName(op.Tag) + "Api",
 		GoMethod:       op.OperationId,
 		GoResponseType: op.ResponseRefName,
 	}
+	applySDKBinding(call, op, aliasTerminalID)
+	return call
 }
 
 // listCall resolves the datadog-api-client-go binding for op's list call: the
@@ -254,13 +277,81 @@ func readCall(op *Operation) *SDKCall {
 // params are query parameters), and the pagination flag. Shared by the plural
 // path and the singular search path.
 func listCall(op *Operation) *SDKCall {
-	c := readCall(op)
+	c := readCall(op, false)
 	c.ItemType = op.ItemRefName
 	c.Paginated = op.Pagination != nil
-	if len(op.QueryParams) > 0 {
+	if op.SDKBinding == nil && len(op.QueryParams) > 0 {
 		c.OptionalParamsType = op.OperationId + "OptionalParameters"
 	}
 	return c
+}
+
+func applySDKBinding(call *SDKCall, op *Operation, aliasTerminalID bool) {
+	if op.SDKBinding == nil {
+		return
+	}
+	call.BindingResolved = true
+	call.OptionalParamsType = op.SDKBinding.OptionalParamsType
+	for _, raw := range op.SDKBinding.Required {
+		arg := raw
+		arg.TFName = SnakeCase(arg.Name)
+		if aliasTerminalID && arg.Location == "path" && strings.HasSuffix(strings.TrimRight(op.Path, "/"), "/{"+arg.Name+"}") {
+			arg.TFName = "id"
+		}
+		call.Arguments = append(call.Arguments, arg)
+	}
+	for _, raw := range op.SDKBinding.Optional {
+		arg := raw
+		arg.TFName = SnakeCase(arg.Name)
+		call.OptionalArguments = append(call.OptionalArguments, arg)
+	}
+}
+
+func buildRequiredInputLeaves(arguments []SDKArgument) ([]*Attribute, error) {
+	var leaves []*Attribute
+	for _, arg := range arguments {
+		if arg.TFName == "id" {
+			continue
+		}
+		if arg.Schema == nil || arg.Schema.Kind != SchemaKindPrimitive {
+			return nil, fmt.Errorf("model: SDK argument %s has unsupported scalar-first type %s", arg.Name, arg.GoType)
+		}
+		tfType, goType, err := FrameworkType(arg.Schema)
+		if err != nil {
+			return nil, fmt.Errorf("model: SDK argument %s: %w", arg.Name, err)
+		}
+		description := arg.Description
+		if description == "" {
+			description = fmt.Sprintf("The %s argument.", arg.Name)
+		}
+		leaves = append(leaves, &Attribute{
+			Path: arg.TFName, TfType: tfType, GoType: goType, Format: arg.Schema.Format,
+			Required: true, Description: description,
+		})
+	}
+	return leaves, nil
+}
+
+func mergeRequiredInputLeaves(argumentGroups ...[]SDKArgument) ([]*Attribute, error) {
+	seen := map[string]*Attribute{}
+	var merged []*Attribute
+	for _, arguments := range argumentGroups {
+		leaves, err := buildRequiredInputLeaves(arguments)
+		if err != nil {
+			return nil, err
+		}
+		for _, leaf := range leaves {
+			if prior, ok := seen[leaf.Path]; ok {
+				if prior.TfType != leaf.TfType {
+					return nil, fmt.Errorf("model: SDK argument %s has conflicting Terraform types %s and %s", leaf.Path, prior.TfType, leaf.TfType)
+				}
+				continue
+			}
+			seen[leaf.Path] = leaf
+			merged = append(merged, leaf)
+		}
+	}
+	return merged, nil
 }
 
 // buildFilterLeaves converts op's scalar query parameters into Optional
@@ -272,7 +363,18 @@ func listCall(op *Operation) *SDKCall {
 func buildFilterLeaves(op *Operation) ([]*Attribute, []Diagnostic) {
 	var leaves []*Attribute
 	var diags []Diagnostic
+	boundRequired := map[string]bool{}
+	if op.SDKBinding != nil {
+		for _, arg := range op.SDKBinding.Required {
+			if arg.Location == "query" {
+				boundRequired[arg.Name] = true
+			}
+		}
+	}
 	for _, p := range op.QueryParams {
+		if boundRequired[p.Name] {
+			continue
+		}
 		if op.Pagination != nil && (p.Name == op.Pagination.LimitParam || p.Name == op.Pagination.PageParam) {
 			continue
 		}

--- a/.generator-v2/internal/model/artifact_test.go
+++ b/.generator-v2/internal/model/artifact_test.go
@@ -53,6 +53,35 @@ var _ = Describe("BuildArtifact", func() {
 		_, err := BuildArtifact(&Operation{})
 		Expect(err).To(HaveOccurred())
 	})
+
+	It("maps scalar SDK arguments to required Terraform inputs and aliases the terminal path parameter to id", func() {
+		op := incidentTypeOp()
+		op.Path = "/api/v2/accounts/{account_id}/incident-types/{incident_type_id}"
+		op.SDKBinding = &SDKOperationBinding{Required: []SDKArgument{
+			{Name: "account_id", GoName: "accountId", GoType: "int64", Location: "path", Schema: primSchema("integer")},
+			{Name: "incident_type_id", GoName: "incidentTypeId", GoType: "string", Location: "path", Schema: primSchema("string")},
+		}}
+
+		art, err := BuildArtifact(op)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(art.Lifecycle.Read.BindingResolved).To(BeTrue())
+		Expect(art.Lifecycle.Read.Arguments).To(HaveLen(2))
+		Expect(art.Lifecycle.Read.Arguments[0].TFName).To(Equal("account_id"))
+		Expect(art.Lifecycle.Read.Arguments[1].TFName).To(Equal("id"))
+		Expect(art.Schema.Attributes[0].Path).To(Equal("account_id"))
+		Expect(art.Schema.Attributes[0].Required).To(BeTrue())
+		Expect(art.Schema.Attributes[0].GoType).To(Equal("types.Int64"))
+	})
+
+	It("rejects collection-valued required SDK arguments in scalar-first mode", func() {
+		op := incidentTypeOp()
+		op.SDKBinding = &SDKOperationBinding{Required: []SDKArgument{
+			{Name: "row_id", GoName: "rowId", GoType: "[]string", Location: "query", Schema: &Schema{Kind: SchemaKindArray, Items: primSchema("string")}},
+		}}
+
+		_, err := BuildArtifact(op)
+		Expect(err).To(MatchError(ContainSubstring("unsupported scalar-first type []string")))
+	})
 })
 
 var _ = Describe("BuildArtifact plural", func() {

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -111,6 +111,10 @@ type Operation struct {
 	// by name. Populated for every operation; the plural data-source path turns
 	// the scalar ones into filters.
 	QueryParams []QueryParam
+	// PathParams are the operation's in:path parameters, normalized and sorted
+	// by name. SDK binding resolves their actual call order from the pinned Go
+	// client's method signature rather than relying on OpenAPI declaration order.
+	PathParams []QueryParam
 	// Pagination is the decoded x-pagination extension, or nil when the
 	// operation declares none.
 	Pagination *Pagination
@@ -130,11 +134,16 @@ type Operation struct {
 	// search op (search-only), and is nil when no search is declared or the
 	// declared operationId is unknown.
 	SearchOp *Operation
+	// SDKBinding is the call signature resolved from the pinned Go SDK. The CLI
+	// fills it before artifact construction. Tests that build parser-shaped
+	// operations directly may leave it nil and exercise the legacy call shape.
+	SDKBinding *SDKOperationBinding
 }
 
-// QueryParam is one in:query OpenAPI parameter, with its inner schema
-// normalized like a request/response body. Name preserves the raw OpenAPI
-// spelling, including brackets (e.g. "filter[keyword]").
+// QueryParam is one normalized OpenAPI path or query parameter (the historical
+// name is retained to avoid broad churn). Its inner schema is normalized like a
+// request/response body, and Name preserves raw spelling such as
+// "filter[keyword]".
 type QueryParam struct {
 	Name        string
 	Required    bool
@@ -152,6 +161,28 @@ type Pagination struct {
 	PageParam string
 	// ResultsPath is the response property holding the result array, e.g. "data".
 	ResultsPath string
+}
+
+// SDKOperationBinding is the pinned Go SDK signature for one OpenAPI operation.
+// Required arguments are positional and retain SDK order. Optional arguments
+// are fields set through With* methods on OptionalParamsType.
+type SDKOperationBinding struct {
+	Required           []SDKArgument
+	Optional           []SDKArgument
+	OptionalParamsType string
+}
+
+// SDKArgument binds one SDK method argument or options setter to an OpenAPI
+// parameter and, after artifact construction, its Terraform model field.
+type SDKArgument struct {
+	Name        string
+	GoName      string
+	GoType      string
+	Location    string
+	Description string
+	Schema      *Schema
+	TFName      string
+	Setter      string
 }
 
 // Schema is a normalized, recursive view of an OpenAPI schema after allOf
@@ -282,6 +313,9 @@ type LifecycleBindings struct {
 
 // SDKCall represents a single datadog-api-client-go invocation.
 type SDKCall struct {
+	// BindingResolved distinguishes an SDK method that genuinely takes no
+	// positional arguments from legacy test fixtures that omit binding data.
+	BindingResolved bool
 	// GoPackage is the versioned SDK package, e.g. "datadogV2".
 	// Rule: "datadog" + strings.ToUpper(version), where version is the path
 	// segment after /api/ in Operation.Path (e.g. /api/v2/... → "datadogV2").
@@ -309,6 +343,10 @@ type SDKCall struct {
 	// NOTE: Schema has no Name field; the model-builder must read this from the
 	// raw libopenapi node, not from Operation.ResponseSchema.
 	GoResponseType string
+	// Arguments are the required positional SDK arguments in call order.
+	Arguments []SDKArgument
+	// OptionalArguments bind Terraform filters to OptionalParamsType setters.
+	OptionalArguments []SDKArgument
 
 	// The fields below back a plural data-source list call.
 

--- a/.generator-v2/internal/parser/schema.go
+++ b/.generator-v2/internal/parser/schema.go
@@ -174,7 +174,7 @@ func (n *schemaNormalizer) fillOperation(op *model.Operation, raw *v3.Operation)
 		op.RequestSchema = req
 	}
 
-	if err := n.fillQueryParams(op, raw); err != nil {
+	if err := n.fillParameters(op, raw); err != nil {
 		return err
 	}
 	op.Pagination = decodePagination(raw)
@@ -201,28 +201,36 @@ func (n *schemaNormalizer) fillOperation(op *model.Operation, raw *v3.Operation)
 	return n.retainResponseDataRef(op, respProxy)
 }
 
-// fillQueryParams normalizes raw's in:query parameters onto op.QueryParams,
-// sorted by name. libopenapi resolves $ref parameters (e.g.
+// fillParameters normalizes raw's in:path and in:query parameters onto the
+// corresponding operation fields, sorted by name. libopenapi resolves $ref parameters (e.g.
 // #/components/parameters/PageNumber) during its build, so each parameter
 // arrives with Name and Schema populated; the inner schema is normalized like a
 // body so type/format/enum/array come through. Raw bracketed names
 // (filter[keyword]) are preserved.
-func (n *schemaNormalizer) fillQueryParams(op *model.Operation, raw *v3.Operation) error {
+func (n *schemaNormalizer) fillParameters(op *model.Operation, raw *v3.Operation) error {
 	for _, p := range raw.Parameters {
-		if p == nil || p.In != "query" || p.Name == "" {
+		if p == nil || (p.In != "query" && p.In != "path") || p.Name == "" {
 			continue
 		}
 		schema, err := n.normalizeProxy(p.Schema, 0)
 		if err != nil {
 			return err
 		}
-		op.QueryParams = append(op.QueryParams, model.QueryParam{
+		parameter := model.QueryParam{
 			Name:        p.Name,
 			Required:    p.Required != nil && *p.Required,
 			Schema:      schema,
 			Description: p.Description,
-		})
+		}
+		if p.In == "path" {
+			op.PathParams = append(op.PathParams, parameter)
+		} else {
+			op.QueryParams = append(op.QueryParams, parameter)
+		}
 	}
+	sort.Slice(op.PathParams, func(i, j int) bool {
+		return op.PathParams[i].Name < op.PathParams[j].Name
+	})
 	sort.Slice(op.QueryParams, func(i, j int) bool {
 		return op.QueryParams[i].Name < op.QueryParams[j].Name
 	})

--- a/.generator-v2/internal/parser/schema_test.go
+++ b/.generator-v2/internal/parser/schema_test.go
@@ -457,7 +457,7 @@ var _ = Describe("NormalizeSchemas list operation", func() {
 		list = opByID(loadSpecMust("schema_normalize_list.yaml"), "ListThings")
 	})
 
-	It("captures only in:query parameters, sorted by name, preserving bracketed names", func() {
+	It("captures query parameters sorted by name, preserving bracketed names", func() {
 		var names []string
 		for _, p := range list.QueryParams {
 			names = append(names, p.Name)
@@ -499,6 +499,10 @@ var _ = Describe("NormalizeSchemas list operation", func() {
 	It("retains a get-by-id data object $ref as ResponseDataRefName, leaving ItemRefName empty", func() {
 		get := opByID(loadSpecMust("schema_normalize_list.yaml"), "GetThing")
 		Expect(get.QueryParams).To(BeEmpty())
+		Expect(get.PathParams).To(HaveLen(1))
+		Expect(get.PathParams[0].Name).To(Equal("thing_id"))
+		Expect(get.PathParams[0].Required).To(BeTrue())
+		Expect(get.PathParams[0].Schema.Type).To(Equal("string"))
 		Expect(get.Pagination).To(BeNil())
 		Expect(get.ItemRefName).To(BeEmpty())
 		Expect(get.ResponseDataRefName).To(Equal("Thing"))

--- a/.generator-v2/internal/sdkbinding/bindings.go
+++ b/.generator-v2/internal/sdkbinding/bindings.go
@@ -1,0 +1,193 @@
+// Package sdkbinding resolves OpenAPI operation parameters against the pinned
+// datadog-api-client-go method signatures used by generated provider code.
+package sdkbinding
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+)
+
+type methodSignature struct {
+	arguments []argumentSignature
+	options   string
+}
+
+type argumentSignature struct {
+	name     string
+	typeName string
+}
+
+// Inventory is the set of SDK methods and option setters discovered in the
+// pinned datadogV2 package.
+type Inventory struct {
+	methods map[string]methodSignature
+	setters map[string]map[string]argumentSignature
+}
+
+// Load parses the generated SDK API files in dir. Parsing source instead of
+// deriving signatures from OpenAPI keeps tfgen aligned with the exact client
+// version the provider compiles against.
+func Load(dir string) (*Inventory, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read SDK API package %s: %w", dir, err)
+	}
+	inv := &Inventory{
+		methods: map[string]methodSignature{},
+		setters: map[string]map[string]argumentSignature{},
+	}
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), "api_") || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			return nil, fmt.Errorf("parse SDK API source %s: %w", path, err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name == nil {
+				continue
+			}
+			receiver := receiverType(fn.Recv)
+			switch {
+			case strings.HasSuffix(receiver, "OptionalParameters") && strings.HasPrefix(fn.Name.Name, "With"):
+				args := functionArguments(fset, fn.Type.Params)
+				if len(args) == 1 {
+					if inv.setters[receiver] == nil {
+						inv.setters[receiver] = map[string]argumentSignature{}
+					}
+					inv.setters[receiver][fn.Name.Name] = args[0]
+				}
+			case strings.HasSuffix(receiver, "Api") && !strings.HasSuffix(fn.Name.Name, "WithPagination"):
+				args := functionArguments(fset, fn.Type.Params)
+				if len(args) == 0 || args[0].name != "ctx" {
+					continue
+				}
+				args = args[1:]
+				sig := methodSignature{}
+				if len(args) > 0 && strings.HasPrefix(args[len(args)-1].typeName, "...") && strings.HasSuffix(args[len(args)-1].typeName, "OptionalParameters") {
+					sig.options = strings.TrimPrefix(args[len(args)-1].typeName, "...")
+					args = args[:len(args)-1]
+				}
+				sig.arguments = args
+				inv.methods[fn.Name.Name] = sig
+			}
+		}
+	}
+	return inv, nil
+}
+
+// Bind resolves op's SDK positional arguments and optional setters to its
+// normalized OpenAPI parameters.
+func (i *Inventory) Bind(op *model.Operation) error {
+	if op == nil {
+		return nil
+	}
+	sig, ok := i.methods[op.OperationId]
+	if !ok {
+		return fmt.Errorf("sdk binding: method %s was not found in the pinned datadogV2 SDK", op.OperationId)
+	}
+	parameters := map[string]model.SDKArgument{}
+	for _, p := range op.PathParams {
+		parameters[canonicalName(p.Name)] = sdkParameter(p, "path")
+	}
+	for _, p := range op.QueryParams {
+		parameters[canonicalName(p.Name)] = sdkParameter(p, "query")
+	}
+
+	binding := &model.SDKOperationBinding{OptionalParamsType: sig.options}
+	for _, sdkArg := range sig.arguments {
+		parameter, ok := parameters[canonicalName(sdkArg.name)]
+		if !ok {
+			return fmt.Errorf("sdk binding: %s argument %s %s has no matching OpenAPI path or query parameter", op.OperationId, sdkArg.name, sdkArg.typeName)
+		}
+		parameter.GoName = sdkArg.name
+		parameter.GoType = sdkArg.typeName
+		binding.Required = append(binding.Required, parameter)
+	}
+
+	if sig.options != "" {
+		setterNames := make([]string, 0, len(i.setters[sig.options]))
+		for setter := range i.setters[sig.options] {
+			setterNames = append(setterNames, setter)
+		}
+		sort.Strings(setterNames)
+		for _, setter := range setterNames {
+			sdkArg := i.setters[sig.options][setter]
+			parameter, ok := parameters[canonicalName(sdkArg.name)]
+			if !ok || parameter.Location != "query" {
+				continue
+			}
+			parameter.GoName = sdkArg.name
+			parameter.GoType = sdkArg.typeName
+			parameter.Setter = setter
+			binding.Optional = append(binding.Optional, parameter)
+		}
+	}
+	op.SDKBinding = binding
+	return nil
+}
+
+func sdkParameter(p model.QueryParam, location string) model.SDKArgument {
+	return model.SDKArgument{
+		Name:        p.Name,
+		Location:    location,
+		Description: p.Description,
+		Schema:      p.Schema,
+	}
+}
+
+func receiverType(fields *ast.FieldList) string {
+	if fields == nil || len(fields.List) != 1 {
+		return ""
+	}
+	t := fields.List[0].Type
+	if star, ok := t.(*ast.StarExpr); ok {
+		t = star.X
+	}
+	ident, _ := t.(*ast.Ident)
+	if ident == nil {
+		return ""
+	}
+	return ident.Name
+}
+
+func functionArguments(fset *token.FileSet, fields *ast.FieldList) []argumentSignature {
+	if fields == nil {
+		return nil
+	}
+	var out []argumentSignature
+	for _, field := range fields.List {
+		var rendered strings.Builder
+		_ = printer.Fprint(&rendered, fset, field.Type)
+		for _, name := range field.Names {
+			out = append(out, argumentSignature{name: name.Name, typeName: rendered.String()})
+		}
+	}
+	return out
+}
+
+func canonicalName(value string) string {
+	var b strings.Builder
+	for _, r := range value {
+		if r >= 'A' && r <= 'Z' {
+			r += 'a' - 'A'
+		}
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/.generator-v2/internal/sdkbinding/bindings_test.go
+++ b/.generator-v2/internal/sdkbinding/bindings_test.go
@@ -1,0 +1,107 @@
+package sdkbinding
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+)
+
+func TestBindResolvesScalarArgumentsInSDKOrder(t *testing.T) {
+	dir := t.TempDir()
+	source := `package datadogV2
+
+type ThingsApi struct{}
+type GetThingOptionalParameters struct{}
+
+func (a *ThingsApi) GetThing(ctx context.Context, accountId string, thingId uuid.UUID, o ...GetThingOptionalParameters) {}
+func (o *GetThingOptionalParameters) WithInclude(include ThingInclude) *GetThingOptionalParameters { return o }
+`
+	if err := os.WriteFile(filepath.Join(dir, "api_things.go"), []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	inv, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	op := &model.Operation{
+		OperationId: "GetThing",
+		PathParams: []model.QueryParam{
+			{Name: "thing_id", Required: true, Schema: scalar("string", "uuid")},
+			{Name: "account_id", Required: true, Schema: scalar("string", "")},
+		},
+		QueryParams: []model.QueryParam{
+			{Name: "include", Schema: scalar("string", "")},
+		},
+	}
+	if err := inv.Bind(op); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := len(op.SDKBinding.Required), 2; got != want {
+		t.Fatalf("required argument count = %d, want %d", got, want)
+	}
+	first, second := op.SDKBinding.Required[0], op.SDKBinding.Required[1]
+	if first.Name != "account_id" || first.GoName != "accountId" || first.GoType != "string" || first.Location != "path" {
+		t.Fatalf("first required argument = %#v", first)
+	}
+	if second.Name != "thing_id" || second.GoName != "thingId" || second.GoType != "uuid.UUID" || second.Location != "path" {
+		t.Fatalf("second required argument = %#v", second)
+	}
+	if got, want := op.SDKBinding.OptionalParamsType, "GetThingOptionalParameters"; got != want {
+		t.Fatalf("optional parameters type = %q, want %q", got, want)
+	}
+	if got, want := len(op.SDKBinding.Optional), 1; got != want {
+		t.Fatalf("optional argument count = %d, want %d", got, want)
+	}
+	optional := op.SDKBinding.Optional[0]
+	if optional.Name != "include" || optional.GoType != "ThingInclude" || optional.Setter != "WithInclude" || optional.Location != "query" {
+		t.Fatalf("optional argument = %#v", optional)
+	}
+}
+
+func TestBindSupportsSingletonMethod(t *testing.T) {
+	dir := t.TempDir()
+	source := `package datadogV2
+type UsersApi struct{}
+func (a *UsersApi) GetCurrentUser(ctx context.Context) {}
+`
+	if err := os.WriteFile(filepath.Join(dir, "api_users.go"), []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	inv, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	op := &model.Operation{OperationId: "GetCurrentUser"}
+	if err := inv.Bind(op); err != nil {
+		t.Fatal(err)
+	}
+	if op.SDKBinding == nil || len(op.SDKBinding.Required) != 0 {
+		t.Fatalf("singleton binding = %#v", op.SDKBinding)
+	}
+}
+
+func TestBindRejectsUnmatchedSDKArgument(t *testing.T) {
+	dir := t.TempDir()
+	source := `package datadogV2
+type ThingsApi struct{}
+func (a *ThingsApi) GetThing(ctx context.Context, thingId string) {}
+`
+	if err := os.WriteFile(filepath.Join(dir, "api_things.go"), []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	inv, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := inv.Bind(&model.Operation{OperationId: "GetThing"}); err == nil {
+		t.Fatal("expected unmatched SDK argument error")
+	}
+}
+
+func scalar(typ, format string) *model.Schema {
+	return &model.Schema{Kind: model.SchemaKindPrimitive, Type: typ, Format: format}
+}


### PR DESCRIPTION
## What does this PR do?

- Discover method signatures and optional-parameter setters from the pinned `datadogV2` SDK source.
- Bind OpenAPI path and query parameters to required SDK arguments in SDK call order.
- Generate Terraform inputs and SDK expressions for scalar strings, booleans, integers, numbers, named scalar types, enums, and UUIDs.
- Treat a terminal path parameter as the Terraform `id`, while exposing additional path or required-query arguments as required attributes.
- Support singleton SDK methods with no ID argument and optional query parameters through SDK `With*` setters.
- Include required and optional inputs in plural data-source identity hashes.

Collection-valued required SDK arguments remain intentionally unsupported in this scalar-first change.

## Why?

tfgen previously assumed every singular read accepted one string ID and every plural read accepted only optional parameters. That prevented generation for singleton endpoints, nested paths, UUID IDs, named scalar arguments, and required scalar query parameters.

## Validation

- `make tfgen-test` — pass with race detection
- `make fmtcheck` — pass
- `make test` — 235 tests pass
- `make vet` — pass
- Build-verified full-spec coverage sweep — all 565 candidates inspected
- Remaining `sdk-arg-binding` gap count — zero

On the combined Graphite stack, build-verified in-scope coverage is 95/157 singular data sources (60.5%) and 122/195 plural data sources (62.6%).

This PR changes generator behavior and tests only; it leaves generated provider artifacts untouched.
