### PR TITLE
[TFgen] (Emit) Emit valid Go: reserved-keyword locals, fmt import, plural item guard

### DIFF
--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -199,20 +199,34 @@ type flattenedEnvelope struct {
 }
 
 // flattenEnvelope recognizes the singular JSON:API envelope at the response root
-// and reshapes it for the walk. It expects a single top-level "data" object whose
-// members are a subset of {id, type, attributes}, with "attributes" an object of
-// leaves only. It hoists each attribute leaf to a top-level path ("response.<leaf>"),
+// and reshapes it for the walk. It expects a top-level "data" object whose members
+// are a subset of {id, type, attributes}, with "attributes" an object of leaves
+// only. It hoists each attribute leaf to a top-level path ("response.<leaf>"),
 // surfaces "id" from id_strategy (data.id only), and drops "type". Anything outside
 // the recognized envelope is appended to b.unsupported and the result is nil.
 func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrategy model.IdStrategy, rootExpr string) *flattenedEnvelope {
-	if len(topLevel) != 1 || tfNameOf(topLevel[0].Path) != "data" || topLevel[0].TfType != "schema.SingleNestedBlock" {
+	// A JSON:API response carries sideloading and request metadata beside the
+	// primary resource: "included" (the hydrated targets of data.relationships),
+	// "meta", "links". None of it is the resource's own state — no hand-written
+	// artifact in the provider surfaces any of it — so drop those siblings the same
+	// way data.relationships is dropped below, rather than failing on a shape that
+	// is in fact recognized. Dropping "included" also keeps its element union out
+	// of the view; that union is the reason these responses need a decision at all.
+	var data *model.Attribute
+	for _, attr := range topLevel {
+		if tfNameOf(attr.Path) == "data" {
+			data = attr
+			continue
+		}
+		b.dropped = append(b.dropped, droppedEnvelopeMember(attr.Path))
+	}
+	if data == nil || data.TfType != "schema.SingleNestedBlock" {
 		b.unsupported = append(b.unsupported, UnsupportedNode{
 			Path:   "response",
-			Reason: "expected a single-member JSON:API envelope {data:{...}}",
+			Reason: "expected a JSON:API envelope with a data object {data:{...}}",
 		})
 		return nil
 	}
-	data := topLevel[0]
 
 	// data members must be a subset of {id, type, attributes}.
 	var attributes *model.Attribute

--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -163,6 +163,7 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 			Assignments: assignments,
 			Lists:       recordLists,
 		},
+		UsesFmt: !searchable,
 		Dropped: b.dropped,
 	}, nil
 }
@@ -555,7 +556,13 @@ func leafVar(tfName string) string {
 	case "state", "attributes", "ok", "d", "data", "resp", "items", "ctx":
 		return v + "Value"
 	}
-	return v
+	// A property named "type" — common in JSON:API payloads and in every
+	// action_connection oneOf variant — would otherwise emit `if type, ok := ...`,
+	// which is not Go. The SDK generator solves this by suffixing "Var"; reuse its
+	// rule rather than a second scheme. The shadow suffix above stays "Value"
+	// because it answers a different question (colliding with a local the template
+	// declares, not with the language).
+	return model.EscapeReservedKeyword(v)
 }
 
 // guardedValue wraps a guarded assignment's local (bound from an Ok-getter, so a
@@ -758,6 +765,14 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 				ElemVar: elemVar, ElemStruct: elemStruct,
 				Scalars: childScalars, Lists: childLists,
 			})
+
+		default:
+			// Without this, an item attribute in any other form was dropped with no
+			// field, no block and no diagnostic — the artifact generated as if the
+			// attribute had never been in the response. Fail instead: silently omitting
+			// a representable attribute is not an acceptable outcome. The singular path's
+			// walk has always had this default; the plural item loop did not.
+			unsupported = append(unsupported, UnsupportedNode{Path: n.Path, Reason: unsupportedReason(n.TfType)})
 		}
 	}
 
@@ -817,6 +832,7 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 			ItemFields: itemAssigns,
 			ItemLists:  itemLists,
 		},
+		UsesFmt: len(filterParams) > 0,
 		Dropped: dropped,
 	}, nil
 }

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -103,11 +103,11 @@ var _ = Describe("BuildDataSourceView", func() {
 			Expect(uerr.Error()).To(ContainSubstring(wantReason))
 			Expect(view).To(Equal(DataSourceView{}), "no view should be produced on failure")
 		},
-		Entry("a non-envelope response root",
+		Entry("a response root with no data object",
 			func(op *model.Operation) {
 				op.ResponseSchema = obj(map[string]*model.Schema{"name": prim("string", "")})
 			},
-			"expected a single-member JSON:API envelope"),
+			"expected a JSON:API envelope with a data object"),
 		Entry("an id_strategy other than data.id",
 			func(op *model.Operation) { op.Tracking.IdStrategy = model.IdStrategyDataAttributesUID },
 			"id_strategy"),
@@ -227,6 +227,30 @@ var _ = Describe("RenderDataSource duplicate field guard", func() {
 		_, err := RenderDataSource(view)
 		Expect(err).To(MatchError(ContainSubstring(`declares tfsdk:"id" twice`)))
 	})
+
+	DescribeTable("drops a JSON:API sibling of data rather than failing on the response shape",
+		func(member string, schema *model.Schema) {
+			op := incidentTypeOperation()
+			op.ResponseSchema.Properties[member] = schema
+			view := mustView(op)
+
+			Expect(view.Dropped).To(HaveLen(1))
+			Expect(view.Dropped[0].Message).To(ContainSubstring("dropped \"response." + member + "\": not part of the surfaced {id, type, attributes} envelope"))
+
+			for _, a := range view.Schema.Attributes {
+				Expect(a.TFName).NotTo(Equal(member))
+			}
+			for _, blk := range view.Schema.Blocks {
+				Expect(blk.TFName).NotTo(Equal(member))
+			}
+		},
+		Entry("meta", "meta", obj(map[string]*model.Schema{"page": prim("string", "")})),
+		Entry("links", "links", obj(map[string]*model.Schema{"next": prim("string", "")})),
+		Entry("included", "included", &model.Schema{
+			Kind:  model.SchemaKindArray,
+			Items: obj(map[string]*model.Schema{"handle": prim("string", "")}),
+		}),
+	)
 })
 
 var _ = Describe("BuildDataSourceView audit fields", func() {

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -349,7 +349,7 @@ var _ = Describe("BuildDataSourceView singular search", func() {
 			Expect(src).To(ContainSubstring(`response.Diagnostics.AddError("filters returned no results", "")`))
 			Expect(src).To(ContainSubstring(`if len(items) > 1 {`))
 			Expect(src).To(ContainSubstring(`use more specific search criteria`))
-			Expect(src).To(ContainSubstring(`d.updateState(&state, items[0])`))
+			Expect(src).To(ContainSubstring(`response.Diagnostics.Append(d.updateState(ctx, &state, items[0])...)`))
 		},
 		Entry("search only", powerpackSearchOperation),
 		Entry("both", datastoreBothOperation),

--- a/.generator-v2/internal/emit/templates/data_source_common.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_common.go.tmpl
@@ -82,10 +82,20 @@ Blocks: map[string]schema.Block{
 {{- end }}
 {{- end -}}
 
+{{/*
+  renderList projects one SDK collection into state. The primitive branch reports
+  the conversion's own diagnostics instead of discarding them, and converts under
+  the caller's ctx: a state mapper has no business minting context.Background(),
+  and a failed ListValueFrom used to leave a zero value in state silently. Each
+  branch opens its own `if` block, so the block-scoped listDiags cannot collide
+  with a sibling or nested list.
+*/}}
 {{- define "renderList" -}}
 {{- if eq .Kind "primitive" -}}
 if {{ .Var }}, ok := {{ .GetterOk }}; ok && {{ .Var }} != nil {
-	{{ .LHS }}, _ = types.ListValueFrom(context.Background(), {{ .ElementType }}, *{{ .Var }})
+	var listDiags diag.Diagnostics
+	{{ .LHS }}, listDiags = types.ListValueFrom(ctx, {{ .ElementType }}, *{{ .Var }})
+	diags.Append(listDiags...)
 } else {
 	{{ .LHS }} = types.ListNull({{ .ElementType }})
 }

--- a/.generator-v2/internal/emit/templates/data_source_plural.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_plural.go.tmpl
@@ -9,7 +9,7 @@ package fwprovider
 
 import (
 	"context"
-{{- if .Read.Filters }}
+{{- if .UsesFmt }}
 	"fmt"
 {{- end }}
 

--- a/.generator-v2/internal/emit/templates/data_source_plural.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_plural.go.tmpl
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/{{ .SDKPackage }}"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -79,11 +80,21 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 	items = append(items, resp.Data...)
 {{- end }}
 
-	d.updateState(&state, &items)
+	response.Diagnostics.Append(d.updateState(ctx, &state, &items)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *{{ .GoName }}DataSource) updateState(state *{{ .GoName }}DataSourceModel, data *[]{{ .SDKPackage }}.{{ .Read.ItemType }}) {
+{{/*
+  updateState returns diagnostics rather than writing them, so it stays free of
+  the datasource request/response types and can fail at a specific schema path.
+  Shape follows the one hand-written precedent that reports from a state mapper,
+  datadog/fwprovider/data_source_datadog_azure_uc_config.go.
+*/}}
+func (d *{{ .GoName }}DataSource) updateState(ctx context.Context, state *{{ .GoName }}DataSourceModel, data *[]{{ .SDKPackage }}.{{ .Read.ItemType }}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	results := make([]*{{ .State.ItemStruct }}, 0, len(*data))
 	for _, item := range *data {
 		r := {{ .State.ItemStruct }}{
@@ -103,5 +114,6 @@ func (d *{{ .GoName }}DataSource) updateState(state *{{ .GoName }}DataSourceMode
 {{- end }}
 	state.ID = types.StringValue(utils.ConvertToSha256(hashingData))
 	state.{{ .State.ItemField }} = results
+	return diags
 }
 {{- end -}}

--- a/.generator-v2/internal/emit/templates/data_source_singular.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_singular.go.tmpl
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/{{ .SDKPackage }}"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 {{- if .Searchable }}
 
@@ -90,7 +91,10 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 		return
 	}
 
-	d.updateState(&state, &resp)
+	response.Diagnostics.Append(d.updateState(ctx, &state, &resp)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 {{- else if .ByID }}
 
 	if !state.ID.IsNull() {
@@ -100,20 +104,33 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 			return
 		}
 
-		d.updateState(&state, resp.GetData())
+		response.Diagnostics.Append(d.updateState(ctx, &state, resp.GetData())...)
 	} else {
 {{ template "searchFetch" . }}
-		d.updateState(&state, items[0])
+		response.Diagnostics.Append(d.updateState(ctx, &state, items[0])...)
+	}
+	if response.Diagnostics.HasError() {
+		return
 	}
 {{- else }}
 {{ template "searchFetch" . }}
-	d.updateState(&state, items[0])
+	response.Diagnostics.Append(d.updateState(ctx, &state, items[0])...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 {{- end }}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *{{ .GoName }}DataSource) updateState(state *{{ .GoName }}DataSourceModel, {{ .State.ParamName }} {{ .State.ParamType }}) {
+{{/*
+  updateState returns diagnostics rather than writing them, so it stays free of
+  the datasource request/response types and can fail at a specific schema path.
+  Shape follows the one hand-written precedent that reports from a state mapper,
+  datadog/fwprovider/data_source_datadog_azure_uc_config.go.
+*/}}
+func (d *{{ .GoName }}DataSource) updateState(ctx context.Context, state *{{ .GoName }}DataSourceModel, {{ .State.ParamName }} {{ .State.ParamType }}) diag.Diagnostics {
+	var diags diag.Diagnostics
 {{- range .State.Preamble }}
 	{{ . }}
 {{- end }}
@@ -125,6 +142,7 @@ func (d *{{ .GoName }}DataSource) updateState(state *{{ .GoName }}DataSourceMode
 {{- range .State.Lists }}
 	{{ template "renderList" . }}
 {{- end }}
+	return diags
 }
 {{- end -}}
 

--- a/.generator-v2/internal/emit/templates/data_source_singular.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_singular.go.tmpl
@@ -11,7 +11,7 @@ package fwprovider
 
 import (
 	"context"
-{{- if not .Searchable }}
+{{- if .UsesFmt }}
 	"fmt"
 {{- end }}
 

--- a/.generator-v2/internal/emit/templates_test.go
+++ b/.generator-v2/internal/emit/templates_test.go
@@ -177,6 +177,9 @@ func pluralFixture() DataSourceView {
 	return DataSourceView{
 		Cardinality: Plural,
 		TypeName:    "teams",
+		// Hand-built views set UsesFmt themselves; the builder computes it for every
+		// view it produces. This fixture's filter hash reaches fmt.Sprintf.
+		UsesFmt:     true,
 		GoName:      "datadogTeams",
 		Description: "Use this data source to retrieve information about existing teams for use in other resources.",
 		SDKPackage:  "datadogV2",

--- a/.generator-v2/internal/emit/view.go
+++ b/.generator-v2/internal/emit/view.go
@@ -77,6 +77,13 @@ type DataSourceView struct {
 	// State holds what updateState assigns back into the model.
 	State StateView
 
+	// UsesFmt selects the "fmt" import. The template is no longer in a position to
+	// decide this: fmt is reached from the by-id not-found message and from a plural
+	// filter hash today, and go/format does not prune an unused import, so an over-
+	// or under-estimate is a compile error either way. Deciding it in Go keeps the
+	// rule in one place as more call sites appear.
+	UsesFmt bool
+
 	// Dropped lists response members skipped from the rendered view (e.g.
 	// relationships), surfaced as diagnostics in the run report. It does not
 	// affect rendering.

--- a/.generator-v2/internal/model/identifier.go
+++ b/.generator-v2/internal/model/identifier.go
@@ -25,6 +25,32 @@ func SnakeCase(value string) string {
 	return patternDoubleUnderscore.ReplaceAllString(value, "_")
 }
 
+// goKeywords is Go's full reserved-word set, the same list the SDK generator
+// carries as formatter.KEYWORDS.
+var goKeywords = map[string]bool{
+	"break": true, "case": true, "chan": true, "const": true, "continue": true,
+	"default": true, "defer": true, "else": true, "fallthrough": true, "for": true,
+	"func": true, "go": true, "goto": true, "if": true, "import": true,
+	"interface": true, "map": true, "package": true, "range": true, "return": true,
+	"select": true, "struct": true, "switch": true, "type": true, "var": true,
+}
+
+// EscapeReservedKeyword appends "Var" to a Go reserved word and returns anything
+// else unchanged — a port of the SDK generator's
+// formatter.escape_reserved_keyword, which is how the SDK itself keeps a property
+// named "type" from producing the local `type`.
+//
+// Reusing the SDK's suffix rather than inventing one means a maintainer who knows
+// the SDK reads generated locals the same way in both codebases. It only ever
+// fires on a lower-camel identifier: an exported field name starts with an
+// upper-case rune, and no Go keyword does.
+func EscapeReservedKeyword(word string) string {
+	if goKeywords[word] {
+		return word + "Var"
+	}
+	return word
+}
+
 // SdkName translates an OpenAPI identifier into the PascalCase form used by
 // datadog-api-client-go.
 //

--- a/.generator-v2/internal/model/keyword_test.go
+++ b/.generator-v2/internal/model/keyword_test.go
@@ -1,0 +1,33 @@
+package model
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Kept out of identifier_test.go, which is still one of the bare-testing files
+// slated for Ginkgo conversion; new specs go in Ginkgo form from the start.
+var _ = Describe("EscapeReservedKeyword", func() {
+	DescribeTable("appends Var to a Go keyword and leaves anything else alone",
+		func(in, want string) { Expect(EscapeReservedKeyword(in)).To(Equal(want)) },
+		// The case that motivated this: a JSON:API "type" property.
+		Entry("type", "type", "typeVar"),
+		Entry("range", "range", "rangeVar"),
+		Entry("func", "func", "funcVar"),
+		Entry("interface", "interface", "interfaceVar"),
+		Entry("var", "var", "varVar"),
+		// Not keywords, however close they look.
+		Entry("typeName", "typeName", "typeName"),
+		Entry("types", "types", "types"),
+		Entry("name", "name", "name"),
+		Entry("empty", "", ""),
+		// Exported spellings can never collide: no Go keyword is capitalized.
+		Entry("Type", "Type", "Type"),
+	)
+
+	It("covers Go's whole reserved-word set", func() {
+		// Mirrors formatter.KEYWORDS in the SDK generator; a short list here would
+		// mean some property name still emits invalid Go.
+		Expect(goKeywords).To(HaveLen(25))
+	})
+})

--- a/.generator-v2/internal/snapshots/data_source_plural.golden
+++ b/.generator-v2/internal/snapshots/data_source_plural.golden
@@ -8,6 +8,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -148,11 +149,15 @@ func (d *datadogTeamsDataSource) Read(ctx context.Context, request datasource.Re
 		items = append(items, paginationResult.Item)
 	}
 
-	d.updateState(&state, &items)
+	response.Diagnostics.Append(d.updateState(ctx, &state, &items)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datadogTeamsDataSource) updateState(state *datadogTeamsDataSourceModel, data *[]datadogV2.Team) {
+func (d *datadogTeamsDataSource) updateState(ctx context.Context, state *datadogTeamsDataSourceModel, data *[]datadogV2.Team) diag.Diagnostics {
+	var diags diag.Diagnostics
 	results := make([]*TeamModel, 0, len(*data))
 	for _, item := range *data {
 		r := TeamModel{
@@ -165,12 +170,16 @@ func (d *datadogTeamsDataSource) updateState(state *datadogTeamsDataSourceModel,
 			UserCount:   types.Int64Value(int64(item.Attributes.GetUserCount())),
 		}
 		if hiddenModules, ok := item.Attributes.GetHiddenModulesOk(); ok && hiddenModules != nil {
-			r.HiddenModules, _ = types.ListValueFrom(context.Background(), types.StringType, *hiddenModules)
+			var listDiags diag.Diagnostics
+			r.HiddenModules, listDiags = types.ListValueFrom(ctx, types.StringType, *hiddenModules)
+			diags.Append(listDiags...)
 		} else {
 			r.HiddenModules = types.ListNull(types.StringType)
 		}
 		if visibleModules, ok := item.Attributes.GetVisibleModulesOk(); ok && visibleModules != nil {
-			r.VisibleModules, _ = types.ListValueFrom(context.Background(), types.StringType, *visibleModules)
+			var listDiags diag.Diagnostics
+			r.VisibleModules, listDiags = types.ListValueFrom(ctx, types.StringType, *visibleModules)
+			diags.Append(listDiags...)
 		} else {
 			r.VisibleModules = types.ListNull(types.StringType)
 		}
@@ -180,4 +189,5 @@ func (d *datadogTeamsDataSource) updateState(state *datadogTeamsDataSourceModel,
 	hashingData := fmt.Sprintf("%s:%t", state.FilterKeyword.ValueString(), state.FilterMe.ValueBool())
 	state.ID = types.StringValue(utils.ConvertToSha256(hashingData))
 	state.Teams = results
+	return diags
 }

--- a/.generator-v2/internal/snapshots/data_source_plural_nested.golden
+++ b/.generator-v2/internal/snapshots/data_source_plural_nested.golden
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -110,11 +111,15 @@ func (d *datadogWidgetsDataSource) Read(ctx context.Context, request datasource.
 	}
 	items = append(items, resp.Data...)
 
-	d.updateState(&state, &items)
+	response.Diagnostics.Append(d.updateState(ctx, &state, &items)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datadogWidgetsDataSource) updateState(state *datadogWidgetsDataSourceModel, data *[]datadogV2.Widget) {
+func (d *datadogWidgetsDataSource) updateState(ctx context.Context, state *datadogWidgetsDataSourceModel, data *[]datadogV2.Widget) diag.Diagnostics {
+	var diags diag.Diagnostics
 	results := make([]*WidgetModel, 0, len(*data))
 	for _, item := range *data {
 		r := WidgetModel{
@@ -139,4 +144,5 @@ func (d *datadogWidgetsDataSource) updateState(state *datadogWidgetsDataSourceMo
 	hashingData := "widgets"
 	state.ID = types.StringValue(utils.ConvertToSha256(hashingData))
 	state.Widgets = results
+	return diags
 }

--- a/.generator-v2/internal/snapshots/data_source_plural_no_params.golden
+++ b/.generator-v2/internal/snapshots/data_source_plural_no_params.golden
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -117,11 +118,15 @@ func (d *datadogDatastoresDataSource) Read(ctx context.Context, request datasour
 	}
 	items = append(items, resp.Data...)
 
-	d.updateState(&state, &items)
+	response.Diagnostics.Append(d.updateState(ctx, &state, &items)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datadogDatastoresDataSource) updateState(state *datadogDatastoresDataSourceModel, data *[]datadogV2.DatastoreData) {
+func (d *datadogDatastoresDataSource) updateState(ctx context.Context, state *datadogDatastoresDataSourceModel, data *[]datadogV2.DatastoreData) diag.Diagnostics {
+	var diags diag.Diagnostics
 	results := make([]*DatastoreDataModel, 0, len(*data))
 	for _, item := range *data {
 		r := DatastoreDataModel{
@@ -140,4 +145,5 @@ func (d *datadogDatastoresDataSource) updateState(state *datadogDatastoresDataSo
 	hashingData := "datastores"
 	state.ID = types.StringValue(utils.ConvertToSha256(hashingData))
 	state.Datastores = results
+	return diags
 }

--- a/.generator-v2/internal/snapshots/data_source_plural_object.golden
+++ b/.generator-v2/internal/snapshots/data_source_plural_object.golden
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -109,11 +110,15 @@ func (d *datadogGizmosDataSource) Read(ctx context.Context, request datasource.R
 	}
 	items = append(items, resp.Data...)
 
-	d.updateState(&state, &items)
+	response.Diagnostics.Append(d.updateState(ctx, &state, &items)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datadogGizmosDataSource) updateState(state *datadogGizmosDataSourceModel, data *[]datadogV2.Gizmo) {
+func (d *datadogGizmosDataSource) updateState(ctx context.Context, state *datadogGizmosDataSourceModel, data *[]datadogV2.Gizmo) diag.Diagnostics {
+	var diags diag.Diagnostics
 	results := make([]*GizmoModel, 0, len(*data))
 	for _, item := range *data {
 		r := GizmoModel{
@@ -136,4 +141,5 @@ func (d *datadogGizmosDataSource) updateState(state *datadogGizmosDataSourceMode
 	hashingData := "gizmos"
 	state.ID = types.StringValue(utils.ConvertToSha256(hashingData))
 	state.Gizmos = results
+	return diags
 }

--- a/.generator-v2/internal/snapshots/data_source_singular.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular.golden
@@ -8,6 +8,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -88,12 +89,16 @@ func (d *datadogIncidentTypeDataSource) Read(ctx context.Context, request dataso
 		return
 	}
 
-	d.updateState(&state, &resp)
+	response.Diagnostics.Append(d.updateState(ctx, &state, &resp)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datadogIncidentTypeDataSource) updateState(state *datadogIncidentTypeDataSourceModel, resp *datadogV2.IncidentTypeResponse) {
+func (d *datadogIncidentTypeDataSource) updateState(ctx context.Context, state *datadogIncidentTypeDataSourceModel, resp *datadogV2.IncidentTypeResponse) diag.Diagnostics {
+	var diags diag.Diagnostics
 	attributes := resp.Data.GetAttributes()
 	if id, ok := resp.Data.GetIdOk(); ok && id != nil {
 		state.ID = types.StringValue(*id)
@@ -107,4 +112,5 @@ func (d *datadogIncidentTypeDataSource) updateState(state *datadogIncidentTypeDa
 	if name, ok := attributes.GetNameOk(); ok && name != nil {
 		state.Name = types.StringValue(*name)
 	}
+	return diags
 }

--- a/.generator-v2/internal/snapshots/data_source_singular_both.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular_both.golden
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -104,7 +105,7 @@ func (d *datadogDatastoreDataSource) Read(ctx context.Context, request datasourc
 			return
 		}
 
-		d.updateState(&state, resp.GetData())
+		response.Diagnostics.Append(d.updateState(ctx, &state, resp.GetData())...)
 	} else {
 		var items []datadogV2.DatastoreData
 		listResp, _, err := d.Api.ListDatastores(d.Auth)
@@ -122,13 +123,17 @@ func (d *datadogDatastoreDataSource) Read(ctx context.Context, request datasourc
 			response.Diagnostics.AddError("filters returned more than one result, use more specific search criteria", "")
 			return
 		}
-		d.updateState(&state, items[0])
+		response.Diagnostics.Append(d.updateState(ctx, &state, items[0])...)
+	}
+	if response.Diagnostics.HasError() {
+		return
 	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datadogDatastoreDataSource) updateState(state *datadogDatastoreDataSourceModel, data datadogV2.DatastoreData) {
+func (d *datadogDatastoreDataSource) updateState(ctx context.Context, state *datadogDatastoreDataSourceModel, data datadogV2.DatastoreData) diag.Diagnostics {
+	var diags diag.Diagnostics
 	attributes := data.GetAttributes()
 	if id, ok := data.GetIdOk(); ok && id != nil {
 		state.ID = types.StringValue(*id)
@@ -154,4 +159,5 @@ func (d *datadogDatastoreDataSource) updateState(state *datadogDatastoreDataSour
 	if primaryKeyGenerationStrategy, ok := attributes.GetPrimaryKeyGenerationStrategyOk(); ok && primaryKeyGenerationStrategy != nil {
 		state.PrimaryKeyGenerationStrategy = types.StringValue(string(*primaryKeyGenerationStrategy))
 	}
+	return diags
 }

--- a/.generator-v2/internal/snapshots/data_source_singular_list.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular_list.golden
@@ -8,6 +8,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -95,12 +96,16 @@ func (d *datadogTeamDataSource) Read(ctx context.Context, request datasource.Rea
 		return
 	}
 
-	d.updateState(&state, &resp)
+	response.Diagnostics.Append(d.updateState(ctx, &state, &resp)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datadogTeamDataSource) updateState(state *datadogTeamDataSourceModel, resp *datadogV2.TeamResponse) {
+func (d *datadogTeamDataSource) updateState(ctx context.Context, state *datadogTeamDataSourceModel, resp *datadogV2.TeamResponse) diag.Diagnostics {
+	var diags diag.Diagnostics
 	attributes := resp.Data.GetAttributes()
 	if id, ok := resp.Data.GetIdOk(); ok && id != nil {
 		state.ID = types.StringValue(*id)
@@ -112,13 +117,18 @@ func (d *datadogTeamDataSource) updateState(state *datadogTeamDataSourceModel, r
 		state.Name = types.StringValue(*name)
 	}
 	if hiddenModules, ok := attributes.GetHiddenModulesOk(); ok && hiddenModules != nil {
-		state.HiddenModules, _ = types.ListValueFrom(context.Background(), types.StringType, *hiddenModules)
+		var listDiags diag.Diagnostics
+		state.HiddenModules, listDiags = types.ListValueFrom(ctx, types.StringType, *hiddenModules)
+		diags.Append(listDiags...)
 	} else {
 		state.HiddenModules = types.ListNull(types.StringType)
 	}
 	if visibleModules, ok := attributes.GetVisibleModulesOk(); ok && visibleModules != nil {
-		state.VisibleModules, _ = types.ListValueFrom(context.Background(), types.StringType, *visibleModules)
+		var listDiags diag.Diagnostics
+		state.VisibleModules, listDiags = types.ListValueFrom(ctx, types.StringType, *visibleModules)
+		diags.Append(listDiags...)
 	} else {
 		state.VisibleModules = types.ListNull(types.StringType)
 	}
+	return diags
 }

--- a/.generator-v2/internal/snapshots/data_source_singular_nested.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular_nested.golden
@@ -8,6 +8,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -124,12 +125,16 @@ func (d *datadogCostBudgetDataSource) Read(ctx context.Context, request datasour
 		return
 	}
 
-	d.updateState(&state, &resp)
+	response.Diagnostics.Append(d.updateState(ctx, &state, &resp)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datadogCostBudgetDataSource) updateState(state *datadogCostBudgetDataSourceModel, resp *datadogV2.BudgetWithEntries) {
+func (d *datadogCostBudgetDataSource) updateState(ctx context.Context, state *datadogCostBudgetDataSourceModel, resp *datadogV2.BudgetWithEntries) diag.Diagnostics {
+	var diags diag.Diagnostics
 	attributes := resp.Data.GetAttributes()
 	if id, ok := resp.Data.GetIdOk(); ok && id != nil {
 		state.ID = types.StringValue(*id)
@@ -161,4 +166,5 @@ func (d *datadogCostBudgetDataSource) updateState(state *datadogCostBudgetDataSo
 			state.Entries = append(state.Entries, entriesModel)
 		}
 	}
+	return diags
 }

--- a/.generator-v2/internal/snapshots/data_source_singular_object.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular_object.golden
@@ -8,6 +8,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -123,12 +124,16 @@ func (d *datadogApmRetentionFilterDataSource) Read(ctx context.Context, request 
 		return
 	}
 
-	d.updateState(&state, &resp)
+	response.Diagnostics.Append(d.updateState(ctx, &state, &resp)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datadogApmRetentionFilterDataSource) updateState(state *datadogApmRetentionFilterDataSourceModel, resp *datadogV2.RetentionFilterResponse) {
+func (d *datadogApmRetentionFilterDataSource) updateState(ctx context.Context, state *datadogApmRetentionFilterDataSourceModel, resp *datadogV2.RetentionFilterResponse) diag.Diagnostics {
+	var diags diag.Diagnostics
 	attributes := resp.Data.GetAttributes()
 	if id, ok := resp.Data.GetIdOk(); ok && id != nil {
 		state.ID = types.StringValue(*id)
@@ -152,10 +157,13 @@ func (d *datadogApmRetentionFilterDataSource) updateState(state *datadogApmReten
 			filterModel.Metadata = metadataModel
 		}
 		if tags, ok := filter.GetTagsOk(); ok && tags != nil {
-			filterModel.Tags, _ = types.ListValueFrom(context.Background(), types.StringType, *tags)
+			var listDiags diag.Diagnostics
+			filterModel.Tags, listDiags = types.ListValueFrom(ctx, types.StringType, *tags)
+			diags.Append(listDiags...)
 		} else {
 			filterModel.Tags = types.ListNull(types.StringType)
 		}
 		state.Filter = filterModel
 	}
+	return diags
 }

--- a/.generator-v2/internal/snapshots/data_source_singular_search.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular_search.golden
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -99,12 +100,16 @@ func (d *datadogPowerpackDataSource) Read(ctx context.Context, request datasourc
 		response.Diagnostics.AddError("filters returned more than one result, use more specific search criteria", "")
 		return
 	}
-	d.updateState(&state, items[0])
+	response.Diagnostics.Append(d.updateState(ctx, &state, items[0])...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datadogPowerpackDataSource) updateState(state *datadogPowerpackDataSourceModel, data datadogV2.PowerpackData) {
+func (d *datadogPowerpackDataSource) updateState(ctx context.Context, state *datadogPowerpackDataSourceModel, data datadogV2.PowerpackData) diag.Diagnostics {
+	var diags diag.Diagnostics
 	attributes := data.GetAttributes()
 	if id, ok := data.GetIdOk(); ok && id != nil {
 		state.ID = types.StringValue(*id)
@@ -115,4 +120,5 @@ func (d *datadogPowerpackDataSource) updateState(state *datadogPowerpackDataSour
 	if name, ok := attributes.GetNameOk(); ok && name != nil {
 		state.Name = types.StringValue(*name)
 	}
+	return diags
 }


### PR DESCRIPTION
## Motivation

Three independent defects in what the emit path produces, none specific to any one artifact. Part of splitting #4051; no dependency on the oneOf work.

## Changes

- **Reserved keywords.** A property named after a Go keyword produced an uncompilable local. The SDK generator already solves this with `formatter.escape_reserved_keyword`, appending `Var`; ported as `model.EscapeReservedKeyword` so a maintainer who knows the SDK reads both codebases the same way. It only ever fires on a lower-camel identifier, an exported field starts with an upper-case rune, and no Go keyword does.
- **The `fmt` import.** Decided in the templates, which no longer know enough: `fmt` is reached from the by-id not-found message and from a plural filter hash, and `go/format` does not prune an unused import, so an over- or under-estimate is a compile error either way. Now decided in Go as `DataSourceView.UsesFmt`.
- **Plural item guard.** An item attribute in any unhandled form was dropped with no field, no block and no diagnostic — the artifact generated as if it had never been in the response. Adds the `default` case the singular walk has always had.

## Testing

`go build ./...` and `go test ./...` green. New `keyword_test.go` covers the escape rule.


