### PR TITLE
[TFgen] (Model) Carry the SDK binding fields on the operation and union types

### DIFF
--- a/.generator-v2/internal/model/artifact.go
+++ b/.generator-v2/internal/model/artifact.go
@@ -244,10 +244,23 @@ func buildItemsBlock(op *Operation) (*Attribute, []Diagnostic, error) {
 	return attr, nil, err
 }
 
+// SDKPackageForPath returns the versioned datadog-api-client-go package an
+// operation path belongs to, e.g. "/api/v2/teams/{id}" → "datadogV2". A path with
+// no version segment yields the bare "datadog" prefix, which is deliberately not
+// a real package: the emit builder fail-slows on it rather than emitting a broken
+// import.
+//
+// It is the one place this derivation lives, so the emitter, the SDK oneOf
+// binding pass and its corroboration test all agree on which package a union's
+// wrapper is declared in.
+func SDKPackageForPath(path string) string {
+	return "datadog" + strings.ToUpper(versionSegment(path))
+}
+
 // readCall resolves the datadog-api-client-go binding for op's read.
 func readCall(op *Operation) *SDKCall {
 	return &SDKCall{
-		GoPackage:      "datadog" + strings.ToUpper(versionSegment(op.Path)),
+		GoPackage:      SDKPackageForPath(op.Path),
 		GoApiStruct:    tagToClassName(op.Tag) + "Api",
 		GoMethod:       op.OperationId,
 		GoResponseType: op.ResponseRefName,

--- a/.generator-v2/internal/model/schema.go
+++ b/.generator-v2/internal/model/schema.go
@@ -343,6 +343,7 @@ func (b *treeBuilder) oneOfVariants(s *Schema, basePath string, mode nestingMode
 	envelope := &OneOfEnvelope{
 		Name:    spec.Name,
 		GoModel: oneOfModelName(spec.Name),
+		SDKType: spec.SDKType,
 		Path:    basePath,
 		// A nullable union maps to an absent envelope, so it is as optional as one
 		// whose containing field is optional.
@@ -437,6 +438,7 @@ func (b *treeBuilder) oneOfVariant(
 		// Carried through, never derived: SDK and Terraform naming diverge.
 		SDKField:       variant.SDKField,
 		SDKConstructor: variant.SDKConstructor,
+		SDKPointer:     variant.SDKPointer,
 		ValueWrapped:   valueWrapped,
 		Attribute:      block,
 	}, nil

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -111,6 +111,11 @@ type Operation struct {
 	Tracking *TrackingFieldMetadata
 	// RequestSchema is the resolved request body schema, if any.
 	RequestSchema *Schema
+	// RequestRefName is the last path segment of the request body $ref, e.g.
+	// "TeamCreateRequest" — the SDK Go request type, and the root the SDK oneOf
+	// binding pass walks from on the request side. Empty when the body is inline
+	// or absent.
+	RequestRefName string
 	// ResponseSchema is the resolved 2xx response schema, if any.
 	ResponseSchema *Schema
 	// ResponseRefName is the last path segment of the 2xx response body $ref,
@@ -199,6 +204,13 @@ type Schema struct {
 	// with the parser's actionable local diagnostic without aborting spec loading
 	// or preventing unrelated artifacts from being generated.
 	UnsupportedReason string
+	// RefName is the OpenAPI component name that supplied this node, e.g.
+	// "ActionConnectionAttributes"; empty for an inline schema. It is the identity
+	// the Datadog go-sdk names its generated model after, so the SDK binding pass
+	// walks the normalized tree and restarts its name accumulation at every node
+	// carrying one — mirroring how the SDK generator's child_models() prefers a
+	// $ref name over the parent-derived alternative name.
+	RefName string
 }
 
 // OneOfSpec is the normalized representation of an OpenAPI oneOf. The envelope
@@ -212,6 +224,15 @@ type OneOfSpec struct {
 	// Path is the canonical request/response schema path used for diagnostics
 	// and as an input to inline envelope naming.
 	Path string
+	// RefName is the OpenAPI component name of the union node itself, empty for an
+	// inline union. It is deliberately separate from Name: Name is a Terraform
+	// identity that falls back to a path-derived spelling, which must never be
+	// mistaken for an SDK type.
+	RefName string
+	// SDKType is the Datadog go-sdk oneOf wrapper struct for this union, e.g.
+	// "ActionConnectionIntegration". It is resolved by the SDK binding pass
+	// (internal/sdkbind) after normalization and stays empty until then.
+	SDKType string
 	// Optional permits the whole envelope to be absent because the containing
 	// OpenAPI field is not required.
 	Optional bool
@@ -251,6 +272,11 @@ type OneOfVariant struct {
 	// SDKConstructor is the generated SDK convenience constructor for this
 	// alternative, when the SDK exposes one.
 	SDKConstructor string
+	// SDKPointer is true when the wrapper member and its convenience constructor
+	// take a pointer, which is every alternative except a free-form object: the SDK
+	// emits that one as a bare map, already nil-able. Mappers must not take the
+	// address of a member the SDK left unpointered.
+	SDKPointer bool
 	// ValueWrapped is true for primitive, list, and map alternatives, whose
 	// Terraform variant model exposes a single field named value. Object
 	// alternatives expose their generated fields directly.
@@ -350,6 +376,11 @@ type OneOfEnvelope struct {
 	Name string
 	// GoModel is the generated Go struct holding one pointer field per variant.
 	GoModel string
+	// SDKType is the Datadog go-sdk oneOf wrapper struct this envelope maps to,
+	// carried through from OneOfSpec. It is a separate identity from Name and
+	// GoModel: an inline union's envelope name is path-derived and names no SDK
+	// struct. Empty until the SDK binding pass has run.
+	SDKType string
 	// Path is the union's own schema path, used by validators and diagnostics. For
 	// a collection of unions it is the element path (e.g. "response.choices[]"),
 	// which is not the path of any attribute in the tree.
@@ -383,6 +414,10 @@ type OneOfEnvelopeVariant struct {
 	// aws_integration binds to the SDK's AWSIntegration, not AwsIntegration).
 	SDKField       string
 	SDKConstructor string
+	// SDKPointer is true when the SDK wrapper member and its convenience
+	// constructor take a pointer — every alternative except a free-form object,
+	// which the SDK emits as a bare, already-nil-able map.
+	SDKPointer bool
 	// ValueWrapped is true for every non-object alternative — scalar, list, map, or
 	// a directly nested union — whose block holds a single child named "value".
 	// Object alternatives expose their own fields directly instead.

--- a/.generator-v2/internal/parser/schema.go
+++ b/.generator-v2/internal/parser/schema.go
@@ -179,6 +179,12 @@ func (n *schemaNormalizer) fillOperation(op *model.Operation, raw *v3.Operation)
 	}
 	if reqProxy := requestBodySchemaProxy(raw); reqProxy != nil {
 		required := raw.RequestBody.Required != nil && *raw.RequestBody.Required
+		// Capture the request type name before normalizeProxy follows the $ref and
+		// discards it — the mirror of ResponseRefName below. It is the SDK root the
+		// oneOf binding pass walks from on the request side.
+		if ref, ok := schemaRef(reqProxy); ok {
+			op.RequestRefName = lastRefSegment(ref)
+		}
 		req, err := n.normalizeProxyAt(reqProxy, 0, schemaContext{
 			path:     "request",
 			required: required,
@@ -479,6 +485,10 @@ func (n *schemaNormalizer) normalizeSchema(s *base.Schema, depth int, ctx schema
 		Enum:        enumValues(s),
 		Sensitive:   n.isSensitive(s),
 		Description: s.Description,
+		// The component name that led here, retained because the Datadog go-sdk
+		// names its generated model after it. ctx carries the first $ref of the
+		// chain; a node reached inline leaves this empty.
+		RefName: ctx.refName,
 	}
 
 	// The kind (set above by classifyKind) decides which children to recurse into
@@ -569,8 +579,12 @@ type oneOfAlternativeSource struct {
 // associated with the same alternative without guessing downstream.
 func (n *schemaNormalizer) normalizeOneOf(s *base.Schema, depth int, ctx schemaContext) (*model.OneOfSpec, error) {
 	union := &model.OneOfSpec{
-		Name:          oneOfEnvelopeName(ctx),
-		Path:          ctx.path,
+		Name: oneOfEnvelopeName(ctx),
+		Path: ctx.path,
+		// Kept apart from Name so the SDK binding pass can tell a component-backed
+		// union (whose wrapper is this name) from an inline one (whose wrapper it
+		// must derive from the SDK root), without inspecting Name's spelling.
+		RefName:       ctx.refName,
 		Optional:      !ctx.required,
 		Nullable:      schemaAllowsNull(s),
 		Discriminator: normalizeDiscriminator(s.Discriminator),


### PR DESCRIPTION
## Motivation

Groundwork for deriving the go-sdk oneOf wrapper bindings: the model needs somewhere to record which SDK type backs each union and each of its alternatives before anything can compute it.

## Changes

- Adds the binding fields to `Operation`, `Schema`, `OneOfSpec`, `OneOfVariant`, `OneOfEnvelope` and `OneOfEnvelopeVariant`.
- Has the parser carry the component identity it already resolves through to them.

Nothing reads these yet — the binder that fills them in is #4099 — but keeping the shape change separate keeps that PR to the derivation itself.

## Testing

`go build ./...` and `go test ./...` green. No behaviour change, so no new specs.


