### PR TITLE
[APIR-3056] Fail CI when a generated file is hand-edited

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,38 @@ jobs:
             echo "code=false" >> "$GITHUB_OUTPUT"
           fi
 
+  # Generated files (marked with the standard Go "Code generated ... DO NOT
+  # EDIT." header) must only be produced by tfgen, never hand-edited. The
+  # generate/* and retire/* branches are created by the tfgen-split workflow
+  # itself and are allowed to touch them, as are PRs opened by dd-octo-sts.
+  no-generated-file-edits:
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login != 'dd-octo-sts[bot]' &&
+      !startsWith(github.head_ref, 'generate/') &&
+      !startsWith(github.head_ref, 'retire/')
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Fail if a generated file was hand-edited
+        run: |
+          files=$(git diff --name-only --diff-filter=d "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}")
+          generated=""
+          for f in $files; do
+            if grep -qE '^// Code generated .* DO NOT EDIT\.$' "$f" 2>/dev/null; then
+              generated="$generated$f"$'\n'
+            fi
+          done
+          if [ -n "$generated" ]; then
+            echo "::error::The following generated files were edited by hand. They are produced by tfgen and must not be edited directly - update the OpenAPI spec or generator instead:"
+            echo "$generated"
+            exit 1
+          fi
+          echo "No generated files were edited."
+
   pre-commit:
     runs-on: ubuntu-latest
     if: (github.event.action != 'closed' && github.event.pull_request.merged != true) || github.event_name == 'schedule'
@@ -217,12 +249,12 @@ jobs:
   # Final job for branch protection rules - depends on all other jobs
   all-checks:
     runs-on: ubuntu-latest
-    needs: [changes, linter-checks, unit-tests, test, test-tofu]
+    needs: [changes, no-generated-file-edits, linter-checks, unit-tests, test, test-tofu]
     if: always()
     steps:
       - name: Check all jobs passed
         run: |
-          results="${{ needs.changes.result }} ${{ needs.linter-checks.result }} ${{ needs.unit-tests.result }} ${{ needs.test.result }} ${{ needs.test-tofu.result }}"
+          results="${{ needs.changes.result }} ${{ needs.no-generated-file-edits.result }} ${{ needs.linter-checks.result }} ${{ needs.unit-tests.result }} ${{ needs.test.result }} ${{ needs.test-tofu.result }}"
           for result in $results; do
             if [[ "$result" != "success" && "$result" != "skipped" ]]; then
               echo "One or more jobs failed or were cancelled"


### PR DESCRIPTION
## Motivation

Jira: https://datadoghq.atlassian.net/browse/APIR-3056

Files produced by tfgen carry the standard Go "Code generated ... DO NOT EDIT." header, but nothing currently stops a human from editing them directly, which silently diverges the checked-in file from what the generator would produce.

## Changes

- Added a `no-generated-file-edits` job to `.github/workflows/test.yml` that scans the PR diff for any changed file carrying the "Code generated ... DO NOT EDIT." marker and fails the build if found.
- Exempted the `generate/*` and `retire/*` branches (created by the `tfgen-split` workflow) and PRs opened by `dd-octo-sts[bot]`, since those are the legitimate paths for generated file changes.
- Wired the new job into the `all-checks` gate.

## Testing

Validated the workflow YAML parses correctly.