### PR TITLE
[tfgen] Normalize bounded allOf schemas

### DIFF
--- a/.generator-v2/internal/model/schema.go
+++ b/.generator-v2/internal/model/schema.go
@@ -22,12 +22,17 @@ const (
 // one rather than emitting a types.Dynamic escape hatch. (oneOf variants are
 // dropped, not errored.)
 type UnsupportedKindError struct {
-	Path string
-	Kind SchemaKind
+	Path   string
+	Kind   SchemaKind
+	Reason string
 }
 
 func (e *UnsupportedKindError) Error() string {
-	return fmt.Sprintf("model: cannot build attribute at %q: schema kind %q is not representable", e.Path, e.Kind)
+	msg := fmt.Sprintf("model: cannot build attribute at %q: schema kind %q is not representable", e.Path, e.Kind)
+	if e.Reason != "" {
+		msg += ": " + e.Reason
+	}
+	return msg
 }
 
 // BuildResponseTree converts a response-body schema into an AttributeTree,
@@ -92,7 +97,7 @@ func buildAttribute(s *Schema, path string, mode nestingMode, diags *[]Diagnosti
 	case SchemaKindPrimitive, SchemaKindObject, SchemaKindArray, SchemaKindMap:
 		// representable — continue
 	default:
-		return nil, &UnsupportedKindError{Path: path, Kind: s.Kind}
+		return nil, &UnsupportedKindError{Path: path, Kind: s.Kind, Reason: s.UnsupportedReason}
 	}
 
 	// A collection whose element is a oneOf variant has no representable element

--- a/.generator-v2/internal/model/schema_test.go
+++ b/.generator-v2/internal/model/schema_test.go
@@ -410,6 +410,24 @@ var _ = Describe("BuildResponseTree defensive guard", func() {
 			"response.m{}.bad"),
 	)
 
+	It("includes an unsupported reason without losing the full attribute path", func() {
+		tree, _, err := BuildResponseTree(objSchema(map[string]*Schema{
+			"composed": {
+				Kind:              SchemaKindUnsupported,
+				UnsupportedReason: `allOf property "status" is declared by multiple branches`,
+			},
+		}))
+		Expect(tree).To(BeNil())
+		var uke *UnsupportedKindError
+		Expect(errors.As(err, &uke)).To(BeTrue(), "expected *UnsupportedKindError, got %T: %v", err, err)
+		Expect(uke.Path).To(Equal("response.composed"))
+		Expect(uke.Kind).To(Equal(SchemaKindUnsupported))
+		Expect(uke.Reason).To(Equal(`allOf property "status" is declared by multiple branches`))
+		Expect(uke.Error()).To(Equal(
+			`model: cannot build attribute at "response.composed": schema kind "unsupported" is not representable: allOf property "status" is declared by multiple branches`,
+		))
+	})
+
 	It("returns the type-mapping error for a non-object root that cannot be mapped (array-of-array)", func() {
 		tree, _, err := BuildResponseTree(arrSchema(arrSchema(primSchema("string"))))
 		Expect(tree).To(BeNil())

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -189,6 +189,11 @@ type SDKArgument struct {
 // flattening and oneOf/anyOf variant detection.
 type Schema struct {
 	Kind SchemaKind
+	// UnsupportedReason explains why a node classified as Unsupported cannot be
+	// represented. It is empty for legacy unsupported nodes whose kind alone is
+	// sufficient, and is surfaced by the attribute-tree builder for artifact-local
+	// failures.
+	UnsupportedReason string
 	// Properties is populated for objects only; iteration is always sorted.
 	Properties map[string]*Schema
 	// Required is populated for objects only; sorted.

--- a/.generator-v2/internal/parser/schema.go
+++ b/.generator-v2/internal/parser/schema.go
@@ -335,38 +335,52 @@ func (n *schemaNormalizer) referenceNameThroughOverlay(proxy *base.SchemaProxy) 
 // resolveOverlayToSchema resolves refs and unwraps single-structural-branch
 // allOf metadata overlays until it reaches the schema that owns the shape.
 func (n *schemaNormalizer) resolveOverlayToSchema(proxy *base.SchemaProxy) (*base.Schema, error) {
-	for proxy != nil {
-		if proxy.IsReference() {
-			target, err := n.resolveRef(proxy.GetReference())
-			if err != nil {
-				return nil, err
-			}
-			proxy = target
-			continue
+	return n.resolveOverlayToSchemaAt(proxy, 0, make(map[string]bool))
+}
+
+func (n *schemaNormalizer) resolveOverlayToSchemaAt(proxy *base.SchemaProxy, depth int, onStack map[string]bool) (*base.Schema, error) {
+	if proxy == nil {
+		return nil, nil
+	}
+	if proxy.IsReference() {
+		ref := proxy.GetReference()
+		if onStack[ref] || (n.maxDepth > 0 && depth >= n.maxDepth) {
+			return nil, nil
 		}
-		schema := proxy.Schema()
-		branch, ok, err := n.singleAllOfStructuralBranch(schema)
+		target, err := n.resolveRef(ref)
 		if err != nil {
 			return nil, err
 		}
-		if !ok {
-			return schema, nil
-		}
-		proxy = branch
+		onStack[ref] = true
+		defer delete(onStack, ref)
+		return n.resolveOverlayToSchemaAt(target, depth+1, onStack)
 	}
-	return nil, nil
+
+	schema := proxy.Schema()
+	branch, ok, err := n.singleAllOfStructuralBranchAt(schema, depth, onStack)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return schema, nil
+	}
+	return n.resolveOverlayToSchemaAt(branch, depth, onStack)
 }
 
 // singleAllOfStructuralBranch finds a unique non-annotation branch. It returns
 // ok=false for schemas that are not overlays (including genuine multi-branch
 // compositions), so callers never invent a single SDK identity for a composite.
 func (n *schemaNormalizer) singleAllOfStructuralBranch(s *base.Schema) (*base.SchemaProxy, bool, error) {
+	return n.singleAllOfStructuralBranchAt(s, 0, make(map[string]bool))
+}
+
+func (n *schemaNormalizer) singleAllOfStructuralBranchAt(s *base.Schema, depth int, onStack map[string]bool) (*base.SchemaProxy, bool, error) {
 	if s == nil || len(s.AllOf) == 0 {
 		return nil, false, nil
 	}
 	var structural *base.SchemaProxy
 	for _, branch := range s.AllOf {
-		raw, err := n.resolveToSchema(branch)
+		raw, err := n.resolveToSchemaAt(branch, depth, onStack)
 		if err != nil {
 			return nil, false, err
 		}
@@ -384,18 +398,43 @@ func (n *schemaNormalizer) singleAllOfStructuralBranch(s *base.Schema) (*base.Sc
 // findPropertyProxy finds a named property through refs and allOf object
 // composition. Strict duplicate-property rejection happens during normalization;
 // this helper stays conservative and returns no identity if raw branches expose
-// the property more than once.
+// the property more than once. Ref depth and the active path are bounded like
+// schema normalization so malformed recursive compositions cannot loop here.
 func (n *schemaNormalizer) findPropertyProxy(proxy *base.SchemaProxy, name string) (*base.SchemaProxy, error) {
-	schema, err := n.resolveToSchema(proxy)
-	if err != nil || schema == nil {
-		return nil, err
+	return n.findPropertyProxyAt(proxy, name, 0, make(map[string]bool))
+}
+
+func (n *schemaNormalizer) findPropertyProxyAt(proxy *base.SchemaProxy, name string, depth int, onStack map[string]bool) (*base.SchemaProxy, error) {
+	for proxy != nil {
+		if proxy.IsReference() {
+			ref := proxy.GetReference()
+			if onStack[ref] || (n.maxDepth > 0 && depth >= n.maxDepth) {
+				return nil, nil
+			}
+			target, err := n.resolveRef(ref)
+			if err != nil {
+				return nil, err
+			}
+			onStack[ref] = true
+			defer delete(onStack, ref)
+			return n.findPropertyProxyAt(target, name, depth+1, onStack)
+		}
+		break
+	}
+	if proxy == nil {
+		return nil, nil
+	}
+
+	schema := proxy.Schema()
+	if schema == nil {
+		return nil, nil
 	}
 	var found *base.SchemaProxy
 	if schema.Properties != nil {
 		found = schema.Properties.GetOrZero(name)
 	}
 	for _, branch := range schema.AllOf {
-		candidate, err := n.findPropertyProxy(branch, name)
+		candidate, err := n.findPropertyProxyAt(branch, name, depth, onStack)
 		if err != nil {
 			return nil, err
 		}
@@ -414,15 +453,25 @@ func (n *schemaNormalizer) findPropertyProxy(proxy *base.SchemaProxy, name strin
 // underlying *base.Schema, mirroring normalizeProxy's resolution but returning
 // the raw libopenapi node so callers can read $ref names the model discards.
 func (n *schemaNormalizer) resolveToSchema(proxy *base.SchemaProxy) (*base.Schema, error) {
+	return n.resolveToSchemaAt(proxy, 0, make(map[string]bool))
+}
+
+func (n *schemaNormalizer) resolveToSchemaAt(proxy *base.SchemaProxy, depth int, onStack map[string]bool) (*base.Schema, error) {
 	if proxy == nil {
 		return nil, nil
 	}
 	if proxy.IsReference() {
-		target, err := n.resolveRef(proxy.GetReference())
+		ref := proxy.GetReference()
+		if onStack[ref] || (n.maxDepth > 0 && depth >= n.maxDepth) {
+			return nil, nil
+		}
+		target, err := n.resolveRef(ref)
 		if err != nil {
 			return nil, err
 		}
-		return n.resolveToSchema(target)
+		onStack[ref] = true
+		defer delete(onStack, ref)
+		return n.resolveToSchemaAt(target, depth+1, onStack)
 	}
 	return proxy.Schema(), nil
 }
@@ -660,6 +709,9 @@ func (n *schemaNormalizer) normalizeAllOf(s *base.Schema, depth int) (*model.Sch
 		if outerType != "" && !schemaKindMatchesType(out, outerType) {
 			return unsupportedSchema(fmt.Sprintf("allOf outer type %q conflicts with branch %d schema kind %q", outerType, branches[0].index, out.Kind)), nil
 		}
+		if reason := applyAllOfScalarConstraints(out, s, branches[0].index); reason != "" {
+			return unsupportedSchema(reason), nil
+		}
 		if len(s.Required) > 0 {
 			if out.Kind != model.SchemaKindObject {
 				return unsupportedSchema(fmt.Sprintf("allOf declares outer required fields for branch %d schema kind %q", branches[0].index, out.Kind)), nil
@@ -678,6 +730,9 @@ func (n *schemaNormalizer) normalizeAllOf(s *base.Schema, depth int) (*model.Sch
 
 	if outerType != "" && outerType != "object" {
 		return unsupportedSchema(fmt.Sprintf("allOf object composition conflicts with outer type %q", outerType)), nil
+	}
+	if s.Format != "" || len(s.Enum) > 0 {
+		return unsupportedSchema("allOf object composition declares scalar outer constraints"), nil
 	}
 
 	out := &model.Schema{
@@ -727,6 +782,59 @@ func (n *schemaNormalizer) normalizeAllOf(s *base.Schema, depth int) (*model.Sch
 	return out, nil
 }
 
+// applyAllOfScalarConstraints applies the scalar constraints the normalized
+// model understands. Two enum declarations are intersected; incompatible
+// formats and empty enum intersections remain unsupported rather than silently
+// widening the generated Terraform schema.
+func applyAllOfScalarConstraints(out *model.Schema, outer *base.Schema, branchIndex int) string {
+	if outer.Format == "" && len(outer.Enum) == 0 {
+		return ""
+	}
+	if out.Kind != model.SchemaKindPrimitive {
+		return fmt.Sprintf("allOf declares scalar outer constraints for branch %d schema kind %q", branchIndex, out.Kind)
+	}
+
+	if outer.Format != "" {
+		if out.Format != "" && out.Format != outer.Format {
+			return fmt.Sprintf("allOf outer format %q conflicts with branch %d format %q", outer.Format, branchIndex, out.Format)
+		}
+		out.Format = outer.Format
+	}
+
+	outerEnum := enumValues(outer)
+	if len(outerEnum) == 0 {
+		return ""
+	}
+	if len(out.Enum) == 0 {
+		out.Enum = outerEnum
+		return ""
+	}
+	intersection := intersectEnums(out.Enum, outerEnum)
+	if len(intersection) == 0 {
+		return fmt.Sprintf("allOf outer enum has no values in common with branch %d enum", branchIndex)
+	}
+	out.Enum = intersection
+	return ""
+}
+
+// intersectEnums returns the unique common values in the left-hand declaration's
+// order, keeping generated validators stable.
+func intersectEnums(left, right []string) []string {
+	rightValues := make(map[string]bool, len(right))
+	for _, value := range right {
+		rightValues[value] = true
+	}
+	seen := make(map[string]bool, len(left))
+	var intersection []string
+	for _, value := range left {
+		if rightValues[value] && !seen[value] {
+			intersection = append(intersection, value)
+			seen[value] = true
+		}
+	}
+	return intersection
+}
+
 // unionRequired returns the sorted union of two required-property lists.
 func unionRequired(left, right []string) []string {
 	required := make(map[string]bool, len(left)+len(right))
@@ -771,13 +879,77 @@ func unsupportedAllOfOuterStructure(s *base.Schema) string {
 // when authored explicitly. A completely empty schema is not an annotation: it
 // remains an arbitrary/untyped value and must not be discarded.
 func (n *schemaNormalizer) isAnnotationOnlySchema(s *base.Schema) bool {
-	if s == nil || len(s.Type) > 0 || len(s.AllOf) > 0 || len(s.OneOf) > 0 || len(s.AnyOf) > 0 ||
-		(s.Properties != nil && orderedmap.Len(s.Properties) > 0) || s.Items != nil || s.AdditionalProperties != nil {
+	if s == nil || hasStructuralOrConstraintKeywords(s) {
 		return false
 	}
 	hasExtension := s.Extensions != nil && orderedmap.Len(s.Extensions) > 0
 	return s.Title != "" || s.Description != "" || s.Example != nil || len(s.Examples) > 0 ||
 		s.Default != nil || hasExtension || n.isSensitive(s)
+}
+
+// hasStructuralOrConstraintKeywords distinguishes schemas that narrow values
+// from genuine metadata-only overlays. Keep this deliberately conservative:
+// accepting an unknown assertion here would discard it and widen the generated
+// Terraform schema.
+func hasStructuralOrConstraintKeywords(s *base.Schema) bool {
+	// Type and composition keywords.
+	if len(s.Type) > 0 || len(s.AllOf) > 0 || len(s.OneOf) > 0 || len(s.AnyOf) > 0 {
+		return true
+	}
+	if s.Not != nil || s.Discriminator != nil {
+		return true
+	}
+
+	// Object and collection structure.
+	if s.Properties != nil && orderedmap.Len(s.Properties) > 0 {
+		return true
+	}
+	if s.Items != nil || s.AdditionalProperties != nil || len(s.PrefixItems) > 0 {
+		return true
+	}
+	if s.Contains != nil || s.MinContains != nil || s.MaxContains != nil {
+		return true
+	}
+
+	// Conditional and dependent schemas.
+	if s.If != nil || s.Then != nil || s.Else != nil {
+		return true
+	}
+	if s.DependentSchemas != nil && orderedmap.Len(s.DependentSchemas) > 0 {
+		return true
+	}
+	if s.DependentRequired != nil && orderedmap.Len(s.DependentRequired) > 0 {
+		return true
+	}
+	if s.PatternProperties != nil && orderedmap.Len(s.PatternProperties) > 0 {
+		return true
+	}
+	if s.PropertyNames != nil || s.UnevaluatedItems != nil || s.UnevaluatedProperties != nil {
+		return true
+	}
+
+	// Scalar and collection constraints.
+	if s.MultipleOf != nil || s.Maximum != nil || s.Minimum != nil {
+		return true
+	}
+	if s.ExclusiveMaximum != nil || s.ExclusiveMinimum != nil {
+		return true
+	}
+	if s.MaxLength != nil || s.MinLength != nil || s.Pattern != "" || s.Format != "" {
+		return true
+	}
+	if s.MaxItems != nil || s.MinItems != nil || s.UniqueItems != nil {
+		return true
+	}
+	if s.MaxProperties != nil || s.MinProperties != nil || len(s.Required) > 0 {
+		return true
+	}
+
+	// Exact-value and reference constraints.
+	if len(s.Enum) > 0 || s.Const != nil {
+		return true
+	}
+	return s.DynamicRef != "" || s.ContentSchema != nil
 }
 
 func unsupportedSchema(reason string) *model.Schema {

--- a/.generator-v2/internal/parser/schema.go
+++ b/.generator-v2/internal/parser/schema.go
@@ -184,11 +184,14 @@ func (n *schemaNormalizer) fillOperation(op *model.Operation, raw *v3.Operation)
 		return nil
 	}
 	// Capture the response type name from the top-level body proxy before
-	// normalizeProxy follows the $ref and discards it. An inline/absent body
-	// leaves ResponseRefName empty.
-	if respProxy.IsReference() {
-		op.ResponseRefName = lastRefSegment(respProxy.GetReference())
+	// normalizeProxy follows the $ref and discards it. OpenAPI 3.0 $ref siblings
+	// arrive as a synthetic single-structural-branch allOf, so look through that
+	// overlay as well. An inline/composed/absent body leaves ResponseRefName empty.
+	responseRefName, err := n.referenceNameThroughOverlay(respProxy)
+	if err != nil {
+		return err
 	}
+	op.ResponseRefName = responseRefName
 	resp, err := n.normalizeProxy(respProxy, 0)
 	if err != nil {
 		return err
@@ -267,38 +270,144 @@ func (n *schemaNormalizer) retainItemRef(op *model.Operation, respProxy *base.Sc
 	if op.Pagination != nil && op.Pagination.ResultsPath != "" {
 		resultsPath = op.Pagination.ResultsPath
 	}
-	body, err := n.resolveToSchema(respProxy)
-	if err != nil || body == nil || body.Properties == nil {
+	propProxy, err := n.findPropertyProxy(respProxy, resultsPath)
+	if err != nil || propProxy == nil {
 		return err
 	}
-	prop, err := n.resolveToSchema(body.Properties.GetOrZero(resultsPath))
+	prop, err := n.resolveOverlayToSchema(propProxy)
 	if err != nil || prop == nil {
 		return err
 	}
 	if !hasType(prop, "array") || prop.Items == nil || !prop.Items.IsA() {
 		return nil
 	}
-	if elem := prop.Items.A; elem != nil && elem.IsReference() {
-		op.ItemRefName = lastRefSegment(elem.GetReference())
+	itemRefName, err := n.referenceNameThroughOverlay(prop.Items.A)
+	if err != nil {
+		return err
 	}
+	op.ItemRefName = itemRefName
 	return nil
 }
 
 // retainResponseDataRef records op.ResponseDataRefName: the last $ref segment of a
 // by-id response's "data" property when that property is a single object
-// reference (e.g. "FullAPIKey"). A list response's "data" is an inline array, not
-// a reference, so it leaves the field empty (retainItemRef covers that). This lets
-// the model detect a "both" data source whose by-id record shape diverges from its
-// list element shape.
+// reference (e.g. "FullAPIKey"). A list response whose "data" resolves to an
+// array leaves the field empty even when that array is referenced (retainItemRef
+// covers it). This lets the model detect a "both" data source whose by-id record
+// shape diverges from its list element shape.
 func (n *schemaNormalizer) retainResponseDataRef(op *model.Operation, respProxy *base.SchemaProxy) error {
-	body, err := n.resolveToSchema(respProxy)
-	if err != nil || body == nil || body.Properties == nil {
+	data, err := n.findPropertyProxy(respProxy, defaultResultsPath)
+	if err != nil || data == nil {
 		return err
 	}
-	if data := body.Properties.GetOrZero(defaultResultsPath); data != nil && data.IsReference() {
-		op.ResponseDataRefName = lastRefSegment(data.GetReference())
+	dataSchema, err := n.resolveOverlayToSchema(data)
+	if err != nil {
+		return err
 	}
+	if dataSchema != nil && hasType(dataSchema, "array") {
+		return nil
+	}
+	dataRefName, err := n.referenceNameThroughOverlay(data)
+	if err != nil {
+		return err
+	}
+	op.ResponseDataRefName = dataRefName
 	return nil
+}
+
+// referenceNameThroughOverlay returns the last segment of a direct $ref or of
+// the sole structural branch in an allOf metadata overlay. Multi-branch object
+// compositions deliberately have no single SDK type identity.
+func (n *schemaNormalizer) referenceNameThroughOverlay(proxy *base.SchemaProxy) (string, error) {
+	for proxy != nil {
+		if proxy.IsReference() {
+			return lastRefSegment(proxy.GetReference()), nil
+		}
+		branch, ok, err := n.singleAllOfStructuralBranch(proxy.Schema())
+		if err != nil || !ok {
+			return "", err
+		}
+		proxy = branch
+	}
+	return "", nil
+}
+
+// resolveOverlayToSchema resolves refs and unwraps single-structural-branch
+// allOf metadata overlays until it reaches the schema that owns the shape.
+func (n *schemaNormalizer) resolveOverlayToSchema(proxy *base.SchemaProxy) (*base.Schema, error) {
+	for proxy != nil {
+		if proxy.IsReference() {
+			target, err := n.resolveRef(proxy.GetReference())
+			if err != nil {
+				return nil, err
+			}
+			proxy = target
+			continue
+		}
+		schema := proxy.Schema()
+		branch, ok, err := n.singleAllOfStructuralBranch(schema)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return schema, nil
+		}
+		proxy = branch
+	}
+	return nil, nil
+}
+
+// singleAllOfStructuralBranch finds a unique non-annotation branch. It returns
+// ok=false for schemas that are not overlays (including genuine multi-branch
+// compositions), so callers never invent a single SDK identity for a composite.
+func (n *schemaNormalizer) singleAllOfStructuralBranch(s *base.Schema) (*base.SchemaProxy, bool, error) {
+	if s == nil || len(s.AllOf) == 0 {
+		return nil, false, nil
+	}
+	var structural *base.SchemaProxy
+	for _, branch := range s.AllOf {
+		raw, err := n.resolveToSchema(branch)
+		if err != nil {
+			return nil, false, err
+		}
+		if n.isAnnotationOnlySchema(raw) {
+			continue
+		}
+		if structural != nil {
+			return nil, false, nil
+		}
+		structural = branch
+	}
+	return structural, structural != nil, nil
+}
+
+// findPropertyProxy finds a named property through refs and allOf object
+// composition. Strict duplicate-property rejection happens during normalization;
+// this helper stays conservative and returns no identity if raw branches expose
+// the property more than once.
+func (n *schemaNormalizer) findPropertyProxy(proxy *base.SchemaProxy, name string) (*base.SchemaProxy, error) {
+	schema, err := n.resolveToSchema(proxy)
+	if err != nil || schema == nil {
+		return nil, err
+	}
+	var found *base.SchemaProxy
+	if schema.Properties != nil {
+		found = schema.Properties.GetOrZero(name)
+	}
+	for _, branch := range schema.AllOf {
+		candidate, err := n.findPropertyProxy(branch, name)
+		if err != nil {
+			return nil, err
+		}
+		if candidate == nil {
+			continue
+		}
+		if found != nil {
+			return nil, nil
+		}
+		found = candidate
+	}
+	return found, nil
 }
 
 // resolveToSchema follows a schema proxy through one or more $ref hops to its
@@ -418,6 +527,9 @@ func (n *schemaNormalizer) normalizeSchema(s *base.Schema, depth int) (*model.Sc
 	if s == nil {
 		return nil, nil
 	}
+	if len(s.AllOf) > 0 {
+		return n.normalizeAllOf(s, depth)
+	}
 	out := &model.Schema{
 		Kind:        classifyKind(s),
 		Type:        firstType(s),
@@ -482,6 +594,235 @@ func (n *schemaNormalizer) normalizeSchema(s *base.Schema, depth int) (*model.Sc
 	}
 
 	return out, nil
+}
+
+// normalizeAllOf flattens the bounded allOf subset used by the Datadog API
+// spec. A single structural branch is a metadata overlay; multiple structural
+// branches must all be objects with disjoint properties. Annotation-only
+// branches are ignored structurally but may supply a local description or
+// sensitive marker. Anything outside that subset becomes an Unsupported schema
+// with a reason so only the affected artifact fails later in the model layer.
+func (n *schemaNormalizer) normalizeAllOf(s *base.Schema, depth int) (*model.Schema, error) {
+	if reason := unsupportedAllOfOuterStructure(s); reason != "" {
+		return unsupportedSchema(reason), nil
+	}
+
+	type structuralBranch struct {
+		index  int
+		schema *model.Schema
+	}
+	branches := make([]structuralBranch, 0, len(s.AllOf))
+	annotationDescription := ""
+	sensitive := n.isSensitive(s)
+
+	for i, proxy := range s.AllOf {
+		branch, err := n.normalizeProxy(proxy, depth)
+		if err != nil {
+			return nil, err
+		}
+		if branch == nil {
+			return unsupportedSchema(fmt.Sprintf("allOf branch %d has no schema", i+1)), nil
+		}
+
+		raw, err := n.resolveToSchema(proxy)
+		if err != nil {
+			return nil, err
+		}
+		if branch.Kind == model.SchemaKindUnsupported && branch.UnsupportedReason == "" && n.isAnnotationOnlySchema(raw) {
+			if annotationDescription == "" && raw.Description != "" {
+				annotationDescription = raw.Description
+			}
+			sensitive = sensitive || n.isSensitive(raw)
+			continue
+		}
+
+		if branch.Kind == model.SchemaKindUnsupported {
+			reason := branch.UnsupportedReason
+			if reason == "" {
+				reason = fmt.Sprintf("allOf branch %d has unsupported schema kind %q", i+1, branch.Kind)
+			}
+			return unsupportedSchema(reason), nil
+		}
+		branches = append(branches, structuralBranch{index: i + 1, schema: branch})
+	}
+
+	if len(branches) == 0 {
+		return unsupportedSchema("allOf has no structural branches"), nil
+	}
+
+	outerType := firstType(s)
+	if len(s.Type) > 1 {
+		return unsupportedSchema("allOf declares multiple outer types"), nil
+	}
+
+	if len(branches) == 1 {
+		out := cloneSchema(branches[0].schema)
+		if outerType != "" && !schemaKindMatchesType(out, outerType) {
+			return unsupportedSchema(fmt.Sprintf("allOf outer type %q conflicts with branch %d schema kind %q", outerType, branches[0].index, out.Kind)), nil
+		}
+		if len(s.Required) > 0 {
+			if out.Kind != model.SchemaKindObject {
+				return unsupportedSchema(fmt.Sprintf("allOf declares outer required fields for branch %d schema kind %q", branches[0].index, out.Kind)), nil
+			}
+			out.Required = unionRequired(out.Required, s.Required)
+		}
+		out.Sensitive = out.Sensitive || sensitive
+		switch {
+		case s.Description != "":
+			out.Description = s.Description
+		case annotationDescription != "":
+			out.Description = annotationDescription
+		}
+		return out, nil
+	}
+
+	if outerType != "" && outerType != "object" {
+		return unsupportedSchema(fmt.Sprintf("allOf object composition conflicts with outer type %q", outerType)), nil
+	}
+
+	out := &model.Schema{
+		Kind:        model.SchemaKindObject,
+		Type:        "object",
+		Properties:  make(map[string]*model.Schema),
+		Sensitive:   sensitive,
+		Description: s.Description,
+	}
+	if out.Description == "" {
+		out.Description = annotationDescription
+	}
+
+	propertyBranch := make(map[string]int)
+	required := make(map[string]bool, len(s.Required))
+	for _, name := range s.Required {
+		required[name] = true
+	}
+	for _, branch := range branches {
+		if branch.schema.Kind != model.SchemaKindObject {
+			return unsupportedSchema(fmt.Sprintf(
+				"allOf branch %d has schema kind %q; multi-branch composition supports objects only",
+				branch.index, branch.schema.Kind,
+			)), nil
+		}
+		out.Sensitive = out.Sensitive || branch.schema.Sensitive
+		for name, child := range branch.schema.Properties {
+			if previous, exists := propertyBranch[name]; exists {
+				return unsupportedSchema(fmt.Sprintf(
+					"allOf property %q is declared by branches %d and %d",
+					name, previous, branch.index,
+				)), nil
+			}
+			propertyBranch[name] = branch.index
+			out.Properties[name] = cloneSchema(child)
+		}
+		for _, name := range branch.schema.Required {
+			required[name] = true
+		}
+	}
+
+	out.Required = make([]string, 0, len(required))
+	for name := range required {
+		out.Required = append(out.Required, name)
+	}
+	sort.Strings(out.Required)
+	return out, nil
+}
+
+// unionRequired returns the sorted union of two required-property lists.
+func unionRequired(left, right []string) []string {
+	required := make(map[string]bool, len(left)+len(right))
+	for _, name := range left {
+		required[name] = true
+	}
+	for _, name := range right {
+		required[name] = true
+	}
+	out := make([]string, 0, len(required))
+	for name := range required {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// unsupportedAllOfOuterStructure rejects combinations whose structure lives
+// both outside and inside allOf. The current Datadog subset uses only an outer
+// type assertion plus annotation/constraint metadata; merging outer properties,
+// variants, arrays, or maps would require broader JSON Schema intersection
+// semantics.
+func unsupportedAllOfOuterStructure(s *base.Schema) string {
+	switch {
+	case len(s.OneOf) > 0:
+		return "allOf combined with outer oneOf is not supported"
+	case len(s.AnyOf) > 0:
+		return "allOf combined with outer anyOf is not supported"
+	case s.Properties != nil && orderedmap.Len(s.Properties) > 0:
+		return "allOf combined with outer properties is not supported"
+	case s.Items != nil:
+		return "allOf combined with outer items is not supported"
+	case s.AdditionalProperties != nil:
+		return "allOf combined with outer additionalProperties is not supported"
+	default:
+		return ""
+	}
+}
+
+// isAnnotationOnlySchema recognizes the sibling-only branch libopenapi creates
+// for an OpenAPI 3.0 $ref with description/example siblings, plus the same form
+// when authored explicitly. A completely empty schema is not an annotation: it
+// remains an arbitrary/untyped value and must not be discarded.
+func (n *schemaNormalizer) isAnnotationOnlySchema(s *base.Schema) bool {
+	if s == nil || len(s.Type) > 0 || len(s.AllOf) > 0 || len(s.OneOf) > 0 || len(s.AnyOf) > 0 ||
+		(s.Properties != nil && orderedmap.Len(s.Properties) > 0) || s.Items != nil || s.AdditionalProperties != nil {
+		return false
+	}
+	hasExtension := s.Extensions != nil && orderedmap.Len(s.Extensions) > 0
+	return s.Title != "" || s.Description != "" || s.Example != nil || len(s.Examples) > 0 ||
+		s.Default != nil || hasExtension || n.isSensitive(s)
+}
+
+func unsupportedSchema(reason string) *model.Schema {
+	return &model.Schema{Kind: model.SchemaKindUnsupported, UnsupportedReason: reason}
+}
+
+func schemaKindMatchesType(s *model.Schema, typ string) bool {
+	if s == nil {
+		return false
+	}
+	switch typ {
+	case "object":
+		return s.Kind == model.SchemaKindObject || s.Kind == model.SchemaKindMap
+	case "array":
+		return s.Kind == model.SchemaKindArray
+	case "string", "integer", "number", "boolean":
+		return s.Kind == model.SchemaKindPrimitive && s.Type == typ
+	default:
+		return false
+	}
+}
+
+// cloneSchema returns a deep copy so applying allOf metadata never mutates a
+// normalized branch or any child reachable from it.
+func cloneSchema(s *model.Schema) *model.Schema {
+	if s == nil {
+		return nil
+	}
+	out := *s
+	out.Enum = append([]string(nil), s.Enum...)
+	out.Required = append([]string(nil), s.Required...)
+	out.Items = cloneSchema(s.Items)
+	if s.Properties != nil {
+		out.Properties = make(map[string]*model.Schema, len(s.Properties))
+		for name, child := range s.Properties {
+			out.Properties[name] = cloneSchema(child)
+		}
+	}
+	if s.Variants != nil {
+		out.Variants = make([]*model.Schema, len(s.Variants))
+		for i, variant := range s.Variants {
+			out.Variants[i] = cloneSchema(variant)
+		}
+	}
+	return &out
 }
 
 // classifyKind derives the SchemaKind from structure, not type alone. Precedence

--- a/.generator-v2/internal/parser/schema_test.go
+++ b/.generator-v2/internal/parser/schema_test.go
@@ -370,6 +370,17 @@ var _ = Describe("NormalizeSchemas allOf normalization", func() {
 		Expect(status.Sensitive).To(BeTrue())
 	})
 
+	It("preserves supported outer scalar constraints", func() {
+		formatted := schemaProperty(request, "outer_format")
+		Expect(formatted.Kind).To(Equal(model.SchemaKindPrimitive))
+		Expect(formatted.Type).To(Equal("string"))
+		Expect(formatted.Format).To(Equal("date-time"))
+
+		enumerated := schemaProperty(request, "outer_enum")
+		Expect(enumerated.Kind).To(Equal(model.SchemaKindPrimitive))
+		Expect(enumerated.Enum).To(Equal([]string{"inactive"}))
+	})
+
 	It("preserves the existing reference-depth limit through allOf", func() {
 		limited := opByID(loadSpecMust("schema_normalize_allof_depth.yaml", WithMaxDepth(1)), "CreateAllOfDepth").RequestSchema
 		Expect(schemaProperty(limited, "depth_limited").Kind).To(Equal(model.SchemaKindRefCycle))
@@ -386,6 +397,7 @@ var _ = Describe("NormalizeSchemas allOf normalization", func() {
 		Entry("annotations without structure", "no_structure", "allOf has no structural branches"),
 		Entry("outer type conflict", "outer_type_conflict", `allOf object composition conflicts with outer type "string"`),
 		Entry("outer and branch properties", "outer_properties", "allOf combined with outer properties is not supported"),
+		Entry("constraint-bearing annotation branch", "constrained_annotation", `allOf branch 2 has unsupported schema kind "unsupported"`),
 	)
 
 	It("normalizes representative JSON:API responses and retains SDK reference identities through overlays", func() {
@@ -422,6 +434,27 @@ var _ = Describe("NormalizeSchemas allOf normalization", func() {
 		artifact, goodErr := model.BuildArtifact(list)
 		Expect(goodErr).NotTo(HaveOccurred())
 		Expect(artifact.Name).To(Equal("allof_items"))
+	})
+})
+
+var _ = Describe("raw schema identity traversal", func() {
+
+	It("terminates property lookup through a recursive allOf", func() {
+		components := loadComponents("schema_raw_traversal_cycles.yaml")
+		normalizer := &schemaNormalizer{components: components, maxDepth: 16}
+
+		property, err := normalizer.findPropertyProxy(componentProxy(components, "PropertyLoop"), "missing")
+		Expect(err).To(Succeed())
+		Expect(property).To(BeNil())
+	})
+
+	It("terminates overlay resolution through a recursive allOf", func() {
+		components := loadComponents("schema_raw_traversal_cycles.yaml")
+		normalizer := &schemaNormalizer{components: components, maxDepth: 16}
+
+		schema, err := normalizer.resolveOverlayToSchema(componentProxy(components, "OverlayLoop"))
+		Expect(err).To(Succeed())
+		Expect(schema).To(BeNil())
 	})
 })
 

--- a/.generator-v2/internal/parser/schema_test.go
+++ b/.generator-v2/internal/parser/schema_test.go
@@ -297,6 +297,135 @@ var _ = Describe("NormalizeSchemas $ref resolution", func() {
 })
 
 // -------------------------------------------------------------------
+//  allOf normalization
+// -------------------------------------------------------------------
+
+var _ = Describe("NormalizeSchemas allOf normalization", func() {
+
+	var request *model.Schema
+	var list *model.Operation
+	var get *model.Operation
+
+	BeforeEach(func() {
+		spec := loadSpecMust("schema_normalize_allof.yaml")
+		request = opByID(spec, "CreateAllOfCases").RequestSchema
+		list = opByID(spec, "ListAllOfItems")
+		get = opByID(spec, "GetAllOfItem")
+	})
+
+	It("preserves a local description on an OpenAPI 3.0 $ref sibling while resolving the referenced shape", func() {
+		status := schemaProperty(request, "ref_description")
+		Expect(status.Kind).To(Equal(model.SchemaKindPrimitive))
+		Expect(status.Type).To(Equal("string"))
+		Expect(status.Format).To(Equal("uuid"))
+		Expect(status.Enum).To(Equal([]string{"active", "inactive"}))
+		Expect(status.Description).To(Equal("Local status description."))
+	})
+
+	It("ignores a non-structural example sibling without losing the referenced description", func() {
+		status := schemaProperty(request, "ref_example")
+		Expect(status.Kind).To(Equal(model.SchemaKindPrimitive))
+		Expect(status.Description).To(Equal("Referenced status description."))
+	})
+
+	It("treats an authored single-branch allOf as a metadata overlay", func() {
+		status := schemaProperty(request, "single_authored")
+		Expect(status.Kind).To(Equal(model.SchemaKindPrimitive))
+		Expect(status.Type).To(Equal("string"))
+		Expect(status.Description).To(Equal("Authored single-branch description."))
+	})
+
+	DescribeTable("merges object branches with deterministic properties and required fields",
+		func(property string, wantProperties, wantRequired []string) {
+			composed := schemaProperty(request, property)
+			Expect(composed.Kind).To(Equal(model.SchemaKindObject))
+			Expect(composed.Properties).To(HaveLen(len(wantProperties)))
+			for _, name := range wantProperties {
+				Expect(composed.Properties).To(HaveKey(name))
+			}
+			Expect(composed.Required).To(Equal(wantRequired))
+		},
+		Entry("two referenced objects", "two_objects", []string{"alpha", "beta", "zeta"}, []string{"alpha", "beta", "zeta"}),
+		Entry("three referenced objects", "three_objects", []string{"alpha", "beta", "gamma", "zeta"}, []string{"alpha", "beta", "gamma", "zeta"}),
+		Entry("a reference and an inline object", "object_with_inline", []string{"alpha", "delta", "zeta"}, []string{"alpha", "delta", "zeta"}),
+		Entry("outer required fields", "outer_required", []string{"alpha", "theta", "zeta"}, []string{"alpha", "theta", "zeta"}),
+		Entry("a nested composition", "nested_objects", []string{"alpha", "beta", "gamma", "zeta"}, []string{"alpha", "beta", "gamma", "zeta"}),
+	)
+
+	It("uses a referenced metadata-only branch as the composed object's description", func() {
+		composed := schemaProperty(request, "metadata_ref")
+		Expect(composed.Kind).To(Equal(model.SchemaKindObject))
+		Expect(composed.Description).To(Equal("Description supplied by a metadata-only base."))
+	})
+
+	It("applies description precedence outer schema, annotation branch, then structural branch", func() {
+		Expect(schemaProperty(request, "outer_description").Description).To(Equal("Outer description wins."))
+		Expect(schemaProperty(request, "annotation_description").Description).To(Equal("Annotation description wins."))
+		Expect(schemaProperty(request, "ref_example").Description).To(Equal("Referenced status description."))
+	})
+
+	It("ORs the sensitive marker from an annotation-only branch onto the structural result", func() {
+		status := schemaProperty(request, "sensitive_overlay")
+		Expect(status.Kind).To(Equal(model.SchemaKindPrimitive))
+		Expect(status.Sensitive).To(BeTrue())
+	})
+
+	It("preserves the existing reference-depth limit through allOf", func() {
+		limited := opByID(loadSpecMust("schema_normalize_allof_depth.yaml", WithMaxDepth(1)), "CreateAllOfDepth").RequestSchema
+		Expect(schemaProperty(limited, "depth_limited").Kind).To(Equal(model.SchemaKindRefCycle))
+	})
+
+	DescribeTable("keeps unsupported intersections local to their schema node and explains why",
+		func(property, reason string) {
+			unsupported := schemaProperty(request, property)
+			Expect(unsupported.Kind).To(Equal(model.SchemaKindUnsupported))
+			Expect(unsupported.UnsupportedReason).To(Equal(reason))
+		},
+		Entry("duplicate property", "duplicate_property", `allOf property "alpha" is declared by branches 1 and 2`),
+		Entry("mixed object and primitive", "mixed_kinds", `allOf branch 2 has schema kind "primitive"; multi-branch composition supports objects only`),
+		Entry("annotations without structure", "no_structure", "allOf has no structural branches"),
+		Entry("outer type conflict", "outer_type_conflict", `allOf object composition conflicts with outer type "string"`),
+		Entry("outer and branch properties", "outer_properties", "allOf combined with outer properties is not supported"),
+	)
+
+	It("normalizes representative JSON:API responses and retains SDK reference identities through overlays", func() {
+		Expect(list.ResponseRefName).To(Equal("AllOfItemsResponse"))
+		Expect(list.ItemRefName).To(Equal("AllOfItem"))
+		Expect(list.ResponseDataRefName).To(BeEmpty())
+		Expect(get.ResponseRefName).To(Equal("AllOfItemResponse"))
+		Expect(get.ResponseDataRefName).To(Equal("AllOfItem"))
+
+		data := schemaProperty(list.ResponseSchema, "data")
+		Expect(data.Kind).To(Equal(model.SchemaKindArray))
+		Expect(data.Items.Kind).To(Equal(model.SchemaKindObject))
+		Expect(data.Items.Properties).To(HaveKey("id"))
+		Expect(data.Items.Properties).To(HaveKey("type"))
+		attributes := schemaProperty(data.Items, "attributes")
+		result := schemaProperty(attributes, "result")
+		Expect(result.Kind).To(Equal(model.SchemaKindPrimitive))
+		Expect(result.Description).To(Equal("Local result description."))
+
+		artifact, err := model.BuildArtifact(list)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(artifact.Schema.Attributes).To(HaveLen(1))
+		Expect(artifact.Schema.Attributes[0].Path).To(Equal("response.data"))
+	})
+
+	It("loads the whole spec but fails only the artifact containing an unsupported composition", func() {
+		bad := opByID(loadSpecMust("schema_normalize_allof.yaml"), "ListBadAllOfItems")
+		_, err := model.BuildArtifact(bad)
+		var unsupported *model.UnsupportedKindError
+		Expect(errors.As(err, &unsupported)).To(BeTrue(), "expected *UnsupportedKindError, got %T: %v", err, err)
+		Expect(unsupported.Path).To(Equal("response.data[].composed"))
+		Expect(unsupported.Reason).To(Equal(`allOf property "alpha" is declared by branches 1 and 2`))
+
+		artifact, goodErr := model.BuildArtifact(list)
+		Expect(goodErr).NotTo(HaveOccurred())
+		Expect(artifact.Name).To(Equal("allof_items"))
+	})
+})
+
+// -------------------------------------------------------------------
 //  Depth limit → SchemaKindRefCycle
 // -------------------------------------------------------------------
 
@@ -519,4 +648,15 @@ func paramByName(op *model.Operation, name string) model.QueryParam {
 	}
 	Fail("query parameter " + name + " not found on " + op.OperationId)
 	return model.QueryParam{}
+}
+
+// schemaProperty returns a named normalized object property or fails the test.
+func schemaProperty(schema *model.Schema, name string) *model.Schema {
+	GinkgoHelper()
+	Expect(schema).NotTo(BeNil())
+	Expect(schema.Kind).To(Equal(model.SchemaKindObject))
+	property, ok := schema.Properties[name]
+	Expect(ok).To(BeTrue(), "schema property %s not found", name)
+	Expect(property).NotTo(BeNil())
+	return property
 }

--- a/.generator-v2/internal/testdata/parser/schema_normalize_allof.yaml
+++ b/.generator-v2/internal/testdata/parser/schema_normalize_allof.yaml
@@ -1,0 +1,288 @@
+openapi: 3.0.0
+info:
+  title: normalize allOf fixture
+  version: 1.0.0
+paths:
+  /request-cases:
+    post:
+      operationId: CreateAllOfCases
+      tags:
+        - AllOf
+      x-datadog-tf-generator:
+        artifact_kind: resource
+        artifact_name: allof_cases
+        group:
+          create: CreateAllOfCases
+          read: CreateAllOfCases
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ref_description:
+                  $ref: '#/components/schemas/Status'
+                  description: Local status description.
+                ref_example:
+                  $ref: '#/components/schemas/Status'
+                  example: active
+                single_authored:
+                  description: Authored single-branch description.
+                  allOf:
+                    - $ref: '#/components/schemas/Status'
+                two_objects:
+                  allOf:
+                    - $ref: '#/components/schemas/ObjectA'
+                    - $ref: '#/components/schemas/ObjectB'
+                three_objects:
+                  allOf:
+                    - $ref: '#/components/schemas/ObjectA'
+                    - $ref: '#/components/schemas/ObjectB'
+                    - $ref: '#/components/schemas/ObjectC'
+                object_with_inline:
+                  allOf:
+                    - $ref: '#/components/schemas/ObjectA'
+                    - type: object
+                      properties:
+                        delta:
+                          type: boolean
+                          description: Delta flag.
+                      required:
+                        - delta
+                outer_required:
+                  type: object
+                  required:
+                    - theta
+                  allOf:
+                    - $ref: '#/components/schemas/ObjectA'
+                    - $ref: '#/components/schemas/OptionalObject'
+                nested_objects:
+                  allOf:
+                    - $ref: '#/components/schemas/ObjectAB'
+                    - $ref: '#/components/schemas/ObjectC'
+                metadata_ref:
+                  allOf:
+                    - $ref: '#/components/schemas/DescriptionOnlyBase'
+                    - $ref: '#/components/schemas/ObjectA'
+                    - $ref: '#/components/schemas/ObjectB'
+                outer_description:
+                  type: object
+                  description: Outer description wins.
+                  allOf:
+                    - description: Annotation branch description.
+                    - $ref: '#/components/schemas/ObjectA'
+                annotation_description:
+                  allOf:
+                    - description: Annotation description wins.
+                    - $ref: '#/components/schemas/Status'
+                sensitive_overlay:
+                  allOf:
+                    - $ref: '#/components/schemas/Status'
+                    - x-datadog-tf-generator:
+                        sensitive: true
+                duplicate_property:
+                  allOf:
+                    - $ref: '#/components/schemas/ObjectA'
+                    - $ref: '#/components/schemas/DuplicateAlpha'
+                mixed_kinds:
+                  allOf:
+                    - $ref: '#/components/schemas/ObjectA'
+                    - $ref: '#/components/schemas/Status'
+                no_structure:
+                  allOf:
+                    - description: Annotation without a structural branch.
+                outer_type_conflict:
+                  type: string
+                  allOf:
+                    - $ref: '#/components/schemas/ObjectA'
+                    - $ref: '#/components/schemas/ObjectB'
+                outer_properties:
+                  type: object
+                  properties:
+                    outside:
+                      type: string
+                  allOf:
+                    - $ref: '#/components/schemas/ObjectA'
+      responses:
+        '204':
+          description: No content.
+  /items:
+    get:
+      operationId: ListAllOfItems
+      tags:
+        - AllOf
+      x-datadog-tf-generator:
+        artifact_kind: data_source
+        artifact_name: allof_items
+        cardinality: plural
+        group:
+          read: ListAllOfItems
+      responses:
+        '200':
+          description: OK.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllOfItemsResponse'
+                description: Local list response description.
+  /items/{item_id}:
+    get:
+      operationId: GetAllOfItem
+      tags:
+        - AllOf
+      x-datadog-tf-generator:
+        artifact_kind: data_source
+        artifact_name: allof_item
+        group:
+          read: GetAllOfItem
+      parameters:
+        - name: item_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllOfItemResponse'
+  /bad-items:
+    get:
+      operationId: ListBadAllOfItems
+      tags:
+        - AllOf
+      x-datadog-tf-generator:
+        artifact_kind: data_source
+        artifact_name: bad_allof_items
+        cardinality: plural
+        group:
+          read: ListBadAllOfItems
+      responses:
+        '200':
+          description: OK.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadAllOfItemsResponse'
+components:
+  schemas:
+    Status:
+      type: string
+      format: uuid
+      description: Referenced status description.
+      enum:
+        - active
+        - inactive
+    ObjectA:
+      type: object
+      properties:
+        zeta:
+          type: string
+          description: Zeta value.
+        alpha:
+          type: string
+          description: Alpha value.
+      required:
+        - zeta
+        - alpha
+    ObjectB:
+      type: object
+      properties:
+        beta:
+          type: integer
+          description: Beta value.
+      required:
+        - beta
+    ObjectC:
+      type: object
+      properties:
+        gamma:
+          type: number
+          description: Gamma value.
+      required:
+        - gamma
+    OptionalObject:
+      type: object
+      properties:
+        theta:
+          type: string
+          description: Theta value.
+    ObjectAB:
+      allOf:
+        - $ref: '#/components/schemas/ObjectA'
+        - $ref: '#/components/schemas/ObjectB'
+    DescriptionOnlyBase:
+      description: Description supplied by a metadata-only base.
+    DuplicateAlpha:
+      type: object
+      properties:
+        alpha:
+          type: integer
+          description: Conflicting alpha value.
+    AllOfItemsResponse:
+      allOf:
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/AllOfItemsData'
+              example: []
+        - type: object
+          properties:
+            meta:
+              type: string
+              description: Response metadata.
+    AllOfItemsData:
+      type: array
+      items:
+        $ref: '#/components/schemas/AllOfItem'
+    AllOfItemResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/AllOfItem'
+          description: Local item data description.
+    AllOfItem:
+      allOf:
+        - $ref: '#/components/schemas/JSONAPIIdentity'
+        - type: object
+          properties:
+            attributes:
+              $ref: '#/components/schemas/AllOfItemAttributes'
+          required:
+            - attributes
+    JSONAPIIdentity:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Item ID.
+        type:
+          type: string
+          description: Item type.
+      required:
+        - id
+        - type
+    AllOfItemAttributes:
+      type: object
+      properties:
+        result:
+          $ref: '#/components/schemas/Status'
+          description: Local result description.
+      required:
+        - result
+    BadAllOfItemsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/BadAllOfItem'
+    BadAllOfItem:
+      type: object
+      properties:
+        composed:
+          allOf:
+            - $ref: '#/components/schemas/ObjectA'
+            - $ref: '#/components/schemas/DuplicateAlpha'

--- a/.generator-v2/internal/testdata/parser/schema_normalize_allof.yaml
+++ b/.generator-v2/internal/testdata/parser/schema_normalize_allof.yaml
@@ -80,6 +80,22 @@ paths:
                     - $ref: '#/components/schemas/Status'
                     - x-datadog-tf-generator:
                         sensitive: true
+                outer_format:
+                  format: date-time
+                  allOf:
+                    - type: string
+                outer_enum:
+                  enum:
+                    - inactive
+                    - pending
+                  allOf:
+                    - $ref: '#/components/schemas/Status'
+                constrained_annotation:
+                  allOf:
+                    - $ref: '#/components/schemas/Status'
+                    - description: This branch also constrains the value.
+                      enum:
+                        - active
                 duplicate_property:
                   allOf:
                     - $ref: '#/components/schemas/ObjectA'

--- a/.generator-v2/internal/testdata/parser/schema_normalize_allof_depth.yaml
+++ b/.generator-v2/internal/testdata/parser/schema_normalize_allof_depth.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.0
+info:
+  title: normalize allOf depth fixture
+  version: 1.0.0
+paths:
+  /depth:
+    post:
+      operationId: CreateAllOfDepth
+      x-datadog-tf-generator:
+        artifact_kind: resource
+        artifact_name: allof_depth
+        group:
+          create: CreateAllOfDepth
+          read: CreateAllOfDepth
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                depth_limited:
+                  $ref: '#/components/schemas/NestedOverlay'
+      responses:
+        '204':
+          description: No content.
+components:
+  schemas:
+    NestedOverlay:
+      allOf:
+        - $ref: '#/components/schemas/Status'
+    Status:
+      type: string

--- a/.generator-v2/internal/testdata/parser/schema_raw_traversal_cycles.yaml
+++ b/.generator-v2/internal/testdata/parser/schema_raw_traversal_cycles.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+info:
+  title: Raw schema traversal cycles
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    PropertyLoop:
+      allOf:
+        - type: object
+          properties:
+            name:
+              type: string
+        - $ref: '#/components/schemas/PropertyLoop'
+    OverlayLoop:
+      allOf:
+        - $ref: '#/components/schemas/OverlayLoop'


### PR DESCRIPTION
## Motivation

TFgen resolves pure OpenAPI `$ref` schemas before building its attribute tree, but it previously classified every `allOf` schema as unsupported. This also affected ordinary OpenAPI 3.0 `$ref` nodes with `description` or `example` siblings because libopenapi represents those siblings as a synthetic `allOf` overlay.

On top of #4080, that gap accounted for 28 blocked direct artifacts, including otherwise ordinary objects and arrays such as budget costs, ServiceNow results, notification rules, tables, and widgets.

This PR adds bounded `allOf` normalization for the shapes used by the Datadog API spec while deliberately avoiding general JSON Schema intersection semantics.

## Changes

### Normalize the supported `allOf` subset

- Treat a single structural branch plus annotation-only branches as a metadata overlay.
- Merge multi-branch object compositions when their properties are disjoint.
- Union and sort required fields, preserve description precedence, and OR sensitive markers.
- Preserve response and item reference identities through single-branch overlays so SDK binding continues to use the correct generated types.

### Keep unsupported intersections artifact-local

- Reject duplicate properties, mixed structural kinds, incompatible outer types, and other unsupported intersections with deterministic reasons.
- Carry those reasons through the normalized schema and include them in the existing full-path `UnsupportedKindError`.
- Continue processing the rest of the spec so one unsupported composition fails only its affected artifact.

### Add regression coverage

- Cover synthetic OpenAPI 3.0 `$ref` siblings, authored overlays, two- and three-object composition, inline branches, nested composition, metadata precedence, sensitivity, depth limits, and rejection cases.
- Exercise representative JSON:API list and singular responses through artifact construction.

The direct `unsupported-schema-kind` population fell from 68 to 41 artifacts. Ten affected rows now pass, while seventeen advance to a later independent blocker such as UUID conversion or generated-model naming. No unexplained outcomes changed outside the affected resource footprint.

## QA Instructions

Automated validation:

- `make tfgen-test`
- `make tfgen-build`
- `make fmtcheck`
- `make test`
- `make vet`

Full-spec validation used `datadog-api-spec` commit `efa610ceed9a69e8e4319ef4b4f46f344be283e4` and SDK version `v2.62.1-0.20260724190103-95e5c326c65e`, running every SDK-bound singular, plural, and paired candidate.

`make errcheck` retains the repository's existing legacy unchecked-error failures; it reports no findings under `.generator-v2`.

## Blast Radius

This changes only generator-v2 schema normalization and diagnostics. It does not modify existing provider resources, checked-in generated data sources, Terraform schemas, or runtime API behavior.

The new behavior applies only when a source OpenAPI schema contains `allOf`. Unsupported or ambiguous intersections remain rejected per artifact rather than being guessed. The PR is a single commit and can be reverted independently; it is stacked on #4080 and should be reviewed and merged after that PR.
