### PR TITLE
[TFgen] (sdkbind) Derive the SDK oneOf wrapper bindings

### DIFF
--- a/.generator-v2/internal/cli/generate.go
+++ b/.generator-v2/internal/cli/generate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/emit"
 	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
 	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/parser"
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/sdkbind"
 )
 
 // errCheckFailed signals that --check found files that would change.
@@ -235,6 +236,14 @@ func generateArtifact(op *model.Operation, outputRoot, testsOutputRoot, examples
 			Message:  fmt.Sprintf("resource generation not yet supported (kind=%s)", op.Tracking.ArtifactKind),
 		}}
 		return entry, nil, nil, nil
+	}
+
+	// Resolve the SDK oneOf wrapper, members and constructors before the schema is
+	// projected, since the projection carries those bindings onto each envelope
+	// rather than deriving them. Binding is per operation, so an unresolvable union
+	// fails only this artifact.
+	if err := sdkbind.BindOperation(op); err != nil {
+		return failEntry(entry, err), nil, nil, nil
 	}
 
 	artifact, err := model.BuildArtifact(op)

--- a/.generator-v2/internal/sdkbind/bind.go
+++ b/.generator-v2/internal/sdkbind/bind.go
@@ -1,0 +1,279 @@
+// Package sdkbind resolves the Datadog go-sdk bindings for every OpenAPI oneOf
+// reachable from a normalized operation: the generated wrapper struct, and for
+// each alternative the wrapper member that selects it plus the convenience
+// constructor that builds it.
+//
+// It runs after parser normalization and before the Terraform projection, and it
+// writes only into OneOfSpec.SDKType and OneOfVariant.SDKField/SDKConstructor/
+// SDKPointer. The fields model.BuildResponseTree carries through onto each
+// OneOfEnvelope.
+//
+// Method of record : every name here is **re-derived** by reimplementing the go-sdk
+// generator's own logic over the same OpenAPI input. gotype.go holds the naming rules;
+// this file holds the walk that decides which generated model a union lives in.
+//
+// The walk exists because a wrapper's identity is positional, not local. The SDK
+// generator's child_models() names a model after its $ref component when it has
+// one, and otherwise after the accumulated path from the enclosing named model,
+// parent name plus camel_case(property), plus "Item" per array step. A Terraform
+// envelope name must never stand in for that: an inline union's envelope name is
+// path-derived for generated-model stability and names no SDK struct.
+package sdkbind
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+)
+
+// BindOperation resolves the SDK oneOf bindings for every union reachable from
+// op's request and response schemas, mutating the normalized schemas in place. It
+// is idempotent: re-running it over an already-bound operation recomputes the same
+// values.
+//
+// Failures are collected rather than returned on first sight, and the returned
+// *UnresolvedBindingError names the artifact, the operation, and every union path
+// and alternative it could not bind. Because binding is per operation, one
+// artifact's unresolvable union cannot stop another artifact from generating.
+//
+// A position whose SDK model name cannot be determined is walked *past*, not
+// abandoned: only a union actually standing at such a position fails, so an
+// unnameable branch holding no union costs nothing.
+func BindOperation(op *model.Operation) error {
+	if op == nil {
+		return nil
+	}
+	b := &binder{visited: make(map[visitKey]bool)}
+	// Each body root is the SDK type the operation's method signature names, which
+	// is where the SDK generator's own naming starts too.
+	b.walk(op.RequestSchema, op.RequestRefName, "request")
+	b.walk(op.ResponseSchema, op.ResponseRefName, "response")
+
+	if len(b.failures) == 0 {
+		return nil
+	}
+	return &UnresolvedBindingError{
+		Artifact:  artifactName(op),
+		Operation: op.OperationId,
+		Failures:  b.failures,
+	}
+}
+
+// BindSpec binds every operation in spec, returning one error per operation that
+// had an unresolvable union, keyed by operation. It exists for callers that want
+// to bind the whole spec up front; the generate path binds per artifact so a
+// failure lands on that artifact's report entry.
+func BindSpec(spec *model.Spec) map[*model.Operation]error {
+	if spec == nil {
+		return nil
+	}
+	var failed map[*model.Operation]error
+	for _, op := range spec.Operations {
+		if err := BindOperation(op); err != nil {
+			if failed == nil {
+				failed = make(map[*model.Operation]error)
+			}
+			failed[op] = err
+		}
+	}
+	return failed
+}
+
+type binder struct {
+	failures []Failure
+	// visited guards termination over the normalized graph, which is a DAG rather
+	// than a tree: mergeOneOfSiblings shares one sibling-constraint node across
+	// every alternative it was merged into. Keying on (node, SDK name) rather than
+	// on the node alone keeps a shared node bound correctly when two positions give
+	// it two different SDK names, instead of letting whichever position was walked
+	// first decide for both.
+	visited map[visitKey]bool
+}
+
+type visitKey struct {
+	schema  *model.Schema
+	sdkName string
+}
+
+// walk descends s, carrying the name of the generated SDK model this node lives
+// in. sdkName is empty at a position whose model the rules cannot name; the walk
+// continues so that only a union standing there fails.
+//
+// This mirrors openapi.child_models: a $ref restarts the name, an object property
+// appends camel_case(key), and an array element appends "Item".
+func (b *binder) walk(s *model.Schema, sdkName, path string) {
+	if s == nil {
+		return
+	}
+	// get_name(schema) or alternative_name: a component name always wins over the
+	// name accumulated from the parent.
+	if s.RefName != "" {
+		sdkName = s.RefName
+	}
+
+	key := visitKey{schema: s, sdkName: sdkName}
+	if b.visited[key] {
+		return
+	}
+	b.visited[key] = true
+
+	switch s.Kind {
+	case model.SchemaKindOneOf:
+		b.bindUnion(s.OneOf, sdkName, path)
+
+	case model.SchemaKindObject:
+		for _, name := range sortedKeys(s.Properties) {
+			b.walk(s.Properties[name], childModelName(sdkName, model.SdkName(name)), childPath(path, name))
+		}
+
+	case model.SchemaKindArray:
+		b.walk(s.Items, childModelName(sdkName, "Item"), childPath(path, "[]"))
+
+	case model.SchemaKindMap:
+		// child_models only recurses into additionalProperties when the value is a
+		// $ref, so a map value is nameable through its own component name or not at
+		// all: pass no accumulated name and let the $ref rule above supply one.
+		b.walk(s.Items, "", childPath(path, "{}"))
+	}
+}
+
+// bindUnion resolves one union's wrapper and members. The wrapper is the generated
+// model the union node itself became: its component name when it has one, else the
+// name the walk accumulated (model_oneof.j2's `name`).
+func (b *binder) bindUnion(spec *model.OneOfSpec, sdkName, path string) {
+	if spec == nil {
+		return
+	}
+	// Prefer the union's own component name over the accumulated one. They agree
+	// wherever both exist — the walk sets sdkName from the same RefName — but the
+	// spec's copy is the identity the parser recorded, so read it directly.
+	wrapper := spec.RefName
+	if wrapper == "" {
+		wrapper = sdkName
+	}
+	unionPath := spec.Path
+	if unionPath == "" {
+		unionPath = path
+	}
+
+	if wrapper == "" {
+		b.failures = append(b.failures, Failure{
+			Path: unionPath,
+			Reason: "inline union sits at a position with no generated SDK model to name its " +
+				"wrapper (the go-sdk names an inline model after the enclosing model plus the " +
+				"property path, which does not resolve here); replace the inline oneOf with a " +
+				"$ref to a named schema component",
+		})
+		// Still bind the members below: their names do not depend on the wrapper, and
+		// reporting one wrapper failure is more useful than also reporting every
+		// alternative as unbound.
+	}
+	spec.SDKType = wrapper
+
+	for i := range spec.Variants {
+		v := &spec.Variants[i]
+		member, pointer, err := memberBinding(*v)
+		if err != nil {
+			b.failures = append(b.failures, Failure{
+				Path:    unionPath,
+				Variant: v.TFName,
+				Reason:  err.Error(),
+			})
+			v.SDKField, v.SDKConstructor, v.SDKPointer = "", "", false
+			continue
+		}
+		v.SDKField = member
+		v.SDKPointer = pointer
+		// model_oneof.j2 emits `<Member>As<Union>` for every alternative,
+		// unconditionally — so this is never optional, and an empty wrapper name
+		// leaves it empty rather than half-formed.
+		if wrapper != "" {
+			v.SDKConstructor = member + "As" + wrapper
+		} else {
+			v.SDKConstructor = ""
+		}
+
+		// An alternative may itself be a union, or contain one.
+		b.walk(v.Schema, v.RefName, childPath(unionPath, v.TFName))
+	}
+}
+
+// childModelName appends one path step to an accumulated SDK model name. An empty
+// parent stays empty: child_models has no name to build on either, so the child is
+// unnameable rather than named after the step alone.
+func childModelName(parent, step string) string {
+	if parent == "" {
+		return ""
+	}
+	return parent + step
+}
+
+// childPath mirrors the parser's path spelling so a binding diagnostic points at
+// the same node a normalization diagnostic would.
+func childPath(parent, child string) string {
+	if parent == "" {
+		return child
+	}
+	if child == "[]" || child == "{}" {
+		return parent + child
+	}
+	return parent + "." + child
+}
+
+func sortedKeys(m map[string]*model.Schema) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func artifactName(op *model.Operation) string {
+	if op.Tracking != nil {
+		return op.Tracking.ArtifactName
+	}
+	return ""
+}
+
+// Failure is one union (or one of its alternatives) the derivation could not bind.
+type Failure struct {
+	// Path is the union's schema path, e.g. "response.data.attributes.integration".
+	Path string
+	// Variant is the Terraform variant name when the failure is specific to one
+	// alternative, empty when it concerns the wrapper itself.
+	Variant string
+	// Reason states what could not be derived and what the maintainer can do.
+	Reason string
+}
+
+// UnresolvedBindingError reports every SDK oneOf binding an operation could not
+// resolve. It names the artifact, operation, union path and alternative so the
+// diagnostic is actionable without reading the specification.
+type UnresolvedBindingError struct {
+	Artifact  string
+	Operation string
+	Failures  []Failure
+}
+
+func (e *UnresolvedBindingError) Error() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "sdkbind: artifact %q operation %q: %d unresolved SDK oneOf binding(s):",
+		e.Artifact, e.Operation, len(e.Failures))
+	for _, f := range e.Failures {
+		b.WriteString("\n  ")
+		b.WriteString(f.Path)
+		if f.Variant != "" {
+			b.WriteString(" variant ")
+			b.WriteString(f.Variant)
+		}
+		b.WriteString(": ")
+		b.WriteString(f.Reason)
+	}
+	return b.String()
+}

--- a/.generator-v2/internal/sdkbind/bind_test.go
+++ b/.generator-v2/internal/sdkbind/bind_test.go
@@ -1,0 +1,262 @@
+package sdkbind
+
+import (
+	"errors"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/parser"
+)
+
+var placementSpec = filepath.Join("../testdata/sdkbind", "bind_placement.yaml")
+
+// loadBound loads the placement fixture and binds every operation, returning the
+// operations keyed by operationId together with each one's binding error.
+func loadBound() (map[string]*model.Operation, map[string]error) {
+	GinkgoHelper()
+	spec, err := parser.LoadSpec(placementSpec)
+	Expect(err).To(Succeed())
+
+	ops := make(map[string]*model.Operation, len(spec.Operations))
+	errs := make(map[string]error, len(spec.Operations))
+	for _, op := range spec.Operations {
+		ops[op.OperationId] = op
+		if bindErr := BindOperation(op); bindErr != nil {
+			errs[op.OperationId] = bindErr
+		}
+	}
+	return ops, errs
+}
+
+// unionAt walks a normalized schema down a slash-delimited path of steps, where a
+// step is a property name, "[]" for an array element, or "{}" for a map value, and
+// returns the OneOfSpec it lands on.
+func unionAt(root *model.Schema, steps ...string) *model.OneOfSpec {
+	GinkgoHelper()
+	node := root
+	for _, step := range steps {
+		Expect(node).NotTo(BeNil(), "walked off the tree before %q", step)
+		switch step {
+		case "[]", "{}":
+			node = node.Items
+		default:
+			Expect(node.Properties).To(HaveKey(step))
+			node = node.Properties[step]
+		}
+	}
+	Expect(node).NotTo(BeNil())
+	Expect(node.Kind).To(Equal(model.SchemaKindOneOf), "node is %s, not a union", node.Kind)
+	Expect(node.OneOf).NotTo(BeNil())
+	return node.OneOf
+}
+
+// variant returns the named alternative of a union.
+func variant(spec *model.OneOfSpec, tfName string) model.OneOfVariant {
+	GinkgoHelper()
+	for _, v := range spec.Variants {
+		if v.TFName == tfName {
+			return v
+		}
+	}
+	Fail("union " + spec.Path + " has no variant " + tfName)
+	return model.OneOfVariant{}
+}
+
+var _ = Describe("BindOperation", func() {
+
+	Context("wrapper placement", func() {
+		It("binds a component-backed union to its own component name", func() {
+			ops, errs := loadBound()
+			Expect(errs).NotTo(HaveKey("GetWidget"))
+
+			union := unionAt(ops["GetWidget"].ResponseSchema, "data", "attributes", "integration")
+			Expect(union.SDKType).To(Equal("WidgetIntegration"))
+			Expect(union.RefName).To(Equal("WidgetIntegration"))
+		})
+
+		It("binds an inline union to the enclosing model plus the property name", func() {
+			// child_models names an inline model <parent><CamelProperty>, so the union
+			// at WidgetAttributes.inline_choice is WidgetAttributesInlineChoice — a name
+			// the Terraform envelope identity (path-derived) would never produce.
+			ops, _ := loadBound()
+			union := unionAt(ops["GetWidget"].ResponseSchema, "data", "attributes", "inline_choice")
+			Expect(union.SDKType).To(Equal("WidgetAttributesInlineChoice"))
+			Expect(union.RefName).To(BeEmpty())
+			Expect(union.Name).NotTo(Equal(union.SDKType),
+				"the Terraform envelope name must not be reused as the SDK wrapper")
+		})
+
+		It("appends Item for an inline union in a list", func() {
+			ops, _ := loadBound()
+			union := unionAt(ops["GetWidget"].ResponseSchema, "data", "attributes", "choices", "[]")
+			Expect(union.SDKType).To(Equal("WidgetAttributesChoicesItem"))
+		})
+
+		It("binds a union at the response root to the response type", func() {
+			ops, errs := loadBound()
+			Expect(errs).NotTo(HaveKey("GetRoot"))
+
+			root := ops["GetRoot"].ResponseSchema
+			Expect(root.Kind).To(Equal(model.SchemaKindOneOf))
+			Expect(root.OneOf.SDKType).To(Equal("RootUnion"))
+		})
+
+		It("binds a union nested inside another union's alternative", func() {
+			ops, _ := loadBound()
+			outer := unionAt(ops["GetWidget"].ResponseSchema, "data", "attributes", "integration")
+			aws := variant(outer, "aws_integration")
+			inner := unionAt(aws.Schema, "credentials")
+			Expect(inner.SDKType).To(Equal("AWSCredentials"))
+		})
+
+		It("binds a union on the request side from the request root", func() {
+			ops, errs := loadBound()
+			Expect(errs).NotTo(HaveKey("CreateWidget"))
+
+			op := ops["CreateWidget"]
+			Expect(op.RequestRefName).To(Equal("WidgetCreateRequest"),
+				"the request $ref name is the SDK root the request-side walk starts from")
+			union := unionAt(op.RequestSchema, "data", "attributes", "payload")
+			Expect(union.SDKType).To(Equal("WidgetCreateAttributesPayload"))
+		})
+	})
+
+	Context("members and constructors", func() {
+		It("binds each referenced alternative to its component member and constructor", func() {
+			ops, _ := loadBound()
+			union := unionAt(ops["GetWidget"].ResponseSchema, "data", "attributes", "integration")
+
+			aws := variant(union, "aws_integration")
+			Expect(aws.SDKField).To(Equal("AWSIntegration"))
+			Expect(aws.SDKConstructor).To(Equal("AWSIntegrationAsWidgetIntegration"))
+			Expect(aws.SDKPointer).To(BeTrue())
+
+			http := variant(union, "http_integration")
+			Expect(http.SDKField).To(Equal("HTTPIntegration"))
+			Expect(http.SDKConstructor).To(Equal("HTTPIntegrationAsWidgetIntegration"))
+		})
+
+		It("binds a primitive alternative to its upperfirst Go spelling", func() {
+			ops, _ := loadBound()
+			union := unionAt(ops["GetWidget"].ResponseSchema, "data", "attributes", "inline_choice")
+
+			str := variant(union, "string")
+			Expect(str.SDKField).To(Equal("String"))
+			Expect(str.SDKConstructor).To(Equal("StringAsWidgetAttributesInlineChoice"))
+
+			b := variant(union, "boolean")
+			Expect(b.SDKField).To(Equal("Bool"))
+			Expect(b.SDKConstructor).To(Equal("BoolAsWidgetAttributesInlineChoice"))
+		})
+
+		It("emits a constructor for every alternative, never only some", func() {
+			// model_oneof.j2 emits <Member>As<Union> unconditionally; treating it as
+			// optional silently degrades request mapping to direct member assignment.
+			ops, _ := loadBound()
+			for _, union := range []*model.OneOfSpec{
+				unionAt(ops["GetWidget"].ResponseSchema, "data", "attributes", "integration"),
+				unionAt(ops["GetWidget"].ResponseSchema, "data", "attributes", "inline_choice"),
+				unionAt(ops["GetWidget"].ResponseSchema, "data", "attributes", "choices", "[]"),
+				unionAt(ops["CreateWidget"].RequestSchema, "data", "attributes", "payload"),
+			} {
+				Expect(union.Variants).NotTo(BeEmpty())
+				for _, v := range union.Variants {
+					Expect(v.SDKConstructor).To(Equal(v.SDKField+"As"+union.SDKType),
+						"union %s variant %s", union.Path, v.TFName)
+				}
+			}
+		})
+
+		It("binds an integer alternative to Int32, not Int64", func() {
+			ops, _ := loadBound()
+			union := unionAt(ops["CreateWidget"].RequestSchema, "data", "attributes", "payload")
+			Expect(variant(union, "integer").SDKField).To(Equal("Int32"))
+		})
+	})
+
+	Context("unresolvable positions", func() {
+		It("fails the union whose position no SDK model names", func() {
+			_, errs := loadBound()
+
+			err := errs["GetWidgetUnnamed"]
+			Expect(err).To(HaveOccurred())
+
+			var unresolved *UnresolvedBindingError
+			Expect(errors.As(err, &unresolved)).To(BeTrue())
+			Expect(unresolved.Artifact).To(Equal("widget_unnamed"))
+			Expect(unresolved.Operation).To(Equal("GetWidgetUnnamed"))
+			Expect(unresolved.Failures).To(HaveLen(1))
+			Expect(unresolved.Failures[0].Path).To(Equal("response.by_key{}"))
+			Expect(unresolved.Failures[0].Reason).To(ContainSubstring("$ref"))
+		})
+
+		It("does not fail an unrelated artifact for it", func() {
+			// Binding is per operation, so one artifact's unnameable union leaves the
+			// others generable.
+			_, errs := loadBound()
+			Expect(errs).NotTo(HaveKey("GetWidget"))
+			Expect(errs).NotTo(HaveKey("CreateWidget"))
+			Expect(errs).NotTo(HaveKey("GetRoot"))
+		})
+
+		It("names the artifact, operation and union path in its diagnostic", func() {
+			_, errs := loadBound()
+			msg := errs["GetWidgetUnnamed"].Error()
+			Expect(msg).To(ContainSubstring("widget_unnamed"))
+			Expect(msg).To(ContainSubstring("GetWidgetUnnamed"))
+			Expect(msg).To(ContainSubstring("response.by_key{}"))
+		})
+
+		It("leaves no half-formed constructor on an unbound union", func() {
+			ops, _ := loadBound()
+			union := unionAt(ops["GetWidgetUnnamed"].ResponseSchema, "by_key", "{}")
+			Expect(union.SDKType).To(BeEmpty())
+			Expect(union.Variants).NotTo(BeEmpty())
+			for _, v := range union.Variants {
+				Expect(v.SDKConstructor).To(BeEmpty(),
+					"variant %s got a constructor without a wrapper to build", v.TFName)
+			}
+		})
+	})
+
+	Context("contract", func() {
+		It("is idempotent", func() {
+			ops, _ := loadBound()
+			op := ops["GetWidget"]
+			union := unionAt(op.ResponseSchema, "data", "attributes", "integration")
+			before := *union
+
+			Expect(BindOperation(op)).To(Succeed())
+			after := unionAt(op.ResponseSchema, "data", "attributes", "integration")
+			Expect(after.SDKType).To(Equal(before.SDKType))
+			Expect(after.Variants).To(Equal(before.Variants))
+		})
+
+		It("tolerates a nil operation and empty schemas", func() {
+			Expect(BindOperation(nil)).To(Succeed())
+			Expect(BindOperation(&model.Operation{OperationId: "Empty"})).To(Succeed())
+		})
+
+		It("binds every operation of a spec through BindSpec", func() {
+			spec, err := parser.LoadSpec(placementSpec)
+			Expect(err).To(Succeed())
+
+			failed := BindSpec(spec)
+			var failedIDs []string
+			for op := range failed {
+				failedIDs = append(failedIDs, op.OperationId)
+			}
+			Expect(failedIDs).To(ConsistOf("GetWidgetUnnamed"))
+
+			for _, op := range spec.Operations {
+				if op.OperationId != "GetRoot" {
+					continue
+				}
+				Expect(op.ResponseSchema.OneOf.SDKType).To(Equal("RootUnion"))
+			}
+		})
+	})
+})

--- a/.generator-v2/internal/sdkbind/corroborate_test.go
+++ b/.generator-v2/internal/sdkbind/corroborate_test.go
@@ -1,0 +1,339 @@
+//go:build integration
+
+// This test corroborates the derivation in bind.go/gotype.go against the pinned
+// datadog-api-client-go, and is the one place in this package that reads generated
+// SDK source. It exists because a derivation fails differently from a lookup: a
+// lookup that misses returns nothing, while a wrong derivation returns a plausible
+// name for a symbol that does not exist,
+//
+// It is corroboration, never the source of a name and it reads declarations with
+// go/ast only.
+//
+// Behind -tags=integration because it shells out to `go list -m` and parses a few
+// thousand generated files, neither of which belongs in the default unit run.
+package sdkbind
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.yaml.in/yaml/v4"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+	tfparser "github.com/terraform-providers/terraform-provider-datadog/generator/internal/parser"
+)
+
+// corpusDir holds the checked-in mini-OAS slices: real Datadog response shapes,
+// unannotated, which this test annotates in memory to opt each read operation in.
+const corpusDir = "../testdata/mini-oas"
+
+// providerRoot is the provider module, whose go.mod pins the SDK this generator's
+// output must compile against.
+const providerRoot = "../../.."
+
+// packageDecls is what one generated SDK package declares, read from source.
+type packageDecls struct {
+	// structFields maps a struct type name to its field names.
+	structFields map[string][]string
+	// funcs holds every top-level function name.
+	funcs map[string]bool
+}
+
+func (d packageDecls) hasField(structName, field string) bool {
+	for _, f := range d.structFields[structName] {
+		if f == field {
+			return true
+		}
+	}
+	return false
+}
+
+// sdkPackageDecls parses <sdk>/api/<pkg> and returns its declarations. It reads
+// only exported declarations' names, never types, so nothing here depends on the
+// SDK being linkable.
+func sdkPackageDecls(pkg string) (packageDecls, error) {
+	sdkDir, err := sdkModuleDir()
+	if err != nil {
+		return packageDecls{}, err
+	}
+	dir := filepath.Join(sdkDir, "api", pkg)
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, dir, nil, parser.SkipObjectResolution)
+	if err != nil {
+		return packageDecls{}, err
+	}
+
+	decls := packageDecls{
+		structFields: make(map[string][]string),
+		funcs:        make(map[string]bool),
+	}
+	for _, p := range pkgs {
+		for _, file := range p.Files {
+			for _, d := range file.Decls {
+				switch decl := d.(type) {
+				case *ast.FuncDecl:
+					if decl.Recv == nil {
+						decls.funcs[decl.Name.Name] = true
+					}
+				case *ast.GenDecl:
+					for _, spec := range decl.Specs {
+						ts, ok := spec.(*ast.TypeSpec)
+						if !ok {
+							continue
+						}
+						st, ok := ts.Type.(*ast.StructType)
+						if !ok {
+							continue
+						}
+						var fields []string
+						for _, f := range st.Fields.List {
+							for _, name := range f.Names {
+								fields = append(fields, name.Name)
+							}
+						}
+						decls.structFields[ts.Name.Name] = fields
+					}
+				}
+			}
+		}
+	}
+	return decls, nil
+}
+
+// sdkModuleDir resolves the pinned SDK's module directory through the provider
+// module, so the version read is exactly the one the provider builds against.
+func sdkModuleDir() (string, error) {
+	cmd := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", "github.com/DataDog/datadog-api-client-go/v2")
+	cmd.Dir = providerRoot
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// annotatedCorpus loads every mini-OAS slice with its by-id (else first) GET
+// annotated as a singular data source, and binds it. It returns the operations
+// that carry at least one union, keyed by "<artifact>:<operationId>".
+func annotatedCorpus() map[string]*model.Operation {
+	GinkgoHelper()
+	entries, err := os.ReadDir(corpusDir)
+	Expect(err).To(Succeed())
+
+	tmp := GinkgoT().TempDir()
+	withUnions := make(map[string]*model.Operation)
+
+	for _, e := range entries {
+		name, ok := strings.CutPrefix(e.Name(), "mini-datadog_")
+		if !ok || !strings.HasSuffix(name, ".yaml") {
+			continue
+		}
+		artifact := strings.TrimSuffix(name, ".yaml")
+
+		annotated, ok := annotateReadOp(filepath.Join(corpusDir, e.Name()), artifact, tmp)
+		if !ok {
+			continue
+		}
+		spec, err := tfparser.LoadSpec(annotated)
+		if err != nil {
+			// A slice the parser rejects outright (e.g. a $ref cycle) has no bindings
+			// to corroborate; the corpus-level failures are tracked as their own tasks.
+			continue
+		}
+		for _, op := range spec.Operations {
+			if op.Tracking == nil {
+				continue
+			}
+			_ = BindOperation(op) // failures are asserted separately; bound unions still count
+			if len(collectUnions(op)) > 0 {
+				withUnions[artifact+":"+op.OperationId] = op
+			}
+		}
+	}
+	return withUnions
+}
+
+// annotateReadOp writes a copy of the slice at src with its read operation opted
+// in, and returns the copy's path. It mirrors the README's documented annotation.
+func annotateReadOp(src, artifact, tmpDir string) (string, bool) {
+	GinkgoHelper()
+	raw, err := os.ReadFile(src)
+	Expect(err).To(Succeed())
+
+	var doc yaml.Node
+	Expect(yaml.Unmarshal(raw, &doc)).To(Succeed())
+
+	var spec map[string]any
+	Expect(yaml.Unmarshal(raw, &spec)).To(Succeed())
+
+	paths, ok := spec["paths"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	// Prefer a by-id GET (a path with a {param}); that is the singular read.
+	var chosenPath string
+	var chosenOp map[string]any
+	for _, p := range sortedMapKeys(paths) {
+		item, ok := paths[p].(map[string]any)
+		if !ok {
+			continue
+		}
+		get, ok := item["get"].(map[string]any)
+		if !ok || get["operationId"] == nil {
+			continue
+		}
+		if chosenOp == nil || (!strings.Contains(chosenPath, "{") && strings.Contains(p, "{")) {
+			chosenPath, chosenOp = p, get
+		}
+	}
+	if chosenOp == nil {
+		return "", false
+	}
+	chosenOp["x-datadog-tf-generator"] = map[string]any{
+		"artifact_kind": "data_source",
+		"artifact_name": artifact,
+		"group":         map[string]any{"read": chosenOp["operationId"]},
+	}
+
+	out, err := yaml.Marshal(spec)
+	Expect(err).To(Succeed())
+	dst := filepath.Join(tmpDir, artifact+".yaml")
+	Expect(os.WriteFile(dst, out, 0o600)).To(Succeed())
+	return dst, true
+}
+
+func sortedMapKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// collectUnions returns every union reachable from op's request and response
+// schemas, keyed by schema path.
+func collectUnions(op *model.Operation) map[string]*model.OneOfSpec {
+	found := make(map[string]*model.OneOfSpec)
+	seen := make(map[*model.Schema]bool)
+	var walk func(s *model.Schema)
+	walk = func(s *model.Schema) {
+		if s == nil || seen[s] {
+			return
+		}
+		seen[s] = true
+		if s.Kind == model.SchemaKindOneOf && s.OneOf != nil {
+			found[s.OneOf.Path] = s.OneOf
+			for _, v := range s.OneOf.Variants {
+				walk(v.Schema)
+			}
+			return
+		}
+		for _, child := range s.Properties {
+			walk(child)
+		}
+		walk(s.Items)
+	}
+	walk(op.RequestSchema)
+	walk(op.ResponseSchema)
+	return found
+}
+
+var _ = Describe("SDK oneOf binding, corroborated against the pinned SDK", func() {
+
+	It("resolves every union in the mini-OAS corpus to a wrapper, member and constructor that exist", func() {
+		corpus := annotatedCorpus()
+		Expect(corpus).NotTo(BeEmpty(), "no corpus slice produced a union to corroborate")
+
+		declsByPackage := make(map[string]packageDecls)
+		var problems []string
+		var checked int
+
+		for key, op := range corpus {
+			pkg := model.SDKPackageForPath(op.Path)
+			decls, ok := declsByPackage[pkg]
+			if !ok {
+				var err error
+				decls, err = sdkPackageDecls(pkg)
+				Expect(err).To(Succeed(), "reading SDK package %s", pkg)
+				declsByPackage[pkg] = decls
+			}
+
+			for path, union := range collectUnions(op) {
+				if union.SDKType == "" {
+					// An unresolved union is reported by BindOperation as a diagnostic, not
+					// a wrong name; it is out of scope for a name-existence check.
+					continue
+				}
+				checked++
+				if _, exists := decls.structFields[union.SDKType]; !exists {
+					problems = append(problems, key+" "+path+
+						": derived wrapper "+pkg+"."+union.SDKType+" is not declared in the SDK")
+					continue
+				}
+				if !decls.hasField(union.SDKType, "UnparsedObject") {
+					problems = append(problems, key+" "+path+
+						": derived wrapper "+union.SDKType+" is not a oneOf wrapper (no UnparsedObject member)")
+				}
+				for _, v := range union.Variants {
+					if v.SDKField == "" {
+						continue
+					}
+					if !decls.hasField(union.SDKType, v.SDKField) {
+						problems = append(problems, key+" "+path+" variant "+v.TFName+
+							": derived member "+union.SDKType+"."+v.SDKField+" is not declared")
+					}
+					if !decls.funcs[v.SDKConstructor] {
+						problems = append(problems, key+" "+path+" variant "+v.TFName+
+							": derived constructor "+pkg+"."+v.SDKConstructor+" is not declared")
+					}
+				}
+			}
+		}
+
+		// Reported so a shrinking corpus is visible rather than silently vacuous: a
+		// corroboration that checks nothing passes just as loudly as one that checks
+		// everything.
+		AddReportEntry("unions corroborated", checked)
+		AddReportEntry("corpus operations with unions", len(corpus))
+
+		Expect(checked).To(BeNumerically(">", 0), "no bound union was corroborated")
+		Expect(problems).To(BeEmpty(), "derived SDK bindings that do not exist in the pinned SDK")
+	})
+
+	It("binds every alternative of action_connection's integration union", func() {
+		// The acceptance bar: 25 unions, and every outer alternative
+		// resolving both a member and a constructor.
+		corpus := annotatedCorpus()
+		var op *model.Operation
+		for key, candidate := range corpus {
+			if strings.HasPrefix(key, "action_connection:") {
+				op = candidate
+				break
+			}
+		}
+		Expect(op).NotTo(BeNil(), "action_connection produced no union")
+
+		unions := collectUnions(op)
+		Expect(len(unions)).To(BeNumerically(">=", 25),
+			"expected the integration union plus one credentials union per integration variant")
+
+		integration := unions["response.data.attributes.integration"]
+		Expect(integration).NotTo(BeNil())
+		Expect(integration.SDKType).To(Equal("ActionConnectionIntegration"))
+		Expect(integration.Variants).To(HaveLen(24))
+		for _, v := range integration.Variants {
+			Expect(v.SDKField).NotTo(BeEmpty(), "variant %s bound no SDK member", v.TFName)
+			Expect(v.SDKConstructor).To(Equal(v.SDKField+"AsActionConnectionIntegration"),
+				"variant %s", v.TFName)
+		}
+	})
+})

--- a/.generator-v2/internal/testdata/sdkbind/bind_placement.yaml
+++ b/.generator-v2/internal/testdata/sdkbind/bind_placement.yaml
@@ -1,0 +1,210 @@
+# Fixture for internal/sdkbind: every position a oneOf can occupy relative to the
+# Datadog go-sdk's generated models, so the binding walk is exercised against the
+# real parser rather than hand-built model structs.
+#
+# Expected SDK wrapper per union (derived per child_models):
+#   response.data.attributes.integration          → WidgetIntegration   ($ref)
+#   response.data.attributes.inline_choice        → WidgetAttributesInlineChoice
+#   response.data.attributes.choices[]            → WidgetAttributesChoicesItem
+#   …integration.aws_integration.credentials      → AWSCredentials       ($ref)
+#   request.data.attributes.payload               → WidgetCreateAttributesPayload
+#   response (root)                               → RootUnion           ($ref)
+#
+# GetWidgetUnnamed is the one operation expected to fail, and it is kept separate
+# so every other operation binds cleanly: its union sits at a map value, a position
+# child_models only descends into through a $ref, so no generated model names it.
+#   response.by_key{}                             → (none)
+openapi: 3.0.0
+info:
+  title: sdkbind placement fixture
+  version: "1.0"
+paths:
+  /api/v2/widgets/{widget_id}:
+    get:
+      operationId: GetWidget
+      tags:
+        - Widgets
+      x-datadog-tf-generator:
+        artifact_kind: data_source
+        artifact_name: widget
+        group:
+          read: GetWidget
+      parameters:
+        - name: widget_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WidgetResponse'
+  /api/v2/widgets:
+    post:
+      operationId: CreateWidget
+      tags:
+        - Widgets
+      x-datadog-tf-generator:
+        artifact_kind: resource
+        artifact_name: widget_create
+        group:
+          # read is required by the tracking-field contract (a group must name a
+          # read or a search); only the create half matters to this fixture.
+          create: CreateWidget
+          read: GetWidget
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WidgetCreateRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WidgetCreateResponse'
+  /api/v2/unnamed/{widget_id}:
+    get:
+      operationId: GetWidgetUnnamed
+      tags:
+        - Widgets
+      x-datadog-tf-generator:
+        artifact_kind: data_source
+        artifact_name: widget_unnamed
+        group:
+          read: GetWidgetUnnamed
+      parameters:
+        - name: widget_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WidgetUnnamedResponse'
+  /api/v2/roots:
+    get:
+      operationId: GetRoot
+      tags:
+        - Widgets
+      x-datadog-tf-generator:
+        artifact_kind: data_source
+        artifact_name: root
+        group:
+          read: GetRoot
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RootUnion'
+components:
+  schemas:
+    WidgetResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/Widget'
+    Widget:
+      type: object
+      properties:
+        id:
+          type: string
+        attributes:
+          $ref: '#/components/schemas/WidgetAttributes'
+    WidgetAttributes:
+      type: object
+      description: The definition of `WidgetAttributes` object.
+      properties:
+        integration:
+          $ref: '#/components/schemas/WidgetIntegration'
+        inline_choice:
+          description: An inline union, named after the enclosing model plus the property.
+          oneOf:
+            - type: string
+            - type: boolean
+        choices:
+          type: array
+          description: A list whose element is an inline union.
+          items:
+            oneOf:
+              - type: string
+              - $ref: '#/components/schemas/WidgetSetting'
+    WidgetIntegration:
+      description: The definition of `WidgetIntegration` object.
+      oneOf:
+        - $ref: '#/components/schemas/AWSIntegration'
+        - $ref: '#/components/schemas/HTTPIntegration'
+    AWSIntegration:
+      type: object
+      properties:
+        credentials:
+          $ref: '#/components/schemas/AWSCredentials'
+    AWSCredentials:
+      description: A union nested inside another union's alternative.
+      oneOf:
+        - $ref: '#/components/schemas/AWSAssumeRole'
+    AWSAssumeRole:
+      type: object
+      properties:
+        role_name:
+          type: string
+    HTTPIntegration:
+      type: object
+      properties:
+        base_url:
+          type: string
+    WidgetSetting:
+      type: object
+      properties:
+        name:
+          type: string
+    RootUnion:
+      description: A union at the response root.
+      oneOf:
+        - $ref: '#/components/schemas/WidgetSetting'
+        - type: string
+    WidgetCreateRequest:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/WidgetCreateData'
+    WidgetCreateData:
+      type: object
+      properties:
+        attributes:
+          $ref: '#/components/schemas/WidgetCreateAttributes'
+    WidgetCreateAttributes:
+      type: object
+      properties:
+        payload:
+          description: An inline union on the request side.
+          oneOf:
+            - type: string
+            - type: integer
+    WidgetCreateResponse:
+      type: object
+      description: Kept union-free so the create operation exercises only the request walk.
+      properties:
+        data:
+          $ref: '#/components/schemas/WidgetSetting'
+    WidgetUnnamedResponse:
+      type: object
+      properties:
+        by_key:
+          type: object
+          description: A map whose value is an inline union — no SDK model names it.
+          additionalProperties:
+            oneOf:
+              - type: string
+              - type: boolean


### PR DESCRIPTION
## Motivation

The emit path cannot render a oneOf envelope without knowing which go-sdk type backs it: the SDK wraps each union in a generated struct exposing plain pointer members and `GetActualInstance`, not the `Get<Field>Ok` getters the state mapper is built on.

## Changes

- `binder.walk` descends an operation's schemas carrying the SDK type name alongside the path, so each union is bound to the wrapper the SDK actually generates *for its placement* — a property, a collection element, a nested alternative — rather than to a name guessed from the union's own component.
- `bindUnion` fills the wrapper name, each alternative's member and pointerness, and the constructor.
- `BindOperation` binds one operation and fails only that artifact, so one unresolvable union cannot take down a whole run; `BindSpec` maps each operation to its own error. An alternative the SDK cannot name surfaces as `UnresolvedBindingError` naming the union and the offending alternative.
- Wired into `generate.go` ahead of `BuildArtifact`, since the projection carries these bindings onto each envelope rather than deriving them itself.

## Testing

`go build ./...` and `go test ./...` green. `corroborate_test.go` checks the derived names against the real `datadog-api-client-go` source rather than against our own expectations — which is what makes this a port of the SDK generator's rules and not a plausible reimplementation of them. `bind_placement.yaml` covers each placement.


