### PR TITLE
[tfgen] Support typed nested collections

### DIFF
--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -392,9 +392,8 @@ func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrat
 		return nil
 	}
 
-	// Hoist the attribute children to top-level paths: scalar leaves, array nodes
-	// (list-of-primitive / list-of-object), and bare nested objects are in scope;
-	// a map is not.
+	// Hoist the attribute children to top-level paths: scalar leaves, typed list/map
+	// attributes, list-of-object blocks, and bare nested objects are in scope.
 	leaves := make([]*model.Attribute, 0, len(attributes.Children))
 	for _, child := range attributes.Children {
 		if isAuditField(tfNameOf(child.Path)) {
@@ -407,7 +406,7 @@ func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrat
 			b.dropped = append(b.dropped, droppedIDCollision(child.Path))
 			continue
 		}
-		if !isLeafType(child.TfType) && !isArrayType(child.TfType) && !isObjectType(child.TfType) {
+		if !isLeafType(child.TfType) && !isArrayType(child.TfType) && !isMapType(child.TfType) && !isObjectType(child.TfType) {
 			b.unsupported = append(b.unsupported, UnsupportedNode{
 				Path:   child.Path,
 				Reason: "nesting under attributes is not supported",
@@ -547,11 +546,33 @@ func (b *dataSourceBuilder) walk(structName, modelStem, receiver, lhsPrefix stri
 			})
 			fields = append(fields, ModelFieldView{GoField: field, GoType: a.GoType, TFName: tfName}) // types.List
 			lists = append(lists, ListAssignment{
-				Kind:        "primitive",
-				LHS:         lhsPrefix + "." + field,
-				GetterOk:    getterOk(receiver, tfName),
-				Var:         leafVar(tfName),
+				Kind:          "primitive",
+				ContainerKind: "list",
+				LHS:           lhsPrefix + "." + field,
+				GetterOk:      getterOk(receiver, tfName),
+				Var:           leafVar(tfName),
+				ElementType:   a.ElementType,
+			})
+
+		case "schema.MapAttribute":
+			attrViews = append(attrViews, AttrView{
+				TFName:      tfName,
+				TFType:      a.TfType,
 				ElementType: a.ElementType,
+				Description: a.Description,
+				Required:    a.Required,
+				Optional:    a.Optional,
+				Computed:    a.Computed,
+				Sensitive:   a.Sensitive,
+			})
+			fields = append(fields, ModelFieldView{GoField: field, GoType: a.GoType, TFName: tfName})
+			lists = append(lists, ListAssignment{
+				Kind:          "primitive",
+				ContainerKind: "map",
+				LHS:           lhsPrefix + "." + field,
+				GetterOk:      getterOk(receiver, tfName),
+				Var:           leafVar(tfName),
+				ElementType:   a.ElementType,
 			})
 
 		case "schema.ListNestedBlock":
@@ -653,6 +674,9 @@ func isArrayType(tfType string) bool {
 		return false
 	}
 }
+
+// isMapType reports whether tfType is a typed dynamic-key map attribute.
+func isMapType(tfType string) bool { return tfType == "schema.MapAttribute" }
 
 // isObjectType reports whether tfType is a bare nested object the envelope
 // hoists into single-object machinery (schema.SingleNestedBlock).
@@ -764,8 +788,6 @@ func wrapValue(a *model.Attribute, chain string) string {
 // TfType the singular emit path does not yet handle.
 func unsupportedReason(tfType string) string {
 	switch tfType {
-	case "schema.MapAttribute":
-		return "map not yet supported"
 	case "schema.MapNestedAttribute":
 		return "map-of-object not yet supported"
 	case "schema.SingleNestedAttribute", "schema.ListNestedAttribute":
@@ -849,9 +871,9 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 	}
 
 	// Non-scalar attributes append after the scalars and map after the literal via
-	// ItemLists, read off item.Attributes: a list-of-primitive as a ListAttribute,
-	// a list-of-object as a ListNestedBlock, and a bare object as a
-	// SingleNestedBlock — each with its element struct walked.
+	// ItemLists, read off item.Attributes: primitive-terminal lists/maps as leaf
+	// attributes, list-of-object as a ListNestedBlock, and a bare object as a
+	// SingleNestedBlock — object forms have their element struct walked.
 	var itemBlocks []AttrView
 	var itemLists []ListAssignment
 	for _, n := range nonScalars {
@@ -859,13 +881,17 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 		field := goFieldName(tfName)
 		getter := getterOk("item.Attributes", tfName)
 		switch n.TfType {
-		case "schema.ListAttribute":
+		case "schema.ListAttribute", "schema.MapAttribute":
+			containerKind := "list"
+			if n.TfType == "schema.MapAttribute" {
+				containerKind = "map"
+			}
 			itemAttrs = append(itemAttrs, AttrView{
 				TFName: tfName, TFType: n.TfType, ElementType: n.ElementType, Description: n.Description, Computed: true,
 			})
 			itemFields = append(itemFields, ModelFieldView{GoField: field, GoType: n.GoType, TFName: tfName})
 			itemLists = append(itemLists, ListAssignment{
-				Kind: "primitive", LHS: "r." + field, GetterOk: getter, Var: leafVar(tfName), ElementType: n.ElementType,
+				Kind: "primitive", ContainerKind: containerKind, LHS: "r." + field, GetterOk: getter, Var: leafVar(tfName), ElementType: n.ElementType,
 			})
 		case "schema.ListNestedBlock":
 			elemStem := itemStem + model.SdkName(tfName)
@@ -1014,7 +1040,7 @@ func flattenItemElement(block *model.Attribute, unsupported *[]UnsupportedNode, 
 				switch {
 				case isLeafType(leaf.TfType):
 					scalars = append(scalars, itemElementLeaf{attr: leaf, chain: itemGetter("item.Attributes", tfNameOf(leaf.Path))})
-				case isArrayType(leaf.TfType), isObjectType(leaf.TfType):
+				case isArrayType(leaf.TfType), isMapType(leaf.TfType), isObjectType(leaf.TfType):
 					nonScalars = append(nonScalars, leaf)
 				default:
 					*unsupported = append(*unsupported, UnsupportedNode{Path: leaf.Path, Reason: "nesting under item attributes is not supported"})

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -881,9 +881,77 @@ var _ = Describe("BuildDataSourceView singular arrays", func() {
 
 		// Sorted by attribute name, both string arrays become guarded primitive lists.
 		Expect(view.State.Lists).To(Equal([]ListAssignment{
-			{Kind: "primitive", LHS: "state.HiddenModules", GetterOk: "attributes.GetHiddenModulesOk()", Var: "hiddenModules", ElementType: "types.StringType"},
-			{Kind: "primitive", LHS: "state.VisibleModules", GetterOk: "attributes.GetVisibleModulesOk()", Var: "visibleModules", ElementType: "types.StringType"},
+			{Kind: "primitive", ContainerKind: "list", LHS: "state.HiddenModules", GetterOk: "attributes.GetHiddenModulesOk()", Var: "hiddenModules", ElementType: "types.StringType"},
+			{Kind: "primitive", ContainerKind: "list", LHS: "state.VisibleModules", GetterOk: "attributes.GetVisibleModulesOk()", Var: "visibleModules", ElementType: "types.StringType"},
 		}))
+	})
+
+	It("emits recursive list/map types and the matching state constructors", func() {
+		op := teamSingularOperation()
+		attrs := op.ResponseSchema.Properties["data"].Properties["attributes"].Properties
+		attrs["host_tags_lists"] = &model.Schema{
+			Kind: model.SchemaKindArray, Description: "Host tag conjunctions.",
+			Items: &model.Schema{Kind: model.SchemaKindArray, Items: prim("string", "A host tag.")},
+		}
+		attrs["group_bys"] = &model.Schema{
+			Kind: model.SchemaKindMap, Description: "Named grouping dimensions.",
+			Items: &model.Schema{Kind: model.SchemaKindArray, Items: prim("string", "A grouping dimension.")},
+		}
+		attrs["cloud_provider"] = &model.Schema{
+			Kind: model.SchemaKindMap, Description: "Cloud provider filters.",
+			Items: &model.Schema{Kind: model.SchemaKindMap, Items: &model.Schema{
+				Kind: model.SchemaKindArray, Items: prim("string", "A filter value."),
+			}},
+		}
+
+		view := mustView(op)
+		attributes := map[string]AttrView{}
+		for _, attr := range view.Schema.Attributes {
+			attributes[attr.TFName] = attr
+		}
+		Expect(attributes["host_tags_lists"].TFType).To(Equal("schema.ListAttribute"))
+		Expect(attributes["host_tags_lists"].ElementType).To(Equal("types.ListType{ElemType: types.StringType}"))
+		Expect(attributes["group_bys"].TFType).To(Equal("schema.MapAttribute"))
+		Expect(attributes["group_bys"].ElementType).To(Equal("types.ListType{ElemType: types.StringType}"))
+		Expect(attributes["cloud_provider"].TFType).To(Equal("schema.MapAttribute"))
+		Expect(attributes["cloud_provider"].ElementType).To(Equal("types.MapType{ElemType: types.ListType{ElemType: types.StringType}}"))
+
+		assignments := map[string]ListAssignment{}
+		for _, assignment := range view.State.Lists {
+			assignments[assignment.LHS] = assignment
+		}
+		Expect(assignments["state.HostTagsLists"].ContainerKind).To(Equal("list"))
+		Expect(assignments["state.GroupBys"].ContainerKind).To(Equal("map"))
+		Expect(assignments["state.CloudProvider"].ContainerKind).To(Equal("map"))
+
+		rendered, err := RenderDataSource(view)
+		Expect(err).NotTo(HaveOccurred())
+		src := string(rendered)
+		Expect(src).To(ContainSubstring("types.ListValueFrom(context.Background(), types.ListType{ElemType: types.StringType}, *hostTagsLists)"))
+		Expect(src).To(ContainSubstring("types.MapValueFrom(context.Background(), types.ListType{ElemType: types.StringType}, *groupBys)"))
+		Expect(src).To(ContainSubstring("types.MapNull(types.MapType{ElemType: types.ListType{ElemType: types.StringType}})"))
+	})
+
+	It("emits a typed map nested inside an object-list element", func() {
+		op := costBudgetOperation()
+		entry := op.ResponseSchema.Properties["data"].Properties["attributes"].Properties["entries"].Items
+		entry.Properties["metadata"] = &model.Schema{
+			Kind: model.SchemaKindMap, Description: "Entry metadata.",
+			Items: prim("string", "A metadata value."),
+		}
+
+		view := mustView(op)
+		entries := view.State.Lists[0]
+		nested := map[string]ListAssignment{}
+		for _, assignment := range entries.Lists {
+			nested[assignment.LHS] = assignment
+		}
+		Expect(nested["entriesModel.Metadata"].Kind).To(Equal("primitive"))
+		Expect(nested["entriesModel.Metadata"].ContainerKind).To(Equal("map"))
+		Expect(nested["entriesModel.Metadata"].ElementType).To(Equal("types.StringType"))
+		rendered, err := RenderDataSource(view)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(rendered)).To(ContainSubstring("types.MapValueFrom(context.Background(), types.StringType, *metadata)"))
 	})
 
 	It("produces a deeply-equal view across two runs", func() {
@@ -902,6 +970,27 @@ var _ = Describe("BuildDataSourceView plural", func() {
 		view, err := BuildDataSourceView(art)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(view).To(Equal(pluralFixture()))
+	})
+
+	It("emits a recursively typed map on a plural result item", func() {
+		op := teamsOperation()
+		attributes := op.ResponseSchema.Properties["data"].Items.Properties["attributes"].Properties
+		attributes["group_bys"] = &model.Schema{
+			Kind: model.SchemaKindMap, Description: "Named grouping dimensions.",
+			Items: &model.Schema{Kind: model.SchemaKindArray, Items: prim("string", "A grouping dimension.")},
+		}
+
+		view := mustView(op)
+		itemCollections := map[string]ListAssignment{}
+		for _, assignment := range view.State.ItemLists {
+			itemCollections[assignment.LHS] = assignment
+		}
+		Expect(itemCollections["r.GroupBys"].Kind).To(Equal("primitive"))
+		Expect(itemCollections["r.GroupBys"].ContainerKind).To(Equal("map"))
+		Expect(itemCollections["r.GroupBys"].ElementType).To(Equal("types.ListType{ElemType: types.StringType}"))
+		rendered, err := RenderDataSource(view)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(rendered)).To(ContainSubstring("types.MapValueFrom(context.Background(), types.ListType{ElemType: types.StringType}, *groupBys)"))
 	})
 
 	It("drops array and enum query params from the filter set", func() {

--- a/.generator-v2/internal/emit/templates/data_source_common.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_common.go.tmpl
@@ -85,9 +85,17 @@ Blocks: map[string]schema.Block{
 {{- define "renderList" -}}
 {{- if eq .Kind "primitive" -}}
 if {{ .Var }}, ok := {{ .GetterOk }}; ok && {{ .Var }} != nil {
+	{{- if eq .ContainerKind "map" }}
+	{{ .LHS }}, _ = types.MapValueFrom(context.Background(), {{ .ElementType }}, *{{ .Var }})
+	{{- else }}
 	{{ .LHS }}, _ = types.ListValueFrom(context.Background(), {{ .ElementType }}, *{{ .Var }})
+	{{- end }}
 } else {
+	{{- if eq .ContainerKind "map" }}
+	{{ .LHS }} = types.MapNull({{ .ElementType }})
+	{{- else }}
 	{{ .LHS }} = types.ListNull({{ .ElementType }})
+	{{- end }}
 }
 {{- else if eq .Kind "object" -}}
 if {{ .Var }}, ok := {{ .GetterOk }}; ok && {{ .Var }} != nil {

--- a/.generator-v2/internal/emit/templates_test.go
+++ b/.generator-v2/internal/emit/templates_test.go
@@ -296,8 +296,8 @@ func pluralFixture() DataSourceView {
 				{LHS: "UserCount", RHS: "types.Int64Value(int64(item.Attributes.GetUserCount()))"},
 			},
 			ItemLists: []ListAssignment{
-				{Kind: "primitive", LHS: "r.HiddenModules", GetterOk: "item.Attributes.GetHiddenModulesOk()", Var: "hiddenModules", ElementType: "types.StringType"},
-				{Kind: "primitive", LHS: "r.VisibleModules", GetterOk: "item.Attributes.GetVisibleModulesOk()", Var: "visibleModules", ElementType: "types.StringType"},
+				{Kind: "primitive", ContainerKind: "list", LHS: "r.HiddenModules", GetterOk: "item.Attributes.GetHiddenModulesOk()", Var: "hiddenModules", ElementType: "types.StringType"},
+				{Kind: "primitive", ContainerKind: "list", LHS: "r.VisibleModules", GetterOk: "item.Attributes.GetVisibleModulesOk()", Var: "visibleModules", ElementType: "types.StringType"},
 			},
 		},
 	}

--- a/.generator-v2/internal/emit/view.go
+++ b/.generator-v2/internal/emit/view.go
@@ -262,9 +262,10 @@ type StateView struct {
 	// ItemFields are the item struct's literal fields ("<GoField>: <RHS>"),
 	// evaluated against the loop variable "item".
 	ItemFields []StateAssignment
-	// ItemLists are the item's list-valued assignments, rendered by "renderList"
-	// after the struct literal (they cannot sit in the literal: a primitive list
-	// is a two-value ListValueFrom, an object list is a loop).
+	// ItemLists are the item's collection-valued assignments, rendered by
+	// "renderList" after the struct literal (they cannot sit in the literal: a
+	// primitive-terminal collection uses a two-value ValueFrom helper, while an
+	// object list uses a loop).
 	ItemLists []ListAssignment
 }
 
@@ -284,16 +285,20 @@ type StateAssignment struct {
 }
 
 // ListAssignment is a nested-state assignment rendered by the updateState
-// "renderList" partial. A primitive list maps the SDK slice into a types.List via
-// types.ListValueFrom; an object list loops the SDK elements into a generated
-// nested model slice, recursing through Scalars (the element's leaf fields) and
-// Lists (its nested list fields); an object_single maps one nested object into a
-// generated model pointer, assigned once instead of looped. All forms are guarded
-// by an Ok-getter so an absent field stays null.
+// "renderList" partial. A primitive-terminal collection maps the SDK value into
+// a types.List or types.Map via the matching ValueFrom helper; an object list
+// loops the SDK elements into a generated nested model slice, recursing through
+// Scalars (the element's leaf fields) and Lists (its nested list fields); an
+// object_single maps one nested object into a generated model pointer, assigned
+// once instead of looped. All forms are guarded by an Ok-getter so an absent
+// field stays null.
 type ListAssignment struct {
 	// Kind is "primitive", "object", or "object_single" (a single nested object,
 	// assigned once rather than appended in a loop).
 	Kind string
+	// ContainerKind is "list" or "map" for Kind == "primitive". It selects
+	// the framework ValueFrom and Null constructors used by the template.
+	ContainerKind string
 	// LHS is the assignment target, e.g. "state.VisibleModules" (top level) or
 	// "entriesModel.TagFilters" (nested element field).
 	LHS string
@@ -302,8 +307,9 @@ type ListAssignment struct {
 	GetterOk string
 	// Var is the local bound from GetterOk (a pointer to the slice).
 	Var string
-	// ElementType is the framework element type for a primitive list, e.g.
-	// "types.StringType". Empty for an object list.
+	// ElementType is the framework element type for a primitive-terminal
+	// collection, e.g. "types.ListType{ElemType: types.StringType}". Empty for
+	// an object list.
 	ElementType string
 
 	// The fields below back an object list (Kind == "object").

--- a/.generator-v2/internal/model/framework_types.go
+++ b/.generator-v2/internal/model/framework_types.go
@@ -19,7 +19,7 @@ func FrameworkType(s *Schema) (tfType, goType string, err error) {
 			return "", "", fmt.Errorf("model: array schema has nil items, no element type to map")
 		}
 		switch s.Items.Kind {
-		case SchemaKindPrimitive:
+		case SchemaKindPrimitive, SchemaKindArray, SchemaKindMap:
 			return "schema.ListAttribute", "types.List", nil
 		case SchemaKindObject:
 			return "schema.ListNestedBlock", "types.List", nil
@@ -32,7 +32,7 @@ func FrameworkType(s *Schema) (tfType, goType string, err error) {
 			return "", "", fmt.Errorf("model: map schema has nil value, no value type to map")
 		}
 		switch s.Items.Kind {
-		case SchemaKindPrimitive:
+		case SchemaKindPrimitive, SchemaKindArray, SchemaKindMap:
 			return "schema.MapAttribute", "types.Map", nil
 		case SchemaKindObject:
 			return "schema.MapNestedAttribute", "types.Map", nil
@@ -63,26 +63,41 @@ func primitiveFrameworkType(s *Schema) (tfType, goType string, err error) {
 	}
 }
 
-// ElementType maps a primitive element/value schema to its framework attr.Type
-// (e.g. types.StringType). Non-primitive elements error, since they nest via
-// Children rather than an element type.
+// ElementType recursively maps a collection element/value schema to its
+// framework attr.Type (for example types.StringType or
+// types.MapType{ElemType: types.ListType{ElemType: types.StringType}}). Objects
+// still nest via Children and therefore have no attr.Type expression here.
 func ElementType(elem *Schema) (string, error) {
 	if elem == nil {
 		return "", fmt.Errorf("model: collection has nil element, no element type to map")
 	}
-	if elem.Kind != SchemaKindPrimitive {
-		return "", fmt.Errorf("model: collection element kind %q has no scalar element type", elem.Kind)
-	}
-	switch elem.Type {
-	case "string":
-		return "types.StringType", nil
-	case "integer":
-		return "types.Int64Type", nil
-	case "number":
-		return "types.Float64Type", nil
-	case "boolean":
-		return "types.BoolType", nil
+	switch elem.Kind {
+	case SchemaKindPrimitive:
+		switch elem.Type {
+		case "string":
+			return "types.StringType", nil
+		case "integer":
+			return "types.Int64Type", nil
+		case "number":
+			return "types.Float64Type", nil
+		case "boolean":
+			return "types.BoolType", nil
+		default:
+			return "", fmt.Errorf("model: primitive element type %q has no framework element type", elem.Type)
+		}
+	case SchemaKindArray:
+		child, err := ElementType(elem.Items)
+		if err != nil {
+			return "", err
+		}
+		return "types.ListType{ElemType: " + child + "}", nil
+	case SchemaKindMap:
+		child, err := ElementType(elem.Items)
+		if err != nil {
+			return "", err
+		}
+		return "types.MapType{ElemType: " + child + "}", nil
 	default:
-		return "", fmt.Errorf("model: primitive element type %q has no framework element type", elem.Type)
+		return "", fmt.Errorf("model: collection element kind %q has no framework element type", elem.Kind)
 	}
 }

--- a/.generator-v2/internal/model/framework_types_test.go
+++ b/.generator-v2/internal/model/framework_types_test.go
@@ -44,11 +44,23 @@ var _ = Describe("FrameworkType", func() {
 		Entry("an array of primitive becomes ListAttribute / types.List",
 			&Schema{Kind: SchemaKindArray, Items: &Schema{Kind: SchemaKindPrimitive, Type: "string"}},
 			"schema.ListAttribute", "types.List"),
+		Entry("an array of array becomes ListAttribute / types.List",
+			arrSchema(arrSchema(primSchema("string"))),
+			"schema.ListAttribute", "types.List"),
+		Entry("an array of map becomes ListAttribute / types.List",
+			arrSchema(mapSchema(primSchema("string"))),
+			"schema.ListAttribute", "types.List"),
 		Entry("an array of object becomes ListNestedBlock / types.List",
 			&Schema{Kind: SchemaKindArray, Items: &Schema{Kind: SchemaKindObject}},
 			"schema.ListNestedBlock", "types.List"),
 		Entry("a map of primitive becomes MapAttribute / types.Map",
 			&Schema{Kind: SchemaKindMap, Items: &Schema{Kind: SchemaKindPrimitive, Type: "string"}},
+			"schema.MapAttribute", "types.Map"),
+		Entry("a map of array becomes MapAttribute / types.Map",
+			mapSchema(arrSchema(primSchema("string"))),
+			"schema.MapAttribute", "types.Map"),
+		Entry("a map of map becomes MapAttribute / types.Map",
+			mapSchema(mapSchema(primSchema("string"))),
 			"schema.MapAttribute", "types.Map"),
 		Entry("a map of object becomes MapNestedAttribute / types.Map",
 			&Schema{Kind: SchemaKindMap, Items: &Schema{Kind: SchemaKindObject}},
@@ -73,23 +85,14 @@ var _ = Describe("FrameworkType", func() {
 			&Schema{Kind: SchemaKindPrimitive, Type: ""}, "primitive type"),
 		Entry("an array with nil items has no element type to map",
 			&Schema{Kind: SchemaKindArray}, "nil items"),
-		Entry("an array of array is deferred — error names the element kind",
-			&Schema{Kind: SchemaKindArray, Items: &Schema{Kind: SchemaKindArray, Items: &Schema{Kind: SchemaKindPrimitive, Type: "string"}}},
-			`"array"`),
-		Entry("an array of map is deferred — error names the element kind",
-			&Schema{Kind: SchemaKindArray, Items: &Schema{Kind: SchemaKindMap, Items: &Schema{Kind: SchemaKindPrimitive, Type: "string"}}},
-			`"map"`),
-		Entry("a map of map is deferred — error names the value kind",
-			&Schema{Kind: SchemaKindMap, Items: &Schema{Kind: SchemaKindMap, Items: &Schema{Kind: SchemaKindPrimitive, Type: "string"}}},
-			`"map"`),
 	)
 })
 
-// ElementType is only meaningful for collection-of-primitive nodes; nested
-// (object) collections carry their shape in Children, not an element type.
+// ElementType represents any list/map chain ending in a primitive; object
+// collections carry their shape in Children instead.
 var _ = Describe("ElementType", func() {
 
-	DescribeTable("maps a primitive element/value schema to its framework attr.Type",
+	DescribeTable("maps a primitive-terminal element/value schema to its framework attr.Type",
 		func(elem *Schema, want string) {
 			got, err := ElementType(elem)
 			Expect(err).NotTo(HaveOccurred())
@@ -103,18 +106,25 @@ var _ = Describe("ElementType", func() {
 			&Schema{Kind: SchemaKindPrimitive, Type: "number"}, "types.Float64Type"),
 		Entry("a boolean element becomes types.BoolType",
 			&Schema{Kind: SchemaKindPrimitive, Type: "boolean"}, "types.BoolType"),
+		Entry("an array element becomes a recursive ListType",
+			arrSchema(primSchema("string")), "types.ListType{ElemType: types.StringType}"),
+		Entry("a map element becomes a recursive MapType",
+			mapSchema(primSchema("string")), "types.MapType{ElemType: types.StringType}"),
+		Entry("a deep map-map-list element preserves every level",
+			mapSchema(mapSchema(arrSchema(primSchema("string")))),
+			"types.MapType{ElemType: types.MapType{ElemType: types.ListType{ElemType: types.StringType}}}"),
 	)
 
-	DescribeTable("errors for a non-primitive element (those use nested forms, not ElementType)",
+	DescribeTable("errors for elements that do not terminate in a primitive",
 		func(elem *Schema) {
 			_, err := ElementType(elem)
 			Expect(err).To(HaveOccurred())
 		},
 		Entry("an object element has no scalar element type",
 			&Schema{Kind: SchemaKindObject}),
-		Entry("an array element has no scalar element type",
-			&Schema{Kind: SchemaKindArray, Items: &Schema{Kind: SchemaKindPrimitive, Type: "string"}}),
-		Entry("a map element has no scalar element type",
-			&Schema{Kind: SchemaKindMap, Items: &Schema{Kind: SchemaKindPrimitive, Type: "string"}}),
+		Entry("an array ending in unsupported JSON has no element type",
+			arrSchema(&Schema{Kind: SchemaKindUnsupported})),
+		Entry("a map ending in an object uses nested form",
+			mapSchema(objSchema(nil))),
 	)
 })

--- a/.generator-v2/internal/model/schema.go
+++ b/.generator-v2/internal/model/schema.go
@@ -142,8 +142,8 @@ func buildAttribute(s *Schema, path string, mode nestingMode, diags *[]Diagnosti
 		attr.Validators = []ValidatorSpec{{Name: "stringvalidator.OneOf", Args: args}}
 	}
 
-	// Recurse into nested shapes, or record a primitive collection's element type.
-	// FrameworkType already validated array/map elements, so the else branch is primitive.
+	// Recurse into object shapes, or record the recursive element type for a
+	// collection chain that terminates in a primitive.
 	switch s.Kind {
 	case SchemaKindObject:
 		children, err := buildChildren(s.Properties, path+".", mode, diags)

--- a/.generator-v2/internal/model/schema_test.go
+++ b/.generator-v2/internal/model/schema_test.go
@@ -232,6 +232,26 @@ var _ = Describe("BuildResponseTree type delegation and composites", func() {
 		Expect(labels.Children).To(BeEmpty())
 	})
 
+	DescribeTable("builds recursively typed collections as leaf attributes",
+		func(name string, schema *Schema, wantTFType, wantGoType, wantElementType string) {
+			tree, _, err := BuildResponseTree(objSchema(map[string]*Schema{name: schema}))
+			Expect(err).NotTo(HaveOccurred())
+			attr := attrByPath(tree, "response."+name)
+			Expect(attr.TfType).To(Equal(wantTFType))
+			Expect(attr.GoType).To(Equal(wantGoType))
+			Expect(attr.ElementType).To(Equal(wantElementType))
+			Expect(attr.Children).To(BeEmpty())
+		},
+		Entry("array of arrays", "matrix", arrSchema(arrSchema(primSchema("string"))),
+			"schema.ListAttribute", "types.List", "types.ListType{ElemType: types.StringType}"),
+		Entry("map of arrays", "groups", mapSchema(arrSchema(primSchema("string"))),
+			"schema.MapAttribute", "types.Map", "types.ListType{ElemType: types.StringType}"),
+		Entry("array of typed maps", "rows", arrSchema(mapSchema(primSchema("string"))),
+			"schema.ListAttribute", "types.List", "types.MapType{ElemType: types.StringType}"),
+		Entry("deep map-map-list", "providers", mapSchema(mapSchema(arrSchema(primSchema("string")))),
+			"schema.MapAttribute", "types.Map", "types.MapType{ElemType: types.ListType{ElemType: types.StringType}}"),
+	)
+
 	It("builds map<object> as a MapNestedAttribute with {} value children", func() {
 		tree, _, err := BuildResponseTree(objSchema(map[string]*Schema{
 			"configs": mapSchema(objSchema(map[string]*Schema{"x": primSchema("string")})),
@@ -255,13 +275,13 @@ var _ = Describe("BuildResponseTree type delegation and composites", func() {
 		Expect(options.Children[0].TfType).To(Equal("schema.BoolAttribute"))
 	})
 
-	It("surfaces a FrameworkType error for a deferred composite property (array-of-array)", func() {
+	It("surfaces an element-type error for a nested collection ending in unsupported JSON", func() {
 		tree, _, err := BuildResponseTree(objSchema(map[string]*Schema{
-			"matrix": arrSchema(arrSchema(primSchema("string"))),
+			"matrix": arrSchema(arrSchema(&Schema{Kind: SchemaKindUnsupported})),
 		}))
 		Expect(tree).To(BeNil())
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("array"))
+		Expect(err.Error()).To(ContainSubstring("unsupported"))
 	})
 })
 
@@ -428,11 +448,12 @@ var _ = Describe("BuildResponseTree defensive guard", func() {
 		))
 	})
 
-	It("returns the type-mapping error for a non-object root that cannot be mapped (array-of-array)", func() {
+	It("builds a recursively typed non-object root", func() {
 		tree, _, err := BuildResponseTree(arrSchema(arrSchema(primSchema("string"))))
-		Expect(tree).To(BeNil())
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("array"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tree.Attributes).To(HaveLen(1))
+		Expect(tree.Attributes[0].TfType).To(Equal("schema.ListAttribute"))
+		Expect(tree.Attributes[0].ElementType).To(Equal("types.ListType{ElemType: types.StringType}"))
 	})
 
 	It("builds a well-formed object nested several levels deep without error", func() {

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -259,8 +259,9 @@ type Attribute struct {
 	// GoType is the corresponding model-struct type, e.g. types.String.
 	GoType string
 	// ElementType is the framework attr.Type for a list/map element value,
-	// e.g. "types.StringType". Set ONLY for ListAttribute/MapAttribute
-	// (collection-of-primitive); empty for everything else.
+	// e.g. "types.StringType" or "types.ListType{ElemType: types.StringType}".
+	// Set only for ListAttribute/MapAttribute collection chains ending in a
+	// primitive; empty for everything else.
 	ElementType string
 	// Format is the OpenAPI format (e.g. "date-time"). It distinguishes SDK
 	// getters whose Go return type differs from the bare scalar: a date-time

--- a/.generator-v2/internal/parser/schema.go
+++ b/.generator-v2/internal/parser/schema.go
@@ -563,7 +563,7 @@ func (n *schemaNormalizer) normalizeSchema(s *base.Schema, depth int) (*model.Sc
 			if err != nil {
 				return nil, err
 			}
-			out.Items = elementOrUnsupported(item)
+			out.Items = collectionElement(item)
 		}
 
 	case model.SchemaKindMap:
@@ -576,7 +576,7 @@ func (n *schemaNormalizer) normalizeSchema(s *base.Schema, depth int) (*model.Sc
 			if err != nil {
 				return nil, err
 			}
-			out.Items = elementOrUnsupported(value)
+			out.Items = collectionElement(value)
 		} else {
 			out.Items = &model.Schema{Kind: model.SchemaKindUnsupported}
 		}
@@ -873,21 +873,14 @@ func isMap(s *base.Schema) bool {
 	return ap.IsA() || (ap.IsB() && ap.B)
 }
 
-// elementOrUnsupported returns elem unless it is itself a collection (array or
-// map). A Terraform list/map element type must be a primitive or object, so a
-// collection-of-collection has no representable element; returning the Unsupported
-// sentinel makes the attribute-tree builder reject it like any other
-// unrepresentable node.
-func elementOrUnsupported(elem *model.Schema) *model.Schema {
+// collectionElement preserves recursively typed collection shapes. Terraform
+// attr.Type values can represent list/map chains such as list(list(string)) and
+// map(list(string)); only a missing element schema needs an Unsupported sentinel.
+func collectionElement(elem *model.Schema) *model.Schema {
 	if elem == nil {
 		return &model.Schema{Kind: model.SchemaKindUnsupported}
 	}
-	switch elem.Kind {
-	case model.SchemaKindArray, model.SchemaKindMap:
-		return &model.Schema{Kind: model.SchemaKindUnsupported}
-	default:
-		return elem
-	}
+	return elem
 }
 
 // hasType reports whether t is in the schema's type set (a slice, since 3.1

--- a/.generator-v2/internal/parser/schema_test.go
+++ b/.generator-v2/internal/parser/schema_test.go
@@ -110,17 +110,19 @@ var _ = Describe("NormalizeSchemas unsupported classification", func() {
 		Expect(op.RequestSchema.Type).To(Equal("string"))
 	})
 
-	DescribeTable("downgrades a collection-of-collection element to unsupported, since a list/map element must be a primitive or object",
-		func(operationId string, wantParentKind model.SchemaKind) {
+	DescribeTable("preserves recursively typed collection elements",
+		func(operationId string, wantParentKind, wantChildKind model.SchemaKind) {
 			op := opByID(spec, operationId)
 			Expect(op.RequestSchema.Kind).To(Equal(wantParentKind), "the outer collection keeps its structural kind")
 			Expect(op.RequestSchema.Items).NotTo(BeNil())
-			Expect(op.RequestSchema.Items.Kind).To(Equal(model.SchemaKindUnsupported), "the nested-collection element is rewritten to the unsupported sentinel")
+			Expect(op.RequestSchema.Items.Kind).To(Equal(wantChildKind))
+			Expect(op.RequestSchema.Items.Items).NotTo(BeNil())
+			Expect(op.RequestSchema.Items.Items.Kind).To(Equal(model.SchemaKindPrimitive))
 		},
-		Entry("array-of-array → array with an unsupported element", "CreateArrayOfArray", model.SchemaKindArray),
-		Entry("array-of-map → array with an unsupported element", "CreateArrayOfMap", model.SchemaKindArray),
-		Entry("map-of-array → map with an unsupported value", "CreateMapOfArray", model.SchemaKindMap),
-		Entry("map-of-map → map with an unsupported value", "CreateMapOfMap", model.SchemaKindMap),
+		Entry("array-of-array", "CreateArrayOfArray", model.SchemaKindArray, model.SchemaKindArray),
+		Entry("array-of-map", "CreateArrayOfMap", model.SchemaKindArray, model.SchemaKindMap),
+		Entry("map-of-array", "CreateMapOfArray", model.SchemaKindMap, model.SchemaKindArray),
+		Entry("map-of-map", "CreateMapOfMap", model.SchemaKindMap, model.SchemaKindMap),
 	)
 })
 


### PR DESCRIPTION
## Motivation

TFgen currently replaces an array or map nested inside another collection with an unsupported-schema sentinel. Terraform Plugin Framework can represent recursively typed collections natively, so valid SDK shapes such as `[][]string`, `map[string][]string`, and `map[string]map[string][]string` are blocked unnecessarily.

This PR is stacked on #4102. It preserves typed collection chains through parsing, models them as recursive Framework element types, and emits their state without encoding values as JSON strings.

## Changes

- Preserve nested array and map schemas instead of downgrading them during normalization.
- Recursively construct `types.ListType` and `types.MapType` expressions for collection chains that terminate in a Terraform primitive.
- Emit `schema.ListAttribute` and `schema.MapAttribute` leaves with matching `types.ListValueFrom` or `types.MapValueFrom` state conversion.
- Support typed maps at the response root, on plural result items, and inside generated object-list models.
- Add parser, model, emitter, and rendered-source coverage for nested lists, nested maps, mixed list/map chains, and unsupported terminal values.

Collections ending in arbitrary JSON or an object remain fail-closed. Supporting those shapes would require separate dynamic-value or nested-object semantics and is intentionally outside this PR.

## QA Instructions

- `make tfgen-test` — passed on this branch and on the fully integrated stack.
- `make tfgen-build` — passed.
- `make fmtcheck` — passed.
- `make test` — passed, 235 provider tests.
- `make vet` — passed.

Focused generation/build probes passed for the affected full-spec operations. An exhaustive build-verified sweep was also run against all 565 candidates using a temporary integration head containing every PR in the stack, including the latest API-accessor and `allOf` follow-ups.

| View | Before | After | Gain |
|---|---:|---:|---:|
| Singular | 111/156 (71.2%) | 115/156 (73.7%) | +4 |
| Plural | 155/194 (79.9%) | 161/194 (83.0%) | +6 |
| Combined | 266/350 (76.0%) | 276/350 (78.9%) | +10 |

No previously passing candidate regressed. New build-verified coverage includes ServiceNow templates, CSM threat policies, resource-evaluation filters, aggregated connections, signal investigation queries and suggested actions, and tag-pipeline rulesets.

## Blast Radius

The change is limited to generator-v2 schema normalization, generated Framework schema types, and generated response-to-state conversion. It does not modify handwritten data sources or existing Terraform state. Generated artifacts may now expose typed attributes that previously failed generation. Arbitrary JSON and object-terminal collections remain blocked rather than being represented ambiguously. The PR can be reverted without a state migration.
