### PR TITLE
[APIR-3056] (CI) Exclude generator templates from generated-file check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,11 +72,11 @@ jobs:
           files=$(git diff --name-only --diff-filter=d "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}")
           generated=""
           for f in $files; do
-            # testdata/snapshots fixtures (e.g. generator golden files)
-            # intentionally contain this header as fixture content; they
-            # aren't tfgen output.
+            # testdata/snapshots fixtures (e.g. generator golden files) and
+            # generator templates (*.go.tmpl) intentionally contain this
+            # header as fixture/template content; they aren't tfgen output.
             case "$f" in
-              */testdata/*|*/snapshots/*) continue ;;
+              */testdata/*|*/snapshots/*|*.go.tmpl) continue ;;
             esac
             # Match tfgen's exact header rather than the generic Go "Code
             # generated ... DO NOT EDIT." pattern, so this check doesn't flag


### PR DESCRIPTION
## Motivation

Jira: https://datadoghq.atlassian.net/browse/APIR-3056

Follow-up to #4107. The `no-generated-file-edits` gate skips `testdata/`/`snapshots/` fixtures but still flags generator template files (`*.go.tmpl`) that carry the tfgen `// Code generated by tfgen; DO NOT EDIT.` header as literal template content — those templates are hand-edited by design, not tfgen output.

## Changes

- Skip any changed file ending in `.go.tmpl` when scanning for the generated-file header in `.github/workflows/test.yml`.

## Testing

- Not directly testable outside of CI; relying on this PR's own CI run of the `no-generated-file-edits` job.