### PR TITLE
[TFgen] Return diagnostics from the generated updateState

### DIFF
--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -349,7 +349,7 @@ var _ = Describe("BuildDataSourceView singular search", func() {
 			Expect(src).To(ContainSubstring(`response.Diagnostics.AddError("filters returned no results", "")`))
 			Expect(src).To(ContainSubstring(`if len(items) > 1 {`))
 			Expect(src).To(ContainSubstring(`use more specific search criteria`))
-			Expect(src).To(ContainSubstring(`d.updateState(&state, items[0])`))
+			Expect(src).To(ContainSubstring(`response.Diagnostics.Append(d.updateState(ctx, &state, items[0])...)`))
 		},
 		Entry("search only", powerpackSearchOperation),
 		Entry("both", datastoreBothOperation),

--- a/.generator-v2/internal/emit/templates/data_source_common.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_common.go.tmpl
@@ -82,10 +82,20 @@ Blocks: map[string]schema.Block{
 {{- end }}
 {{- end -}}
 
+{{/*
+  renderList projects one SDK collection into state. The primitive branch reports
+  the conversion's own diagnostics instead of discarding them, and converts under
+  the caller's ctx: a state mapper has no business minting context.Background(),
+  and a failed ListValueFrom used to leave a zero value in state silently. Each
+  branch opens its own `if` block, so the block-scoped listDiags cannot collide
+  with a sibling or nested list.
+*/}}
 {{- define "renderList" -}}
 {{- if eq .Kind "primitive" -}}
 if {{ .Var }}, ok := {{ .GetterOk }}; ok && {{ .Var }} != nil {
-	{{ .LHS }}, _ = types.ListValueFrom(context.Background(), {{ .ElementType }}, *{{ .Var }})
+	var listDiags diag.Diagnostics
+	{{ .LHS }}, listDiags = types.ListValueFrom(ctx, {{ .ElementType }}, *{{ .Var }})
+	diags.Append(listDiags...)
 } else {
 	{{ .LHS }} = types.ListNull({{ .ElementType }})
 }

--- a/.generator-v2/internal/emit/templates/data_source_plural.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_plural.go.tmpl
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/{{ .SDKPackage }}"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -79,11 +80,21 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 	items = append(items, resp.Data...)
 {{- end }}
 
-	d.updateState(&state, &items)
+	response.Diagnostics.Append(d.updateState(ctx, &state, &items)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *{{ .GoName }}DataSource) updateState(state *{{ .GoName }}DataSourceModel, data *[]{{ .SDKPackage }}.{{ .Read.ItemType }}) {
+{{/*
+  updateState returns diagnostics rather than writing them, so it stays free of
+  the datasource request/response types and can fail at a specific schema path.
+  Shape follows the one hand-written precedent that reports from a state mapper,
+  datadog/fwprovider/data_source_datadog_azure_uc_config.go.
+*/}}
+func (d *{{ .GoName }}DataSource) updateState(ctx context.Context, state *{{ .GoName }}DataSourceModel, data *[]{{ .SDKPackage }}.{{ .Read.ItemType }}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	results := make([]*{{ .State.ItemStruct }}, 0, len(*data))
 	for _, item := range *data {
 		r := {{ .State.ItemStruct }}{
@@ -103,5 +114,6 @@ func (d *{{ .GoName }}DataSource) updateState(state *{{ .GoName }}DataSourceMode
 {{- end }}
 	state.ID = types.StringValue(utils.ConvertToSha256(hashingData))
 	state.{{ .State.ItemField }} = results
+	return diags
 }
 {{- end -}}

--- a/.generator-v2/internal/emit/templates/data_source_singular.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_singular.go.tmpl
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/{{ .SDKPackage }}"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 {{- if .Searchable }}
 
@@ -90,7 +91,10 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 		return
 	}
 
-	d.updateState(&state, &resp)
+	response.Diagnostics.Append(d.updateState(ctx, &state, &resp)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 {{- else if .ByID }}
 
 	if !state.ID.IsNull() {
@@ -100,20 +104,33 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 			return
 		}
 
-		d.updateState(&state, resp.GetData())
+		response.Diagnostics.Append(d.updateState(ctx, &state, resp.GetData())...)
 	} else {
 {{ template "searchFetch" . }}
-		d.updateState(&state, items[0])
+		response.Diagnostics.Append(d.updateState(ctx, &state, items[0])...)
+	}
+	if response.Diagnostics.HasError() {
+		return
 	}
 {{- else }}
 {{ template "searchFetch" . }}
-	d.updateState(&state, items[0])
+	response.Diagnostics.Append(d.updateState(ctx, &state, items[0])...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 {{- end }}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *{{ .GoName }}DataSource) updateState(state *{{ .GoName }}DataSourceModel, {{ .State.ParamName }} {{ .State.ParamType }}) {
+{{/*
+  updateState returns diagnostics rather than writing them, so it stays free of
+  the datasource request/response types and can fail at a specific schema path.
+  Shape follows the one hand-written precedent that reports from a state mapper,
+  datadog/fwprovider/data_source_datadog_azure_uc_config.go.
+*/}}
+func (d *{{ .GoName }}DataSource) updateState(ctx context.Context, state *{{ .GoName }}DataSourceModel, {{ .State.ParamName }} {{ .State.ParamType }}) diag.Diagnostics {
+	var diags diag.Diagnostics
 {{- range .State.Preamble }}
 	{{ . }}
 {{- end }}
@@ -125,6 +142,7 @@ func (d *{{ .GoName }}DataSource) updateState(state *{{ .GoName }}DataSourceMode
 {{- range .State.Lists }}
 	{{ template "renderList" . }}
 {{- end }}
+	return diags
 }
 {{- end -}}
 

--- a/.generator-v2/internal/snapshots/data_source_plural.golden
+++ b/.generator-v2/internal/snapshots/data_source_plural.golden
@@ -8,6 +8,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -148,11 +149,15 @@ func (d *datadogTeamsDataSource) Read(ctx context.Context, request datasource.Re
 		items = append(items, paginationResult.Item)
 	}
 
-	d.updateState(&state, &items)
+	response.Diagnostics.Append(d.updateState(ctx, &state, &items)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datadogTeamsDataSource) updateState(state *datadogTeamsDataSourceModel, data *[]datadogV2.Team) {
+func (d *datadogTeamsDataSource) updateState(ctx context.Context, state *datadogTeamsDataSourceModel, data *[]datadogV2.Team) diag.Diagnostics {
+	var diags diag.Diagnostics
 	results := make([]*TeamModel, 0, len(*data))
 	for _, item := range *data {
 		r := TeamModel{
@@ -165,12 +170,16 @@ func (d *datadogTeamsDataSource) updateState(state *datadogTeamsDataSourceModel,
 			UserCount:   types.Int64Value(int64(item.Attributes.GetUserCount())),
 		}
 		if hiddenModules, ok := item.Attributes.GetHiddenModulesOk(); ok && hiddenModules != nil {
-			r.HiddenModules, _ = types.ListValueFrom(context.Background(), types.StringType, *hiddenModules)
+			var listDiags diag.Diagnostics
+			r.HiddenModules, listDiags = types.ListValueFrom(ctx, types.StringType, *hiddenModules)
+			diags.Append(listDiags...)
 		} else {
 			r.HiddenModules = types.ListNull(types.StringType)
 		}
 		if visibleModules, ok := item.Attributes.GetVisibleModulesOk(); ok && visibleModules != nil {
-			r.VisibleModules, _ = types.ListValueFrom(context.Background(), types.StringType, *visibleModules)
+			var listDiags diag.Diagnostics
+			r.VisibleModules, listDiags = types.ListValueFrom(ctx, types.StringType, *visibleModules)
+			diags.Append(listDiags...)
 		} else {
 			r.VisibleModules = types.ListNull(types.StringType)
 		}
@@ -180,4 +189,5 @@ func (d *datadogTeamsDataSource) updateState(state *datadogTeamsDataSourceModel,
 	hashingData := fmt.Sprintf("%s:%t", state.FilterKeyword.ValueString(), state.FilterMe.ValueBool())
 	state.ID = types.StringValue(utils.ConvertToSha256(hashingData))
 	state.Teams = results
+	return diags
 }

--- a/.generator-v2/internal/snapshots/data_source_plural_nested.golden
+++ b/.generator-v2/internal/snapshots/data_source_plural_nested.golden
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -110,11 +111,15 @@ func (d *datadogWidgetsDataSource) Read(ctx context.Context, request datasource.
 	}
 	items = append(items, resp.Data...)
 
-	d.updateState(&state, &items)
+	response.Diagnostics.Append(d.updateState(ctx, &state, &items)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datadogWidgetsDataSource) updateState(state *datadogWidgetsDataSourceModel, data *[]datadogV2.Widget) {
+func (d *datadogWidgetsDataSource) updateState(ctx context.Context, state *datadogWidgetsDataSourceModel, data *[]datadogV2.Widget) diag.Diagnostics {
+	var diags diag.Diagnostics
 	results := make([]*WidgetModel, 0, len(*data))
 	for _, item := range *data {
 		r := WidgetModel{
@@ -139,4 +144,5 @@ func (d *datadogWidgetsDataSource) updateState(state *datadogWidgetsDataSourceMo
 	hashingData := "widgets"
 	state.ID = types.StringValue(utils.ConvertToSha256(hashingData))
 	state.Widgets = results
+	return diags
 }

--- a/.generator-v2/internal/snapshots/data_source_plural_no_params.golden
+++ b/.generator-v2/internal/snapshots/data_source_plural_no_params.golden
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -117,11 +118,15 @@ func (d *datadogDatastoresDataSource) Read(ctx context.Context, request datasour
 	}
 	items = append(items, resp.Data...)
 
-	d.updateState(&state, &items)
+	response.Diagnostics.Append(d.updateState(ctx, &state, &items)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datadogDatastoresDataSource) updateState(state *datadogDatastoresDataSourceModel, data *[]datadogV2.DatastoreData) {
+func (d *datadogDatastoresDataSource) updateState(ctx context.Context, state *datadogDatastoresDataSourceModel, data *[]datadogV2.DatastoreData) diag.Diagnostics {
+	var diags diag.Diagnostics
 	results := make([]*DatastoreDataModel, 0, len(*data))
 	for _, item := range *data {
 		r := DatastoreDataModel{
@@ -140,4 +145,5 @@ func (d *datadogDatastoresDataSource) updateState(state *datadogDatastoresDataSo
 	hashingData := "datastores"
 	state.ID = types.StringValue(utils.ConvertToSha256(hashingData))
 	state.Datastores = results
+	return diags
 }

--- a/.generator-v2/internal/snapshots/data_source_plural_object.golden
+++ b/.generator-v2/internal/snapshots/data_source_plural_object.golden
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -109,11 +110,15 @@ func (d *datadogGizmosDataSource) Read(ctx context.Context, request datasource.R
 	}
 	items = append(items, resp.Data...)
 
-	d.updateState(&state, &items)
+	response.Diagnostics.Append(d.updateState(ctx, &state, &items)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datadogGizmosDataSource) updateState(state *datadogGizmosDataSourceModel, data *[]datadogV2.Gizmo) {
+func (d *datadogGizmosDataSource) updateState(ctx context.Context, state *datadogGizmosDataSourceModel, data *[]datadogV2.Gizmo) diag.Diagnostics {
+	var diags diag.Diagnostics
 	results := make([]*GizmoModel, 0, len(*data))
 	for _, item := range *data {
 		r := GizmoModel{
@@ -136,4 +141,5 @@ func (d *datadogGizmosDataSource) updateState(state *datadogGizmosDataSourceMode
 	hashingData := "gizmos"
 	state.ID = types.StringValue(utils.ConvertToSha256(hashingData))
 	state.Gizmos = results
+	return diags
 }

--- a/.generator-v2/internal/snapshots/data_source_singular.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular.golden
@@ -8,6 +8,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -88,12 +89,16 @@ func (d *datadogIncidentTypeDataSource) Read(ctx context.Context, request dataso
 		return
 	}
 
-	d.updateState(&state, &resp)
+	response.Diagnostics.Append(d.updateState(ctx, &state, &resp)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datadogIncidentTypeDataSource) updateState(state *datadogIncidentTypeDataSourceModel, resp *datadogV2.IncidentTypeResponse) {
+func (d *datadogIncidentTypeDataSource) updateState(ctx context.Context, state *datadogIncidentTypeDataSourceModel, resp *datadogV2.IncidentTypeResponse) diag.Diagnostics {
+	var diags diag.Diagnostics
 	attributes := resp.Data.GetAttributes()
 	if id, ok := resp.Data.GetIdOk(); ok && id != nil {
 		state.ID = types.StringValue(*id)
@@ -107,4 +112,5 @@ func (d *datadogIncidentTypeDataSource) updateState(state *datadogIncidentTypeDa
 	if name, ok := attributes.GetNameOk(); ok && name != nil {
 		state.Name = types.StringValue(*name)
 	}
+	return diags
 }

--- a/.generator-v2/internal/snapshots/data_source_singular_both.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular_both.golden
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -104,7 +105,7 @@ func (d *datadogDatastoreDataSource) Read(ctx context.Context, request datasourc
 			return
 		}
 
-		d.updateState(&state, resp.GetData())
+		response.Diagnostics.Append(d.updateState(ctx, &state, resp.GetData())...)
 	} else {
 		var items []datadogV2.DatastoreData
 		listResp, _, err := d.Api.ListDatastores(d.Auth)
@@ -122,13 +123,17 @@ func (d *datadogDatastoreDataSource) Read(ctx context.Context, request datasourc
 			response.Diagnostics.AddError("filters returned more than one result, use more specific search criteria", "")
 			return
 		}
-		d.updateState(&state, items[0])
+		response.Diagnostics.Append(d.updateState(ctx, &state, items[0])...)
+	}
+	if response.Diagnostics.HasError() {
+		return
 	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datadogDatastoreDataSource) updateState(state *datadogDatastoreDataSourceModel, data datadogV2.DatastoreData) {
+func (d *datadogDatastoreDataSource) updateState(ctx context.Context, state *datadogDatastoreDataSourceModel, data datadogV2.DatastoreData) diag.Diagnostics {
+	var diags diag.Diagnostics
 	attributes := data.GetAttributes()
 	if id, ok := data.GetIdOk(); ok && id != nil {
 		state.ID = types.StringValue(*id)
@@ -154,4 +159,5 @@ func (d *datadogDatastoreDataSource) updateState(state *datadogDatastoreDataSour
 	if primaryKeyGenerationStrategy, ok := attributes.GetPrimaryKeyGenerationStrategyOk(); ok && primaryKeyGenerationStrategy != nil {
 		state.PrimaryKeyGenerationStrategy = types.StringValue(string(*primaryKeyGenerationStrategy))
 	}
+	return diags
 }

--- a/.generator-v2/internal/snapshots/data_source_singular_list.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular_list.golden
@@ -8,6 +8,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -95,12 +96,16 @@ func (d *datadogTeamDataSource) Read(ctx context.Context, request datasource.Rea
 		return
 	}
 
-	d.updateState(&state, &resp)
+	response.Diagnostics.Append(d.updateState(ctx, &state, &resp)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datadogTeamDataSource) updateState(state *datadogTeamDataSourceModel, resp *datadogV2.TeamResponse) {
+func (d *datadogTeamDataSource) updateState(ctx context.Context, state *datadogTeamDataSourceModel, resp *datadogV2.TeamResponse) diag.Diagnostics {
+	var diags diag.Diagnostics
 	attributes := resp.Data.GetAttributes()
 	if id, ok := resp.Data.GetIdOk(); ok && id != nil {
 		state.ID = types.StringValue(*id)
@@ -112,13 +117,18 @@ func (d *datadogTeamDataSource) updateState(state *datadogTeamDataSourceModel, r
 		state.Name = types.StringValue(*name)
 	}
 	if hiddenModules, ok := attributes.GetHiddenModulesOk(); ok && hiddenModules != nil {
-		state.HiddenModules, _ = types.ListValueFrom(context.Background(), types.StringType, *hiddenModules)
+		var listDiags diag.Diagnostics
+		state.HiddenModules, listDiags = types.ListValueFrom(ctx, types.StringType, *hiddenModules)
+		diags.Append(listDiags...)
 	} else {
 		state.HiddenModules = types.ListNull(types.StringType)
 	}
 	if visibleModules, ok := attributes.GetVisibleModulesOk(); ok && visibleModules != nil {
-		state.VisibleModules, _ = types.ListValueFrom(context.Background(), types.StringType, *visibleModules)
+		var listDiags diag.Diagnostics
+		state.VisibleModules, listDiags = types.ListValueFrom(ctx, types.StringType, *visibleModules)
+		diags.Append(listDiags...)
 	} else {
 		state.VisibleModules = types.ListNull(types.StringType)
 	}
+	return diags
 }

--- a/.generator-v2/internal/snapshots/data_source_singular_nested.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular_nested.golden
@@ -8,6 +8,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -124,12 +125,16 @@ func (d *datadogCostBudgetDataSource) Read(ctx context.Context, request datasour
 		return
 	}
 
-	d.updateState(&state, &resp)
+	response.Diagnostics.Append(d.updateState(ctx, &state, &resp)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datadogCostBudgetDataSource) updateState(state *datadogCostBudgetDataSourceModel, resp *datadogV2.BudgetWithEntries) {
+func (d *datadogCostBudgetDataSource) updateState(ctx context.Context, state *datadogCostBudgetDataSourceModel, resp *datadogV2.BudgetWithEntries) diag.Diagnostics {
+	var diags diag.Diagnostics
 	attributes := resp.Data.GetAttributes()
 	if id, ok := resp.Data.GetIdOk(); ok && id != nil {
 		state.ID = types.StringValue(*id)
@@ -161,4 +166,5 @@ func (d *datadogCostBudgetDataSource) updateState(state *datadogCostBudgetDataSo
 			state.Entries = append(state.Entries, entriesModel)
 		}
 	}
+	return diags
 }

--- a/.generator-v2/internal/snapshots/data_source_singular_object.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular_object.golden
@@ -8,6 +8,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -123,12 +124,16 @@ func (d *datadogApmRetentionFilterDataSource) Read(ctx context.Context, request 
 		return
 	}
 
-	d.updateState(&state, &resp)
+	response.Diagnostics.Append(d.updateState(ctx, &state, &resp)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datadogApmRetentionFilterDataSource) updateState(state *datadogApmRetentionFilterDataSourceModel, resp *datadogV2.RetentionFilterResponse) {
+func (d *datadogApmRetentionFilterDataSource) updateState(ctx context.Context, state *datadogApmRetentionFilterDataSourceModel, resp *datadogV2.RetentionFilterResponse) diag.Diagnostics {
+	var diags diag.Diagnostics
 	attributes := resp.Data.GetAttributes()
 	if id, ok := resp.Data.GetIdOk(); ok && id != nil {
 		state.ID = types.StringValue(*id)
@@ -152,10 +157,13 @@ func (d *datadogApmRetentionFilterDataSource) updateState(state *datadogApmReten
 			filterModel.Metadata = metadataModel
 		}
 		if tags, ok := filter.GetTagsOk(); ok && tags != nil {
-			filterModel.Tags, _ = types.ListValueFrom(context.Background(), types.StringType, *tags)
+			var listDiags diag.Diagnostics
+			filterModel.Tags, listDiags = types.ListValueFrom(ctx, types.StringType, *tags)
+			diags.Append(listDiags...)
 		} else {
 			filterModel.Tags = types.ListNull(types.StringType)
 		}
 		state.Filter = filterModel
 	}
+	return diags
 }

--- a/.generator-v2/internal/snapshots/data_source_singular_search.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular_search.golden
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -99,12 +100,16 @@ func (d *datadogPowerpackDataSource) Read(ctx context.Context, request datasourc
 		response.Diagnostics.AddError("filters returned more than one result, use more specific search criteria", "")
 		return
 	}
-	d.updateState(&state, items[0])
+	response.Diagnostics.Append(d.updateState(ctx, &state, items[0])...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datadogPowerpackDataSource) updateState(state *datadogPowerpackDataSourceModel, data datadogV2.PowerpackData) {
+func (d *datadogPowerpackDataSource) updateState(ctx context.Context, state *datadogPowerpackDataSourceModel, data datadogV2.PowerpackData) diag.Diagnostics {
+	var diags diag.Diagnostics
 	attributes := data.GetAttributes()
 	if id, ok := data.GetIdOk(); ok && id != nil {
 		state.ID = types.StringValue(*id)
@@ -115,4 +120,5 @@ func (d *datadogPowerpackDataSource) updateState(state *datadogPowerpackDataSour
 	if name, ok := attributes.GetNameOk(); ok && name != nil {
 		state.Name = types.StringValue(*name)
 	}
+	return diags
 }


### PR DESCRIPTION
## Motivation

The generated `updateState` discarded the diagnostics of its own type conversions and minted a `context.Background()` to do it. A failed `ListValueFrom` left a zero value in state with nothing said about it.

Part of splitting #4051 into reviewable pieces. This one has no dependency on the oneOf work.

## Changes

- `renderList`'s primitive branch reports the conversion's diagnostics instead of dropping them, and converts under the caller's `ctx`, a state mapper has no business creating its own context.
- `updateState` returns `diag.Diagnostics` so callers can surface what it found.
- Each branch opens its own `if` block, so the block-scoped `listDiags` cannot collide with a sibling or nested list.

## Testing

`go build ./...` and `go test ./...` green in `.generator-v2`. Golden files regenerated — the diff is the new `diags` plumbing in every rendered data source.


