### PR TITLE
[datadog_synthetics_test] Prevent error when step params variable/pattern is empty

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -6053,7 +6053,11 @@ func convertStepParamsValueForConfig(stepType interface{}, key string, value int
 		return value, diags
 
 	case "pattern", "variable":
-		return value.([]interface{})[0], diags
+		valueList, ok := value.([]interface{})
+		if !ok || len(valueList) == 0 {
+			return nil, diags
+		}
+		return valueList[0], diags
 
 	case "drag_drop_options":
 		optsList, ok := value.([]interface{})

--- a/datadog/resource_datadog_synthetics_test_unit_test.go
+++ b/datadog/resource_datadog_synthetics_test_unit_test.go
@@ -1,0 +1,32 @@
+package datadog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestConvertStepParamsValueForConfig_EmptyVariableOrPattern reproduces the
+// panic reported by a customer: when an Optional/MaxItems(1) list-typed step
+// param such as "variable" or "pattern" is left unset in the config,
+// Terraform passes it through as an empty []interface{} rather than "". The
+// function used to blindly index [0] into it, causing an
+// "index out of range [0] with length 0" panic.
+func TestConvertStepParamsValueForConfig_EmptyVariableOrPattern(t *testing.T) {
+	for _, key := range []string{"variable", "pattern"} {
+		t.Run(key, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				result, diags := convertStepParamsValueForConfig(nil, key, []interface{}{})
+				assert.Nil(t, result)
+				assert.Empty(t, diags)
+			})
+		})
+	}
+}
+
+func TestConvertStepParamsValueForConfig_NonEmptyVariableOrPattern(t *testing.T) {
+	value := []interface{}{map[string]interface{}{"name": "foo"}}
+	result, diags := convertStepParamsValueForConfig(nil, "variable", value)
+	assert.Equal(t, value[0], result)
+	assert.Empty(t, diags)
+}


### PR DESCRIPTION
# What

Fixes a provider crash reported by a customer: index out of range [0] with length 0 panic in `convertStepParamsValueForConfig`.

variable and pattern step params are optional list blocks (`MaxItems: 1`). When left unset in a browser step config, Terraform passes them through as an empty list rather than an empty string, so the existing `!= ""` guard didn't catch it, and the code indexed [0] blind - panicking and crashing the plugin mid-apply.

# Fix

Guard the empty-list case the same way `drag_drop_options` already does, returning `nil` instead of indexing into nothing.