### PR TITLE
[TFgen] (oneOf) Project oneOf unions into typed Terraform envelopes

### DIFF
--- a/.generator-v2/internal/model/artifact.go
+++ b/.generator-v2/internal/model/artifact.go
@@ -219,8 +219,8 @@ const defaultResultsPath = "data"
 // buildItemsBlock builds the plural items block from the results array alone
 // (op.Pagination.ResultsPath, else "data"), so response siblings such as
 // meta/links/included are dropped rather than emitted. Returns a nil Attribute
-// when the response declares no such array, and the drop diagnostics raised
-// while building the element.
+// when the response declares no such array, plus the diagnostics raised while
+// building the element (none today: an element either projects or fails).
 func buildItemsBlock(op *Operation) (*Attribute, []Diagnostic, error) {
 	resultsPath := defaultResultsPath
 	if op.Pagination != nil && op.Pagination.ResultsPath != "" {
@@ -233,9 +233,15 @@ func buildItemsBlock(op *Operation) (*Attribute, []Diagnostic, error) {
 	if arr == nil {
 		return nil, nil, nil
 	}
-	var diags []Diagnostic
-	attr, err := buildAttribute(arr, "response."+resultsPath, nestBlock, &diags)
-	return attr, diags, err
+	required := false
+	for _, name := range op.ResponseSchema.Required {
+		if name == resultsPath {
+			required = true
+			break
+		}
+	}
+	attr, err := (&treeBuilder{kind: responseTree}).attribute(arr, "response."+resultsPath, nestBlock, required)
+	return attr, nil, err
 }
 
 // readCall resolves the datadog-api-client-go binding for op's read.

--- a/.generator-v2/internal/model/framework_types.go
+++ b/.generator-v2/internal/model/framework_types.go
@@ -6,6 +6,12 @@ import "fmt"
 // schema.* symbol (e.g. schema.StringAttribute), goType the types.* value (e.g.
 // types.String). Objects map to the block form (the builder rewrites to attribute
 // form where needed); unrepresentable kinds return an error naming the offender.
+//
+// A oneOf node has no entry of its own: its Terraform shape is a synthetic
+// envelope whose form depends on where the union sits, so the attribute-tree
+// builder decides it. A collection *of* unions does have an entry — the list or
+// map is representable regardless of what its elements are, and it nests the
+// element's variant blocks the same way it would an object's properties.
 func FrameworkType(s *Schema) (tfType, goType string, err error) {
 	switch s.Kind {
 	case SchemaKindPrimitive:
@@ -21,7 +27,7 @@ func FrameworkType(s *Schema) (tfType, goType string, err error) {
 		switch s.Items.Kind {
 		case SchemaKindPrimitive:
 			return "schema.ListAttribute", "types.List", nil
-		case SchemaKindObject:
+		case SchemaKindObject, SchemaKindOneOf:
 			return "schema.ListNestedBlock", "types.List", nil
 		default:
 			return "", "", fmt.Errorf("model: array element kind %q is not representable", s.Items.Kind)
@@ -34,7 +40,7 @@ func FrameworkType(s *Schema) (tfType, goType string, err error) {
 		switch s.Items.Kind {
 		case SchemaKindPrimitive:
 			return "schema.MapAttribute", "types.Map", nil
-		case SchemaKindObject:
+		case SchemaKindObject, SchemaKindOneOf:
 			return "schema.MapNestedAttribute", "types.Map", nil
 		default:
 			return "", "", fmt.Errorf("model: map value kind %q is not representable", s.Items.Kind)

--- a/.generator-v2/internal/model/framework_types_test.go
+++ b/.generator-v2/internal/model/framework_types_test.go
@@ -53,6 +53,12 @@ var _ = Describe("FrameworkType", func() {
 		Entry("a map of object becomes MapNestedAttribute / types.Map",
 			&Schema{Kind: SchemaKindMap, Items: &Schema{Kind: SchemaKindObject}},
 			"schema.MapNestedAttribute", "types.Map"),
+		Entry("an array of oneOf nests its element's variant blocks, like an array of object",
+			&Schema{Kind: SchemaKindArray, Items: &Schema{Kind: SchemaKindOneOf}},
+			"schema.ListNestedBlock", "types.List"),
+		Entry("a map of oneOf nests its value's variant blocks, like a map of object",
+			&Schema{Kind: SchemaKindMap, Items: &Schema{Kind: SchemaKindOneOf}},
+			"schema.MapNestedAttribute", "types.Map"),
 	)
 
 	DescribeTable("returns an error naming the offender for an unrepresentable node",

--- a/.generator-v2/internal/model/oneof_envelope_test.go
+++ b/.generator-v2/internal/model/oneof_envelope_test.go
@@ -1,0 +1,293 @@
+package model
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// The tree *shape* of a projected envelope is pinned in schema_test.go. These
+// specs cover the metadata the emit layer reads off the projection, and the
+// failure paths that must not degrade into a dropped field.
+
+var _ = Describe("oneOf envelope metadata", func() {
+
+	// envelopeAt projects schema and returns the OneOfEnvelope carried by the
+	// attribute at path.
+	envelopeAt := func(schema *Schema, path string) *OneOfEnvelope {
+		GinkgoHelper()
+		tree, _, err := BuildResponseTree(schema)
+		Expect(err).NotTo(HaveOccurred())
+		envelope := attrByPath(tree, path).OneOf
+		Expect(envelope).NotTo(BeNil(), "no oneOf envelope on the attribute at %q", path)
+		return envelope
+	}
+
+	It("names the envelope model after the parser's envelope identity", func() {
+		envelope := envelopeAt(
+			objSchema(map[string]*Schema{
+				"choice": oneOfSchema(
+					"response.choice",
+					"ActionConnectionIntegration",
+					primitiveOneOfVariant("boolean", "boolean"),
+				),
+			}),
+			"response.choice",
+		)
+		Expect(envelope.Name).To(Equal("ActionConnectionIntegration"))
+		Expect(envelope.GoModel).To(Equal("ActionConnectionIntegrationModel"))
+		Expect(envelope.Path).To(Equal("response.choice"))
+	})
+
+	It("gives two uses of one reusable component the same generated model", func() {
+		shared := func() *Schema {
+			return oneOfSchema("", "Credentials", primitiveOneOfVariant("string", "string"))
+		}
+		first := shared()
+		first.OneOf.Path = "response.a"
+		second := shared()
+		second.OneOf.Path = "response.b"
+
+		tree, _, err := BuildResponseTree(objSchema(map[string]*Schema{"a": first, "b": second}))
+		Expect(err).NotTo(HaveOccurred())
+
+		a := attrByPath(tree, "response.a").OneOf
+		b := attrByPath(tree, "response.b").OneOf
+		Expect(a.GoModel).To(Equal(b.GoModel))
+		Expect(a.Variants[0].GoModel).To(Equal(b.Variants[0].GoModel))
+		// Only the tree position differs, so a reader can tell the two uses apart.
+		Expect(a.Path).NotTo(Equal(b.Path))
+	})
+
+	It("hangs the envelope off the collection attribute when the union is an element", func() {
+		tree, _, err := BuildResponseTree(objSchema(map[string]*Schema{
+			"choices": arrSchema(oneOfSchema(
+				"response.choices[]",
+				"ChoicesItem",
+				primitiveOneOfVariant("string", "string"),
+			)),
+		}))
+		Expect(err).NotTo(HaveOccurred())
+
+		collection := attrByPath(tree, "response.choices")
+		Expect(collection.TfType).To(Equal("schema.ListNestedBlock"))
+		Expect(collection.OneOf).NotTo(BeNil())
+		// The envelope path is the element path, which no attribute occupies.
+		Expect(collection.OneOf.Path).To(Equal("response.choices[]"))
+		Expect(collection.OneOf.Variants[0].Attribute.Path).To(Equal("response.choices[].string"))
+	})
+
+	It("orders variants by Terraform name whatever order the parser hands over", func() {
+		envelope := envelopeAt(
+			oneOfSchema(
+				"response",
+				"Choice",
+				primitiveOneOfVariant("string", "string"),
+				objectOneOfVariant("alpha", map[string]*Schema{"x": primSchema("string")}),
+				primitiveOneOfVariant("boolean", "boolean"),
+			),
+			"response",
+		)
+		names := make([]string, len(envelope.Variants))
+		for i, v := range envelope.Variants {
+			names[i] = v.TFName
+		}
+		Expect(names).To(Equal([]string{"alpha", "boolean", "string"}))
+	})
+
+	It("points each variant at the same block the envelope attribute lists as a child", func() {
+		tree, _, err := BuildResponseTree(oneOfSchema(
+			"response",
+			"Choice",
+			primitiveOneOfVariant("boolean", "boolean"),
+			primitiveOneOfVariant("string", "string"),
+		))
+		Expect(err).NotTo(HaveOccurred())
+
+		envelope := attrByPath(tree, "response")
+		Expect(envelope.OneOf.Variants).To(HaveLen(len(envelope.Children)))
+		for i, variant := range envelope.OneOf.Variants {
+			Expect(variant.Attribute).To(BeIdenticalTo(envelope.Children[i]),
+				"variant %q must alias Children[%d]", variant.TFName, i)
+		}
+	})
+
+	DescribeTable("value-wraps every alternative that has no fields of its own",
+		func(variant OneOfVariant, wantWrapped bool, wantChildPath, wantChildType string) {
+			envelope := envelopeAt(oneOfSchema("response", "Choice", variant), "response")
+			Expect(envelope.Variants).To(HaveLen(1))
+			Expect(envelope.Variants[0].ValueWrapped).To(Equal(wantWrapped))
+
+			child := envelope.Variants[0].Attribute.Children[0]
+			Expect(child.Path).To(Equal(wantChildPath))
+			Expect(child.TfType).To(Equal(wantChildType))
+		},
+		Entry("a scalar alternative",
+			primitiveOneOfVariant("string", "string"),
+			true, "response.string.value", "schema.StringAttribute"),
+		Entry("a list alternative",
+			OneOfVariant{TFName: "list", GoName: "List", Schema: arrSchema(primSchema("string"))},
+			true, "response.list.value", "schema.ListAttribute"),
+		Entry("a map alternative",
+			OneOfVariant{TFName: "map", GoName: "Map", Schema: mapSchema(primSchema("string"))},
+			true, "response.map.value", "schema.MapAttribute"),
+		Entry("an object alternative exposes its fields directly instead",
+			objectOneOfVariant("object", map[string]*Schema{"name": primSchema("string")}),
+			false, "response.object.name", "schema.StringAttribute"),
+		Entry("an alternative that is itself a union has no fields to expose either",
+			OneOfVariant{
+				TFName: "nested",
+				GoName: "Nested",
+				Schema: oneOfSchema("response.nested.value", "Nested", primitiveOneOfVariant("string", "string")),
+			},
+			true, "response.nested.value", "schema.SingleNestedBlock"),
+	)
+
+	It("derives the variant's Go field and model from the parser's Go name", func() {
+		envelope := envelopeAt(
+			oneOfSchema("response", "Choice", objectOneOfVariant("aws_integration", nil)),
+			"response",
+		)
+		variant := envelope.Variants[0]
+		Expect(variant.GoField).To(Equal("AwsIntegration"))
+		Expect(variant.GoModel).To(Equal("ChoiceAwsIntegrationModel"))
+	})
+
+	It("carries the SDK binding through untouched rather than deriving it from Terraform names", func() {
+		variant := objectOneOfVariant("aws_integration", nil)
+		// The SDK keeps the component's acronym casing, which the snake_case
+		// Terraform name cannot reproduce — hence the passthrough.
+		variant.SDKField = "AWSIntegration"
+		variant.SDKConstructor = "AWSIntegrationAsActionConnectionIntegration"
+
+		envelope := envelopeAt(oneOfSchema("response", "Choice", variant), "response")
+		Expect(envelope.Variants[0].SDKField).To(Equal("AWSIntegration"))
+		Expect(envelope.Variants[0].SDKConstructor).To(Equal("AWSIntegrationAsActionConnectionIntegration"))
+	})
+
+	DescribeTable("marks the envelope optional when it may legally be absent",
+		func(mutate func(*OneOfSpec), wantOptional bool) {
+			schema := oneOfSchema("response", "Choice", primitiveOneOfVariant("string", "string"))
+			mutate(schema.OneOf)
+			Expect(envelopeAt(schema, "response").Optional).To(Equal(wantOptional))
+		},
+		Entry("a required, non-nullable union is not optional",
+			func(*OneOfSpec) {}, false),
+		Entry("an optional containing field makes the envelope optional",
+			func(s *OneOfSpec) { s.Optional = true }, true),
+		Entry("a nullable union is optional too — null is an absent envelope",
+			func(s *OneOfSpec) { s.Nullable = true }, true),
+	)
+
+	It("marks a response envelope Computed and a request envelope Required", func() {
+		schema := oneOfSchema("response", "Choice", primitiveOneOfVariant("string", "string"))
+
+		Expect(envelopeAt(schema, "response").Computed).To(BeTrue())
+
+		tree, _, err := BuildRequestTree(oneOfSchema("request", "Choice", primitiveOneOfVariant("string", "string")))
+		Expect(err).NotTo(HaveOccurred())
+		envelope := attrByPath(tree, "request")
+		Expect(envelope.OneOf.Computed).To(BeFalse())
+		Expect(envelope.Required).To(BeTrue())
+		Expect(envelope.Optional).To(BeFalse())
+		// A branch is a choice, so it is never itself mandatory; the wrapped value
+		// is, once its branch is selected.
+		branch := attrByPath(tree, "request.string")
+		Expect(branch.Optional).To(BeTrue())
+		Expect(branch.Required).To(BeFalse())
+		Expect(attrByPath(tree, "request.string.value").Required).To(BeTrue())
+	})
+
+	It("leaves an optional request envelope optional rather than required", func() {
+		schema := oneOfSchema("request", "Choice", primitiveOneOfVariant("string", "string"))
+		schema.OneOf.Optional = true
+
+		tree, _, err := BuildRequestTree(schema)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(attrByPath(tree, "request").Optional).To(BeTrue())
+		Expect(attrByPath(tree, "request").Required).To(BeFalse())
+	})
+})
+
+var _ = Describe("oneOf envelope projection failures", func() {
+
+	// Every case here must fail the artifact. A union that cannot be projected is
+	// never skipped: silently dropping it is not an acceptable outcome.
+	expectProjectionError := func(schema *Schema) *OneOfProjectionError {
+		GinkgoHelper()
+		tree, diags, err := BuildResponseTree(schema)
+		Expect(tree).To(BeNil())
+		Expect(diags).To(BeEmpty(), "a failed projection must not be reported as a droppable diagnostic")
+
+		var projection *OneOfProjectionError
+		Expect(errors.As(err, &projection)).To(BeTrue(), "expected *OneOfProjectionError, got %T: %v", err, err)
+		return projection
+	}
+
+	// at wraps a union as the "choice" property of a response object, so the
+	// projection reports the position the union actually occupies in the tree.
+	at := func(union *Schema) *Schema {
+		return objSchema(map[string]*Schema{"choice": union})
+	}
+
+	It("fails a union with no non-null alternative to select", func() {
+		err := expectProjectionError(at(oneOfSchema("response.choice", "Choice")))
+		Expect(err.Envelope).To(Equal("Choice"))
+		Expect(err.Path).To(Equal("response.choice"))
+		Expect(err.Error()).To(ContainSubstring("no non-null alternative"))
+	})
+
+	It("fails a union the parser left without an envelope name", func() {
+		err := expectProjectionError(at(oneOfSchema("response.choice", "", primitiveOneOfVariant("string", "string"))))
+		Expect(err.Path).To(Equal("response.choice"))
+		Expect(err.Error()).To(ContainSubstring("no generated envelope name"))
+	})
+
+	It("fails an alternative with no stable Terraform name", func() {
+		err := expectProjectionError(at(oneOfSchema(
+			"response.choice",
+			"Choice",
+			OneOfVariant{Schema: primSchema("string")},
+		)))
+		Expect(err.Path).To(Equal("response.choice"))
+		Expect(err.Error()).To(ContainSubstring("no stable Terraform variant name"))
+	})
+
+	It("names the envelope, alternative and path when an alternative is unrepresentable", func() {
+		err := expectProjectionError(objSchema(map[string]*Schema{
+			"choice": oneOfSchema(
+				"response.choice",
+				"Choice",
+				primitiveOneOfVariant("string", "string"),
+				OneOfVariant{
+					TFName: "broken",
+					GoName: "Broken",
+					Schema: &Schema{Kind: SchemaKindUnsupported, UnsupportedReason: "anyOf has no Terraform equivalent"},
+				},
+			),
+		}))
+		Expect(err.Envelope).To(Equal("Choice"))
+		Expect(err.Variant).To(Equal("broken"))
+		Expect(err.Path).To(Equal("response.choice"))
+
+		// The underlying per-node failure stays reachable, so the reason the
+		// alternative could not be represented survives to the run report.
+		var unsupported *UnsupportedKindError
+		Expect(errors.As(err, &unsupported)).To(BeTrue())
+		Expect(unsupported.Path).To(Equal("response.choice.broken.value"))
+		Expect(err.Error()).To(ContainSubstring("anyOf has no Terraform equivalent"))
+	})
+
+	It("fails a one_of node the parser left without a normalized union", func() {
+		tree, _, err := BuildResponseTree(objSchema(map[string]*Schema{
+			"choice": {Kind: SchemaKindOneOf},
+		}))
+		Expect(tree).To(BeNil())
+
+		var unsupported *UnsupportedKindError
+		Expect(errors.As(err, &unsupported)).To(BeTrue())
+		Expect(unsupported.Path).To(Equal("response.choice"))
+		Expect(unsupported.Reason).To(ContainSubstring("no normalized union"))
+	})
+})

--- a/.generator-v2/internal/model/schema.go
+++ b/.generator-v2/internal/model/schema.go
@@ -16,11 +16,26 @@ const (
 	nestAttribute
 )
 
+// treeKind distinguishes the two entry points, which differ only in presence
+// flags: a response tree is state the provider reads back, so every node is
+// Computed, whereas a request tree is practitioner input, so every node is
+// Required or Optional instead.
+type treeKind int
+
+const (
+	responseTree treeKind = iota
+	requestTree
+)
+
+// oneOfValueField is the single child a non-object oneOf alternative exposes.
+// A scalar, list, map, or directly nested union has no fields of its own to
+// surface, so its variant block wraps the whole alternative under this name.
+const oneOfValueField = "value"
+
 // UnsupportedKindError reports a schema kind that cannot become a Terraform
 // attribute — anyOf (classified unsupported), a ref_cycle, or any other
 // unsupported node. The attribute-tree builder fails the artifact when it reaches
-// one rather than emitting a types.Dynamic escape hatch. (oneOf variants are
-// dropped, not errored.)
+// one rather than emitting a types.Dynamic escape hatch.
 type UnsupportedKindError struct {
 	Path   string
 	Kind   SchemaKind
@@ -39,59 +54,100 @@ func (e *UnsupportedKindError) Error() string {
 	return fmt.Sprintf("model: cannot build attribute at %q: schema kind %q is not representable", e.Path, e.Kind)
 }
 
+// OneOfProjectionError reports a union that cannot be projected into a Terraform
+// envelope. It names the envelope, the offending alternative and the schema path
+// so a maintainer can find the union in the OpenAPI document, and it wraps the
+// underlying per-alternative failure when there is one. A oneOf is never dropped
+// from the tree: either it projects, or its artifact fails with this error.
+type OneOfProjectionError struct {
+	// Envelope is the generated envelope name (OneOfSpec.Name).
+	Envelope string
+	// Variant is the Terraform variant name, empty when the whole envelope failed.
+	Variant string
+	// Path is the union's schema path.
+	Path string
+	// Reason states the failure directly; when empty, Err carries it.
+	Reason string
+	Err    error
+}
+
+func (e *OneOfProjectionError) Error() string {
+	reason := e.Reason
+	if reason == "" && e.Err != nil {
+		reason = e.Err.Error()
+	}
+	if e.Variant != "" {
+		return fmt.Sprintf(
+			"model: cannot project oneOf envelope %q alternative %q at %q: %s",
+			e.Envelope, e.Variant, e.Path, reason,
+		)
+	}
+	return fmt.Sprintf("model: cannot project oneOf envelope %q at %q: %s", e.Envelope, e.Path, reason)
+}
+
+func (e *OneOfProjectionError) Unwrap() error { return e.Err }
+
 // BuildResponseTree converts a response-body schema into an AttributeTree,
-// rooting every attribute path at "response.". It also returns the info
-// diagnostics raised while dropping oneOf-variant nodes from the tree.
+// rooting every attribute path at "response." and marking every node Computed.
+//
+// The returned diagnostics are the non-fatal notes raised during the walk; the
+// conversion currently produces none, since every node either projects into the
+// tree or fails the artifact.
 func BuildResponseTree(s *Schema) (*AttributeTree, []Diagnostic, error) {
-	return build(s, "response")
+	return (&treeBuilder{kind: responseTree}).build(s, "response")
 }
 
 // BuildRequestTree converts a request-body schema into an AttributeTree, rooting
-// every attribute path at "request.". Like BuildResponseTree it returns the
-// drop diagnostics raised during the walk.
+// every attribute path at "request." and marking each node Required or Optional
+// rather than Computed. Like BuildResponseTree it returns the diagnostics raised
+// during the walk.
 func BuildRequestTree(s *Schema) (*AttributeTree, []Diagnostic, error) {
-	return build(s, "request")
+	return (&treeBuilder{kind: requestTree}).build(s, "request")
+}
+
+// treeBuilder carries the state of one AttributeTree conversion. Only the entry
+// point's kind varies across a run; the recursion is otherwise a pure function of
+// the schema node, its path, and its nesting context.
+type treeBuilder struct {
+	kind treeKind
 }
 
 // build is the shared recursion behind both entry points, differing only in root.
 // A root object explodes its properties into top-level attributes; any other kind
-// becomes one attribute at Path == root, and a nil schema yields an empty tree.
-// A root that is itself a dropped oneOf variant has nothing to render and fails.
-func build(s *Schema, root string) (*AttributeTree, []Diagnostic, error) {
+// — including a bare union or a collection of unions — becomes one attribute at
+// Path == root. A nil schema yields an empty tree.
+func (b *treeBuilder) build(s *Schema, root string) (*AttributeTree, []Diagnostic, error) {
 	tree := &AttributeTree{}
-	var diags []Diagnostic
 	if s == nil {
-		return tree, diags, nil
+		return tree, nil, nil
 	}
 	if s.Kind == SchemaKindObject {
-		attrs, err := buildChildren(s.Properties, root+".", nestBlock, &diags)
+		attrs, err := b.children(s, root+".", nestBlock)
 		if err != nil {
 			return nil, nil, err
 		}
 		tree.Attributes = attrs
-		return tree, diags, nil
+		return tree, nil, nil
 	}
-	attr, err := buildAttribute(s, root, nestBlock, &diags)
+	// A body root is always present, so it is required when it is input at all.
+	attr, err := b.attribute(s, root, nestBlock, true)
 	if err != nil {
 		return nil, nil, err
 	}
-	if attr == nil {
-		return nil, nil, fmt.Errorf("model: schema at %q is a dropped oneOf variant with no representable attributes", root)
-	}
 	tree.Attributes = []*Attribute{attr}
-	return tree, diags, nil
+	return tree, nil, nil
 }
 
-// buildAttribute converts one schema node at path into an Attribute, recursing
-// into its properties, element, or value schema. mode threads the nesting world
-// down. A oneOf variant — at this node, or as a collection's element — has no
-// Terraform representation, so buildAttribute drops it: it returns a nil
-// Attribute (for the caller to skip) and records an info diagnostic on diags.
-func buildAttribute(s *Schema, path string, mode nestingMode, diags *[]Diagnostic) (*Attribute, error) {
-	// A oneOf variant node: drop it from the tree.
-	if s.Kind == SchemaKindVariant {
-		*diags = append(*diags, droppedDiag(path, "oneOf variant has no Terraform representation"))
-		return nil, nil
+// attribute converts one schema node at path into an Attribute, recursing into its
+// properties, element, or value schema. mode threads the nesting world down, and
+// required says whether the node must be configured (a request-tree concern only).
+// Every non-representable kind fails here rather than being skipped, so no marked
+// field can disappear from the generated schema.
+func (b *treeBuilder) attribute(s *Schema, path string, mode nestingMode, required bool) (*Attribute, error) {
+	// A union has no framework type of its own: it projects into a synthetic
+	// envelope whose form depends on where it sits, so it is handled separately.
+	if s.Kind == SchemaKindOneOf {
+		return b.envelope(s, path, mode, required)
 	}
 
 	// The remaining non-representable kinds (anyOf and other unsupported nodes,
@@ -108,13 +164,6 @@ func buildAttribute(s *Schema, path string, mode nestingMode, diags *[]Diagnosti
 		}
 	}
 
-	// A collection whose element is a oneOf variant has no representable element
-	// type, so drop the whole collection attribute.
-	if (s.Kind == SchemaKindArray || s.Kind == SchemaKindMap) && s.Items != nil && s.Items.Kind == SchemaKindVariant {
-		*diags = append(*diags, droppedDiag(path, "collection element is a oneOf variant, which has no Terraform representation"))
-		return nil, nil
-	}
-
 	tfType, goType, err := FrameworkType(s)
 	if err != nil {
 		return nil, err
@@ -122,12 +171,7 @@ func buildAttribute(s *Schema, path string, mode nestingMode, diags *[]Diagnosti
 	// Inside a map value the framework forbids blocks, so rewrite block forms to
 	// attribute forms (leaf types are unaffected).
 	if mode == nestAttribute {
-		switch tfType {
-		case "schema.SingleNestedBlock":
-			tfType = "schema.SingleNestedAttribute"
-		case "schema.ListNestedBlock":
-			tfType = "schema.ListNestedAttribute"
-		}
+		tfType = attributeForm(tfType)
 	}
 
 	attr := &Attribute{
@@ -135,10 +179,10 @@ func buildAttribute(s *Schema, path string, mode nestingMode, diags *[]Diagnosti
 		TfType:      tfType,
 		GoType:      goType,
 		Format:      s.Format,
-		Computed:    true,
 		Sensitive:   s.Sensitive,
 		Description: s.Description,
 	}
+	b.applyPresence(attr, required)
 
 	// A string enum becomes a OneOf validator; non-string enums produce none for now.
 	if s.Kind == SchemaKindPrimitive && s.Type == "string" && len(s.Enum) > 0 {
@@ -151,23 +195,33 @@ func buildAttribute(s *Schema, path string, mode nestingMode, diags *[]Diagnosti
 	}
 
 	// Recurse into nested shapes, or record a primitive collection's element type.
-	// FrameworkType already validated array/map elements, so the else branch is primitive.
+	// FrameworkType already validated array/map elements, so the final branch of
+	// each switch is primitive.
 	switch s.Kind {
 	case SchemaKindObject:
-		children, err := buildChildren(s.Properties, path+".", mode, diags)
+		children, err := b.children(s, path+".", mode)
 		if err != nil {
 			return nil, err
 		}
 		attr.Children = children
 
 	case SchemaKindArray:
-		if s.Items.Kind == SchemaKindObject {
-			children, err := buildChildren(s.Items.Properties, path+"[].", mode, diags)
+		switch s.Items.Kind {
+		case SchemaKindObject:
+			children, err := b.children(s.Items, path+"[].", mode)
 			if err != nil {
 				return nil, err
 			}
 			attr.Children = children
-		} else {
+		case SchemaKindOneOf:
+			// The list itself carries the envelope: its elements are variant
+			// blocks, so no attribute stands at the element path.
+			variants, envelope, err := b.oneOfVariants(s.Items, path+"[]", mode)
+			if err != nil {
+				return nil, err
+			}
+			attr.Children, attr.OneOf = variants, envelope
+		default:
 			elem, err := ElementType(s.Items)
 			if err != nil {
 				return nil, err
@@ -176,15 +230,22 @@ func buildAttribute(s *Schema, path string, mode nestingMode, diags *[]Diagnosti
 		}
 
 	case SchemaKindMap:
-		if s.Items.Kind == SchemaKindObject {
+		switch s.Items.Kind {
+		case SchemaKindObject:
 			// A map<object> is a NestedAttributeObject; force everything beneath it
 			// into attribute form regardless of the incoming mode.
-			children, err := buildChildren(s.Items.Properties, path+"{}.", nestAttribute, diags)
+			children, err := b.children(s.Items, path+"{}.", nestAttribute)
 			if err != nil {
 				return nil, err
 			}
 			attr.Children = children
-		} else {
+		case SchemaKindOneOf:
+			variants, envelope, err := b.oneOfVariants(s.Items, path+"{}", nestAttribute)
+			if err != nil {
+				return nil, err
+			}
+			attr.Children, attr.OneOf = variants, envelope
+		default:
 			elem, err := ElementType(s.Items)
 			if err != nil {
 				return nil, err
@@ -196,38 +257,227 @@ func buildAttribute(s *Schema, path string, mode nestingMode, diags *[]Diagnosti
 	return attr, nil
 }
 
-// buildChildren builds one child attribute per property, each pathed prefix+key.
-// Keys are visited sorted, making recursion deterministic and the result
-// Path-sorted. A property that builds to a nil Attribute (a dropped oneOf
-// variant) is skipped rather than appended.
-func buildChildren(props map[string]*Schema, prefix string, mode nestingMode, diags *[]Diagnostic) ([]*Attribute, error) {
+// children builds one child attribute per property of parent, each pathed
+// prefix+key. Keys are visited sorted, making recursion deterministic and the
+// result Path-sorted. Required-ness comes from the parent's required list, which
+// only reaches the output in a request tree.
+func (b *treeBuilder) children(parent *Schema, prefix string, mode nestingMode) ([]*Attribute, error) {
+	props := parent.Properties
 	keys := make([]string, 0, len(props))
 	for k := range props {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 
+	required := make(map[string]bool, len(parent.Required))
+	for _, name := range parent.Required {
+		required[name] = true
+	}
+
 	children := make([]*Attribute, 0, len(props))
 	for _, key := range keys {
 		// Terraform attribute names must be snake_case; SnakeCase normalizes camelCase
 		// OAS names and is idempotent on already-snake names (SdkName recovers the getter).
-		child, err := buildAttribute(props[key], prefix+SnakeCase(key), mode, diags)
+		child, err := b.attribute(props[key], prefix+SnakeCase(key), mode, required[key])
 		if err != nil {
 			return nil, err
-		}
-		if child == nil {
-			continue // dropped (e.g. a oneOf variant)
 		}
 		children = append(children, child)
 	}
 	return children, nil
 }
 
-// droppedDiag is an info diagnostic recording one node skipped from the attribute
-// tree, keeping the run report explicit about what was not rendered.
-func droppedDiag(path, reason string) Diagnostic {
-	return Diagnostic{
-		Severity: SeverityInfo,
-		Message:  fmt.Sprintf("dropped %q: %s", path, reason),
+// envelope projects a union standing at its own position in the tree — the schema
+// root, or an object property — into the synthetic block that holds its variants.
+func (b *treeBuilder) envelope(s *Schema, path string, mode nestingMode, required bool) (*Attribute, error) {
+	variants, envelope, err := b.oneOfVariants(s, path, mode)
+	if err != nil {
+		return nil, err
+	}
+	attr := &Attribute{
+		Path:        path,
+		TfType:      singleNestedForm(mode),
+		GoType:      "types.Object",
+		Sensitive:   s.Sensitive,
+		Description: s.Description,
+		Children:    variants,
+		OneOf:       envelope,
+	}
+	// The envelope is required only when its containing field demands a value and
+	// the union itself is neither optional nor nullable; a nullable union is
+	// represented by an absent envelope rather than a null variant.
+	b.applyPresence(attr, required && !envelope.Optional)
+	return attr, nil
+}
+
+// oneOfVariants projects the alternatives of a normalized union into one nested
+// block each, pathed under basePath, and returns them with the envelope metadata
+// the emit layer needs. basePath is the union's own schema path: the envelope
+// attribute's path for a root or property union, and the element path
+// ("choices[]", "choices{}") when the union is a collection's element — in that
+// case the collection attribute carries the envelope and these blocks are its
+// children directly.
+func (b *treeBuilder) oneOfVariants(s *Schema, basePath string, mode nestingMode) ([]*Attribute, *OneOfEnvelope, error) {
+	spec := s.OneOf
+	if spec == nil {
+		return nil, nil, &UnsupportedKindError{
+			Path:   basePath,
+			Kind:   s.Kind,
+			Reason: "oneOf node carries no normalized union",
+		}
+	}
+	if spec.Name == "" {
+		return nil, nil, &OneOfProjectionError{
+			Path:   basePath,
+			Reason: "union has no generated envelope name to build a model from",
+		}
+	}
+	if len(spec.Variants) == 0 {
+		return nil, nil, &OneOfProjectionError{
+			Envelope: spec.Name,
+			Path:     basePath,
+			Reason:   "union has no non-null alternative to select",
+		}
+	}
+
+	envelope := &OneOfEnvelope{
+		Name:    spec.Name,
+		GoModel: oneOfModelName(spec.Name),
+		Path:    basePath,
+		// A nullable union maps to an absent envelope, so it is as optional as one
+		// whose containing field is optional.
+		Optional: spec.Optional || spec.Nullable,
+		Computed: b.kind == responseTree,
+		Variants: make([]OneOfEnvelopeVariant, 0, len(spec.Variants)),
+	}
+
+	// Order by Terraform name so neither OpenAPI alternative order nor a caller's
+	// construction order can reach the generated schema. The parser already sorts;
+	// sorting a copy here keeps the projection correct for any caller without
+	// mutating the spec.
+	ordered := make([]OneOfVariant, len(spec.Variants))
+	copy(ordered, spec.Variants)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].TFName < ordered[j].TFName })
+
+	blocks := make([]*Attribute, 0, len(ordered))
+	for _, variant := range ordered {
+		block, projected, err := b.oneOfVariant(envelope, variant, basePath, mode)
+		if err != nil {
+			return nil, nil, err
+		}
+		blocks = append(blocks, block)
+		envelope.Variants = append(envelope.Variants, projected)
+	}
+	return blocks, envelope, nil
+}
+
+// oneOfVariant projects one alternative into its nested block. An object
+// alternative exposes its own fields; every other shape — scalar, list, map, or a
+// directly nested union — has no fields to expose, so it gets a single child named
+// "value" holding the alternative itself.
+func (b *treeBuilder) oneOfVariant(
+	envelope *OneOfEnvelope,
+	variant OneOfVariant,
+	basePath string,
+	mode nestingMode,
+) (*Attribute, OneOfEnvelopeVariant, error) {
+	fail := func(reason string, err error) (*Attribute, OneOfEnvelopeVariant, error) {
+		return nil, OneOfEnvelopeVariant{}, &OneOfProjectionError{
+			Envelope: envelope.Name,
+			Variant:  variant.TFName,
+			Path:     basePath,
+			Reason:   reason,
+			Err:      err,
+		}
+	}
+	if variant.TFName == "" {
+		return fail("alternative has no stable Terraform variant name", nil)
+	}
+	if variant.Schema == nil {
+		return fail("alternative has no normalized schema", nil)
+	}
+
+	path := basePath + "." + variant.TFName
+	block := &Attribute{
+		Path:        path,
+		TfType:      singleNestedForm(mode),
+		GoType:      "types.Object",
+		Sensitive:   variant.Schema.Sensitive,
+		Description: variant.Schema.Description,
+	}
+	// A variant is a choice, never a mandatory field: exactly-one selection is
+	// enforced by the envelope's validator and by request mapping, not by marking
+	// every branch Required.
+	b.applyPresence(block, false)
+
+	valueWrapped := variant.Schema.Kind != SchemaKindObject
+	if valueWrapped {
+		// The wrapped value is present whenever its variant is selected.
+		value, err := b.attribute(variant.Schema, path+"."+oneOfValueField, mode, true)
+		if err != nil {
+			return fail("", err)
+		}
+		block.Children = []*Attribute{value}
+	} else {
+		children, err := b.children(variant.Schema, path+".", mode)
+		if err != nil {
+			return fail("", err)
+		}
+		block.Children = children
+	}
+
+	goField := variant.GoName
+	if goField == "" {
+		goField = SdkName(variant.TFName)
+	}
+	return block, OneOfEnvelopeVariant{
+		TFName:  variant.TFName,
+		GoField: goField,
+		GoModel: oneOfModelName(envelope.Name + goField),
+		// Carried through, never derived: SDK and Terraform naming diverge.
+		SDKField:       variant.SDKField,
+		SDKConstructor: variant.SDKConstructor,
+		ValueWrapped:   valueWrapped,
+		Attribute:      block,
+	}, nil
+}
+
+// applyPresence sets the framework presence flags. Response state is entirely
+// Computed; request input is Required when the schema says so and Optional
+// otherwise. Exactly one flag ends up set either way, as the framework requires.
+func (b *treeBuilder) applyPresence(a *Attribute, required bool) {
+	if b.kind == responseTree {
+		a.Computed = true
+		return
+	}
+	a.Required = required
+	a.Optional = !required
+}
+
+// attributeForm rewrites a block framework type into its nested-attribute
+// counterpart, leaving leaf and already-attribute forms alone.
+func attributeForm(tfType string) string {
+	switch tfType {
+	case "schema.SingleNestedBlock":
+		return "schema.SingleNestedAttribute"
+	case "schema.ListNestedBlock":
+		return "schema.ListNestedAttribute"
+	default:
+		return tfType
 	}
 }
+
+// singleNestedForm is the single-nested framework type valid in mode's nesting
+// world. Envelopes and variant blocks are always single-nested: the envelope holds
+// one variant, the variant one alternative.
+func singleNestedForm(mode nestingMode) string {
+	if mode == nestAttribute {
+		return "schema.SingleNestedAttribute"
+	}
+	return "schema.SingleNestedBlock"
+}
+
+// oneOfModelName is the generated Go struct name for an envelope or variant.
+// Deriving it from the envelope's name (rather than from the use site) is what
+// lets two uses of one reusable union share a single generated model.
+func oneOfModelName(name string) string { return name + "Model" }

--- a/.generator-v2/internal/model/schema_test.go
+++ b/.generator-v2/internal/model/schema_test.go
@@ -473,16 +473,7 @@ var _ = Describe("BuildResponseTree defensive guard", func() {
 	})
 })
 
-// Pending: these specs characterize the oneOf envelope projection before it
-// exists. They are written first, deliberately, so the behaviour they describe is
-// settled in review before any of it is implemented -- but a red suite cannot be
-// merged, and this stack merges bottom-up. PDescribe keeps them reported as
-// pending rather than failing.
-//
-// The commit that projects unions into typed envelopes turns this back into
-// Describe; the specs must all pass at that point, which is what makes them a
-// check on that commit rather than decoration.
-var _ = PDescribe("BuildResponseTree retains oneOf envelopes", func() {
+var _ = Describe("BuildResponseTree retains oneOf envelopes", func() {
 
 	assertRetained := func(
 		buildTree func(*Schema) (*AttributeTree, []Diagnostic, error),

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -326,6 +326,72 @@ type Attribute struct {
 	Description string
 	// Children holds nested attributes for nested blocks.
 	Children []*Attribute
+	// OneOf is non-nil when this attribute carries a synthetic oneOf envelope:
+	// either the envelope itself (a union at the root or an object property) or
+	// the collection whose element is a union. Children then holds the variant
+	// blocks, and OneOf holds the naming and SDK-binding metadata the emit layer
+	// needs to map them.
+	OneOf *OneOfEnvelope
+}
+
+// OneOfEnvelope is the Terraform projection of a parser-normalized OneOfSpec: the
+// synthetic block holding one nested variant block per non-null alternative,
+// exactly one of which is selected whenever the envelope is present.
+//
+// It hangs off the Attribute standing at the union's position in the tree; that
+// attribute's Children are the projected variant blocks, in the same order as
+// Variants. Terraform concerns live here rather than on OneOfSpec so that
+// OpenAPI normalization stays free of them.
+type OneOfEnvelope struct {
+	// Name is the parser-assigned envelope identity (OneOfSpec.Name): the OpenAPI
+	// component name for a reusable union, a deterministic path-derived name for
+	// an inline one. Two uses of the same component share a Name, which is what
+	// lets emit generate one model per envelope instead of one per use site.
+	Name string
+	// GoModel is the generated Go struct holding one pointer field per variant.
+	GoModel string
+	// Path is the union's own schema path, used by validators and diagnostics. For
+	// a collection of unions it is the element path (e.g. "response.choices[]"),
+	// which is not the path of any attribute in the tree.
+	Path string
+	// Optional permits the whole envelope to be absent because its containing
+	// OpenAPI field is optional or nullable. When false, exactly one variant must
+	// be selected.
+	Optional bool
+	// Computed marks a response-only envelope, where selection is enforced by
+	// response mapping rather than by practitioner configuration.
+	Computed bool
+	// Variants are the projected non-null alternatives, ordered by TFName so
+	// neither OpenAPI alternative order nor map iteration can reach the output.
+	Variants []OneOfEnvelopeVariant
+}
+
+// OneOfEnvelopeVariant is one projected alternative of a OneOfEnvelope.
+type OneOfEnvelopeVariant struct {
+	// TFName is the stable snake_case nested-block name.
+	TFName string
+	// GoField is the pointer field naming this variant on the envelope's model.
+	// The pointer being non-nil is what selects the variant.
+	GoField string
+	// GoModel is the generated Go struct for this variant's own fields.
+	GoModel string
+	// SDKField is the Datadog go-sdk wrapper member whose presence selects this
+	// alternative, and SDKConstructor the SDK convenience constructor for it. Both
+	// are carried through from the parser's OneOfVariant and stay empty until the
+	// SDK binding pass resolves them: the projection never derives an SDK identity
+	// from a Terraform name, since the two conventions differ (a variant named
+	// aws_integration binds to the SDK's AWSIntegration, not AwsIntegration).
+	SDKField       string
+	SDKConstructor string
+	// ValueWrapped is true for every non-object alternative — scalar, list, map, or
+	// a directly nested union — whose block holds a single child named "value".
+	// Object alternatives expose their own fields directly instead.
+	ValueWrapped bool
+	// Attribute is this variant's projected block: the same pointer as the
+	// envelope-carrying attribute's Children entry at this index. Children drives
+	// schema rendering; this field lets the mapper reach a block without
+	// re-deriving the ordering.
+	Attribute *Attribute
 }
 
 // Literal is a default value rendered as a Go source expression


### PR DESCRIPTION
## Motivation

A oneOf has no framework type of its own, so the tree builder dropped it and recorded an info diagnostic. Dropping data the API exposes is not an acceptable outcome, and it made every union-bearing response silently lossy.

## Changes

Projects each union into a synthetic envelope: one `SingleNestedBlock` (or the attribute form inside a map value) holding one nested block per alternative, exactly one of which is set. A primitive alternative is wrapped in a `value` field, since Terraform has no bare-scalar block. The envelope's shape depends on where the union sits — tree root, object property, collection element — and each placement is handled explicitly rather than approximated.

Consequences of no longer dropping:

- `droppedDiag` and the diagnostics threading disappear from this path. Nothing is dropped here anymore, so `build` returns no diagnostics.
- The walk moves onto a `treeBuilder` receiver carrying the tree kind, which is what lets a request tree mark presence (Required/Optional) where a response tree marks Computed.
- A per-alternative failure surfaces as `OneOfProjectionError`, naming the envelope and wrapping the underlying cause, instead of failing anonymously.

Emit still refuses these artifacts — the generated state mapper needs the SDK's oneOf wrapper binding, which lands in #4099/#4051.

## Testing

`go build ./...` and `go test ./...` green. Turns the pending characterization specs from #4042 back into `Describe`: `internal/model` goes from `110 passed | 11 pending` to `145 passed | 0 pending`.

> **Known follow-up:** removing the drop diagnostics leaves `[]Diagnostic` vestigial on `BuildResponseTree`/`BuildRequestTree`/`buildItemsBlock` — `golangci-lint` flags `buildItemsBlock - result 1 is always nil (unparam)`. Signatures left as-is here to keep the diff to the projection.


