### PR TITLE
[tfgen] Handle UUID and absent response IDs

### DIFF
--- a/.generator-v2/internal/cli/generate_test.go
+++ b/.generator-v2/internal/cli/generate_test.go
@@ -25,6 +25,56 @@ func runTfgen(args ...string) error {
 	return root.Execute()
 }
 
+// TestGenerateHandlesUUIDResponseAndOptionalFilter drives a production-shaped
+// incident-notification-template list operation through parsing, pinned-SDK
+// binding, model construction, and rendering. Its response data ID and optional
+// incident-type filter are both UUIDs, covering the two emitter boundaries
+// together.
+func TestGenerateHandlesUUIDResponseAndOptionalFilter(t *testing.T) {
+	spec, err := os.ReadFile(filepath.Join("..", "testdata", "mini-oas", "mini-datadog_incident_notification_template.yaml"))
+	if err != nil {
+		t.Fatalf("reading incident notification template spec: %v", err)
+	}
+	annotation := `      operationId: ListIncidentNotificationTemplates
+      x-datadog-tf-generator:
+        artifact_kind: data_source
+        artifact_name: incident_notification_templates
+        tf_description: Use this data source to retrieve incident notification templates.
+        group:
+          read: ListIncidentNotificationTemplates
+        cardinality: plural
+`
+	annotated := strings.Replace(string(spec),
+		"      operationId: ListIncidentNotificationTemplates\n", annotation, 1)
+	if annotated == string(spec) {
+		t.Fatal("failed to annotate ListIncidentNotificationTemplates")
+	}
+
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "incident_notification_templates.yaml")
+	if err := os.WriteFile(specPath, []byte(annotated), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runTfgen("generate", "--spec", specPath,
+		"--output-root", dir,
+		"--examples-output-root", filepath.Join(dir, "examples"),
+		"--report", filepath.Join(dir, "report.json")); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	generated := mustRead(t, filepath.Join(dir, "data_source_datadog_incident_notification_templates.go"))
+	for _, want := range []string{
+		`"github.com/google/uuid"`,
+		`parsedFilterIncidentType, err := uuid.Parse(state.FilterIncidentType.ValueString())`,
+		`optionalParams.WithFilterIncidentType(parsedFilterIncidentType)`,
+		`types.StringValue(item.GetId().String())`,
+	} {
+		if !strings.Contains(generated, want) {
+			t.Errorf("generated data source missing %q:\n%s", want, generated)
+		}
+	}
+}
+
 // TestGenerateWiresMaxDepth proves the --max-depth flag value reaches LoadSpec:
 // the same deep-but-acyclic spec loads at a high bound and fails at a low one.
 // If the flag were ignored, both runs would behave identically.

--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -117,7 +117,7 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 	leafFields := b.models[0].Fields
 
 	inputAttrs, inputFields := buildInputViews(inputLeaves)
-	filterParams := buildFilterParams(search, filterLeaves, &b.unsupported)
+	filterParams, filterUUID := buildFilterParams(search, filterLeaves, &b.unsupported)
 	readArgs, readUUID := buildArgumentViews(read, &b.unsupported)
 	searchArgs, searchUUID := buildArgumentViews(search, &b.unsupported)
 	if len(b.unsupported) > 0 {
@@ -136,7 +136,10 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 	fields := append([]ModelFieldView{idField}, inputFields...)
 	b.models[0].Fields = append(fields, leafFields...)
 
-	assignments := append([]StateAssignment{env.idAssign}, recordScalars...)
+	assignments := recordScalars
+	if env.idAssign != nil {
+		assignments = append([]StateAssignment{*env.idAssign}, assignments...)
+	}
 
 	var readView, searchView SDKReadView
 	if hasRead {
@@ -161,7 +164,7 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 		SDKPackage:  primary.GoPackage,
 		APIStruct:   primary.GoApiStruct,
 		APIAccessor: "Get" + primary.GoApiStruct + strings.TrimPrefix(primary.GoPackage, "datadog"),
-		UsesUUID:    readUUID || searchUUID,
+		UsesUUID:    readUUID || searchUUID || filterUUID,
 		ByID:        byID,
 		Searchable:  searchable,
 		Read:        readView,
@@ -250,15 +253,16 @@ func buildArgumentViews(call *model.SDKCall, unsupported *[]UnsupportedNode) ([]
 	return views, usesUUID
 }
 
-func buildFilterParams(call *model.SDKCall, leaves []*model.Attribute, unsupported *[]UnsupportedNode) []FilterParamView {
+func buildFilterParams(call *model.SDKCall, leaves []*model.Attribute, unsupported *[]UnsupportedNode) ([]FilterParamView, bool) {
 	if call == nil {
-		return nil
+		return nil, false
 	}
 	byName := map[string]model.SDKArgument{}
 	for _, arg := range call.OptionalArguments {
 		byName[arg.TFName] = arg
 	}
 	var params []FilterParamView
+	usesUUID := false
 	for _, leaf := range leaves {
 		tfName := tfNameOf(leaf.Path)
 		if !call.BindingResolved {
@@ -275,19 +279,21 @@ func buildFilterParams(call *model.SDKCall, leaves []*model.Attribute, unsupport
 			})
 			continue
 		}
-		expr, uuidVar, _, reason := sdkArgumentExpression(call.GoPackage, arg)
-		if uuidVar != "" {
-			reason = "optional UUID arguments are not supported by scalar-first binding"
-		}
+		expr, uuidVar, uuidSource, reason := sdkArgumentExpression(call.GoPackage, arg)
 		if reason != "" {
 			*unsupported = append(*unsupported, UnsupportedNode{Path: "sdk." + call.GoMethod + "." + arg.Name, Reason: reason})
 			continue
 		}
-		params = append(params, FilterParamView{
+		param := FilterParamView{
 			StateField: model.SdkName(tfName), ParamField: model.SdkName(tfName), ValueExpr: expr, Setter: arg.Setter,
-		})
+		}
+		if uuidVar != "" {
+			param.UUIDVar, param.UUIDSource, param.TFName = uuidVar, uuidSource, tfName
+			usesUUID = true
+		}
+		params = append(params, param)
 	}
-	return params
+	return params, usesUUID
 }
 
 func sdkArgumentExpression(sdkPackage string, arg model.SDKArgument) (expr, uuidVar, uuidSource, reason string) {
@@ -331,7 +337,7 @@ func sdkArgumentExpression(sdkPackage string, arg model.SDKArgument) (expr, uuid
 type flattenedEnvelope struct {
 	leaves   []*model.Attribute
 	idField  ModelFieldView
-	idAssign StateAssignment
+	idAssign *StateAssignment
 	preamble []string
 }
 
@@ -393,8 +399,8 @@ func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrat
 			b.dropped = append(b.dropped, droppedAuditField(child.Path))
 			continue
 		}
-		// The envelope id is surfaced unconditionally below, so an id under
-		// attributes always collides with it.
+		// The root model always reserves id for Terraform identity, so an id under
+		// attributes collides even when the response has no data.id getter.
 		if tfNameOf(child.Path) == "id" {
 			b.dropped = append(b.dropped, droppedIDCollision(child.Path))
 			continue
@@ -425,20 +431,24 @@ func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrat
 		return nil
 	}
 
-	idValueExpr := "*id"
-	if id != nil && id.IsEnum {
-		idValueExpr = "string(*id)"
-	}
-	return &flattenedEnvelope{
-		leaves:  leaves,
-		idField: ModelFieldView{GoField: "ID", GoType: "types.String", TFName: "id"},
-		idAssign: StateAssignment{
+	var idAssign *StateAssignment
+	if id != nil {
+		idAssign = &StateAssignment{
 			Var:      "id",
 			GetterOk: rootExpr + ".GetIdOk()",
 			LHS:      "state.ID",
-			RHS:      "types.StringValue(" + idValueExpr + ")",
-		},
-		preamble: []string{"attributes := " + rootExpr + ".GetAttributes()"},
+			RHS:      guardedValue(id, "id"),
+		}
+	}
+	var preamble []string
+	if len(leaves) > 0 {
+		preamble = []string{"attributes := " + rootExpr + ".GetAttributes()"}
+	}
+	return &flattenedEnvelope{
+		leaves:   leaves,
+		idField:  ModelFieldView{GoField: "ID", GoType: "types.String", TFName: "id"},
+		idAssign: idAssign,
+		preamble: preamble,
 	}
 }
 
@@ -693,13 +703,14 @@ func leafVar(tfName string) string {
 
 // guardedValue wraps a guarded assignment's local (bound from an Ok-getter, so a
 // pointer) in the types.*Value constructor matching the model field's GoType. A
-// date-time pointer renders via .String(); a named enum pointer is dereferenced
-// and cast back to string; integers are cast to int64 as the framework expects.
+// date-time or UUID pointer renders via .String(); a named enum pointer is
+// dereferenced and cast back to string; integers are cast to int64 as the
+// framework expects.
 func guardedValue(a *model.Attribute, varName string) string {
 	switch a.GoType {
 	case "types.String":
 		switch {
-		case a.Format == "date-time":
+		case a.Format == "date-time" || a.Format == "uuid":
 			return "types.StringValue(" + varName + ".String())"
 		case a.IsEnum:
 			return "types.StringValue(string(*" + varName + "))"
@@ -720,13 +731,14 @@ func guardedValue(a *model.Attribute, varName string) string {
 // wrapValue wraps an SDK getter chain in the types.*Value constructor matching
 // the model field's GoType, casting integers to int64 as the framework expects.
 // For strings it also reconciles getters whose Go return type is not a bare
-// string: a date-time getter returns time.Time (rendered via .String()) and an
-// enum getter returns a named string type (cast back with string(...)).
+// string: date-time and UUID getters return stringer values (rendered via
+// .String()) and enum getters return named string types (cast back with
+// string(...)).
 func wrapValue(a *model.Attribute, chain string) string {
 	switch a.GoType {
 	case "types.String":
 		switch {
-		case a.Format == "date-time":
+		case a.Format == "date-time" || a.Format == "uuid":
 			chain += ".String()"
 		case a.IsEnum:
 			chain = "string(" + chain + ")"
@@ -802,7 +814,7 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 	}
 
 	inputAttrs, inputFields := buildInputViews(inputLeaves)
-	filterParams := buildFilterParams(call, filterLeaves, &unsupported)
+	filterParams, filterUUID := buildFilterParams(call, filterLeaves, &unsupported)
 	callArgs, usesUUID := buildArgumentViews(call, &unsupported)
 
 	// b hosts walk so list-of-object item fields generate their element structs.
@@ -911,7 +923,7 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 		SDKPackage:  call.GoPackage,
 		APIStruct:   call.GoApiStruct,
 		APIAccessor: "Get" + call.GoApiStruct + strings.TrimPrefix(call.GoPackage, "datadog"),
-		UsesUUID:    usesUUID,
+		UsesUUID:    usesUUID || filterUUID,
 		Read: SDKReadView{
 			Method:             call.GoMethod,
 			Paginated:          call.Paginated,

--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -153,6 +153,7 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 			OptionalParamsType: search.OptionalParamsType,
 			Filters:            filterParams,
 			Arguments:          searchArgs,
+			HashInputs:         buildHashInputs(inputLeaves),
 		}
 	}
 

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -60,10 +60,11 @@ var _ = Describe("BuildDataSourceView", func() {
 		}))
 	})
 
-	It("renders a date-time string via .String(), a named enum via a string() cast, and avoids shadowing state", func() {
+	It("renders date-time and UUID strings via .String(), a named enum via a string() cast, and avoids shadowing state", func() {
 		op := incidentTypeOperation()
 		attrs := op.ResponseSchema.Properties["data"].Properties["attributes"].Properties
 		attrs["resolved_at"] = &model.Schema{Kind: model.SchemaKindPrimitive, Type: "string", Format: "date-time"}
+		attrs["owner_id"] = &model.Schema{Kind: model.SchemaKindPrimitive, Type: "string", Format: "uuid"}
 		attrs["state"] = &model.Schema{Kind: model.SchemaKindPrimitive, Type: "string", Enum: []string{"active", "archived"}}
 		art, err := model.BuildArtifact(op)
 		Expect(err).NotTo(HaveOccurred())
@@ -77,9 +78,48 @@ var _ = Describe("BuildDataSourceView", func() {
 		}
 		Expect(assign["state.ResolvedAt"].RHS).To(Equal("types.StringValue(resolvedAt.String())"))
 		Expect(assign["state.ResolvedAt"].GetterOk).To(Equal("attributes.GetResolvedAtOk()"))
+		Expect(assign["state.OwnerId"].RHS).To(Equal("types.StringValue(ownerId.String())"))
 		// "state" would shadow the updateState receiver, so its local is suffixed.
 		Expect(assign["state.State"].Var).To(Equal("stateValue"))
 		Expect(assign["state.State"].RHS).To(Equal("types.StringValue(string(*stateValue))"))
+	})
+
+	It("renders a UUID envelope id through its canonical string form", func() {
+		op := incidentTypeOperation()
+		op.ResponseSchema.Properties["data"].Properties["id"].Format = "uuid"
+
+		view := mustView(op)
+		Expect(view.State.Assignments[0]).To(Equal(StateAssignment{
+			Var: "id", GetterOk: "resp.Data.GetIdOk()", LHS: "state.ID", RHS: "types.StringValue(id.String())",
+		}))
+	})
+
+	It("keeps the Terraform identity without calling an absent response ID getter", func() {
+		op := incidentTypeOperation()
+		delete(op.ResponseSchema.Properties["data"].Properties, "id")
+
+		view := mustView(op)
+		Expect(view.Models[0].Fields[0]).To(Equal(ModelFieldView{
+			GoField: "ID", GoType: "types.String", TFName: "id",
+		}))
+		Expect(view.State.Assignments).NotTo(ContainElement(HaveField("LHS", "state.ID")))
+
+		rendered, err := RenderDataSource(view)
+		Expect(err).NotTo(HaveOccurred())
+		src := string(rendered)
+		Expect(src).NotTo(ContainSubstring("GetIdOk()"))
+		Expect(src).NotTo(ContainSubstring("state.ID ="))
+	})
+
+	It("omits the attributes preamble when no response assignments use it", func() {
+		op := incidentTypeOperation()
+		op.ResponseSchema.Properties["data"].Properties["attributes"].Properties = map[string]*model.Schema{}
+
+		view := mustView(op)
+		Expect(view.State.Preamble).To(BeEmpty())
+		rendered, err := RenderDataSource(view)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(rendered)).NotTo(ContainSubstring("attributes :="))
 	})
 
 	It("renders a Go-keyword attribute through a safe guarded local", func() {
@@ -386,6 +426,32 @@ var _ = Describe("BuildDataSourceView singular search", func() {
 			Expect(view.State.ParamName).To(Equal("data"))
 			Expect(view.State.ParamType).To(Equal("datadogV2.PowerpackData"))
 			Expect(view.State.Preamble).To(Equal([]string{"attributes := data.GetAttributes()"}))
+		})
+
+		It("parses an optional UUID filter before calling its pinned SDK setter", func() {
+			op := powerpackSearchOperation()
+			op.QueryParams[0].Schema.Format = "uuid"
+			op.SDKBinding = &model.SDKOperationBinding{
+				OptionalParamsType: "ListPowerpacksOptionalParameters",
+				Optional: []model.SDKArgument{{
+					Name: "filter[name]", GoName: "filterName", GoType: "uuid.UUID", Location: "query",
+					Schema: op.QueryParams[0].Schema, Setter: "WithFilterName",
+				}},
+			}
+
+			view := mustView(op)
+			Expect(view.UsesUUID).To(BeTrue())
+			Expect(view.Search.Filters).To(Equal([]FilterParamView{{
+				StateField: "FilterName", ParamField: "FilterName", ValueExpr: "parsedFilterName", Setter: "WithFilterName",
+				UUIDVar: "parsedFilterName", UUIDSource: "state.FilterName.ValueString()", TFName: "filter_name",
+			}}))
+
+			rendered, err := RenderDataSource(view)
+			Expect(err).NotTo(HaveOccurred())
+			src := string(rendered)
+			Expect(src).To(ContainSubstring(`parsedFilterName, err := uuid.Parse(state.FilterName.ValueString())`))
+			Expect(src).To(ContainSubstring(`response.Diagnostics.AddError("Invalid filter_name", err.Error())`))
+			Expect(src).To(ContainSubstring(`optionalParams.WithFilterName(parsedFilterName)`))
 		})
 
 	})
@@ -808,6 +874,71 @@ var _ = Describe("BuildDataSourceView plural", func() {
 			names = append(names, f.TFName)
 		}
 		Expect(names).To(Equal([]string{"filter_keyword", "filter_me"}))
+	})
+
+	It("renders UUID response values at the item root, in attributes, and in nested objects", func() {
+		op := pluralNestedOperation()
+		item := op.ResponseSchema.Properties["data"].Items
+		item.Properties["id"].Format = "uuid"
+		item.Properties["attributes"].Properties["owner_id"] = &model.Schema{
+			Kind: model.SchemaKindPrimitive, Type: "string", Format: "uuid", Description: "The owner UUID.",
+		}
+		item.Properties["attributes"].Properties["parts"].Items.Properties["label"].Format = "uuid"
+
+		view := mustView(op)
+		fields := map[string]string{}
+		for _, assignment := range view.State.ItemFields {
+			fields[assignment.LHS] = assignment.RHS
+		}
+		Expect(fields["ID"]).To(Equal("types.StringValue(item.GetId().String())"))
+		Expect(fields["OwnerId"]).To(Equal("types.StringValue(item.Attributes.GetOwnerId().String())"))
+		Expect(view.State.ItemLists[0].Scalars).To(ContainElement(StateAssignment{
+			Var: "label", GetterOk: "partsItem.GetLabelOk()", LHS: "partsModel.Label", RHS: "types.StringValue(label.String())",
+		}))
+	})
+
+	It("parses an optional UUID filter in the plural Read path", func() {
+		op := teamsOperation()
+		filter := op.QueryParams[0]
+		filter.Schema.Format = "uuid"
+		op.SDKBinding = &model.SDKOperationBinding{
+			OptionalParamsType: "ListTeamsOptionalParameters",
+			Optional: []model.SDKArgument{
+				{Name: filter.Name, GoName: "filterKeyword", GoType: "uuid.UUID", Location: "query", Schema: filter.Schema, Setter: "WithFilterKeyword"},
+				{Name: "filter[me]", GoName: "filterMe", GoType: "bool", Location: "query", Schema: op.QueryParams[1].Schema, Setter: "WithFilterMe"},
+			},
+		}
+
+		view := mustView(op)
+		Expect(view.UsesUUID).To(BeTrue())
+		rendered, err := RenderDataSource(view)
+		Expect(err).NotTo(HaveOccurred())
+		src := string(rendered)
+		Expect(src).To(ContainSubstring(`parsedFilterKeyword, err := uuid.Parse(state.FilterKeyword.ValueString())`))
+		Expect(src).To(ContainSubstring(`optionalParams.WithFilterKeyword(parsedFilterKeyword)`))
+	})
+
+	It("uses the pinned setter type rather than UUID schema format for input syntax", func() {
+		op := teamsOperation()
+		filter := op.QueryParams[0]
+		filter.Schema.Format = "uuid"
+		op.SDKBinding = &model.SDKOperationBinding{
+			OptionalParamsType: "ListTeamsOptionalParameters",
+			Optional: []model.SDKArgument{
+				{Name: filter.Name, GoName: "filterKeyword", GoType: "string", Location: "query", Schema: filter.Schema, Setter: "WithFilterKeyword"},
+				{Name: "filter[me]", GoName: "filterMe", GoType: "bool", Location: "query", Schema: op.QueryParams[1].Schema, Setter: "WithFilterMe"},
+			},
+		}
+
+		view := mustView(op)
+		Expect(view.UsesUUID).To(BeFalse())
+		Expect(view.Read.Filters[0]).To(Equal(FilterParamView{
+			StateField: "FilterKeyword", ParamField: "FilterKeyword",
+			ValueExpr: "state.FilterKeyword.ValueString()", Setter: "WithFilterKeyword",
+		}))
+		rendered, err := RenderDataSource(view)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(rendered)).NotTo(ContainSubstring("github.com/google/uuid"))
 	})
 
 	It("hashes a fixed seed when an endpoint has no filters", func() {

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -454,6 +454,23 @@ var _ = Describe("BuildDataSourceView singular search", func() {
 			Expect(src).To(ContainSubstring(`optionalParams.WithFilterName(parsedFilterName)`))
 		})
 
+		It("hashes the search inputs when the selected record has no id", func() {
+			op := powerpackSearchOperation()
+			delete(op.ResponseSchema.Properties["data"].Items.Properties, "id")
+
+			view := mustView(op)
+			Expect(view.Search.HashInputs).To(Equal([]FilterParamView{
+				{StateField: "FilterName", ValueExpr: "ValueStringPointer()"},
+			}))
+			Expect(view.State.Assignments).NotTo(ContainElement(HaveField("LHS", "state.ID")))
+
+			rendered, err := RenderDataSource(view)
+			Expect(err).NotTo(HaveOccurred())
+			src := string(rendered)
+			Expect(src).To(ContainSubstring(`hashingData := fmt.Sprintf("%s", state.FilterName.ValueString())`))
+			Expect(src).To(ContainSubstring(`state.ID = types.StringValue(utils.ConvertToSha256(hashingData))`))
+		})
+
 	})
 
 	Context("both", func() {
@@ -486,6 +503,22 @@ var _ = Describe("BuildDataSourceView singular search", func() {
 				Description: "Filter datastores by keyword.",
 				Optional:    true,
 			}))
+		})
+
+		It("hashes a fixed seed on the search path when the selected record has no id", func() {
+			op := datastoreBothOperation()
+			delete(op.ResponseSchema.Properties["data"].Properties, "id")
+			delete(op.SearchOp.ResponseSchema.Properties["data"].Items.Properties, "id")
+
+			view := mustView(op)
+			Expect(view.Search.HashInputs).To(BeEmpty())
+			Expect(view.State.Assignments).NotTo(ContainElement(HaveField("LHS", "state.ID")))
+
+			rendered, err := RenderDataSource(view)
+			Expect(err).NotTo(HaveOccurred())
+			src := string(rendered)
+			Expect(src).To(ContainSubstring(`hashingData := "datastore"`))
+			Expect(src).To(ContainSubstring(`state.ID = types.StringValue(utils.ConvertToSha256(hashingData))`))
 		})
 
 	})

--- a/.generator-v2/internal/emit/templates/data_source_plural.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_plural.go.tmpl
@@ -58,6 +58,13 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 	var optionalParams {{ .SDKPackage }}.{{ .Read.OptionalParamsType }}
 {{- range .Read.Filters }}
 	if !state.{{ .StateField }}.IsNull() {
+{{- if .UUIDVar }}
+		{{ .UUIDVar }}, err := uuid.Parse({{ .UUIDSource }})
+		if err != nil {
+			response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
+			return
+		}
+{{- end }}
 {{- if .Setter }}
 		optionalParams.{{ .Setter }}({{ .ValueExpr }})
 {{- else }}

--- a/.generator-v2/internal/emit/templates/data_source_singular.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_singular.go.tmpl
@@ -163,6 +163,13 @@ func (d *{{ .GoName }}DataSource) updateState(state *{{ .GoName }}DataSourceMode
 	var optionalParams {{ .SDKPackage }}.{{ .Search.OptionalParamsType }}
 {{- range .Search.Filters }}
 	if !state.{{ .StateField }}.IsNull() {
+{{- if .UUIDVar }}
+		{{ .UUIDVar }}, err := uuid.Parse({{ .UUIDSource }})
+		if err != nil {
+			response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
+			return
+		}
+{{- end }}
 {{- if .Setter }}
 		optionalParams.{{ .Setter }}({{ .ValueExpr }})
 {{- else }}

--- a/.generator-v2/internal/emit/templates/data_source_singular.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_singular.go.tmpl
@@ -11,7 +11,7 @@ package fwprovider
 
 import (
 	"context"
-{{- if not .Searchable }}
+{{- if or (not .Searchable) .Search.HashInputs }}
 	"fmt"
 {{- end }}
 
@@ -129,10 +129,12 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 	} else {
 {{ template "searchFetch" . }}
 		d.updateState(&state, items[0])
+{{ template "searchIdentityFallback" . }}
 	}
 {{- else }}
 {{ template "searchFetch" . }}
 	d.updateState(&state, items[0])
+{{ template "searchIdentityFallback" . }}
 {{- end }}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
@@ -151,6 +153,17 @@ func (d *{{ .GoName }}DataSource) updateState(state *{{ .GoName }}DataSourceMode
 	{{ template "renderList" . }}
 {{- end }}
 }
+{{- end -}}
+
+{{- define "searchIdentityFallback" -}}
+	if state.ID.IsNull() {
+{{- if .Search.HashInputs }}
+		hashingData := fmt.Sprintf("{{ range $i, $f := .Search.HashInputs }}{{ if $i }}:{{ end }}{{ fmtVerb $f.ValueExpr }}{{ end }}", {{- range .Search.HashInputs }} state.{{ .StateField }}.{{ hashExpr .ValueExpr }},{{ end }})
+{{- else }}
+		hashingData := {{ printf "%q" .TypeName }}
+{{- end }}
+		state.ID = types.StringValue(utils.ConvertToSha256(hashingData))
+	}
 {{- end -}}
 
 {{/*

--- a/.generator-v2/internal/emit/view.go
+++ b/.generator-v2/internal/emit/view.go
@@ -56,7 +56,7 @@ type DataSourceView struct {
 	// not expose APIStruct, e.g. "NewCaseManagementApi". Exactly one of
 	// APIAccessor and APIConstructor is populated after accessor resolution.
 	APIConstructor string
-	// UsesUUID adds the google/uuid import and argument parsing blocks.
+	// UsesUUID adds the google/uuid import and SDK-input parsing blocks.
 	UsesUUID bool
 
 	// ByID and Searchable select how a singular data source resolves its one
@@ -155,6 +155,13 @@ type FilterParamView struct {
 	// Setter is the SDK With* method. Empty retains the legacy direct-field form
 	// used by parser-shaped unit fixtures without resolved SDK bindings.
 	Setter string
+	// UUIDVar and UUIDSource request a uuid.Parse preparation inside the filter's
+	// non-null guard before ValueExpr is passed to Setter. They are populated only
+	// when the pinned SDK setter accepts uuid.UUID.
+	UUIDVar    string
+	UUIDSource string
+	// TFName is the Terraform attribute name used in parse diagnostics.
+	TFName string
 }
 
 // SchemaView is the attribute/block split rendered into the Schema method. The

--- a/.generator-v2/internal/emit/view.go
+++ b/.generator-v2/internal/emit/view.go
@@ -124,7 +124,7 @@ type SDKReadView struct {
 	// request's optional-parameters struct.
 	Filters []FilterParamView
 	// HashInputs includes every Terraform input that identifies the returned
-	// collection, both required positional arguments and optional filters.
+	// record or collection, both required positional arguments and optional filters.
 	HashInputs []FilterParamView
 }
 

--- a/.generator-v2/internal/testdata/emit/data_source_singular_both.golden
+++ b/.generator-v2/internal/testdata/emit/data_source_singular_both.golden
@@ -123,6 +123,10 @@ func (d *datadogDatastoreDataSource) Read(ctx context.Context, request datasourc
 			return
 		}
 		d.updateState(&state, items[0])
+		if state.ID.IsNull() {
+			hashingData := "datastore"
+			state.ID = types.StringValue(utils.ConvertToSha256(hashingData))
+		}
 	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)

--- a/.generator-v2/internal/testdata/emit/data_source_singular_search.golden
+++ b/.generator-v2/internal/testdata/emit/data_source_singular_search.golden
@@ -3,6 +3,7 @@ package fwprovider
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -100,6 +101,10 @@ func (d *datadogPowerpackDataSource) Read(ctx context.Context, request datasourc
 		return
 	}
 	d.updateState(&state, items[0])
+	if state.ID.IsNull() {
+		hashingData := fmt.Sprintf("%s", state.FilterName.ValueString())
+		state.ID = types.StringValue(utils.ConvertToSha256(hashingData))
+	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }


### PR DESCRIPTION
## Motivation

After bounded `allOf` normalization, UUID conversion is the next recurring generator-v2 blocker. The Terraform model exposes UUIDs as strings, while the pinned Datadog SDK uses `uuid.UUID` for some request arguments and response getters. The emitter previously rejected optional UUID filters and generated invalid string conversions for UUID response values.

A smaller adjacent blocker affected JSON:API responses whose data object has no `id` getter. Those responses can still populate useful state, but the emitter unconditionally generated `GetIdOk()` and failed to compile.

This PR handles both low-hanging cases at the emitter boundary, where the SDK types and Terraform model types are both known.

## Changes

### Convert UUIDs at SDK boundaries

- Render UUID response values through `.String()` for singular IDs, scalar fields, nested fields, and plural results.
- Parse Terraform string filters with `uuid.Parse` only when the resolved SDK setter accepts `uuid.UUID`.
- Add a Terraform diagnostic and stop the read when a UUID filter is invalid.
- Keep string-backed setters unchanged even when the OpenAPI field carries `format: uuid`.

### Support responses without an ID getter

- Emit the response ID assignment only when `data.id` exists.
- Preserve the Terraform identity already selected from inputs or search results when the response omits an ID.
- Avoid generating an unused attributes preamble when the response has no flattened attribute leaves.

### Add regression coverage

- Cover UUID conversion across singular and plural output shapes.
- Cover optional UUID filters for both UUID-backed and string-backed SDK setters.
- Cover ID-less JSON:API responses and empty attribute envelopes.
- Exercise a production-shaped generated SDK binding through the CLI end-to-end test.

## QA Instructions

Automated validation:

- `make tfgen-test`
- `make tfgen-build`
- `make fmtcheck`
- `make test`
- `make vet`

Emitter package coverage is 86.8%. `make errcheck` retains the repository existing legacy unchecked-error failures and reports no generator-v2 findings.

## Blast Radius

This changes only generator-v2 data-source emission and its tests. It does not modify checked-in provider resources, Terraform schemas, generated documentation, or runtime behavior of existing resources.

UUID parsing is selected from the resolved pinned-SDK setter type rather than inferred from OpenAPI format alone. Responses without `data.id` retain the already established Terraform identity instead of inventing one. The PR is a single commit and can be reverted independently; it is stacked on #4087 and should be reviewed and merged after that PR.