### PR TITLE
[TFgen] Correct $ref resolution for sibling keywords and depth limits

### DIFF
--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -32,20 +32,26 @@ const (
 
 // SchemaKind classifies a normalized Schema node by structure. Primitive,
 // Object, Array and Map are directly emittable as Terraform attributes. OneOf
-// requires a synthetic envelope described by Schema.OneOf. RefCycle ($ref cycle
-// or beyond --max-depth) and Unsupported (no representable type or structure,
-// and anyOf) are fatal — the builder fails the artifact rather than emitting a
-// types.Dynamic escape hatch.
+// requires a synthetic envelope described by Schema.OneOf. RefCycle,
+// DepthExceeded and Unsupported are fatal — the builder fails the artifact rather
+// than emitting a types.Dynamic escape hatch.
+//
+// RefCycle and DepthExceeded are deliberately distinct: a cycle is a property of
+// the document that no flag can fix, whereas exhausting --max-depth says only
+// that the walk stopped early, and raising the limit may resolve the node.
+// Reporting the latter as a cycle sends the reader hunting for a cycle that does
+// not exist.
 type SchemaKind string
 
 const (
-	SchemaKindPrimitive   SchemaKind = "primitive"
-	SchemaKindObject      SchemaKind = "object"
-	SchemaKindArray       SchemaKind = "array"
-	SchemaKindMap         SchemaKind = "map"
-	SchemaKindOneOf       SchemaKind = "one_of"
-	SchemaKindRefCycle    SchemaKind = "ref_cycle"   // $ref cycle or beyond --max-depth
-	SchemaKindUnsupported SchemaKind = "unsupported" // no representable type/structure, or anyOf; always rejected
+	SchemaKindPrimitive     SchemaKind = "primitive"
+	SchemaKindObject        SchemaKind = "object"
+	SchemaKindArray         SchemaKind = "array"
+	SchemaKindMap           SchemaKind = "map"
+	SchemaKindOneOf         SchemaKind = "one_of"
+	SchemaKindRefCycle      SchemaKind = "ref_cycle"      // a $ref that re-enters a schema already being expanded
+	SchemaKindDepthExceeded SchemaKind = "depth_exceeded" // $ref expansion stopped at --max-depth; not a cycle
+	SchemaKindUnsupported   SchemaKind = "unsupported"    // no representable type/structure, or anyOf; always rejected
 
 	// SchemaKindVariant is retained as a source-compatibility alias for code
 	// written before the parser populated Schema.OneOf directly. New code should

--- a/.generator-v2/internal/parser/parser.go
+++ b/.generator-v2/internal/parser/parser.go
@@ -15,7 +15,18 @@ import (
 )
 
 // DefaultMaxDepth bounds recursive $ref expansion when no override is supplied.
-const DefaultMaxDepth = 8
+//
+// It is a guard against absurd-but-acyclic nesting only: genuine $ref cycles are
+// found by DetectRefCycles regardless of depth, so this bound never has to be
+// tight enough to catch them. Raising it therefore costs nothing in correctness.
+//
+// 20 is twice the deepest chain measured across the 33 real Datadog v2 slices in
+// internal/testdata/mini-oas (software_catalog and app_builder_app need 10;
+// action_connection needs 9). The previous value of 8 sat below three of them and
+// exactly at a fourth, so ordinary specs tripped the bound — and, before the two
+// conditions were separated, were reported as $ref cycles that did not exist.
+// Re-measure against that corpus before changing this.
+const DefaultMaxDepth = 20
 
 // Option configures LoadSpec.
 type Option func(*loadConfig)

--- a/.generator-v2/internal/parser/schema.go
+++ b/.generator-v2/internal/parser/schema.go
@@ -201,8 +201,8 @@ func (n *schemaNormalizer) fillOperation(op *model.Operation, raw *v3.Operation)
 	// Capture the response type name from the top-level body proxy before
 	// normalizeProxy follows the $ref and discards it. An inline/absent body
 	// leaves ResponseRefName empty.
-	if respProxy.IsReference() {
-		op.ResponseRefName = lastRefSegment(respProxy.GetReference())
+	if ref, ok := schemaRef(respProxy); ok {
+		op.ResponseRefName = lastRefSegment(ref)
 	}
 	resp, err := n.normalizeProxyAt(respProxy, 0, schemaContext{path: "response", required: true})
 	if err != nil {
@@ -288,8 +288,10 @@ func (n *schemaNormalizer) retainItemRef(op *model.Operation, respProxy *base.Sc
 	if !hasType(prop, "array") || prop.Items == nil || !prop.Items.IsA() {
 		return nil
 	}
-	if elem := prop.Items.A; elem != nil && elem.IsReference() {
-		op.ItemRefName = lastRefSegment(elem.GetReference())
+	if elem := prop.Items.A; elem != nil {
+		if ref, ok := schemaRef(elem); ok {
+			op.ItemRefName = lastRefSegment(ref)
+		}
 	}
 	return nil
 }
@@ -305,8 +307,10 @@ func (n *schemaNormalizer) retainResponseDataRef(op *model.Operation, respProxy 
 	if err != nil || body == nil || body.Properties == nil {
 		return err
 	}
-	if data := body.Properties.GetOrZero(defaultResultsPath); data != nil && data.IsReference() {
-		op.ResponseDataRefName = lastRefSegment(data.GetReference())
+	if data := body.Properties.GetOrZero(defaultResultsPath); data != nil {
+		if ref, ok := schemaRef(data); ok {
+			op.ResponseDataRefName = lastRefSegment(ref)
+		}
 	}
 	return nil
 }
@@ -318,8 +322,8 @@ func (n *schemaNormalizer) resolveToSchema(proxy *base.SchemaProxy) (*base.Schem
 	if proxy == nil {
 		return nil, nil
 	}
-	if proxy.IsReference() {
-		target, err := n.resolveRef(proxy.GetReference())
+	if ref, ok := schemaRef(proxy); ok {
+		target, err := n.resolveRef(ref)
 		if err != nil {
 			return nil, err
 		}
@@ -383,6 +387,34 @@ func responseBodySchemaProxy(op *v3.Operation) *base.SchemaProxy {
 	return nil
 }
 
+// schemaRef returns the $ref a proxy points at, and whether it has one at all.
+//
+// libopenapi's high-level IsReference/GetReference cover a bare $ref, but a node
+// that writes $ref alongside other keywords — {$ref: TokenName, example: "x"},
+// which the Datadog spec does — is reported as a non-reference with an empty
+// reference, leaving a schema carrying only the siblings and therefore no type.
+// OpenAPI 3.0 says keywords beside a $ref are ignored, so the reference is the
+// whole meaning of such a node; the low-level model still records it.
+//
+// Every "is this a reference?" test in this file goes through here, so a sibling
+// can never cost a node its type, its component name, or its SDK type name.
+func schemaRef(proxy *base.SchemaProxy) (string, bool) {
+	if proxy == nil {
+		return "", false
+	}
+	if proxy.IsReference() {
+		if ref := proxy.GetReference(); ref != "" {
+			return ref, true
+		}
+	}
+	if low := proxy.GoLow(); low != nil && low.IsTransformedRefWithSiblings() {
+		if ref := low.GetTransformedRefReference(); ref != "" {
+			return ref, true
+		}
+	}
+	return "", false
+}
+
 // normalizeProxyAt normalizes one schema proxy, resolving a $ref through the
 // component set and counting it against the depth budget. The first component
 // name is retained in ctx before resolution, since libopenapi's resolved schema
@@ -391,15 +423,23 @@ func (n *schemaNormalizer) normalizeProxyAt(proxy *base.SchemaProxy, depth int, 
 	if proxy == nil {
 		return nil, nil
 	}
-	if proxy.IsReference() {
+	if ref, ok := schemaRef(proxy); ok {
 		if ctx.refName == "" {
-			ctx.refName = lastRefSegment(proxy.GetReference())
+			ctx.refName = lastRefSegment(ref)
 		}
 		// depth counts $ref edges already followed; the >= bound matches cycles.go.
+		// Exhausting the budget is not a cycle — cycles.go finds those independently
+		// of depth — so it gets its own kind and says how to lift the limit.
 		if n.maxDepth > 0 && depth >= n.maxDepth {
-			return &model.Schema{Kind: model.SchemaKindRefCycle}, nil
+			return &model.Schema{
+				Kind: model.SchemaKindDepthExceeded,
+				UnsupportedReason: fmt.Sprintf(
+					"$ref expansion stopped at --max-depth=%d before reaching %q; this is a depth limit, not a $ref cycle — re-run with a higher --max-depth if the chain is legitimately this deep",
+					n.maxDepth, ref,
+				),
+			}, nil
 		}
-		target, err := n.resolveRef(proxy.GetReference())
+		target, err := n.resolveRef(ref)
 		if err != nil {
 			return nil, err
 		}

--- a/.generator-v2/internal/parser/schema_test.go
+++ b/.generator-v2/internal/parser/schema_test.go
@@ -540,14 +540,16 @@ var _ = Describe("NormalizeSchemas $ref resolution", func() {
 })
 
 // -------------------------------------------------------------------
-//  Depth limit → SchemaKindRefCycle
+//  Depth limit → SchemaKindDepthExceeded (distinct from a $ref cycle)
 // -------------------------------------------------------------------
 
 var _ = Describe("NormalizeSchemas depth limit", func() {
 
-	It("classifies a $ref that would exceed --max-depth as SchemaKindRefCycle instead of returning an error", func() {
-		// maxDepth=1: body→OuterObject costs depth 1 (OK).
-		// OuterObject.properties.inner→MyString would cost depth 2, which exceeds the bound.
+	// depthLimited normalizes the nested-ref fixture at maxDepth=1 and returns the
+	// node that the bound stopped at. body→OuterObject costs depth 1 (OK);
+	// OuterObject.properties.inner→MyString would cost depth 2, exceeding the bound.
+	depthLimited := func() *model.Schema {
+		GinkgoHelper()
 		spec, err := LoadSpec(
 			filepath.Join("../testdata/parser", "schema_normalize_refs.yaml"),
 			WithMaxDepth(1),
@@ -560,8 +562,35 @@ var _ = Describe("NormalizeSchemas depth limit", func() {
 
 		inner, ok := op.RequestSchema.Properties["inner"]
 		Expect(ok).To(BeTrue(), "Properties must contain the depth-limited 'inner' entry")
-		Expect(inner.Kind).To(Equal(model.SchemaKindRefCycle),
-			"a $ref that exceeds --max-depth must be classified as ref_cycle, not dropped or errored")
+		return inner
+	}
+
+	It("classifies a $ref that would exceed --max-depth as depth_exceeded, not as a cycle", func() {
+		inner := depthLimited()
+		Expect(inner.Kind).To(Equal(model.SchemaKindDepthExceeded),
+			"exhausting --max-depth is not a $ref cycle: cycles.go finds those independently of depth, "+
+				"so labelling it ref_cycle sends the reader hunting for a cycle that does not exist")
+		Expect(inner.Kind).NotTo(Equal(model.SchemaKindRefCycle))
+	})
+
+	It("retains an actionable reason naming the bound, the blocked $ref, and the remedy", func() {
+		reason := depthLimited().UnsupportedReason
+		Expect(reason).To(ContainSubstring("--max-depth=1"), "the reason must name the bound that was hit")
+		Expect(reason).To(ContainSubstring("MyString"), "the reason must name the $ref it stopped short of")
+		Expect(reason).To(ContainSubstring("not a $ref cycle"), "the reason must rule out a cycle explicitly")
+		Expect(reason).To(ContainSubstring("higher --max-depth"), "the reason must state the remedy")
+	})
+
+	It("resolves the same node once the bound is raised, proving it was never a cycle", func() {
+		spec, err := LoadSpec(
+			filepath.Join("../testdata/parser", "schema_normalize_refs.yaml"),
+			WithMaxDepth(8),
+		)
+		Expect(err).To(Succeed())
+
+		inner := opByID(spec, "CreateNestedRef").RequestSchema.Properties["inner"]
+		Expect(inner.Kind).To(Equal(model.SchemaKindPrimitive))
+		Expect(inner.Type).To(Equal("string"))
 	})
 })
 
@@ -759,3 +788,62 @@ func paramByName(op *model.Operation, name string) model.QueryParam {
 	Fail("query parameter " + name + " not found on " + op.OperationId)
 	return model.QueryParam{}
 }
+
+// -------------------------------------------------------------------
+//  $ref with sibling keywords
+// -------------------------------------------------------------------
+
+// OpenAPI 3.0 specifies that keywords beside a $ref are ignored. libopenapi
+// surfaces such a node as a non-reference schema carrying only the siblings, so
+// normalization must follow the $ref itself or the node silently loses its type
+// and fails its artifact as "unsupported".
+var _ = Describe("NormalizeSchemas $ref with sibling keywords", func() {
+
+	var props map[string]*model.Schema
+
+	BeforeEach(func() {
+		spec := loadSpecMust("schema_normalize_ref_siblings.yaml")
+		op := opByID(spec, "GetSiblings")
+		Expect(op.ResponseSchema).NotTo(BeNil())
+		Expect(op.ResponseSchema.Kind).To(Equal(model.SchemaKindObject))
+		props = op.ResponseSchema.Properties
+	})
+
+	// wantType is the OpenAPI "type" keyword the referenced schema declares.
+	// normalizeSchema records it for every kind, not only primitives, so an object
+	// alternative carries "object" here.
+	DescribeTable("resolves the reference and ignores the sibling",
+		func(property string, wantKind model.SchemaKind, wantType string) {
+			got := props[property]
+			Expect(got).NotTo(BeNil(), "property %q missing from the normalized object", property)
+			Expect(got.Kind).To(Equal(wantKind), "property %q normalized to the wrong kind", property)
+			Expect(got.Type).To(Equal(wantType))
+		},
+		Entry("$ref + example", "named", model.SchemaKindPrimitive, "string"),
+		Entry("$ref + description", "described", model.SchemaKindPrimitive, "string"),
+		Entry("$ref + example + description", "multi", model.SchemaKindPrimitive, "string"),
+		Entry("a bare $ref (control)", "plain", model.SchemaKindPrimitive, "string"),
+		Entry("$ref to an object + example", "nested", model.SchemaKindObject, "object"),
+	)
+
+	It("keeps the referenced enum when a sibling is present", func() {
+		Expect(props["kind"].Kind).To(Equal(model.SchemaKindPrimitive))
+		Expect(props["kind"].Enum).To(Equal([]string{"SECRET", "PUBLIC"}))
+	})
+
+	It("resolves a collection element that is a $ref with a sibling", func() {
+		params := props["params"]
+		Expect(params.Kind).To(Equal(model.SchemaKindArray))
+		Expect(params.Items.Kind).To(Equal(model.SchemaKindObject))
+		Expect(params.Items.Properties).To(HaveKey("name"))
+	})
+
+	It("resolves a $ref-with-sibling nested inside a referenced object", func() {
+		// UrlParam.name is itself {$ref: TokenName, example: ...} — the shape that
+		// blocked datadog_action_connection.
+		name := props["nested"].Properties["name"]
+		Expect(name).NotTo(BeNil())
+		Expect(name.Kind).To(Equal(model.SchemaKindPrimitive))
+		Expect(name.Type).To(Equal("string"))
+	})
+})

--- a/.generator-v2/internal/testdata/parser/schema_normalize_ref_siblings.yaml
+++ b/.generator-v2/internal/testdata/parser/schema_normalize_ref_siblings.yaml
@@ -1,0 +1,80 @@
+openapi: 3.0.0
+info:
+  title: normalize $ref-with-siblings fixture
+  version: 1.0.0
+# A $ref carrying sibling keywords. OpenAPI 3.0 says siblings of $ref are ignored,
+# so each property below must normalize to whatever its referenced schema says —
+# the sibling must never cost the node its type. Shapes taken from the real
+# Datadog spec, where UrlParam.name is {$ref: TokenName, example: ...}.
+paths:
+  /siblings:
+    get:
+      operationId: GetSiblings
+      x-datadog-tf-generator:
+        artifact_kind: data_source
+        artifact_name: siblings
+        group:
+          read: GetSiblings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  # $ref + example → still the referenced string
+                  named:
+                    $ref: '#/components/schemas/TokenName'
+                    example: MyUrlParameter
+                  # $ref + description → still the referenced string
+                  described:
+                    $ref: '#/components/schemas/TokenName'
+                    description: An overriding description.
+                  # $ref + several siblings at once
+                  multi:
+                    $ref: '#/components/schemas/TokenName'
+                    example: MyToken
+                    description: Both at once.
+                  # $ref to an object, with a sibling
+                  nested:
+                    $ref: '#/components/schemas/UrlParam'
+                    example: '{}'
+                  # a bare $ref, as the control case
+                  plain:
+                    $ref: '#/components/schemas/TokenName'
+                  # $ref to an enum, with a sibling: the enum must survive
+                  kind:
+                    $ref: '#/components/schemas/TokenType'
+                    example: SECRET
+                  # a collection whose element is a $ref with a sibling
+                  params:
+                    type: array
+                    description: The url parameters.
+                    items:
+                      $ref: '#/components/schemas/UrlParam'
+                      example: '{}'
+components:
+  schemas:
+    TokenName:
+      type: string
+      description: Name for tokens.
+      pattern: '^[A-Za-z][A-Za-z\d]*$'
+    TokenType:
+      type: string
+      description: The definition of the TokenType object.
+      enum:
+        - SECRET
+        - PUBLIC
+    UrlParam:
+      type: object
+      description: The definition of the UrlParam object.
+      required:
+        - name
+        - value
+      properties:
+        name:
+          $ref: '#/components/schemas/TokenName'
+          example: MyUrlParameter
+        value:
+          type: string
+          description: The UrlParam value.


### PR DESCRIPTION
## Motivation

Two parser defects that together blocked the only mini-OAS data source with a oneOf inside its surfaced attributes.

## Changes

- **`$ref` beside sibling keywords.** `{$ref: TokenName, example: "x"}` — which the Datadog spec writes — lost its type entirely: libopenapi's high-level API reports such a node as a non-reference with an empty reference, so normalization saw only the siblings and classified it unsupported. OpenAPI 3.0 ignores keywords beside a `$ref`, so the reference *is* the whole meaning of the node, and the low-level model still records it. Every "is this a reference?" test now routes through `parser.schemaRef`, including the `RefName` extractions — otherwise a sibling silently empties an SDK type name or a oneOf variant's component name.
- **Depth vs cycle.** Exhausting `--max-depth` was reported as `SchemaKindRefCycle`, naming a cycle that does not exist. Adds `SchemaKindDepthExceeded`, carrying a reason that names the bound, the `$ref` it stopped short of, that it is not a cycle, and the remedy.
- **`DefaultMaxDepth` 8 → 20.** The deepest chain across the 33 real slices in `internal/testdata/mini-oas` is 10 (`software_catalog`, `app_builder_app`; `action_connection` 9), so three sat above the old bound and one sat exactly on it. Safe because cycle detection is depth-independent, leaving this as a guard against absurd-but-acyclic nesting only.

## Testing

`go build ./...` and `go test ./...` green. New `schema_normalize_ref_siblings.yaml` fixture plus parser specs for both defects.


