### PR TITLE
[TFgen] (Emit) Fail the artifact on a oneOf envelope emit cannot render yet

### DIFF
--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -35,6 +35,35 @@ func (e *UnsupportedEmitError) Error() string {
 // off, established by the StateView preamble "attributes := resp.Data.GetAttributes()".
 const envelopeReceiver = "attributes"
 
+// collectOneOfEnvelopes records every oneOf envelope reachable from attrs as an
+// unsupported node.
+//
+// The model layer projects each union into a typed envelope, but rendering one
+// needs the Datadog go-sdk's oneOf wrapper binding: the wrapper exposes plain
+// pointer members and a GetActualInstance method rather than the Get<Field>Ok
+// getters this path's state mapper is built on. Until that mapping exists, failing
+// the artifact here is the only correct outcome — the alternatives are emitting
+// getter calls the SDK does not have, or dropping the union, which is what the
+// generator did before the envelope projection, and is not acceptable.
+//
+// Descent stops at an envelope: one diagnostic per union is enough to fail the
+// artifact, and a union nested inside a variant is already covered by its parent.
+func collectOneOfEnvelopes(attrs []*model.Attribute, out *[]UnsupportedNode) {
+	for _, a := range attrs {
+		if a.OneOf != nil {
+			*out = append(*out, UnsupportedNode{
+				Path: a.OneOf.Path,
+				Reason: fmt.Sprintf(
+					"oneOf envelope %q needs the SDK oneOf wrapper mapping, which the emit path does not implement yet",
+					a.OneOf.Name,
+				),
+			})
+			continue
+		}
+		collectOneOfEnvelopes(a.Children, out)
+	}
+}
+
 // BuildDataSourceView derives the singular DataSourceView from a.Schema and
 // a.Lifecycle. It resolves the SDK-call bindings onto the view, then runs a
 // flattening pass that recognizes the singular JSON:API envelope
@@ -101,6 +130,13 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 
 	rootStruct := dsGoName(a.Name) + "DataSourceModel"
 	env := b.flattenEnvelope(topLevel, idStrategy, rootExpr)
+
+	// Scan for oneOf envelopes only across what survived flattening: a union under
+	// a dropped envelope member (e.g. included[]) never reaches the generated code,
+	// so it must not fail the artifact.
+	if env != nil {
+		collectOneOfEnvelopes(env.leaves, &b.unsupported)
+	}
 
 	if len(b.unsupported) > 0 {
 		return DataSourceView{}, &UnsupportedEmitError{Nodes: b.unsupported}
@@ -642,6 +678,10 @@ func unsupportedReason(tfType string) string {
 func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 	var unsupported []UnsupportedNode
 	var dropped []DroppedMember
+
+	if a.Schema != nil {
+		collectOneOfEnvelopes(a.Schema.Attributes, &unsupported)
+	}
 
 	var call *model.SDKCall
 	if a.Lifecycle != nil {

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -251,6 +251,36 @@ var _ = Describe("RenderDataSource duplicate field guard", func() {
 			Items: obj(map[string]*model.Schema{"handle": prim("string", "")}),
 		}),
 	)
+
+	It("drops included, keeping its element union out of the view entirely", func() {
+		// The real shape: included is an array whose element is a oneOf, since it
+		// sideloads more than one resource type (User | LeakedKey for an API key).
+		op := incidentTypeOperation()
+		op.ResponseSchema.Properties["included"] = &model.Schema{
+			Kind: model.SchemaKindArray,
+			Items: &model.Schema{
+				Kind: model.SchemaKindOneOf,
+				OneOf: &model.OneOfSpec{
+					Name: "IncidentTypeResponseIncludedItem",
+					Path: "response.included[]",
+					Variants: []model.OneOfVariant{{
+						TFName: "user",
+						GoName: "User",
+						Schema: obj(map[string]*model.Schema{"handle": prim("string", "")}),
+					}},
+				},
+			},
+		}
+		art, err := model.BuildArtifact(op)
+		Expect(err).NotTo(HaveOccurred())
+		// The model still projects the union faithfully; only the view drops it.
+		Expect(art.Schema.Attributes).To(ContainElement(HaveField("Path", "response.included")))
+
+		view, err := BuildDataSourceView(art)
+		Expect(err).NotTo(HaveOccurred(), "a union under a dropped member must not fail the artifact")
+		Expect(view.Dropped).To(HaveLen(1))
+		Expect(view.Dropped[0].Message).To(ContainSubstring("dropped \"response.included\": not part of the surfaced {id, type, attributes} envelope"))
+	})
 })
 
 var _ = Describe("BuildDataSourceView audit fields", func() {


### PR DESCRIPTION
## Motivation

The model layer now projects unions into typed envelopes (#4095), but rendering one needs the Datadog go-sdk's oneOf wrapper binding: the wrapper exposes plain pointer members and `GetActualInstance`, not the `Get<Field>Ok` getters this path's state mapper is built on.

## Changes

Until that mapping exists, failing here is the only correct outcome. The alternatives are emitting getter calls the SDK does not have, or dropping the union — which is what the generator did before the projection, and which is not acceptable.

- The singular scan runs over what survived envelope flattening rather than the raw schema, so a union under a dropped member never fails the artifact: `included` is sideloaded metadata the data source does not surface, and its element union is precisely the union that made these responses need a decision at all.
- Descent stops at an envelope — one diagnostic per union is enough to fail the artifact, and a union nested inside a variant is already covered by its parent.

## Testing

`go build ./...` and `go test ./...` green. A spec covers the union-under-dropped-`included` case explicitly.


