### PR TITLE
[datadog_incident_postmortem_template] enable unstable operations for incident postmortem templates

### DIFF
--- a/datadog/fwprovider/framework_provider.go
+++ b/datadog/fwprovider/framework_provider.go
@@ -734,6 +734,12 @@ func defaultConfigureFunc(p *FrameworkProvider, request *provider.ConfigureReque
 	ddClientConfig.SetUnstableOperationEnabled("v2.DeleteIncidentNotificationTemplate", true)
 	ddClientConfig.SetUnstableOperationEnabled("v2.ListIncidentNotificationTemplates", true)
 
+	// Enable IncidentPostmortemTemplate
+	ddClientConfig.SetUnstableOperationEnabled("v2.CreateIncidentPostmortemTemplate", true)
+	ddClientConfig.SetUnstableOperationEnabled("v2.GetIncidentPostmortemTemplate", true)
+	ddClientConfig.SetUnstableOperationEnabled("v2.UpdateIncidentPostmortemTemplate", true)
+	ddClientConfig.SetUnstableOperationEnabled("v2.DeleteIncidentPostmortemTemplate", true)
+
 	// Enable OrgGroup
 	ddClientConfig.SetUnstableOperationEnabled("v2.CreateOrgGroup", true)
 	ddClientConfig.SetUnstableOperationEnabled("v2.GetOrgGroup", true)

--- a/datadog/tests/framework_provider_test.go
+++ b/datadog/tests/framework_provider_test.go
@@ -96,6 +96,12 @@ func buildFrameworkDatadogClient(ctx context.Context, httpClient *http.Client) *
 	config.SetUnstableOperationEnabled("v2.DeleteIncidentNotificationTemplate", true)
 	config.SetUnstableOperationEnabled("v2.ListIncidentNotificationTemplates", true)
 
+	// Enable IncidentPostmortemTemplate
+	config.SetUnstableOperationEnabled("v2.CreateIncidentPostmortemTemplate", true)
+	config.SetUnstableOperationEnabled("v2.GetIncidentPostmortemTemplate", true)
+	config.SetUnstableOperationEnabled("v2.UpdateIncidentPostmortemTemplate", true)
+	config.SetUnstableOperationEnabled("v2.DeleteIncidentPostmortemTemplate", true)
+
 	config.SetUnstableOperationEnabled("v2.ListIncidentUserDefinedFields", true)
 	config.SetUnstableOperationEnabled("v2.CreateIncidentUserDefinedField", true)
 	config.SetUnstableOperationEnabled("v2.GetIncidentUserDefinedField", true)


### PR DESCRIPTION
The `datadog_incident_postmortem_template` resource was added in #4026 and registered in the framework provider, but the corresponding unstable operations were never enabled. Every operation on the resource fails:

    Could not create incident postmortem template, unexpected error:
    Unstable operation 'v2.CreateIncidentPostmortemTemplate' is disabled.
    HTTP Response: <nil>

This makes the resource unusable in all released versions that contain it (v4.17.0 onward). Enable the four operations the resource calls, in both the provider and the acceptance test client config, matching the existing `IncidentNotificationTemplate` block.