### PR TITLE
[TFgen] (sdkbind) Derive Go types and wrapper members for oneOf variants

### DIFF
--- a/.generator-v2/internal/model/identifier.go
+++ b/.generator-v2/internal/model/identifier.go
@@ -51,8 +51,22 @@ func EscapeReservedKeyword(word string) string {
 	return word
 }
 
+// UpperFirst upper-cases the first rune and leaves the rest untouched, a port of
+// the SDK generator's utils.upperfirst. It is not a PascalCase conversion: the
+// SDK applies it to an already-formed name (a component name, or a Go type
+// spelling) when deriving a oneOf wrapper member, so "AWSIntegration" and
+// "string" must come back as "AWSIntegration" and "String" respectively.
+func UpperFirst(value string) string {
+	if value == "" {
+		return ""
+	}
+	runes := []rune(value)
+	return string(unicode.ToUpper(runes[0])) + string(runes[1:])
+}
+
 // SdkName translates an OpenAPI identifier into the PascalCase form used by
-// datadog-api-client-go.
+// datadog-api-client-go. It is the port of the SDK generator's
+// utils.camel_case (snake_case, then upperfirst each underscore-delimited part).
 //
 // OperationIds in the Datadog spec are already PascalCase and serve as SDK
 // method anchors directly; SdkName is for snake_case property and parameter names.

--- a/.generator-v2/internal/sdkbind/gotype.go
+++ b/.generator-v2/internal/sdkbind/gotype.go
@@ -1,0 +1,153 @@
+package sdkbind
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+)
+
+// This file ports the parts of the Datadog go-sdk generator that decide what a
+// oneOf wrapper's members are called. Everything here is a re-derivation from the
+// pinned generator's own source — never a lookup of the generated package, and
+// never reflection. The upstream sources are:
+//
+//	.generator/src/generator/templates/model_oneof.j2  (member + constructor shape)
+//	.generator/src/generator/openapi.py     type_to_go, get_name
+//	.generator/src/generator/formatter.py   simple_type
+//	.generator/src/generator/utils.py       upperfirst
+
+// simpleType ports formatter.simple_type with render_nullable=False, which is how
+// model_oneof.j2 calls it (`get_type(oneOf)` passes no render_nullable, so a
+// nullable alternative is NOT spelled datadog.Nullable<T> in a wrapper member —
+// the nullable spelling applies to simple_type in general, not to the oneOf
+// call site).
+//
+// The second result is false where the Python raises KeyError — an integer or
+// number carrying a format the SDK does not map — because there the SDK generator
+// itself cannot produce a type, so neither can a faithful derivation.
+func simpleType(s *model.Schema) (string, bool) {
+	if s == nil {
+		return "", false
+	}
+	switch s.Type {
+	case "integer":
+		switch s.Format {
+		case "", "int32":
+			return "int32", true
+		case "int64":
+			return "int64", true
+		default:
+			return "", false
+		}
+	case "number":
+		switch s.Format {
+		case "":
+			return "float", true
+		case "double":
+			return "float64", true
+		default:
+			return "", false
+		}
+	case "string":
+		// .get(type_format, "string"): an unmapped format falls back to string.
+		switch s.Format {
+		case "date", "date-time":
+			return "time.Time", true
+		case "binary":
+			return "_io.Reader", true
+		case "uuid":
+			return "uuid.UUID", true
+		default:
+			return "string", true
+		}
+	case "boolean":
+		return "bool", true
+	default:
+		return "", false
+	}
+}
+
+// memberBinding derives the SDK wrapper member for one alternative:
+// `(get_name(oneOf) or get_type(oneOf))|upperfirst` from model_oneof.j2, plus
+// whether that member is a pointer.
+//
+// A referenced alternative is named after its component — `get_name` wins over
+// the Go type spelling for the *name* even where simple_type would also answer —
+// so a variant Terraform calls aws_integration binds to the SDK's AWSIntegration
+// rather than to AwsIntegration.
+//
+// Every alternative is a pointer except a free-form object, which the SDK emits as
+// a bare map because it is already nil-able (model_oneof.j2's
+// isAdditionalPropertiesContainer).
+func memberBinding(v model.OneOfVariant) (name string, pointer bool, err error) {
+	if v.Schema == nil {
+		return "", false, fmt.Errorf("alternative has no normalized schema")
+	}
+	pointer = v.Schema.Kind != model.SchemaKindMap
+
+	if v.RefName != "" {
+		return model.UpperFirst(v.RefName), pointer, nil
+	}
+
+	// Anonymous alternative: the member name is its Go type spelling, so it exists
+	// only for the shapes type_to_go can spell as a Go identifier.
+	if len(v.Schema.Enum) > 0 {
+		// type_to_go skips simple_type when a schema has an enum and then finds no
+		// name, reaching `raise ValueError(f"Unknown type {type_}")`. The SDK cannot
+		// generate this wrapper at all.
+		return "", false, fmt.Errorf(
+			"anonymous enum alternative has no SDK member name (the go-sdk generator " +
+				"cannot name it either); promote it to a named schema component")
+	}
+	spelling, ok := simpleType(v.Schema)
+	if !ok {
+		return "", false, fmt.Errorf(
+			"anonymous %s alternative has no SDK member name; replace the inline "+
+				"alternative with a $ref to a named schema component",
+			describeKind(v.Schema))
+	}
+	name = model.UpperFirst(spelling)
+	// upperfirst of a qualified or composite spelling (time.Time, uuid.UUID,
+	// []Foo, map[string]Foo) is not a Go identifier, so the SDK would emit a
+	// wrapper that does not compile — meaning the specification never contains one.
+	// Fail here rather than derive a plausible name for a member that cannot exist.
+	if !isGoIdentifier(name) {
+		return "", false, fmt.Errorf(
+			"anonymous alternative of Go type %q would yield the SDK member %q, which is not a "+
+				"valid Go identifier, so the go-sdk emits no such member; replace the inline "+
+				"alternative with a $ref to a named schema component",
+			spelling, name)
+	}
+	return name, pointer, nil
+}
+
+// describeKind names a schema's shape for a diagnostic, preferring the OpenAPI
+// type when there is one so the reader can find the node in the specification.
+func describeKind(s *model.Schema) string {
+	if s.Type != "" {
+		if s.Format != "" {
+			return fmt.Sprintf("%s/%s", s.Type, s.Format)
+		}
+		return s.Type
+	}
+	return string(s.Kind)
+}
+
+// isGoIdentifier reports whether name is a legal, non-empty Go identifier. Go
+// keywords are not checked: every name reaching this point starts with an
+// upper-case rune, and no Go keyword does.
+func isGoIdentifier(name string) bool {
+	for i, r := range name {
+		switch {
+		case r == '_':
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+			if i == 0 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return name != ""
+}

--- a/.generator-v2/internal/sdkbind/gotype_test.go
+++ b/.generator-v2/internal/sdkbind/gotype_test.go
@@ -1,0 +1,178 @@
+package sdkbind
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+)
+
+// These specs pin the port of formatter.simple_type and of model_oneof.j2's member
+// rule against the pinned SDK generator's actual behaviour. They
+// deliberately include the four spellings a lookup-based spike inferred wrongly,
+// since a derivation that is wrong produces a plausible name rather than nothing.
+
+var _ = Describe("simpleType (port of formatter.simple_type)", func() {
+	DescribeTable("primitive Go spellings",
+		func(openapiType, format, want string, ok bool) {
+			got, derived := simpleType(&model.Schema{Type: openapiType, Format: format})
+			Expect(derived).To(Equal(ok))
+			Expect(got).To(Equal(want))
+		},
+		// integer: an unformatted integer is int32, NOT int64.
+		Entry("integer, no format", "integer", "", "int32", true),
+		Entry("integer/int32", "integer", "int32", "int32", true),
+		Entry("integer/int64", "integer", "int64", "int64", true),
+		// number: an unformatted number is float; only double is float64.
+		Entry("number, no format", "number", "", "float", true),
+		Entry("number/double", "number", "double", "float64", true),
+		// string: date and date-time both map to time.Time.
+		Entry("string, no format", "string", "", "string", true),
+		Entry("string/date", "string", "date", "time.Time", true),
+		Entry("string/date-time", "string", "date-time", "time.Time", true),
+		Entry("string/uuid", "string", "uuid", "uuid.UUID", true),
+		Entry("string/binary", "string", "binary", "_io.Reader", true),
+		// An unmapped string format falls back to string (.get default).
+		Entry("string/email falls back", "string", "email", "string", true),
+		Entry("boolean", "boolean", "", "bool", true),
+		// Where the Python raises KeyError the SDK cannot generate a type at all.
+		Entry("integer with unmapped format", "integer", "int16", "", false),
+		Entry("number with unmapped format", "number", "float", "", false),
+		Entry("object is not a simple type", "object", "", "", false),
+		Entry("untyped is not a simple type", "", "", "", false),
+	)
+
+	It("does not spell a nullable alternative as datadog.Nullable", func() {
+		// model_oneof.j2 calls get_type(oneOf) with no render_nullable, so the
+		// Nullable prefix never reaches a wrapper member. Nullability is carried on
+		// OneOfSpec.Nullable and represented by an absent envelope instead.
+		got, ok := simpleType(&model.Schema{Type: "string"})
+		Expect(ok).To(BeTrue())
+		Expect(got).To(Equal("string"))
+	})
+})
+
+var _ = Describe("memberBinding (port of model_oneof.j2's member rule)", func() {
+	It("names a referenced alternative after its component, not its Terraform name", func() {
+		// The SDK's get_name wins over the Go type spelling, and acronym casing is
+		// the component's own: AWSIntegration, never AwsIntegration.
+		name, pointer, err := memberBinding(model.OneOfVariant{
+			TFName:  "aws_integration",
+			RefName: "AWSIntegration",
+			Schema:  &model.Schema{Kind: model.SchemaKindObject, RefName: "AWSIntegration"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(name).To(Equal("AWSIntegration"))
+		Expect(pointer).To(BeTrue())
+	})
+
+	It("prefers the component name even where the alternative is a primitive", func() {
+		// get_name is checked before the type spelling, so a component that happens
+		// to be `type: string` binds to its own name.
+		name, _, err := memberBinding(model.OneOfVariant{
+			TFName:  "connection_id",
+			RefName: "ConnectionId",
+			Schema:  &model.Schema{Kind: model.SchemaKindPrimitive, Type: "string", RefName: "ConnectionId"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(name).To(Equal("ConnectionId"))
+	})
+
+	DescribeTable("names an anonymous primitive after its upperfirst Go spelling",
+		func(openapiType, format, want string) {
+			name, pointer, err := memberBinding(model.OneOfVariant{
+				TFName: "value",
+				Schema: &model.Schema{Kind: model.SchemaKindPrimitive, Type: openapiType, Format: format},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(name).To(Equal(want))
+			Expect(pointer).To(BeTrue())
+		},
+		Entry("string", "string", "", "String"),
+		Entry("boolean", "boolean", "", "Bool"),
+		Entry("integer", "integer", "", "Int32"),
+		Entry("integer/int64", "integer", "int64", "Int64"),
+		Entry("number", "number", "", "Float"),
+		Entry("number/double", "number", "double", "Float64"),
+	)
+
+	It("leaves a free-form object member unpointered", func() {
+		// isAdditionalPropertiesContainer: the SDK emits it as a bare map because a
+		// map is already nil-able, so a mapper must not take its address.
+		_, pointer, err := memberBinding(model.OneOfVariant{
+			TFName:  "metadata",
+			RefName: "FreeFormMetadata",
+			Schema:  &model.Schema{Kind: model.SchemaKindMap, RefName: "FreeFormMetadata"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pointer).To(BeFalse())
+	})
+
+	It("refuses an anonymous alternative whose Go spelling is not an identifier", func() {
+		// upperfirst("time.Time") is "Time.Time", which the SDK cannot declare as a
+		// member — so no such member exists and a derived name would be a lie.
+		_, _, err := memberBinding(model.OneOfVariant{
+			TFName: "date_time",
+			Schema: &model.Schema{Kind: model.SchemaKindPrimitive, Type: "string", Format: "date-time"},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("time.Time"))
+		Expect(err.Error()).To(ContainSubstring("not a valid Go identifier"))
+		Expect(err.Error()).To(ContainSubstring("$ref"))
+	})
+
+	It("refuses an anonymous enum alternative", func() {
+		_, _, err := memberBinding(model.OneOfVariant{
+			TFName: "status",
+			Schema: &model.Schema{Kind: model.SchemaKindPrimitive, Type: "string", Enum: []string{"a", "b"}},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("anonymous enum"))
+	})
+
+	It("refuses an anonymous object alternative", func() {
+		_, _, err := memberBinding(model.OneOfVariant{
+			TFName: "inline",
+			Schema: &model.Schema{Kind: model.SchemaKindObject},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no SDK member name"))
+		Expect(err.Error()).To(ContainSubstring("object"))
+	})
+
+	It("names the offending type and format when a format has no SDK spelling", func() {
+		// formatter.simple_type raises KeyError here, so the SDK cannot generate the
+		// wrapper. The diagnostic has to say which node, by its OpenAPI spelling.
+		_, _, err := memberBinding(model.OneOfVariant{
+			TFName: "count",
+			Schema: &model.Schema{Kind: model.SchemaKindPrimitive, Type: "integer", Format: "int16"},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("integer/int16"))
+	})
+
+	It("refuses an anonymous list alternative", func() {
+		// upperfirst("[]Foo") is not a Go identifier, so no such member exists.
+		_, _, err := memberBinding(model.OneOfVariant{
+			TFName: "items",
+			Schema: &model.Schema{Kind: model.SchemaKindArray},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("array"))
+	})
+
+	It("reports a missing normalized schema rather than panicking", func() {
+		_, _, err := memberBinding(model.OneOfVariant{TFName: "broken"})
+		Expect(err).To(MatchError(ContainSubstring("no normalized schema")))
+	})
+})
+
+var _ = Describe("UpperFirst", func() {
+	DescribeTable("upper-cases only the first rune",
+		func(in, want string) { Expect(model.UpperFirst(in)).To(Equal(want)) },
+		Entry("lower-case type spelling", "string", "String"),
+		Entry("already upper", "AWSIntegration", "AWSIntegration"),
+		Entry("preserves inner acronym", "int32", "Int32"),
+		Entry("empty", "", ""),
+	)
+})

--- a/.generator-v2/internal/sdkbind/sdkbind_suite_test.go
+++ b/.generator-v2/internal/sdkbind/sdkbind_suite_test.go
@@ -1,0 +1,13 @@
+package sdkbind
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSdkbind(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Sdkbind Suite")
+}


### PR DESCRIPTION
## Motivation

The pure naming half of the SDK oneOf binding, split from the binder that walks a spec (#4099) so each can be reviewed on its own.

## Changes

- `simpleType` spells the Go type of a primitive or referenced alternative.
- `memberBinding` derives the wrapper member the SDK generates for one alternative, and whether it is a pointer.
- Both are ports of the SDK generator's own rules, so the names we emit match `datadog-api-client-go` rather than approximating it. `memberBinding` leans on `model.UpperFirst` (`utils.upperfirst`), added here — deliberately *not* a PascalCase conversion, since it is applied to an already-formed name: `AWSIntegration` stays `AWSIntegration`, `string` becomes `String`.
- `describeKind` and `isGoIdentifier` support the error paths, so an alternative the SDK cannot name fails with the shape that caused it.

## Testing

`go build ./...` and `go test ./...` green. `gotype_test.go` exercises every branch. `golangci-lint run` reports no `unused` findings despite the binder not landing until the next PR — the unit tests are the consumers.


