### PR TITLE
[tfgen] Qualify generated nested model names

### DIFF
--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -104,7 +104,8 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 		}
 	}
 
-	rootStruct := dsGoName(a.Name) + "DataSourceModel"
+	goName := dsGoName(a.Name)
+	rootStruct := goName + "DataSourceModel"
 	env := b.flattenEnvelope(topLevel, idStrategy, rootExpr)
 
 	if len(b.unsupported) > 0 {
@@ -113,7 +114,7 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 
 	// env is non-nil here: flattenEnvelope records an unsupported node (caught
 	// above) on every failure path. Walk the hoisted leaves into the root struct.
-	recordAttrs, recordBlocks, recordScalars, recordLists := b.walk(rootStruct, b.receiver, "state", env.leaves)
+	recordAttrs, recordBlocks, recordScalars, recordLists := b.walk(rootStruct, goName, b.receiver, "state", env.leaves)
 	leafFields := b.models[0].Fields
 
 	inputAttrs, inputFields := buildInputViews(inputLeaves)
@@ -160,7 +161,7 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 	return DataSourceView{
 		Cardinality: Singular,
 		TypeName:    a.Name,
-		GoName:      dsGoName(a.Name),
+		GoName:      goName,
 		Description: a.Description,
 		SDKPackage:  primary.GoPackage,
 		APIStruct:   primary.GoApiStruct,
@@ -499,11 +500,12 @@ func droppedIDCollision(path string) DroppedMember {
 // struct's slot in b.models up front so a parent precedes its children, then
 // filling its fields as it goes. receiver is the SDK getter root the state mapper
 // reads off ("attributes" at the record root, the loop variable inside a list
-// element); lhsPrefix is the model target the assignments write into ("state", or
-// the per-element accumulator). It returns the schema attr/block views plus the
-// scalar and list state assignments for the caller to place, recursing through
-// nested blocks.
-func (b *dataSourceBuilder) walk(structName, receiver, lhsPrefix string, attrs []*model.Attribute) (attrViews, blockViews []AttrView, scalars []StateAssignment, lists []ListAssignment) {
+// element); modelStem is the artifact-scoped ownership path without the trailing
+// "Model" (for example, "datadogTeamsTeamParts"); lhsPrefix is the model target
+// the assignments write into ("state", or the per-element accumulator). It
+// returns the schema attr/block views plus the scalar and list state assignments
+// for the caller to place, recursing through nested blocks.
+func (b *dataSourceBuilder) walk(structName, modelStem, receiver, lhsPrefix string, attrs []*model.Attribute) (attrViews, blockViews []AttrView, scalars []StateAssignment, lists []ListAssignment) {
 	idx := len(b.models)
 	b.models = append(b.models, ModelStructView{Name: structName})
 	var fields []ModelFieldView
@@ -553,11 +555,12 @@ func (b *dataSourceBuilder) walk(structName, receiver, lhsPrefix string, attrs [
 			})
 
 		case "schema.ListNestedBlock":
-			elemStruct := field + "Model"
+			elemStem := modelStem + field
+			elemStruct := elemStem + "Model"
 			base := lowerFirst(field)
 			loopVar, elemVar := base+"Item", base+"Model"
 			fields = append(fields, ModelFieldView{GoField: field, GoType: "[]*" + elemStruct, TFName: tfName})
-			childAttrs, childBlocks, childScalars, childLists := b.walk(elemStruct, loopVar, elemVar, a.Children)
+			childAttrs, childBlocks, childScalars, childLists := b.walk(elemStruct, elemStem, loopVar, elemVar, a.Children)
 			blockViews = append(blockViews, AttrView{
 				TFName:      tfName,
 				Description: a.Description,
@@ -583,11 +586,12 @@ func (b *dataSourceBuilder) walk(structName, receiver, lhsPrefix string, attrs [
 			})
 
 		case "schema.SingleNestedBlock":
-			childStruct := field + "Model"
+			childStem := modelStem + field
+			childStruct := childStem + "Model"
 			objVar := leafVar(tfName)
 			elemVar := lowerFirst(field) + "Model"
 			fields = append(fields, ModelFieldView{GoField: field, GoType: "*" + childStruct, TFName: tfName})
-			childAttrs, childBlocks, childScalars, childLists := b.walk(childStruct, objVar, elemVar, a.Children)
+			childAttrs, childBlocks, childScalars, childLists := b.walk(childStruct, childStem, objVar, elemVar, a.Children)
 			blockViews = append(blockViews, AttrView{
 				TFName:      tfName,
 				Description: a.Description,
@@ -817,6 +821,9 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 	inputAttrs, inputFields := buildInputViews(inputLeaves)
 	filterParams, filterUUID := buildFilterParams(call, filterLeaves, &unsupported)
 	callArgs, usesUUID := buildArgumentViews(call, &unsupported)
+	goName := dsGoName(a.Name)
+	itemStem := goName + model.SdkName(call.ItemType)
+	itemStruct := itemStem + "Model"
 
 	// b hosts walk so list-of-object item fields generate their element structs.
 	b := &dataSourceBuilder{}
@@ -861,10 +868,11 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 				Kind: "primitive", LHS: "r." + field, GetterOk: getter, Var: leafVar(tfName), ElementType: n.ElementType,
 			})
 		case "schema.ListNestedBlock":
-			elemStruct := model.SdkName(tfName) + "Model"
+			elemStem := itemStem + model.SdkName(tfName)
+			elemStruct := elemStem + "Model"
 			base := lowerFirst(model.SdkName(tfName))
 			loopVar, elemVar := base+"Item", base+"Model"
-			childAttrs, childBlocks, childScalars, childLists := b.walk(elemStruct, loopVar, elemVar, n.Children)
+			childAttrs, childBlocks, childScalars, childLists := b.walk(elemStruct, elemStem, loopVar, elemVar, n.Children)
 			itemBlocks = append(itemBlocks, AttrView{
 				TFName: tfName, Description: n.Description,
 				IsBlock: true, ListBlock: true, Attributes: childAttrs, Blocks: childBlocks,
@@ -876,10 +884,11 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 				Scalars: childScalars, Lists: childLists,
 			})
 		case "schema.SingleNestedBlock":
-			elemStruct := model.SdkName(tfName) + "Model"
+			elemStem := itemStem + model.SdkName(tfName)
+			elemStruct := elemStem + "Model"
 			objVar := leafVar(tfName)
 			elemVar := lowerFirst(model.SdkName(tfName)) + "Model"
-			childAttrs, childBlocks, childScalars, childLists := b.walk(elemStruct, objVar, elemVar, n.Children)
+			childAttrs, childBlocks, childScalars, childLists := b.walk(elemStruct, elemStem, objVar, elemVar, n.Children)
 			itemBlocks = append(itemBlocks, AttrView{
 				TFName: tfName, Description: n.Description,
 				IsBlock: true, ListBlock: false, Attributes: childAttrs, Blocks: childBlocks,
@@ -898,9 +907,7 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 		return DataSourceView{}, &UnsupportedEmitError{Nodes: unsupported}
 	}
 
-	itemStruct := model.SdkName(call.ItemType) + "Model"
 	itemField := model.SdkName(a.Name)
-	goName := dsGoName(a.Name)
 
 	parentFields := append([]ModelFieldView{}, inputFields...)
 	parentFields = append(parentFields,

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -351,6 +351,14 @@ var _ = Describe("RenderDataSource duplicate field guard", func() {
 		_, err := RenderDataSource(view)
 		Expect(err).To(MatchError(ContainSubstring(`declares tfsdk:"id" twice`)))
 	})
+
+	It("fails instead of writing two model types with the same Go name", func() {
+		view := mustView(incidentTypeOperation())
+		view.Models = append(view.Models, ModelStructView{Name: view.Models[0].Name})
+
+		_, err := RenderDataSource(view)
+		Expect(err).To(MatchError(ContainSubstring(`model datadogIncidentTypeDataSourceModel is declared twice`)))
+	})
 })
 
 var _ = Describe("BuildDataSourceView audit fields", func() {
@@ -802,7 +810,7 @@ var _ = Describe("BuildDataSourceView singular nested arrays", func() {
 		for _, m := range view.Models {
 			names = append(names, m.Name)
 		}
-		Expect(names).To(Equal([]string{"datadogCostBudgetDataSourceModel", "EntriesModel", "TagFiltersModel"}))
+		Expect(names).To(Equal([]string{"datadogCostBudgetDataSourceModel", "datadogCostBudgetEntriesModel", "datadogCostBudgetEntriesTagFiltersModel"}))
 	})
 
 	It("maps each element through a guarded loop, recursing for nested arrays", func() {
@@ -816,7 +824,7 @@ var _ = Describe("BuildDataSourceView singular nested arrays", func() {
 		Expect(entries.GetterOk).To(Equal("attributes.GetEntriesOk()"))
 		Expect(entries.LoopVar).To(Equal("entriesItem"))
 		Expect(entries.ElemVar).To(Equal("entriesModel"))
-		Expect(entries.ElemStruct).To(Equal("EntriesModel"))
+		Expect(entries.ElemStruct).To(Equal("datadogCostBudgetEntriesModel"))
 		Expect(entries.Scalars).To(ContainElement(StateAssignment{
 			Var: "amount", GetterOk: "entriesItem.GetAmountOk()",
 			LHS: "entriesModel.Amount", RHS: "types.Float64Value(*amount)",
@@ -828,7 +836,7 @@ var _ = Describe("BuildDataSourceView singular nested arrays", func() {
 		Expect(tagFilters.LHS).To(Equal("entriesModel.TagFilters"))
 		Expect(tagFilters.GetterOk).To(Equal("entriesItem.GetTagFiltersOk()"))
 		Expect(tagFilters.LoopVar).To(Equal("tagFiltersItem"))
-		Expect(tagFilters.ElemStruct).To(Equal("TagFiltersModel"))
+		Expect(tagFilters.ElemStruct).To(Equal("datadogCostBudgetEntriesTagFiltersModel"))
 	})
 
 	It("produces a deeply-equal view across two runs", func() {
@@ -1199,7 +1207,7 @@ var _ = Describe("BuildDataSourceView plural nested arrays", func() {
 		for _, m := range view.Models {
 			names = append(names, m.Name)
 		}
-		Expect(names).To(Equal([]string{"datadogWidgetsDataSourceModel", "WidgetModel", "PartsModel"}))
+		Expect(names).To(Equal([]string{"datadogWidgetsDataSourceModel", "datadogWidgetsWidgetModel", "datadogWidgetsWidgetPartsModel"}))
 	})
 
 	It("maps the object array off item.Attributes into the item accumulator", func() {
@@ -1212,7 +1220,7 @@ var _ = Describe("BuildDataSourceView plural nested arrays", func() {
 		Expect(parts.LHS).To(Equal("r.Parts"))
 		Expect(parts.GetterOk).To(Equal("item.Attributes.GetPartsOk()"))
 		Expect(parts.LoopVar).To(Equal("partsItem"))
-		Expect(parts.ElemStruct).To(Equal("PartsModel"))
+		Expect(parts.ElemStruct).To(Equal("datadogWidgetsWidgetPartsModel"))
 		Expect(parts.Scalars).To(ContainElement(StateAssignment{
 			Var: "label", GetterOk: "partsItem.GetLabelOk()",
 			LHS: "partsModel.Label", RHS: "types.StringValue(*label)",
@@ -1240,6 +1248,16 @@ var _ = Describe("BuildDataSourceView plural nested arrays", func() {
 		second, err := BuildDataSourceView(mustArtifact(pluralNestedOperation()))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(first).To(Equal(second))
+	})
+
+	It("scopes the shared SDK item type to the Terraform artifact", func() {
+		teams := mustView(teamsOperation())
+		roleUsersOperation := teamsOperation()
+		roleUsersOperation.Tracking.ArtifactName = "role_users"
+		roleUsers := mustView(roleUsersOperation)
+
+		Expect(teams.State.ItemStruct).To(Equal("datadogTeamsTeamModel"))
+		Expect(roleUsers.State.ItemStruct).To(Equal("datadogRoleUsersTeamModel"))
 	})
 })
 
@@ -1302,7 +1320,7 @@ var _ = Describe("BuildDataSourceView singular nested objects", func() {
 		for _, m := range view.Models {
 			names = append(names, m.Name)
 		}
-		Expect(names).To(Equal([]string{"datadogApmRetentionFilterDataSourceModel", "FilterModel", "MetadataModel"}))
+		Expect(names).To(Equal([]string{"datadogApmRetentionFilterDataSourceModel", "datadogApmRetentionFilterFilterModel", "datadogApmRetentionFilterFilterMetadataModel"}))
 	})
 
 	It("maps the object through a guarded assignment, recursing into the nested object", func() {
@@ -1319,7 +1337,7 @@ var _ = Describe("BuildDataSourceView singular nested objects", func() {
 		Expect(filter.GetterOk).To(Equal("attributes.GetFilterOk()"))
 		Expect(filter.Var).To(Equal("filter"))
 		Expect(filter.ElemVar).To(Equal("filterModel"))
-		Expect(filter.ElemStruct).To(Equal("FilterModel"))
+		Expect(filter.ElemStruct).To(Equal("datadogApmRetentionFilterFilterModel"))
 		Expect(filter.Scalars).To(ContainElement(StateAssignment{
 			Var: "query", GetterOk: "filter.GetQueryOk()",
 			LHS: "filterModel.Query", RHS: "types.StringValue(*query)",
@@ -1333,7 +1351,7 @@ var _ = Describe("BuildDataSourceView singular nested objects", func() {
 		}
 		Expect(metadata.LHS).To(Equal("filterModel.Metadata"))
 		Expect(metadata.GetterOk).To(Equal("filter.GetMetadataOk()"))
-		Expect(metadata.ElemStruct).To(Equal("MetadataModel"))
+		Expect(metadata.ElemStruct).To(Equal("datadogApmRetentionFilterFilterMetadataModel"))
 	})
 
 	It("renders the guarded object block and the recursive assignment in updateState", func() {
@@ -1352,6 +1370,32 @@ var _ = Describe("BuildDataSourceView singular nested objects", func() {
 		second, err := BuildDataSourceView(mustArtifact(retentionFilterOperation()))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(first).To(Equal(second))
+	})
+
+	It("includes the full parent path when two branches reuse the same leaf name", func() {
+		op := retentionFilterOperation()
+		attrs := op.ResponseSchema.Properties["data"].Properties["attributes"].Properties
+		attrs["primary"] = obj(map[string]*model.Schema{
+			"data": obj(map[string]*model.Schema{"value": prim("string", "The primary value.")}),
+		})
+		attrs["secondary"] = obj(map[string]*model.Schema{
+			"data": obj(map[string]*model.Schema{"value": prim("string", "The secondary value.")}),
+		})
+
+		view := mustView(op)
+		names := make([]string, 0, len(view.Models))
+		for _, modelView := range view.Models {
+			names = append(names, modelView.Name)
+		}
+		Expect(names).To(Equal([]string{
+			"datadogApmRetentionFilterDataSourceModel",
+			"datadogApmRetentionFilterFilterModel",
+			"datadogApmRetentionFilterFilterMetadataModel",
+			"datadogApmRetentionFilterPrimaryModel",
+			"datadogApmRetentionFilterPrimaryDataModel",
+			"datadogApmRetentionFilterSecondaryModel",
+			"datadogApmRetentionFilterSecondaryDataModel",
+		}))
 	})
 })
 
@@ -1414,7 +1458,7 @@ var _ = Describe("BuildDataSourceView plural nested objects", func() {
 		for _, m := range view.Models {
 			names = append(names, m.Name)
 		}
-		Expect(names).To(Equal([]string{"datadogGizmosDataSourceModel", "GizmoModel", "SpecModel"}))
+		Expect(names).To(Equal([]string{"datadogGizmosDataSourceModel", "datadogGizmosGizmoModel", "datadogGizmosGizmoSpecModel"}))
 	})
 
 	It("maps the object off item.Attributes into the item accumulator", func() {
@@ -1427,7 +1471,7 @@ var _ = Describe("BuildDataSourceView plural nested objects", func() {
 		Expect(spec.LHS).To(Equal("r.Spec"))
 		Expect(spec.GetterOk).To(Equal("item.Attributes.GetSpecOk()"))
 		Expect(spec.Var).To(Equal("spec"))
-		Expect(spec.ElemStruct).To(Equal("SpecModel"))
+		Expect(spec.ElemStruct).To(Equal("datadogGizmosGizmoSpecModel"))
 		Expect(spec.Scalars).To(ContainElement(StateAssignment{
 			Var: "shape", GetterOk: "spec.GetShapeOk()",
 			LHS: "specModel.Shape", RHS: "types.StringValue(*shape)",

--- a/.generator-v2/internal/emit/render.go
+++ b/.generator-v2/internal/emit/render.go
@@ -74,13 +74,18 @@ func RenderDataSource(v DataSourceView) ([]byte, error) {
 	return dropBlankLineAfterBrace(formatted), nil
 }
 
-// checkDuplicateFields rejects a model struct that declares the same Terraform
-// name twice. Such a struct renders three ways that do not compile — a
-// redeclared Go field, a duplicate tfsdk tag, and a duplicate key in the schema
-// attribute map — so failing here keeps a broken artifact from being written and
-// reported as created.
+// checkDuplicateFields rejects duplicate Go model names and a model struct that
+// declares the same Terraform name twice. Either shape produces generated code
+// that does not compile, so failing here keeps a broken artifact from being
+// written and reported as created.
 func checkDuplicateFields(models []ModelStructView) error {
+	modelNames := make(map[string]bool, len(models))
 	for _, m := range models {
+		if modelNames[m.Name] {
+			return fmt.Errorf("model %s is declared twice", m.Name)
+		}
+		modelNames[m.Name] = true
+
 		seen := make(map[string]bool, len(m.Fields))
 		for _, f := range m.Fields {
 			if seen[f.TFName] {

--- a/.generator-v2/internal/emit/templates_test.go
+++ b/.generator-v2/internal/emit/templates_test.go
@@ -240,11 +240,11 @@ func pluralFixture() DataSourceView {
 					{Comment: "Query Parameters", GoField: "FilterKeyword", GoType: "types.String", TFName: "filter_keyword"},
 					{GoField: "FilterMe", GoType: "types.Bool", TFName: "filter_me"},
 					{Comment: "Results", GoField: "ID", GoType: "types.String", TFName: "id"},
-					{GoField: "Teams", GoType: "[]*TeamModel", TFName: "teams"},
+					{GoField: "Teams", GoType: "[]*datadogTeamsTeamModel", TFName: "teams"},
 				},
 			},
 			{
-				Name: "TeamModel",
+				Name: "datadogTeamsTeamModel",
 				Fields: []ModelFieldView{
 					{GoField: "Description", GoType: "types.String", TFName: "description"},
 					{GoField: "Handle", GoType: "types.String", TFName: "handle"},
@@ -284,7 +284,7 @@ func pluralFixture() DataSourceView {
 			},
 		},
 		State: StateView{
-			ItemStruct: "TeamModel",
+			ItemStruct: "datadogTeamsTeamModel",
 			ItemField:  "Teams",
 			ItemFields: []StateAssignment{
 				{LHS: "Description", RHS: "types.StringValue(item.Attributes.GetDescription())"},

--- a/.generator-v2/internal/testdata/emit/data_source_plural.golden
+++ b/.generator-v2/internal/testdata/emit/data_source_plural.golden
@@ -23,11 +23,11 @@ type datadogTeamsDataSourceModel struct {
 	FilterMe      types.Bool   `tfsdk:"filter_me"`
 
 	// Results
-	ID    types.String `tfsdk:"id"`
-	Teams []*TeamModel `tfsdk:"teams"`
+	ID    types.String             `tfsdk:"id"`
+	Teams []*datadogTeamsTeamModel `tfsdk:"teams"`
 }
 
-type TeamModel struct {
+type datadogTeamsTeamModel struct {
 	Description    types.String `tfsdk:"description"`
 	Handle         types.String `tfsdk:"handle"`
 	ID             types.String `tfsdk:"id"`
@@ -153,9 +153,9 @@ func (d *datadogTeamsDataSource) Read(ctx context.Context, request datasource.Re
 }
 
 func (d *datadogTeamsDataSource) updateState(state *datadogTeamsDataSourceModel, data *[]datadogV2.Team) {
-	results := make([]*TeamModel, 0, len(*data))
+	results := make([]*datadogTeamsTeamModel, 0, len(*data))
 	for _, item := range *data {
-		r := TeamModel{
+		r := datadogTeamsTeamModel{
 			Description: types.StringValue(item.Attributes.GetDescription()),
 			Handle:      types.StringValue(item.Attributes.GetHandle()),
 			ID:          types.StringValue(item.GetId()),

--- a/.generator-v2/internal/testdata/emit/data_source_plural_nested.golden
+++ b/.generator-v2/internal/testdata/emit/data_source_plural_nested.golden
@@ -18,17 +18,17 @@ var (
 
 type datadogWidgetsDataSourceModel struct {
 	// Results
-	ID      types.String   `tfsdk:"id"`
-	Widgets []*WidgetModel `tfsdk:"widgets"`
+	ID      types.String                 `tfsdk:"id"`
+	Widgets []*datadogWidgetsWidgetModel `tfsdk:"widgets"`
 }
 
-type WidgetModel struct {
-	ID    types.String  `tfsdk:"id"`
-	Name  types.String  `tfsdk:"name"`
-	Parts []*PartsModel `tfsdk:"parts"`
+type datadogWidgetsWidgetModel struct {
+	ID    types.String                      `tfsdk:"id"`
+	Name  types.String                      `tfsdk:"name"`
+	Parts []*datadogWidgetsWidgetPartsModel `tfsdk:"parts"`
 }
 
-type PartsModel struct {
+type datadogWidgetsWidgetPartsModel struct {
 	Label    types.String `tfsdk:"label"`
 	Quantity types.Int64  `tfsdk:"quantity"`
 }
@@ -115,15 +115,15 @@ func (d *datadogWidgetsDataSource) Read(ctx context.Context, request datasource.
 }
 
 func (d *datadogWidgetsDataSource) updateState(state *datadogWidgetsDataSourceModel, data *[]datadogV2.Widget) {
-	results := make([]*WidgetModel, 0, len(*data))
+	results := make([]*datadogWidgetsWidgetModel, 0, len(*data))
 	for _, item := range *data {
-		r := WidgetModel{
+		r := datadogWidgetsWidgetModel{
 			ID:   types.StringValue(item.GetId()),
 			Name: types.StringValue(item.Attributes.GetName()),
 		}
 		if parts, ok := item.Attributes.GetPartsOk(); ok && parts != nil {
 			for _, partsItem := range *parts {
-				partsModel := &PartsModel{}
+				partsModel := &datadogWidgetsWidgetPartsModel{}
 				if label, ok := partsItem.GetLabelOk(); ok && label != nil {
 					partsModel.Label = types.StringValue(*label)
 				}

--- a/.generator-v2/internal/testdata/emit/data_source_plural_no_params.golden
+++ b/.generator-v2/internal/testdata/emit/data_source_plural_no_params.golden
@@ -18,11 +18,11 @@ var (
 
 type datadogDatastoresDataSourceModel struct {
 	// Results
-	ID         types.String          `tfsdk:"id"`
-	Datastores []*DatastoreDataModel `tfsdk:"datastores"`
+	ID         types.String                           `tfsdk:"id"`
+	Datastores []*datadogDatastoresDatastoreDataModel `tfsdk:"datastores"`
 }
 
-type DatastoreDataModel struct {
+type datadogDatastoresDatastoreDataModel struct {
 	CreatorUserId                types.Int64  `tfsdk:"creator_user_id"`
 	CreatorUserUuid              types.String `tfsdk:"creator_user_uuid"`
 	Description                  types.String `tfsdk:"description"`
@@ -122,9 +122,9 @@ func (d *datadogDatastoresDataSource) Read(ctx context.Context, request datasour
 }
 
 func (d *datadogDatastoresDataSource) updateState(state *datadogDatastoresDataSourceModel, data *[]datadogV2.DatastoreData) {
-	results := make([]*DatastoreDataModel, 0, len(*data))
+	results := make([]*datadogDatastoresDatastoreDataModel, 0, len(*data))
 	for _, item := range *data {
-		r := DatastoreDataModel{
+		r := datadogDatastoresDatastoreDataModel{
 			CreatorUserId:                types.Int64Value(int64(item.Attributes.GetCreatorUserId())),
 			CreatorUserUuid:              types.StringValue(item.Attributes.GetCreatorUserUuid()),
 			Description:                  types.StringValue(item.Attributes.GetDescription()),

--- a/.generator-v2/internal/testdata/emit/data_source_plural_object.golden
+++ b/.generator-v2/internal/testdata/emit/data_source_plural_object.golden
@@ -18,17 +18,17 @@ var (
 
 type datadogGizmosDataSourceModel struct {
 	// Results
-	ID     types.String  `tfsdk:"id"`
-	Gizmos []*GizmoModel `tfsdk:"gizmos"`
+	ID     types.String               `tfsdk:"id"`
+	Gizmos []*datadogGizmosGizmoModel `tfsdk:"gizmos"`
 }
 
-type GizmoModel struct {
-	ID   types.String `tfsdk:"id"`
-	Name types.String `tfsdk:"name"`
-	Spec *SpecModel   `tfsdk:"spec"`
+type datadogGizmosGizmoModel struct {
+	ID   types.String                 `tfsdk:"id"`
+	Name types.String                 `tfsdk:"name"`
+	Spec *datadogGizmosGizmoSpecModel `tfsdk:"spec"`
 }
 
-type SpecModel struct {
+type datadogGizmosGizmoSpecModel struct {
 	Shape types.String `tfsdk:"shape"`
 	Size  types.Int64  `tfsdk:"size"`
 }
@@ -114,14 +114,14 @@ func (d *datadogGizmosDataSource) Read(ctx context.Context, request datasource.R
 }
 
 func (d *datadogGizmosDataSource) updateState(state *datadogGizmosDataSourceModel, data *[]datadogV2.Gizmo) {
-	results := make([]*GizmoModel, 0, len(*data))
+	results := make([]*datadogGizmosGizmoModel, 0, len(*data))
 	for _, item := range *data {
-		r := GizmoModel{
+		r := datadogGizmosGizmoModel{
 			ID:   types.StringValue(item.GetId()),
 			Name: types.StringValue(item.Attributes.GetName()),
 		}
 		if spec, ok := item.Attributes.GetSpecOk(); ok && spec != nil {
-			specModel := &SpecModel{}
+			specModel := &datadogGizmosGizmoSpecModel{}
 			if shape, ok := spec.GetShapeOk(); ok && shape != nil {
 				specModel.Shape = types.StringValue(*shape)
 			}

--- a/.generator-v2/internal/testdata/emit/data_source_singular_nested.golden
+++ b/.generator-v2/internal/testdata/emit/data_source_singular_nested.golden
@@ -16,18 +16,18 @@ var (
 )
 
 type datadogCostBudgetDataSourceModel struct {
-	ID      types.String    `tfsdk:"id"`
-	Entries []*EntriesModel `tfsdk:"entries"`
-	Name    types.String    `tfsdk:"name"`
+	ID      types.String                     `tfsdk:"id"`
+	Entries []*datadogCostBudgetEntriesModel `tfsdk:"entries"`
+	Name    types.String                     `tfsdk:"name"`
 }
 
-type EntriesModel struct {
-	Amount     types.Float64      `tfsdk:"amount"`
-	Month      types.Int64        `tfsdk:"month"`
-	TagFilters []*TagFiltersModel `tfsdk:"tag_filters"`
+type datadogCostBudgetEntriesModel struct {
+	Amount     types.Float64                              `tfsdk:"amount"`
+	Month      types.Int64                                `tfsdk:"month"`
+	TagFilters []*datadogCostBudgetEntriesTagFiltersModel `tfsdk:"tag_filters"`
 }
 
-type TagFiltersModel struct {
+type datadogCostBudgetEntriesTagFiltersModel struct {
 	TagKey   types.String `tfsdk:"tag_key"`
 	TagValue types.String `tfsdk:"tag_value"`
 }
@@ -139,7 +139,7 @@ func (d *datadogCostBudgetDataSource) updateState(state *datadogCostBudgetDataSo
 	}
 	if entries, ok := attributes.GetEntriesOk(); ok && entries != nil {
 		for _, entriesItem := range *entries {
-			entriesModel := &EntriesModel{}
+			entriesModel := &datadogCostBudgetEntriesModel{}
 			if amount, ok := entriesItem.GetAmountOk(); ok && amount != nil {
 				entriesModel.Amount = types.Float64Value(*amount)
 			}
@@ -148,7 +148,7 @@ func (d *datadogCostBudgetDataSource) updateState(state *datadogCostBudgetDataSo
 			}
 			if tagFilters, ok := entriesItem.GetTagFiltersOk(); ok && tagFilters != nil {
 				for _, tagFiltersItem := range *tagFilters {
-					tagFiltersModel := &TagFiltersModel{}
+					tagFiltersModel := &datadogCostBudgetEntriesTagFiltersModel{}
 					if tagKey, ok := tagFiltersItem.GetTagKeyOk(); ok && tagKey != nil {
 						tagFiltersModel.TagKey = types.StringValue(*tagKey)
 					}

--- a/.generator-v2/internal/testdata/emit/data_source_singular_object.golden
+++ b/.generator-v2/internal/testdata/emit/data_source_singular_object.golden
@@ -16,19 +16,19 @@ var (
 )
 
 type datadogApmRetentionFilterDataSourceModel struct {
-	ID      types.String `tfsdk:"id"`
-	Enabled types.Bool   `tfsdk:"enabled"`
-	Filter  *FilterModel `tfsdk:"filter"`
-	Name    types.String `tfsdk:"name"`
+	ID      types.String                          `tfsdk:"id"`
+	Enabled types.Bool                            `tfsdk:"enabled"`
+	Filter  *datadogApmRetentionFilterFilterModel `tfsdk:"filter"`
+	Name    types.String                          `tfsdk:"name"`
 }
 
-type FilterModel struct {
-	Metadata *MetadataModel `tfsdk:"metadata"`
-	Query    types.String   `tfsdk:"query"`
-	Tags     types.List     `tfsdk:"tags"`
+type datadogApmRetentionFilterFilterModel struct {
+	Metadata *datadogApmRetentionFilterFilterMetadataModel `tfsdk:"metadata"`
+	Query    types.String                                  `tfsdk:"query"`
+	Tags     types.List                                    `tfsdk:"tags"`
 }
 
-type MetadataModel struct {
+type datadogApmRetentionFilterFilterMetadataModel struct {
 	CreatedBy types.String `tfsdk:"created_by"`
 }
 
@@ -140,12 +140,12 @@ func (d *datadogApmRetentionFilterDataSource) updateState(state *datadogApmReten
 		state.Name = types.StringValue(*name)
 	}
 	if filter, ok := attributes.GetFilterOk(); ok && filter != nil {
-		filterModel := &FilterModel{}
+		filterModel := &datadogApmRetentionFilterFilterModel{}
 		if query, ok := filter.GetQueryOk(); ok && query != nil {
 			filterModel.Query = types.StringValue(*query)
 		}
 		if metadata, ok := filter.GetMetadataOk(); ok && metadata != nil {
-			metadataModel := &MetadataModel{}
+			metadataModel := &datadogApmRetentionFilterFilterMetadataModel{}
 			if createdBy, ok := metadata.GetCreatedByOk(); ok && createdBy != nil {
 				metadataModel.CreatedBy = types.StringValue(*createdBy)
 			}


### PR DESCRIPTION
## Motivation

TFgen currently names nested Go model structs from only their final field name. Different paths such as `forecast.costs` and `budget.costs`, or different generated data sources that both use an SDK `User` model, can therefore declare the same package-level Go type. Those collisions prevent otherwise valid generated data sources from compiling.

This PR is stacked on #4088 and makes generated model names unique to both their Terraform artifact and complete ownership path. The names are private Go implementation details; Terraform attribute names, `tfsdk` tags, state shape, and API behavior remain unchanged.

## Changes

- Seed singular nested model names from the generated data-source name and append every parent path segment during recursive traversal.
- Scope plural item models to the Terraform artifact and SDK item type, then derive nested children from that qualified item path.
- Reject duplicate model type names before rendering an uncompilable artifact.
- Add regression coverage for repeated leaf names under different parents and multiple artifacts sharing the same SDK item type.
- Update golden files mechanically to reflect the new private Go type names.

Readable path-qualified names are longer than leaf-only names, but make generated diagnostics deterministic and understandable without introducing hashes or a global name registry.

## QA Instructions

- `make tfgen-test` — passed, including 140/140 emitter specs.
- `make tfgen-build` — passed.
- `make fmtcheck` — passed.
- `make test` — passed, 235 provider tests.
- `make vet` — passed.
- `make errcheck` — reports the existing repository-wide legacy unchecked-error backlog; no finding touches generator-v2 or this change.

An exhaustive build-verified sweep was run against all 565 full-spec report candidates using a temporary integration head containing every PR in the stack, including the latest API-accessor follow-up. The resulting stack coverage was:

| View | Pass | Coverage |
|---|---:|---:|
| Singular | 111/156 | 71.2% |
| Plural | 155/194 | 79.9% |
| Both | 63/96 | 65.6% |

All previous duplicate Go model declaration diagnostics disappeared. The collision-only set contributed four singular and nine plural build-verified passes. `GetStatusPage` and `ListStatusPages` now expose a separate state-mapping issue rather than a model-name collision.

## Blast Radius

For internal generator users, nested-model name collisions stop blocking generated data sources from compiling. The change is limited to generator-v2's private emitted Go identifiers and can be reverted without affecting existing Terraform configuration or state compatibility.
