### PR TITLE
[TFgen] Scope generated model names to their artifact and component

### DIFF
--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -55,24 +55,30 @@ func (b *dataSourceBuilder) oneOfEnvelope(a *model.Attribute) oneOfRender {
 		return cached
 	}
 
+	// The model layer names an envelope and its variants without knowing which
+	// artifact will render them — a reusable union has no single owner — so emit
+	// applies the artifact scope here, at the one point that does know.
+	envModel := b.namer.qualify(env.GoModel)
+
 	// Reserve the envelope's struct slot before walking the variants so it precedes
 	// their structs in Models, matching how walk orders a parent before its children.
 	envIdx := len(b.models)
-	b.models = append(b.models, ModelStructView{Name: env.GoModel})
+	b.models = append(b.models, ModelStructView{Name: envModel})
 
-	render := oneOfRender{goModel: env.GoModel}
+	render := oneOfRender{goModel: envModel}
 	envFields := make([]ModelFieldView, 0, len(env.Variants))
 
 	for _, v := range env.Variants {
 		sdkVar := lowerFirst(v.GoField) + "Variant"
 		modelVar := lowerFirst(v.GoField) + "Model"
+		variantModel := b.namer.qualify(v.GoModel)
 
 		assign := OneOfVariantAssignment{
 			SDKField:   v.SDKField,
 			SDKVar:     sdkVar,
 			SDKPointer: v.SDKPointer,
 			GoField:    v.GoField,
-			GoModel:    v.GoModel,
+			GoModel:    variantModel,
 			ModelVar:   modelVar,
 		}
 
@@ -81,11 +87,11 @@ func (b *dataSourceBuilder) oneOfEnvelope(a *model.Attribute) oneOfRender {
 			// The SDK member of a non-object alternative *is* the value — a *string,
 			// not a struct with getters — so its single "value" field is assigned by
 			// dereferencing the member rather than reading through Get<Field>Ok.
-			attrs, blocks = b.oneOfValueVariant(env, v, sdkVar, modelVar, &assign)
+			attrs, blocks = b.oneOfValueVariant(env, v, variantModel, sdkVar, modelVar, &assign)
 		} else {
 			var scalars []StateAssignment
 			var lists []ListAssignment
-			attrs, blocks, scalars, lists = b.walk(v.GoModel, sdkVar, modelVar, v.Attribute.Children)
+			attrs, blocks, scalars, lists = b.walk(variantModel, stemOf(v.GoModel), sdkVar, modelVar, v.Attribute.Children)
 			assign.Scalars, assign.Lists = scalars, lists
 		}
 
@@ -101,7 +107,7 @@ func (b *dataSourceBuilder) oneOfEnvelope(a *model.Attribute) oneOfRender {
 		})
 		envFields = append(envFields, ModelFieldView{
 			GoField: v.GoField,
-			GoType:  "*" + v.GoModel,
+			GoType:  "*" + variantModel,
 			TFName:  v.TFName,
 		})
 		render.variants = append(render.variants, assign)
@@ -126,6 +132,7 @@ func (b *dataSourceBuilder) oneOfEnvelope(a *model.Attribute) oneOfRender {
 func (b *dataSourceBuilder) oneOfValueVariant(
 	env *model.OneOfEnvelope,
 	v model.OneOfEnvelopeVariant,
+	variantModel string,
 	sdkVar, modelVar string,
 	assign *OneOfVariantAssignment,
 ) (attrs, blocks []AttrView) {
@@ -164,7 +171,7 @@ func (b *dataSourceBuilder) oneOfValueVariant(
 	// The variant still needs its own one-field model struct; walk would normally
 	// have appended it, and the envelope's field points at it either way.
 	b.models = append(b.models, ModelStructView{
-		Name:   v.GoModel,
+		Name:   variantModel,
 		Fields: []ModelFieldView{{GoField: goField, GoType: value.GoType, TFName: tfName}},
 	})
 	assign.Value = &StateAssignment{
@@ -263,7 +270,7 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 		return buildPluralView(a)
 	}
 
-	b := &dataSourceBuilder{receiver: envelopeReceiver}
+	b := &dataSourceBuilder{receiver: envelopeReceiver, namer: modelNamer{base: dsGoName(a.Name)}}
 
 	// Resolve the SDK calls. read backs the by-id lookup, search the list; the
 	// presence of each selects the resolution shape (read-only / search / both).
@@ -315,7 +322,7 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 		}
 	}
 
-	rootStruct := dsGoName(a.Name) + "DataSourceModel"
+	rootStruct := b.namer.qualify("DataSourceModel")
 	env := b.flattenEnvelope(topLevel, idStrategy, rootExpr)
 
 	if len(b.unsupported) > 0 {
@@ -324,7 +331,9 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 
 	// env is non-nil here: flattenEnvelope records an unsupported node (caught
 	// above) on every failure path. Walk the hoisted leaves into the root struct.
-	recordAttrs, recordBlocks, recordScalars, recordLists := b.walk(rootStruct, b.receiver, "state", env.leaves)
+	// The root's stem is empty: its inline children accumulate from the artifact base
+	// alone, so a top-level "foo" object becomes <base>FooModel.
+	recordAttrs, recordBlocks, recordScalars, recordLists := b.walk(rootStruct, "", b.receiver, "state", env.leaves)
 	leafFields := b.models[0].Fields
 
 	// Search filters: one Optional attribute + model field + param binding each.
@@ -341,6 +350,11 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 	}
 	fields := append([]ModelFieldView{idField}, filterFields...)
 	b.models[0].Fields = append(fields, leafFields...)
+
+	models, conflicts := dedupeModels(b.models)
+	if len(conflicts) > 0 {
+		return DataSourceView{}, &UnsupportedEmitError{Nodes: conflicts}
+	}
 
 	assignments := append([]StateAssignment{env.idAssign}, recordScalars...)
 
@@ -370,7 +384,7 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 		Searchable:  searchable,
 		Read:        readView,
 		Search:      searchView,
-		Models:      b.models,
+		Models:      models,
 		Schema:      SchemaView{Attributes: append(filterAttrs, recordAttrs...), Blocks: recordBlocks},
 		State: StateView{
 			ParamName:   paramName,
@@ -535,7 +549,10 @@ func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrat
 // unsupported-node collector. receiver is the getter root the state-mapper reads
 // leaves off (e.g. "attributes" for the flattened envelope).
 type dataSourceBuilder struct {
-	receiver    string
+	receiver string
+	// namer scopes every model struct name to this artifact and derives nested
+	// names from their OpenAPI component. See modelname.go.
+	namer       modelNamer
 	models      []ModelStructView
 	unsupported []UnsupportedNode
 	// dropped notes envelope members skipped from the attributes-only view
@@ -585,7 +602,16 @@ func droppedIDCollision(path string) DroppedMember {
 // the per-element accumulator). It returns the schema attr/block views plus the
 // scalar and list state assignments for the caller to place, recursing through
 // nested blocks.
-func (b *dataSourceBuilder) walk(structName, receiver, lhsPrefix string, attrs []*model.Attribute) (attrViews, blockViews []AttrView, scalars []StateAssignment, lists []ListAssignment) {
+//
+// stem is this struct's own naming stem, which its children accumulate from when
+// their schema is inline (modelname.go). It is separate from structName because
+// structName is already qualified and suffixed, and a stem must be neither.
+//
+// The same struct may be reserved twice when one OpenAPI component is reached from
+// two properties: each site needs its own assignments, which are expressed against
+// site-specific receivers and LHS prefixes, so both walks run. dedupeModels
+// collapses the duplicate declarations afterwards.
+func (b *dataSourceBuilder) walk(structName, stem, receiver, lhsPrefix string, attrs []*model.Attribute) (attrViews, blockViews []AttrView, scalars []StateAssignment, lists []ListAssignment) {
 	idx := len(b.models)
 	b.models = append(b.models, ModelStructView{Name: structName})
 	var fields []ModelFieldView
@@ -664,11 +690,11 @@ func (b *dataSourceBuilder) walk(structName, receiver, lhsPrefix string, attrs [
 			})
 
 		case "schema.ListNestedBlock":
-			elemStruct := field + "Model"
+			elemStruct, childStem := b.namer.nested(stem, a)
 			base := lowerFirst(field)
 			loopVar, elemVar := base+"Item", base+"Model"
 			fields = append(fields, ModelFieldView{GoField: field, GoType: "[]*" + elemStruct, TFName: tfName})
-			childAttrs, childBlocks, childScalars, childLists := b.walk(elemStruct, loopVar, elemVar, a.Children)
+			childAttrs, childBlocks, childScalars, childLists := b.walk(elemStruct, childStem, loopVar, elemVar, a.Children)
 			blockViews = append(blockViews, AttrView{
 				TFName:      tfName,
 				Description: a.Description,
@@ -694,11 +720,11 @@ func (b *dataSourceBuilder) walk(structName, receiver, lhsPrefix string, attrs [
 			})
 
 		case "schema.SingleNestedBlock":
-			childStruct := field + "Model"
+			childStruct, childStem := b.namer.nested(stem, a)
 			objVar := leafVar(tfName)
 			elemVar := lowerFirst(field) + "Model"
 			fields = append(fields, ModelFieldView{GoField: field, GoType: "*" + childStruct, TFName: tfName})
-			childAttrs, childBlocks, childScalars, childLists := b.walk(childStruct, objVar, elemVar, a.Children)
+			childAttrs, childBlocks, childScalars, childLists := b.walk(childStruct, childStem, objVar, elemVar, a.Children)
 			blockViews = append(blockViews, AttrView{
 				TFName:      tfName,
 				Description: a.Description,
@@ -944,8 +970,21 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 	}
 
 	// b hosts walk so list-of-object item fields generate their element structs.
-	b := &dataSourceBuilder{}
+	b := &dataSourceBuilder{namer: modelNamer{base: dsGoName(a.Name)}}
 	scalarLeaves, nonScalars := flattenItemElement(itemsBlock, &unsupported, &dropped)
+
+	// The item element's own stem. call.ItemType is the response element's component
+	// name, so it plays the same role here that ModelRefName plays under walk: the
+	// item struct is named after its component, and the item's inline children
+	// accumulate from it.
+	// Verbatim, like any other component name: ItemType is already a Go type name
+	// (it is spelled as call.GoPackage + "." + call.ItemType elsewhere), so SdkName
+	// would only mangle its acronyms.
+	var itemStem string
+	if call != nil {
+		itemStem = call.ItemType
+	}
+	itemStruct := b.namer.qualify(itemStem + "Model")
 
 	// Scalar leaves project into the item struct literal, unguarded, off the loop
 	// variable "item".
@@ -1010,10 +1049,12 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 				Kind: "primitive", LHS: "r." + field, GetterOk: getter, Var: leafVar(tfName), ElementType: n.ElementType,
 			})
 		case "schema.ListNestedBlock":
-			elemStruct := model.SdkName(tfName) + "Model"
+			// itemStem, not "": these hang off the item element, so an inline child
+			// accumulates from the item struct the same way it would under walk.
+			elemStruct, childStem := b.namer.nested(itemStem, n)
 			base := lowerFirst(model.SdkName(tfName))
 			loopVar, elemVar := base+"Item", base+"Model"
-			childAttrs, childBlocks, childScalars, childLists := b.walk(elemStruct, loopVar, elemVar, n.Children)
+			childAttrs, childBlocks, childScalars, childLists := b.walk(elemStruct, childStem, loopVar, elemVar, n.Children)
 			itemBlocks = append(itemBlocks, AttrView{
 				TFName: tfName, Description: n.Description,
 				IsBlock: true, ListBlock: true, Attributes: childAttrs, Blocks: childBlocks,
@@ -1025,10 +1066,10 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 				Scalars: childScalars, Lists: childLists,
 			})
 		case "schema.SingleNestedBlock":
-			elemStruct := model.SdkName(tfName) + "Model"
+			elemStruct, childStem := b.namer.nested(itemStem, n)
 			objVar := leafVar(tfName)
 			elemVar := lowerFirst(model.SdkName(tfName)) + "Model"
-			childAttrs, childBlocks, childScalars, childLists := b.walk(elemStruct, objVar, elemVar, n.Children)
+			childAttrs, childBlocks, childScalars, childLists := b.walk(elemStruct, childStem, objVar, elemVar, n.Children)
 			itemBlocks = append(itemBlocks, AttrView{
 				TFName: tfName, Description: n.Description,
 				IsBlock: true, ListBlock: false, Attributes: childAttrs, Blocks: childBlocks,
@@ -1053,7 +1094,6 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 		return DataSourceView{}, &UnsupportedEmitError{Nodes: unsupported}
 	}
 
-	itemStruct := model.SdkName(call.ItemType) + "Model"
 	itemField := model.SdkName(a.Name)
 	goName := dsGoName(a.Name)
 
@@ -1066,10 +1106,14 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 	// Models: parent, the item struct, then any element structs walked for
 	// list-of-object item fields.
 	models := []ModelStructView{
-		{Name: goName + "DataSourceModel", Fields: parentFields},
+		{Name: b.namer.qualify("DataSourceModel"), Fields: parentFields},
 		{Name: itemStruct, Fields: itemFields},
 	}
 	models = append(models, b.models...)
+	models, conflicts := dedupeModels(models)
+	if len(conflicts) > 0 {
+		return DataSourceView{}, &UnsupportedEmitError{Nodes: conflicts}
+	}
 
 	return DataSourceView{
 		Cardinality: Plural,

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -673,7 +673,7 @@ var _ = Describe("BuildDataSourceView singular nested arrays", func() {
 		for _, m := range view.Models {
 			names = append(names, m.Name)
 		}
-		Expect(names).To(Equal([]string{"datadogCostBudgetDataSourceModel", "EntriesModel", "TagFiltersModel"}))
+		Expect(names).To(Equal([]string{"datadogCostBudgetDataSourceModel", "datadogCostBudgetEntriesModel", "datadogCostBudgetEntriesTagFiltersModel"}))
 	})
 
 	It("maps each element through a guarded loop, recursing for nested arrays", func() {
@@ -687,7 +687,7 @@ var _ = Describe("BuildDataSourceView singular nested arrays", func() {
 		Expect(entries.GetterOk).To(Equal("attributes.GetEntriesOk()"))
 		Expect(entries.LoopVar).To(Equal("entriesItem"))
 		Expect(entries.ElemVar).To(Equal("entriesModel"))
-		Expect(entries.ElemStruct).To(Equal("EntriesModel"))
+		Expect(entries.ElemStruct).To(Equal("datadogCostBudgetEntriesModel"))
 		Expect(entries.Scalars).To(ContainElement(StateAssignment{
 			Var: "amount", GetterOk: "entriesItem.GetAmountOk()",
 			LHS: "entriesModel.Amount", RHS: "types.Float64Value(*amount)",
@@ -699,7 +699,7 @@ var _ = Describe("BuildDataSourceView singular nested arrays", func() {
 		Expect(tagFilters.LHS).To(Equal("entriesModel.TagFilters"))
 		Expect(tagFilters.GetterOk).To(Equal("entriesItem.GetTagFiltersOk()"))
 		Expect(tagFilters.LoopVar).To(Equal("tagFiltersItem"))
-		Expect(tagFilters.ElemStruct).To(Equal("TagFiltersModel"))
+		Expect(tagFilters.ElemStruct).To(Equal("datadogCostBudgetEntriesTagFiltersModel"))
 	})
 
 	It("produces a deeply-equal view across two runs", func() {
@@ -979,7 +979,7 @@ var _ = Describe("BuildDataSourceView plural nested arrays", func() {
 		for _, m := range view.Models {
 			names = append(names, m.Name)
 		}
-		Expect(names).To(Equal([]string{"datadogWidgetsDataSourceModel", "WidgetModel", "PartsModel"}))
+		Expect(names).To(Equal([]string{"datadogWidgetsDataSourceModel", "datadogWidgetsWidgetModel", "datadogWidgetsWidgetPartsModel"}))
 	})
 
 	It("maps the object array off item.Attributes into the item accumulator", func() {
@@ -992,7 +992,7 @@ var _ = Describe("BuildDataSourceView plural nested arrays", func() {
 		Expect(parts.LHS).To(Equal("r.Parts"))
 		Expect(parts.GetterOk).To(Equal("item.Attributes.GetPartsOk()"))
 		Expect(parts.LoopVar).To(Equal("partsItem"))
-		Expect(parts.ElemStruct).To(Equal("PartsModel"))
+		Expect(parts.ElemStruct).To(Equal("datadogWidgetsWidgetPartsModel"))
 		Expect(parts.Scalars).To(ContainElement(StateAssignment{
 			Var: "label", GetterOk: "partsItem.GetLabelOk()",
 			LHS: "partsModel.Label", RHS: "types.StringValue(*label)",
@@ -1067,7 +1067,7 @@ var _ = Describe("BuildDataSourceView singular nested objects", func() {
 		for _, m := range view.Models {
 			names = append(names, m.Name)
 		}
-		Expect(names).To(Equal([]string{"datadogApmRetentionFilterDataSourceModel", "FilterModel", "MetadataModel"}))
+		Expect(names).To(Equal([]string{"datadogApmRetentionFilterDataSourceModel", "datadogApmRetentionFilterFilterModel", "datadogApmRetentionFilterFilterMetadataModel"}))
 	})
 
 	It("maps the object through a guarded assignment, recursing into the nested object", func() {
@@ -1084,7 +1084,7 @@ var _ = Describe("BuildDataSourceView singular nested objects", func() {
 		Expect(filter.GetterOk).To(Equal("attributes.GetFilterOk()"))
 		Expect(filter.Var).To(Equal("filter"))
 		Expect(filter.ElemVar).To(Equal("filterModel"))
-		Expect(filter.ElemStruct).To(Equal("FilterModel"))
+		Expect(filter.ElemStruct).To(Equal("datadogApmRetentionFilterFilterModel"))
 		Expect(filter.Scalars).To(ContainElement(StateAssignment{
 			Var: "query", GetterOk: "filter.GetQueryOk()",
 			LHS: "filterModel.Query", RHS: "types.StringValue(*query)",
@@ -1098,7 +1098,7 @@ var _ = Describe("BuildDataSourceView singular nested objects", func() {
 		}
 		Expect(metadata.LHS).To(Equal("filterModel.Metadata"))
 		Expect(metadata.GetterOk).To(Equal("filter.GetMetadataOk()"))
-		Expect(metadata.ElemStruct).To(Equal("MetadataModel"))
+		Expect(metadata.ElemStruct).To(Equal("datadogApmRetentionFilterFilterMetadataModel"))
 	})
 
 	It("renders the guarded object block and the recursive assignment in updateState", func() {
@@ -1179,7 +1179,7 @@ var _ = Describe("BuildDataSourceView plural nested objects", func() {
 		for _, m := range view.Models {
 			names = append(names, m.Name)
 		}
-		Expect(names).To(Equal([]string{"datadogGizmosDataSourceModel", "GizmoModel", "SpecModel"}))
+		Expect(names).To(Equal([]string{"datadogGizmosDataSourceModel", "datadogGizmosGizmoModel", "datadogGizmosGizmoSpecModel"}))
 	})
 
 	It("maps the object off item.Attributes into the item accumulator", func() {
@@ -1192,7 +1192,7 @@ var _ = Describe("BuildDataSourceView plural nested objects", func() {
 		Expect(spec.LHS).To(Equal("r.Spec"))
 		Expect(spec.GetterOk).To(Equal("item.Attributes.GetSpecOk()"))
 		Expect(spec.Var).To(Equal("spec"))
-		Expect(spec.ElemStruct).To(Equal("SpecModel"))
+		Expect(spec.ElemStruct).To(Equal("datadogGizmosGizmoSpecModel"))
 		Expect(spec.Scalars).To(ContainElement(StateAssignment{
 			Var: "shape", GetterOk: "spec.GetShapeOk()",
 			LHS: "specModel.Shape", RHS: "types.StringValue(*shape)",

--- a/.generator-v2/internal/emit/modelname.go
+++ b/.generator-v2/internal/emit/modelname.go
@@ -1,0 +1,148 @@
+package emit
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+)
+
+// modelNamer is the single authority for the Go struct name of every model a
+// generated artifact declares. Every name is built the same way:
+//
+//	<artifact base><stem>Model
+//
+// Both halves are load-bearing, and each closes a distinct collision scope.
+//
+// The **artifact base** (dsGoName, e.g. "datadogActionConnection") closes the
+// cross-artifact scope. Every generated data source lands in package fwprovider, so
+// two artifacts that share an OpenAPI component would otherwise each declare the
+// same struct and neither could be compiled alongside the other. That is not
+// hypothetical: 54 of the components in the mini-OAS corpus appear in more than one
+// slice (GoogleMeetConfigurationReference and IncidentTypeAttributes in three
+// each). Prefixing also makes nested models unexported, which is the provider's own
+// convention for data-source models — hostListMetadataModel, rowModel — so this
+// moves toward the hand-written set rather than away from it.
+//
+// The **stem** closes the within-file scope. It prefers the OpenAPI component name
+// that supplied the object schema (Attribute.ModelRefName) and falls back to the
+// enclosing stem plus the property name when that schema was inline. This is the
+// rule the SDK generator's child_models() applies — get_name(schema) or
+// alternative_name, restarting at every $ref — and the rule oneOf envelope naming
+// already applies through OneOfSpec.Name. Deriving from the property name alone is
+// what produced two different TagFiltersModel structs in one file and made
+// integration_aws_external_id uncompilable.
+//
+// A component-derived stem also makes two uses of one component in one artifact
+// converge on a single struct, which dedupeModels then collapses.
+type modelNamer struct {
+	// base is the artifact's Go name stem, already lowerCamel (dsGoName).
+	base string
+}
+
+// qualify scopes an unqualified model name to the artifact. It is the one place an
+// artifact prefix is applied, so the model layer's OneOfEnvelope.GoModel can stay
+// artifact-agnostic: the model layer does not know which artifact is rendering a
+// reusable union, and emit does.
+func (n modelNamer) qualify(unqualified string) string {
+	return n.base + upperFirst(unqualified)
+}
+
+// nested returns the qualified struct name for the model backing a, plus the stem
+// its own children accumulate from. stem is the enclosing model's stem ("" at the
+// artifact root).
+func (n modelNamer) nested(stem string, a *model.Attribute) (name, childStem string) {
+	childStem = nestedStem(stem, a)
+	return n.qualify(childStem + "Model"), childStem
+}
+
+// nestedStem derives the stem of a's model: the component that supplied its object
+// schema when there is one — restarting the accumulation, exactly as child_models()
+// prefers a $ref name over the parent-derived one — else the enclosing stem plus
+// this attribute's property name.
+//
+// The two branches are spelled differently on purpose. A component name is already
+// a Go-style identifier (it is what the SDK names its own struct), so it is taken
+// verbatim, which is also what the oneOf envelope path does with OneOfSpec.Name.
+// Running it through model.SdkName would mangle acronyms and do so inconsistently —
+// AWSLogSourceTagFilter becomes AwsLogSourceTagFilter while XRayServicesList
+// survives — for no gain. A property name, by contrast, arrives as snake_case and
+// must be converted.
+func nestedStem(stem string, a *model.Attribute) string {
+	if a.ModelRefName != "" {
+		return a.ModelRefName
+	}
+	return stem + model.SdkName(tfNameOf(a.Path))
+}
+
+// stemOf recovers the naming stem from an unqualified model name produced by the
+// model layer (model.oneOfModelName appends "Model" to the envelope or variant
+// identity). Children of that struct accumulate inline names from the stem, so they
+// must not inherit the suffix.
+func stemOf(unqualifiedModel string) string {
+	return strings.TrimSuffix(unqualifiedModel, "Model")
+}
+
+// dedupeModels collapses model structs that share a name, and fails when two of
+// them disagree about their fields.
+//
+// Convergence is expected and correct: one OpenAPI component reached from two
+// properties in the same artifact yields one stem, so it must yield one declaration
+// rather than a redeclaration. Divergence means the naming rule produced one name
+// for two shapes, which is the defect this guards against — fail the artifact
+// naming both, because the alternatives are emitting code that cannot compile or
+// silently dropping one shape's fields, and the silent option is not acceptable.
+func dedupeModels(models []ModelStructView) ([]ModelStructView, []UnsupportedNode) {
+	var out []ModelStructView
+	seen := make(map[string]ModelStructView, len(models))
+	var conflicts []UnsupportedNode
+
+	for _, m := range models {
+		prev, ok := seen[m.Name]
+		if !ok {
+			seen[m.Name] = m
+			out = append(out, m)
+			continue
+		}
+		if fieldsEqual(prev.Fields, m.Fields) {
+			continue
+		}
+		conflicts = append(conflicts, UnsupportedNode{
+			Path: m.Name,
+			Reason: fmt.Sprintf(
+				"two different object shapes both derive the model struct %q (%s vs %s); "+
+					"the generated file would redeclare the type. Give the schemas distinct "+
+					"OpenAPI components so each names its own model",
+				m.Name, fieldList(prev.Fields), fieldList(m.Fields)),
+		})
+	}
+
+	sort.SliceStable(conflicts, func(i, j int) bool { return conflicts[i].Path < conflicts[j].Path })
+	return out, conflicts
+}
+
+func fieldsEqual(a, b []ModelFieldView) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].GoField != b[i].GoField || a[i].GoType != b[i].GoType || a[i].TFName != b[i].TFName {
+			return false
+		}
+	}
+	return true
+}
+
+// fieldList renders a model's fields for a collision diagnostic, so the message
+// shows which two shapes collided rather than only that they did.
+func fieldList(fields []ModelFieldView) string {
+	if len(fields) == 0 {
+		return "{}"
+	}
+	parts := make([]string, len(fields))
+	for i, f := range fields {
+		parts[i] = f.GoField + " " + f.GoType
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}

--- a/.generator-v2/internal/emit/modelname_test.go
+++ b/.generator-v2/internal/emit/modelname_test.go
@@ -1,0 +1,263 @@
+package emit
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+)
+
+// component wraps an object schema with the OpenAPI component name that supplied
+// it, which is what the parser records as Schema.RefName.
+func component(name string, props map[string]*model.Schema) *model.Schema {
+	s := obj(props)
+	s.RefName = name
+	return s
+}
+
+// twoTagFiltersOperation reduces the shape that made integration_aws_external_id
+// uncompilable: two differently-shaped objects, each reachable under a property
+// named "tag_filters", one nested a level deeper than the other. Deriving a model
+// name from the property alone gave both TagFiltersModel.
+func twoTagFiltersOperation() *model.Operation {
+	return &model.Operation{
+		Path:            "/api/v2/integration/aws/accounts/{aws_account_config_id}",
+		Method:          "GET",
+		OperationId:     "GetAWSAccount",
+		Tag:             "AWS Integration",
+		ResponseRefName: "AWSAccountResponse",
+		Tracking: &model.TrackingFieldMetadata{
+			ArtifactKind: model.ArtifactKindDataSource,
+			ArtifactName: "integration_aws_account",
+			IdStrategy:   model.IdStrategyDataID,
+			Group:        &model.OperationGroup{Read: "GetAWSAccount"},
+		},
+		ResponseSchema: obj(map[string]*model.Schema{
+			"data": obj(map[string]*model.Schema{
+				"id":   prim("string", "The account's identifier."),
+				"type": prim("string", "Resource type."),
+				"attributes": obj(map[string]*model.Schema{
+					"logs_config": component("AWSLogsConfig", map[string]*model.Schema{
+						"log_source_config": component("AWSLogSourceConfig", map[string]*model.Schema{
+							"tag_filters": {
+								Kind:        model.SchemaKindArray,
+								Description: "Log source tag filters.",
+								Items: component("AWSLogSourceTagFilter", map[string]*model.Schema{
+									"source": prim("string", "The log source."),
+								}),
+							},
+						}),
+					}),
+					"metrics_config": component("AWSMetricsConfig", map[string]*model.Schema{
+						"tag_filters": {
+							Kind:        model.SchemaKindArray,
+							Description: "Metrics namespace tag filters.",
+							Items: component("AWSNamespaceTagFilter", map[string]*model.Schema{
+								"namespace": prim("string", "The AWS namespace."),
+							}),
+						},
+					}),
+				}),
+			}),
+		}),
+	}
+}
+
+// sharedComponentOperation reaches one component from two properties in one
+// artifact. Both sites must converge on a single declaration rather than
+// redeclaring the type. The properties deliberately avoid created_by/updated_by,
+// which flattenEnvelope drops as server-managed audit fields.
+func sharedComponentOperation() *model.Operation {
+	creator := func() *model.Schema {
+		return component("Creator", map[string]*model.Schema{
+			"email": prim("string", "The creator's email."),
+			"name":  prim("string", "The creator's name."),
+		})
+	}
+	return &model.Operation{
+		Path:            "/api/v2/widgets/{widget_id}",
+		Method:          "GET",
+		OperationId:     "GetWidget",
+		Tag:             "Widgets",
+		ResponseRefName: "WidgetResponse",
+		Tracking: &model.TrackingFieldMetadata{
+			ArtifactKind: model.ArtifactKindDataSource,
+			ArtifactName: "widget",
+			IdStrategy:   model.IdStrategyDataID,
+			Group:        &model.OperationGroup{Read: "GetWidget"},
+		},
+		ResponseSchema: obj(map[string]*model.Schema{
+			"data": obj(map[string]*model.Schema{
+				"id":   prim("string", "The widget's identifier."),
+				"type": prim("string", "Resource type."),
+				"attributes": obj(map[string]*model.Schema{
+					"primary_contact":   creator(),
+					"secondary_contact": creator(),
+				}),
+			}),
+		}),
+	}
+}
+
+func modelNames(view DataSourceView) []string {
+	names := make([]string, 0, len(view.Models))
+	for _, m := range view.Models {
+		names = append(names, m.Name)
+	}
+	return names
+}
+
+var _ = Describe("generated model naming", func() {
+
+	Context("two objects under one property name", func() {
+		It("names each after its own component instead of colliding", func() {
+			view, err := BuildDataSourceView(mustArtifact(twoTagFiltersOperation()))
+			Expect(err).NotTo(HaveOccurred())
+
+			names := modelNames(view)
+			Expect(names).To(ContainElement("datadogIntegrationAwsAccountAWSLogSourceTagFilterModel"))
+			Expect(names).To(ContainElement("datadogIntegrationAwsAccountAWSNamespaceTagFilterModel"))
+		})
+
+		It("declares every model exactly once", func() {
+			view, err := BuildDataSourceView(mustArtifact(twoTagFiltersOperation()))
+			Expect(err).NotTo(HaveOccurred())
+
+			seen := map[string]int{}
+			for _, n := range modelNames(view) {
+				seen[n]++
+			}
+			for name, count := range seen {
+				Expect(count).To(Equal(1), "%s is declared %d times; the file would not compile", name, count)
+			}
+		})
+
+		It("points each tag_filters field at its own struct", func() {
+			view, err := BuildDataSourceView(mustArtifact(twoTagFiltersOperation()))
+			Expect(err).NotTo(HaveOccurred())
+
+			logSource := modelByName(view, "datadogIntegrationAwsAccountAWSLogSourceConfigModel")
+			Expect(logSource.Fields).To(Equal([]ModelFieldView{
+				{GoField: "TagFilters", GoType: "[]*datadogIntegrationAwsAccountAWSLogSourceTagFilterModel", TFName: "tag_filters"},
+			}))
+
+			metrics := modelByName(view, "datadogIntegrationAwsAccountAWSMetricsConfigModel")
+			Expect(metrics.Fields).To(Equal([]ModelFieldView{
+				{GoField: "TagFilters", GoType: "[]*datadogIntegrationAwsAccountAWSNamespaceTagFilterModel", TFName: "tag_filters"},
+			}))
+		})
+
+		It("renders gofmt-clean Go", func() {
+			view, err := BuildDataSourceView(mustArtifact(twoTagFiltersOperation()))
+			Expect(err).NotTo(HaveOccurred())
+			// RenderDataSource runs format.Source, so a duplicate declaration or a
+			// mangled identifier fails here rather than at the provider's build.
+			_, err = RenderDataSource(view)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("scoping to the artifact", func() {
+		It("prefixes every model with the artifact base", func() {
+			// Two data sources sharing a component must not each declare it: they land
+			// in one package, so an unprefixed name is a redeclaration across files.
+			// 54 components in the mini-OAS corpus appear in more than one slice.
+			view, err := BuildDataSourceView(mustArtifact(twoTagFiltersOperation()))
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, n := range modelNames(view) {
+				Expect(n).To(HavePrefix("datadogIntegrationAwsAccount"),
+					"%s is not scoped to its artifact", n)
+			}
+		})
+
+		It("keeps nested models unexported, as the hand-written data sources do", func() {
+			view, err := BuildDataSourceView(mustArtifact(twoTagFiltersOperation()))
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, n := range modelNames(view) {
+				Expect(n[:1]).To(Equal(strings.ToLower(n[:1])), "%s is exported", n)
+			}
+		})
+	})
+
+	Context("one component reached twice", func() {
+		It("collapses to a single declaration both sites point at", func() {
+			view, err := BuildDataSourceView(mustArtifact(sharedComponentOperation()))
+			Expect(err).NotTo(HaveOccurred())
+
+			var creators int
+			for _, n := range modelNames(view) {
+				if n == "datadogWidgetCreatorModel" {
+					creators++
+				}
+			}
+			Expect(creators).To(Equal(1))
+
+			root := modelByName(view, "datadogWidgetDataSourceModel")
+			var types []string
+			for _, f := range root.Fields {
+				if f.TFName == "primary_contact" || f.TFName == "secondary_contact" {
+					types = append(types, f.GoType)
+				}
+			}
+			Expect(types).To(Equal([]string{"*datadogWidgetCreatorModel", "*datadogWidgetCreatorModel"}))
+		})
+	})
+
+	DescribeTable("nestedStem",
+		func(stem string, a *model.Attribute, want string) {
+			Expect(nestedStem(stem, a)).To(Equal(want))
+		},
+		Entry("prefers the component name, verbatim",
+			"Parent", &model.Attribute{Path: "response.tag_filters", ModelRefName: "AWSLogSourceTagFilter"},
+			"AWSLogSourceTagFilter"),
+		Entry("restarts the accumulation at the component, ignoring the enclosing stem",
+			"LogsConfigLogSourceConfig", &model.Attribute{Path: "response.tag_filters", ModelRefName: "AWSNamespaceTagFilter"},
+			"AWSNamespaceTagFilter"),
+		Entry("accumulates from the enclosing stem for an inline schema",
+			"LogSourceConfig", &model.Attribute{Path: "response.logs.log_source_config.tag_filters"},
+			"LogSourceConfigTagFilters"),
+		Entry("converts a snake_case property, since only a component name is already Go-style",
+			"", &model.Attribute{Path: "response.http_token_auth"},
+			"HttpTokenAuth"),
+	)
+
+	Describe("dedupeModels", func() {
+		It("collapses identical declarations without complaint", func() {
+			fields := []ModelFieldView{{GoField: "Name", GoType: "types.String", TFName: "name"}}
+			out, conflicts := dedupeModels([]ModelStructView{
+				{Name: "aModel", Fields: fields},
+				{Name: "aModel", Fields: fields},
+			})
+			Expect(conflicts).To(BeEmpty())
+			Expect(out).To(HaveLen(1))
+		})
+
+		It("preserves first-use order", func() {
+			out, conflicts := dedupeModels([]ModelStructView{
+				{Name: "rootModel"}, {Name: "aModel"}, {Name: "rootModel"}, {Name: "bModel"},
+			})
+			Expect(conflicts).To(BeEmpty())
+			Expect([]string{out[0].Name, out[1].Name, out[2].Name}).To(Equal([]string{"rootModel", "aModel", "bModel"}))
+		})
+
+		It("fails when one name covers two shapes, naming both", func() {
+			// The guard applied to artifact names has no counterpart at the Go
+			// identifier level, so this is the emitter's own defence: emitting the
+			// redeclaration or silently dropping one shape are both worse.
+			out, conflicts := dedupeModels([]ModelStructView{
+				{Name: "tagFiltersModel", Fields: []ModelFieldView{{GoField: "Source", GoType: "types.String", TFName: "source"}}},
+				{Name: "tagFiltersModel", Fields: []ModelFieldView{{GoField: "Namespace", GoType: "types.String", TFName: "namespace"}}},
+			})
+			Expect(out).To(HaveLen(1))
+			Expect(conflicts).To(HaveLen(1))
+			Expect(conflicts[0].Path).To(Equal("tagFiltersModel"))
+			Expect(conflicts[0].Reason).To(ContainSubstring("Source types.String"))
+			Expect(conflicts[0].Reason).To(ContainSubstring("Namespace types.String"))
+			Expect(conflicts[0].Reason).To(ContainSubstring("redeclare"))
+		})
+	})
+})

--- a/.generator-v2/internal/emit/oneof_test.go
+++ b/.generator-v2/internal/emit/oneof_test.go
@@ -145,11 +145,11 @@ var _ = Describe("oneOf envelope emission", func() {
 	Context("the envelope model", func() {
 		It("holds one pointer field per variant, keyed on the Terraform variant name", func() {
 			view := unionView(unionOperation())
-			envelope := modelByName(view, "IncidentNotificationModel")
+			envelope := modelByName(view, "datadogIncidentTypeIncidentNotificationModel")
 
 			Expect(envelope.Fields).To(Equal([]ModelFieldView{
-				{GoField: "String", GoType: "*IncidentNotificationStringModel", TFName: "string"},
-				{GoField: "WebhookNotification", GoType: "*IncidentNotificationWebhookNotificationModel", TFName: "webhook_notification"},
+				{GoField: "String", GoType: "*datadogIncidentTypeIncidentNotificationStringModel", TFName: "string"},
+				{GoField: "WebhookNotification", GoType: "*datadogIncidentTypeIncidentNotificationWebhookNotificationModel", TFName: "webhook_notification"},
 			}))
 		})
 
@@ -166,17 +166,17 @@ var _ = Describe("oneOf envelope emission", func() {
 				}
 			}
 			Expect(field.GoField).To(Equal("Notification"))
-			Expect(field.GoType).To(Equal("*IncidentNotificationModel"))
+			Expect(field.GoType).To(Equal("*datadogIncidentTypeIncidentNotificationModel"))
 		})
 
 		It("gives an object variant its own fields and a scalar variant a single value field", func() {
 			view := unionView(unionOperation())
 
-			Expect(modelByName(view, "IncidentNotificationWebhookNotificationModel").Fields).To(Equal([]ModelFieldView{
+			Expect(modelByName(view, "datadogIncidentTypeIncidentNotificationWebhookNotificationModel").Fields).To(Equal([]ModelFieldView{
 				{GoField: "Enabled", GoType: "types.Bool", TFName: "enabled"},
 				{GoField: "Url", GoType: "types.String", TFName: "url"},
 			}))
-			Expect(modelByName(view, "IncidentNotificationStringModel").Fields).To(Equal([]ModelFieldView{
+			Expect(modelByName(view, "datadogIncidentTypeIncidentNotificationStringModel").Fields).To(Equal([]ModelFieldView{
 				{GoField: "Value", GoType: "types.String", TFName: "value"},
 			}))
 		})
@@ -186,9 +186,9 @@ var _ = Describe("oneOf envelope emission", func() {
 			var envelopeAt, variantAt = -1, -1
 			for i, m := range view.Models {
 				switch m.Name {
-				case "IncidentNotificationModel":
+				case "datadogIncidentTypeIncidentNotificationModel":
 					envelopeAt = i
-				case "IncidentNotificationWebhookNotificationModel":
+				case "datadogIncidentTypeIncidentNotificationWebhookNotificationModel":
 					variantAt = i
 				}
 			}
@@ -243,7 +243,7 @@ var _ = Describe("oneOf envelope emission", func() {
 
 			var envelopeModels int
 			for _, m := range view.Models {
-				if m.Name == "IncidentNotificationModel" {
+				if m.Name == "datadogIncidentTypeIncidentNotificationModel" {
 					envelopeModels++
 				}
 			}
@@ -269,7 +269,7 @@ var _ = Describe("oneOf envelope emission", func() {
 			assign := oneOfAssignmentAt(view, "response.data.attributes.notification")
 
 			Expect(assign.SDKType).To(Equal("IncidentNotification"))
-			Expect(assign.GoModel).To(Equal("IncidentNotificationModel"))
+			Expect(assign.GoModel).To(Equal("datadogIncidentTypeIncidentNotificationModel"))
 			Expect(assign.LHS).To(Equal("state.Notification"))
 			// The wrapper itself is a normal field on its parent; only its members
 			// lack getters.
@@ -377,8 +377,8 @@ var _ = Describe("oneOf envelope emission", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			out := string(src)
-			Expect(out).To(ContainSubstring("type IncidentNotificationModel struct {"))
-			Expect(out).To(ContainSubstring("WebhookNotification *IncidentNotificationWebhookNotificationModel `tfsdk:\"webhook_notification\"`"))
+			Expect(out).To(ContainSubstring("type datadogIncidentTypeIncidentNotificationModel struct {"))
+			Expect(out).To(ContainSubstring("WebhookNotification *datadogIncidentTypeIncidentNotificationWebhookNotificationModel `tfsdk:\"webhook_notification\"`"))
 			Expect(out).To(ContainSubstring(`"notification": schema.SingleNestedBlock{`))
 			Expect(out).To(ContainSubstring(`"webhook_notification": schema.SingleNestedBlock{`))
 		})
@@ -417,7 +417,7 @@ var _ = Describe("oneOf envelope in a collection", func() {
 				field = f
 			}
 		}
-		Expect(field.GoType).To(Equal("[]*IncidentNotificationModel"),
+		Expect(field.GoType).To(Equal("[]*datadogIncidentTypeIncidentNotificationModel"),
 			"each element of the list is one envelope")
 
 		block := blockByName(view.Schema.Blocks, "notifications")
@@ -499,7 +499,7 @@ var _ = Describe("oneOf response mapping", func() {
 		src := string(mustRender(op))
 		// The inner wrapper is reached with an ordinary getter off the outer variant.
 		Expect(src).To(ContainSubstring("if target, ok := webhookNotificationVariant.GetTargetOk(); ok && target != nil {"))
-		Expect(src).To(ContainSubstring("targetEnvelope := &NotificationTargetModel{}"))
+		Expect(src).To(ContainSubstring("targetEnvelope := &datadogIncidentTypeNotificationTargetModel{}"))
 		Expect(src).To(ContainSubstring("targetMatches++"))
 	})
 

--- a/.generator-v2/internal/emit/templates_test.go
+++ b/.generator-v2/internal/emit/templates_test.go
@@ -207,11 +207,11 @@ func pluralFixture() DataSourceView {
 					{Comment: "Query Parameters", GoField: "FilterKeyword", GoType: "types.String", TFName: "filter_keyword"},
 					{GoField: "FilterMe", GoType: "types.Bool", TFName: "filter_me"},
 					{Comment: "Results", GoField: "ID", GoType: "types.String", TFName: "id"},
-					{GoField: "Teams", GoType: "[]*TeamModel", TFName: "teams"},
+					{GoField: "Teams", GoType: "[]*datadogTeamsTeamModel", TFName: "teams"},
 				},
 			},
 			{
-				Name: "TeamModel",
+				Name: "datadogTeamsTeamModel",
 				Fields: []ModelFieldView{
 					{GoField: "Description", GoType: "types.String", TFName: "description"},
 					{GoField: "Handle", GoType: "types.String", TFName: "handle"},
@@ -251,7 +251,7 @@ func pluralFixture() DataSourceView {
 			},
 		},
 		State: StateView{
-			ItemStruct: "TeamModel",
+			ItemStruct: "datadogTeamsTeamModel",
 			ItemField:  "Teams",
 			ItemFields: []StateAssignment{
 				{LHS: "Description", RHS: "types.StringValue(item.Attributes.GetDescription())"},

--- a/.generator-v2/internal/model/schema.go
+++ b/.generator-v2/internal/model/schema.go
@@ -203,7 +203,7 @@ func (b *treeBuilder) attribute(s *Schema, path string, mode nestingMode, requir
 		if err != nil {
 			return nil, err
 		}
-		attr.Children = children
+		attr.Children, attr.ModelRefName = children, s.RefName
 
 	case SchemaKindArray:
 		switch s.Items.Kind {
@@ -212,7 +212,8 @@ func (b *treeBuilder) attribute(s *Schema, path string, mode nestingMode, requir
 			if err != nil {
 				return nil, err
 			}
-			attr.Children = children
+			// The element supplies the struct, so the element's component names it.
+			attr.Children, attr.ModelRefName = children, s.Items.RefName
 		case SchemaKindOneOf:
 			// The list itself carries the envelope: its elements are variant
 			// blocks, so no attribute stands at the element path.
@@ -238,7 +239,7 @@ func (b *treeBuilder) attribute(s *Schema, path string, mode nestingMode, requir
 			if err != nil {
 				return nil, err
 			}
-			attr.Children = children
+			attr.Children, attr.ModelRefName = children, s.Items.RefName
 		case SchemaKindOneOf:
 			variants, envelope, err := b.oneOfVariants(s.Items, path+"{}", nestAttribute)
 			if err != nil {

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -352,6 +352,18 @@ type Attribute struct {
 	Description string
 	// Children holds nested attributes for nested blocks.
 	Children []*Attribute
+	// ModelRefName is the OpenAPI component name that supplied the *object* schema
+	// backing this attribute's generated model struct: the node's own schema for an
+	// object, its element schema for an array or map of objects. Empty when that
+	// schema was inline, and empty for a leaf, which has no struct.
+	//
+	// It exists so emit can name a nested model after its component rather than
+	// after the property that happens to point at it — the same preference the SDK
+	// generator's child_models() applies (get_name(schema) or alternative_name) and
+	// that oneOf envelope naming already applies via OneOfSpec.Name. Without it, two
+	// differently-shaped objects reachable under the same property name produce one
+	// struct name and the artifact cannot compile.
+	ModelRefName string
 	// OneOf is non-nil when this attribute carries a synthetic oneOf envelope:
 	// either the envelope itself (a union at the root or an object property) or
 	// the collection whose element is a union. Children then holds the variant

--- a/.generator-v2/internal/snapshots/data_source_plural.golden
+++ b/.generator-v2/internal/snapshots/data_source_plural.golden
@@ -24,11 +24,11 @@ type datadogTeamsDataSourceModel struct {
 	FilterMe      types.Bool   `tfsdk:"filter_me"`
 
 	// Results
-	ID    types.String `tfsdk:"id"`
-	Teams []*TeamModel `tfsdk:"teams"`
+	ID    types.String             `tfsdk:"id"`
+	Teams []*datadogTeamsTeamModel `tfsdk:"teams"`
 }
 
-type TeamModel struct {
+type datadogTeamsTeamModel struct {
 	Description    types.String `tfsdk:"description"`
 	Handle         types.String `tfsdk:"handle"`
 	ID             types.String `tfsdk:"id"`
@@ -158,9 +158,9 @@ func (d *datadogTeamsDataSource) Read(ctx context.Context, request datasource.Re
 
 func (d *datadogTeamsDataSource) updateState(ctx context.Context, state *datadogTeamsDataSourceModel, data *[]datadogV2.Team) diag.Diagnostics {
 	var diags diag.Diagnostics
-	results := make([]*TeamModel, 0, len(*data))
+	results := make([]*datadogTeamsTeamModel, 0, len(*data))
 	for _, item := range *data {
-		r := TeamModel{
+		r := datadogTeamsTeamModel{
 			Description: types.StringValue(item.Attributes.GetDescription()),
 			Handle:      types.StringValue(item.Attributes.GetHandle()),
 			ID:          types.StringValue(item.GetId()),

--- a/.generator-v2/internal/snapshots/data_source_plural_nested.golden
+++ b/.generator-v2/internal/snapshots/data_source_plural_nested.golden
@@ -19,17 +19,17 @@ var (
 
 type datadogWidgetsDataSourceModel struct {
 	// Results
-	ID      types.String   `tfsdk:"id"`
-	Widgets []*WidgetModel `tfsdk:"widgets"`
+	ID      types.String                 `tfsdk:"id"`
+	Widgets []*datadogWidgetsWidgetModel `tfsdk:"widgets"`
 }
 
-type WidgetModel struct {
-	ID    types.String  `tfsdk:"id"`
-	Name  types.String  `tfsdk:"name"`
-	Parts []*PartsModel `tfsdk:"parts"`
+type datadogWidgetsWidgetModel struct {
+	ID    types.String                      `tfsdk:"id"`
+	Name  types.String                      `tfsdk:"name"`
+	Parts []*datadogWidgetsWidgetPartsModel `tfsdk:"parts"`
 }
 
-type PartsModel struct {
+type datadogWidgetsWidgetPartsModel struct {
 	Label    types.String `tfsdk:"label"`
 	Quantity types.Int64  `tfsdk:"quantity"`
 }
@@ -120,15 +120,15 @@ func (d *datadogWidgetsDataSource) Read(ctx context.Context, request datasource.
 
 func (d *datadogWidgetsDataSource) updateState(ctx context.Context, state *datadogWidgetsDataSourceModel, data *[]datadogV2.Widget) diag.Diagnostics {
 	var diags diag.Diagnostics
-	results := make([]*WidgetModel, 0, len(*data))
+	results := make([]*datadogWidgetsWidgetModel, 0, len(*data))
 	for _, item := range *data {
-		r := WidgetModel{
+		r := datadogWidgetsWidgetModel{
 			ID:   types.StringValue(item.GetId()),
 			Name: types.StringValue(item.Attributes.GetName()),
 		}
 		if parts, ok := item.Attributes.GetPartsOk(); ok && parts != nil {
 			for _, partsItem := range *parts {
-				partsModel := &PartsModel{}
+				partsModel := &datadogWidgetsWidgetPartsModel{}
 				if label, ok := partsItem.GetLabelOk(); ok && label != nil {
 					partsModel.Label = types.StringValue(*label)
 				}

--- a/.generator-v2/internal/snapshots/data_source_plural_no_params.golden
+++ b/.generator-v2/internal/snapshots/data_source_plural_no_params.golden
@@ -19,11 +19,11 @@ var (
 
 type datadogDatastoresDataSourceModel struct {
 	// Results
-	ID         types.String          `tfsdk:"id"`
-	Datastores []*DatastoreDataModel `tfsdk:"datastores"`
+	ID         types.String                           `tfsdk:"id"`
+	Datastores []*datadogDatastoresDatastoreDataModel `tfsdk:"datastores"`
 }
 
-type DatastoreDataModel struct {
+type datadogDatastoresDatastoreDataModel struct {
 	CreatorUserId                types.Int64  `tfsdk:"creator_user_id"`
 	CreatorUserUuid              types.String `tfsdk:"creator_user_uuid"`
 	Description                  types.String `tfsdk:"description"`
@@ -127,9 +127,9 @@ func (d *datadogDatastoresDataSource) Read(ctx context.Context, request datasour
 
 func (d *datadogDatastoresDataSource) updateState(ctx context.Context, state *datadogDatastoresDataSourceModel, data *[]datadogV2.DatastoreData) diag.Diagnostics {
 	var diags diag.Diagnostics
-	results := make([]*DatastoreDataModel, 0, len(*data))
+	results := make([]*datadogDatastoresDatastoreDataModel, 0, len(*data))
 	for _, item := range *data {
-		r := DatastoreDataModel{
+		r := datadogDatastoresDatastoreDataModel{
 			CreatorUserId:                types.Int64Value(int64(item.Attributes.GetCreatorUserId())),
 			CreatorUserUuid:              types.StringValue(item.Attributes.GetCreatorUserUuid()),
 			Description:                  types.StringValue(item.Attributes.GetDescription()),

--- a/.generator-v2/internal/snapshots/data_source_plural_object.golden
+++ b/.generator-v2/internal/snapshots/data_source_plural_object.golden
@@ -19,17 +19,17 @@ var (
 
 type datadogGizmosDataSourceModel struct {
 	// Results
-	ID     types.String  `tfsdk:"id"`
-	Gizmos []*GizmoModel `tfsdk:"gizmos"`
+	ID     types.String               `tfsdk:"id"`
+	Gizmos []*datadogGizmosGizmoModel `tfsdk:"gizmos"`
 }
 
-type GizmoModel struct {
-	ID   types.String `tfsdk:"id"`
-	Name types.String `tfsdk:"name"`
-	Spec *SpecModel   `tfsdk:"spec"`
+type datadogGizmosGizmoModel struct {
+	ID   types.String                 `tfsdk:"id"`
+	Name types.String                 `tfsdk:"name"`
+	Spec *datadogGizmosGizmoSpecModel `tfsdk:"spec"`
 }
 
-type SpecModel struct {
+type datadogGizmosGizmoSpecModel struct {
 	Shape types.String `tfsdk:"shape"`
 	Size  types.Int64  `tfsdk:"size"`
 }
@@ -119,14 +119,14 @@ func (d *datadogGizmosDataSource) Read(ctx context.Context, request datasource.R
 
 func (d *datadogGizmosDataSource) updateState(ctx context.Context, state *datadogGizmosDataSourceModel, data *[]datadogV2.Gizmo) diag.Diagnostics {
 	var diags diag.Diagnostics
-	results := make([]*GizmoModel, 0, len(*data))
+	results := make([]*datadogGizmosGizmoModel, 0, len(*data))
 	for _, item := range *data {
-		r := GizmoModel{
+		r := datadogGizmosGizmoModel{
 			ID:   types.StringValue(item.GetId()),
 			Name: types.StringValue(item.Attributes.GetName()),
 		}
 		if spec, ok := item.Attributes.GetSpecOk(); ok && spec != nil {
-			specModel := &SpecModel{}
+			specModel := &datadogGizmosGizmoSpecModel{}
 			if shape, ok := spec.GetShapeOk(); ok && shape != nil {
 				specModel.Shape = types.StringValue(*shape)
 			}

--- a/.generator-v2/internal/snapshots/data_source_singular_nested.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular_nested.golden
@@ -17,18 +17,18 @@ var (
 )
 
 type datadogCostBudgetDataSourceModel struct {
-	ID      types.String    `tfsdk:"id"`
-	Entries []*EntriesModel `tfsdk:"entries"`
-	Name    types.String    `tfsdk:"name"`
+	ID      types.String                     `tfsdk:"id"`
+	Entries []*datadogCostBudgetEntriesModel `tfsdk:"entries"`
+	Name    types.String                     `tfsdk:"name"`
 }
 
-type EntriesModel struct {
-	Amount     types.Float64      `tfsdk:"amount"`
-	Month      types.Int64        `tfsdk:"month"`
-	TagFilters []*TagFiltersModel `tfsdk:"tag_filters"`
+type datadogCostBudgetEntriesModel struct {
+	Amount     types.Float64                              `tfsdk:"amount"`
+	Month      types.Int64                                `tfsdk:"month"`
+	TagFilters []*datadogCostBudgetEntriesTagFiltersModel `tfsdk:"tag_filters"`
 }
 
-type TagFiltersModel struct {
+type datadogCostBudgetEntriesTagFiltersModel struct {
 	TagKey   types.String `tfsdk:"tag_key"`
 	TagValue types.String `tfsdk:"tag_value"`
 }
@@ -144,7 +144,7 @@ func (d *datadogCostBudgetDataSource) updateState(ctx context.Context, state *da
 	}
 	if entries, ok := attributes.GetEntriesOk(); ok && entries != nil {
 		for _, entriesItem := range *entries {
-			entriesModel := &EntriesModel{}
+			entriesModel := &datadogCostBudgetEntriesModel{}
 			if amount, ok := entriesItem.GetAmountOk(); ok && amount != nil {
 				entriesModel.Amount = types.Float64Value(*amount)
 			}
@@ -153,7 +153,7 @@ func (d *datadogCostBudgetDataSource) updateState(ctx context.Context, state *da
 			}
 			if tagFilters, ok := entriesItem.GetTagFiltersOk(); ok && tagFilters != nil {
 				for _, tagFiltersItem := range *tagFilters {
-					tagFiltersModel := &TagFiltersModel{}
+					tagFiltersModel := &datadogCostBudgetEntriesTagFiltersModel{}
 					if tagKey, ok := tagFiltersItem.GetTagKeyOk(); ok && tagKey != nil {
 						tagFiltersModel.TagKey = types.StringValue(*tagKey)
 					}

--- a/.generator-v2/internal/snapshots/data_source_singular_object.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular_object.golden
@@ -17,19 +17,19 @@ var (
 )
 
 type datadogApmRetentionFilterDataSourceModel struct {
-	ID      types.String `tfsdk:"id"`
-	Enabled types.Bool   `tfsdk:"enabled"`
-	Filter  *FilterModel `tfsdk:"filter"`
-	Name    types.String `tfsdk:"name"`
+	ID      types.String                          `tfsdk:"id"`
+	Enabled types.Bool                            `tfsdk:"enabled"`
+	Filter  *datadogApmRetentionFilterFilterModel `tfsdk:"filter"`
+	Name    types.String                          `tfsdk:"name"`
 }
 
-type FilterModel struct {
-	Metadata *MetadataModel `tfsdk:"metadata"`
-	Query    types.String   `tfsdk:"query"`
-	Tags     types.List     `tfsdk:"tags"`
+type datadogApmRetentionFilterFilterModel struct {
+	Metadata *datadogApmRetentionFilterFilterMetadataModel `tfsdk:"metadata"`
+	Query    types.String                                  `tfsdk:"query"`
+	Tags     types.List                                    `tfsdk:"tags"`
 }
 
-type MetadataModel struct {
+type datadogApmRetentionFilterFilterMetadataModel struct {
 	CreatedBy types.String `tfsdk:"created_by"`
 }
 
@@ -145,12 +145,12 @@ func (d *datadogApmRetentionFilterDataSource) updateState(ctx context.Context, s
 		state.Name = types.StringValue(*name)
 	}
 	if filter, ok := attributes.GetFilterOk(); ok && filter != nil {
-		filterModel := &FilterModel{}
+		filterModel := &datadogApmRetentionFilterFilterModel{}
 		if query, ok := filter.GetQueryOk(); ok && query != nil {
 			filterModel.Query = types.StringValue(*query)
 		}
 		if metadata, ok := filter.GetMetadataOk(); ok && metadata != nil {
-			metadataModel := &MetadataModel{}
+			metadataModel := &datadogApmRetentionFilterFilterMetadataModel{}
 			if createdBy, ok := metadata.GetCreatedByOk(); ok && createdBy != nil {
 				metadataModel.CreatedBy = types.StringValue(*createdBy)
 			}

--- a/.generator-v2/internal/snapshots/data_source_singular_oneof.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular_oneof.golden
@@ -17,23 +17,23 @@ var (
 )
 
 type datadogIncidentTypeDataSourceModel struct {
-	ID           types.String               `tfsdk:"id"`
-	Description  types.String               `tfsdk:"description"`
-	IsDefault    types.Bool                 `tfsdk:"is_default"`
-	Name         types.String               `tfsdk:"name"`
-	Notification *IncidentNotificationModel `tfsdk:"notification"`
+	ID           types.String                                  `tfsdk:"id"`
+	Description  types.String                                  `tfsdk:"description"`
+	IsDefault    types.Bool                                    `tfsdk:"is_default"`
+	Name         types.String                                  `tfsdk:"name"`
+	Notification *datadogIncidentTypeIncidentNotificationModel `tfsdk:"notification"`
 }
 
-type IncidentNotificationModel struct {
-	String              *IncidentNotificationStringModel              `tfsdk:"string"`
-	WebhookNotification *IncidentNotificationWebhookNotificationModel `tfsdk:"webhook_notification"`
+type datadogIncidentTypeIncidentNotificationModel struct {
+	String              *datadogIncidentTypeIncidentNotificationStringModel              `tfsdk:"string"`
+	WebhookNotification *datadogIncidentTypeIncidentNotificationWebhookNotificationModel `tfsdk:"webhook_notification"`
 }
 
-type IncidentNotificationStringModel struct {
+type datadogIncidentTypeIncidentNotificationStringModel struct {
 	Value types.String `tfsdk:"value"`
 }
 
-type IncidentNotificationWebhookNotificationModel struct {
+type datadogIncidentTypeIncidentNotificationWebhookNotificationModel struct {
 	Enabled types.Bool   `tfsdk:"enabled"`
 	Url     types.String `tfsdk:"url"`
 }
@@ -161,16 +161,16 @@ func (d *datadogIncidentTypeDataSource) updateState(ctx context.Context, state *
 		state.Name = types.StringValue(*name)
 	}
 	if notification, ok := attributes.GetNotificationOk(); ok && notification != nil {
-		notificationEnvelope := &IncidentNotificationModel{}
+		notificationEnvelope := &datadogIncidentTypeIncidentNotificationModel{}
 		notificationMatches := 0
 		if stringVariant := notification.String; stringVariant != nil {
-			stringModel := &IncidentNotificationStringModel{}
+			stringModel := &datadogIncidentTypeIncidentNotificationStringModel{}
 			stringModel.Value = types.StringValue(*stringVariant)
 			notificationEnvelope.String = stringModel
 			notificationMatches++
 		}
 		if webhookNotificationVariant := notification.WebhookNotification; webhookNotificationVariant != nil {
-			webhookNotificationModel := &IncidentNotificationWebhookNotificationModel{}
+			webhookNotificationModel := &datadogIncidentTypeIncidentNotificationWebhookNotificationModel{}
 			if enabled, ok := webhookNotificationVariant.GetEnabledOk(); ok && enabled != nil {
 				webhookNotificationModel.Enabled = types.BoolValue(*enabled)
 			}

--- a/.generator-v2/internal/snapshots/data_source_singular_oneof_list.golden
+++ b/.generator-v2/internal/snapshots/data_source_singular_oneof_list.golden
@@ -17,23 +17,23 @@ var (
 )
 
 type datadogIncidentTypeDataSourceModel struct {
-	ID            types.String                 `tfsdk:"id"`
-	Description   types.String                 `tfsdk:"description"`
-	IsDefault     types.Bool                   `tfsdk:"is_default"`
-	Name          types.String                 `tfsdk:"name"`
-	Notifications []*IncidentNotificationModel `tfsdk:"notifications"`
+	ID            types.String                                    `tfsdk:"id"`
+	Description   types.String                                    `tfsdk:"description"`
+	IsDefault     types.Bool                                      `tfsdk:"is_default"`
+	Name          types.String                                    `tfsdk:"name"`
+	Notifications []*datadogIncidentTypeIncidentNotificationModel `tfsdk:"notifications"`
 }
 
-type IncidentNotificationModel struct {
-	String              *IncidentNotificationStringModel              `tfsdk:"string"`
-	WebhookNotification *IncidentNotificationWebhookNotificationModel `tfsdk:"webhook_notification"`
+type datadogIncidentTypeIncidentNotificationModel struct {
+	String              *datadogIncidentTypeIncidentNotificationStringModel              `tfsdk:"string"`
+	WebhookNotification *datadogIncidentTypeIncidentNotificationWebhookNotificationModel `tfsdk:"webhook_notification"`
 }
 
-type IncidentNotificationStringModel struct {
+type datadogIncidentTypeIncidentNotificationStringModel struct {
 	Value types.String `tfsdk:"value"`
 }
 
-type IncidentNotificationWebhookNotificationModel struct {
+type datadogIncidentTypeIncidentNotificationWebhookNotificationModel struct {
 	Enabled types.Bool   `tfsdk:"enabled"`
 	Url     types.String `tfsdk:"url"`
 }
@@ -163,16 +163,16 @@ func (d *datadogIncidentTypeDataSource) updateState(ctx context.Context, state *
 	}
 	if notifications, ok := attributes.GetNotificationsOk(); ok && notifications != nil {
 		for _, notificationsItem := range *notifications {
-			notificationsEnvelope := &IncidentNotificationModel{}
+			notificationsEnvelope := &datadogIncidentTypeIncidentNotificationModel{}
 			notificationsMatches := 0
 			if stringVariant := notificationsItem.String; stringVariant != nil {
-				stringModel := &IncidentNotificationStringModel{}
+				stringModel := &datadogIncidentTypeIncidentNotificationStringModel{}
 				stringModel.Value = types.StringValue(*stringVariant)
 				notificationsEnvelope.String = stringModel
 				notificationsMatches++
 			}
 			if webhookNotificationVariant := notificationsItem.WebhookNotification; webhookNotificationVariant != nil {
-				webhookNotificationModel := &IncidentNotificationWebhookNotificationModel{}
+				webhookNotificationModel := &datadogIncidentTypeIncidentNotificationWebhookNotificationModel{}
 				if enabled, ok := webhookNotificationVariant.GetEnabledOk(); ok && enabled != nil {
 					webhookNotificationModel.Enabled = types.BoolValue(*enabled)
 				}


### PR DESCRIPTION
## Motivation

Two differently-shaped objects reachable under the same property name produced one struct name, and the artifact could not compile.

## Changes

- Adds `Attribute.ModelRefName`: the OpenAPI component that supplied the *object* schema backing a generated model struct — the node's own schema for an object, its element schema for an array or map of objects. Empty when that schema was inline.
- Emit names a nested model after its component rather than after the property that happens to point at it, which is the same preference the SDK generator's `child_models()` applies and that oneOf envelope naming already applies via `OneOfSpec.Name`.
- Scopes every generated model name to its artifact, so two data sources cannot collide, and keeps nested models unexported as the hand-written data sources do.
- `dedupeModels` collapses one component reached twice into a single declaration both sites point at, and reports a real conflict (same name, different fields) rather than silently emitting a redeclaration.

## Testing

`go build ./...` and `go test ./...` green. New `modelname_test.go` covers the collision, scoping and dedup cases. Goldens regenerated — the diff is the artifact-scoped model names throughout, including the two oneOf goldens.


