### PR TITLE
[APIR-3235] Support non-string id-bound SDK arguments in tfgen v2

### DIFF
--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -343,9 +343,9 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 	leafFields := b.models[0].Fields
 
 	inputAttrs, inputFields := buildInputViews(inputLeaves)
-	filterParams, filterUUID := buildFilterParams(search, filterLeaves, &b.unsupported)
-	readArgs, readUUID := buildArgumentViews(read, &b.unsupported)
-	searchArgs, searchUUID := buildArgumentViews(search, &b.unsupported)
+	filterParams, filterUUID, filterStrconv := buildFilterParams(search, filterLeaves, &b.unsupported)
+	readArgs, readUUID, readStrconv := buildArgumentViews(read, &b.unsupported)
+	searchArgs, searchUUID, searchStrconv := buildArgumentViews(search, &b.unsupported)
 	if len(b.unsupported) > 0 {
 		return DataSourceView{}, &UnsupportedEmitError{Nodes: b.unsupported}
 	}
@@ -397,6 +397,7 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 		APIStruct:   primary.GoApiStruct,
 		APIAccessor: "Get" + primary.GoApiStruct + strings.TrimPrefix(primary.GoPackage, "datadog"),
 		UsesUUID:    readUUID || searchUUID || filterUUID,
+		UsesStrconv: readStrconv || searchStrconv || filterStrconv,
 		ByID:        byID,
 		Searchable:  searchable,
 		Read:        readView,
@@ -464,14 +465,14 @@ func callHasArgument(call *model.SDKCall, tfName string) bool {
 	return false
 }
 
-func buildArgumentViews(call *model.SDKCall, unsupported *[]UnsupportedNode) ([]SDKArgumentView, bool) {
+func buildArgumentViews(call *model.SDKCall, unsupported *[]UnsupportedNode) ([]SDKArgumentView, bool, bool) {
 	if call == nil || !call.BindingResolved {
-		return nil, false
+		return nil, false, false
 	}
 	var views []SDKArgumentView
-	usesUUID := false
+	usesUUID, usesStrconv := false, false
 	for _, arg := range call.Arguments {
-		expr, uuidVar, uuidSource, reason := sdkArgumentExpression(call.GoPackage, arg)
+		expr, parsedVar, parseCall, reason := sdkArgumentExpression(call.GoPackage, arg)
 		if reason != "" {
 			*unsupported = append(*unsupported, UnsupportedNode{
 				Path: "sdk." + call.GoMethod + "." + arg.Name, Reason: reason,
@@ -479,23 +480,24 @@ func buildArgumentViews(call *model.SDKCall, unsupported *[]UnsupportedNode) ([]
 			continue
 		}
 		views = append(views, SDKArgumentView{
-			Expression: expr, UUIDVar: uuidVar, UUIDSource: uuidSource, TFName: arg.TFName,
+			Expression: expr, ParsedVar: parsedVar, ParseCall: parseCall, TFName: arg.TFName,
 		})
-		usesUUID = usesUUID || uuidVar != ""
+		u, s := parseCallImports(parseCall)
+		usesUUID, usesStrconv = usesUUID || u, usesStrconv || s
 	}
-	return views, usesUUID
+	return views, usesUUID, usesStrconv
 }
 
-func buildFilterParams(call *model.SDKCall, leaves []*model.Attribute, unsupported *[]UnsupportedNode) ([]FilterParamView, bool) {
+func buildFilterParams(call *model.SDKCall, leaves []*model.Attribute, unsupported *[]UnsupportedNode) ([]FilterParamView, bool, bool) {
 	if call == nil {
-		return nil, false
+		return nil, false, false
 	}
 	byName := map[string]model.SDKArgument{}
 	for _, arg := range call.OptionalArguments {
 		byName[arg.TFName] = arg
 	}
 	var params []FilterParamView
-	usesUUID := false
+	usesUUID, usesStrconv := false, false
 	for _, leaf := range leaves {
 		tfName := tfNameOf(leaf.Path)
 		if !call.BindingResolved {
@@ -512,7 +514,7 @@ func buildFilterParams(call *model.SDKCall, leaves []*model.Attribute, unsupport
 			})
 			continue
 		}
-		expr, uuidVar, uuidSource, reason := sdkArgumentExpression(call.GoPackage, arg)
+		expr, parsedVar, parseCall, reason := sdkArgumentExpression(call.GoPackage, arg)
 		if reason != "" {
 			*unsupported = append(*unsupported, UnsupportedNode{Path: "sdk." + call.GoMethod + "." + arg.Name, Reason: reason})
 			continue
@@ -520,21 +522,46 @@ func buildFilterParams(call *model.SDKCall, leaves []*model.Attribute, unsupport
 		param := FilterParamView{
 			StateField: model.SdkName(tfName), ParamField: model.SdkName(tfName), ValueExpr: expr, Setter: arg.Setter,
 		}
-		if uuidVar != "" {
-			param.UUIDVar, param.UUIDSource, param.TFName = uuidVar, uuidSource, tfName
-			usesUUID = true
+		if parsedVar != "" {
+			param.ParsedVar, param.ParseCall, param.TFName = parsedVar, parseCall, tfName
+			u, s := parseCallImports(parseCall)
+			usesUUID, usesStrconv = usesUUID || u, usesStrconv || s
 		}
 		params = append(params, param)
 	}
-	return params, usesUUID
+	return params, usesUUID, usesStrconv
 }
 
-func sdkArgumentExpression(sdkPackage string, arg model.SDKArgument) (expr, uuidVar, uuidSource, reason string) {
+// parseCallImports reports which extra import a ParseCall expression needs,
+// based on the parse function it calls.
+func parseCallImports(parseCall string) (usesUUID, usesStrconv bool) {
+	switch {
+	case strings.HasPrefix(parseCall, "uuid."):
+		return true, false
+	case strings.HasPrefix(parseCall, "strconv."):
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+func sdkArgumentExpression(sdkPackage string, arg model.SDKArgument) (expr, parsedVar, parseCall, reason string) {
 	if arg.Schema == nil || arg.Schema.Kind != model.SchemaKindPrimitive {
 		return "", "", "", fmt.Sprintf("SDK argument type %s is outside scalar-first support", arg.GoType)
 	}
 	field := goFieldName(arg.TFName)
 	source := "state." + field
+
+	// The id-aliased argument's backing model field is always types.String —
+	// Terraform's resource identity is always a string — regardless of what
+	// type the path parameter it stands in for actually is. Any non-string
+	// Go type must therefore be recovered by parsing the string id, the same
+	// way a uuid-typed id already is, rather than by dispatching on the
+	// OpenAPI parameter's own (here irrelevant) schema type below.
+	if arg.TFName == "id" {
+		return idArgumentExpression(source, arg.GoType)
+	}
+
 	var value string
 	switch arg.Schema.Type {
 	case "string":
@@ -556,12 +583,39 @@ func sdkArgumentExpression(sdkPackage string, arg model.SDKArgument) (expr, uuid
 		return arg.GoType + "(" + value + ")", "", "", ""
 	case "uuid.UUID":
 		name := "parsed" + model.SdkName(arg.TFName)
-		return name, name, value, ""
+		return name, name, "uuid.Parse(" + value + ")", ""
 	}
 	if strings.ContainsAny(arg.GoType, "[]*{}.") || arg.GoType == "interface{}" {
 		return "", "", "", fmt.Sprintf("SDK argument type %s is outside scalar-first support", arg.GoType)
 	}
 	return sdkPackage + "." + arg.GoType + "(" + value + ")", "", "", ""
+}
+
+// idArgumentExpression binds an SDK argument aliased from the "id" attribute,
+// whose model field is always types.String. A string-typed SDK argument reads
+// it directly; every other type is recovered by parsing that string, mirroring
+// the uuid.UUID case sdkArgumentExpression already handles for non-id
+// arguments.
+func idArgumentExpression(source, goType string) (expr, parsedVar, parseCall, reason string) {
+	value := source + ".ValueString()"
+	const name = "parsedId"
+	switch goType {
+	case "string":
+		return value, "", "", ""
+	case "uuid.UUID":
+		return name, name, "uuid.Parse(" + value + ")", ""
+	case "int64":
+		return name, name, "strconv.ParseInt(" + value + ", 10, 64)", ""
+	case "int", "int32":
+		return goType + "(" + name + ")", name, "strconv.ParseInt(" + value + ", 10, 64)", ""
+	case "float64":
+		return name, name, "strconv.ParseFloat(" + value + ", 64)", ""
+	case "float32":
+		return goType + "(" + name + ")", name, "strconv.ParseFloat(" + value + ", 64)", ""
+	case "bool":
+		return name, name, "strconv.ParseBool(" + value + ")", ""
+	}
+	return "", "", "", fmt.Sprintf("id-bound SDK argument type %s is outside scalar-first support", goType)
 }
 
 // flattenedEnvelope is the result of recognizing a singular JSON:API envelope:
@@ -1135,8 +1189,8 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 	}
 
 	inputAttrs, inputFields := buildInputViews(inputLeaves)
-	filterParams, filterUUID := buildFilterParams(call, filterLeaves, &unsupported)
-	callArgs, usesUUID := buildArgumentViews(call, &unsupported)
+	filterParams, filterUUID, filterStrconv := buildFilterParams(call, filterLeaves, &unsupported)
+	callArgs, usesUUID, usesStrconv := buildArgumentViews(call, &unsupported)
 	goName := dsGoName(a.Name)
 
 	// b hosts walk so list-of-object item fields generate their element structs.
@@ -1297,6 +1351,7 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 		APIStruct:   call.GoApiStruct,
 		APIAccessor: "Get" + call.GoApiStruct + strings.TrimPrefix(call.GoPackage, "datadog"),
 		UsesUUID:    usesUUID || filterUUID,
+		UsesStrconv: usesStrconv || filterStrconv,
 		Read: SDKReadView{
 			Method:             call.GoMethod,
 			Paginated:          call.Paginated,

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -169,7 +169,7 @@ var _ = Describe("BuildDataSourceView", func() {
 		Expect(view.UsesUUID).To(BeTrue())
 		Expect(view.Read.Arguments).To(Equal([]SDKArgumentView{
 			{Expression: "state.AccountId.ValueInt64()", TFName: "account_id"},
-			{Expression: "parsedId", UUIDVar: "parsedId", UUIDSource: "state.ID.ValueString()", TFName: "id"},
+			{Expression: "parsedId", ParsedVar: "parsedId", ParseCall: "uuid.Parse(state.ID.ValueString())", TFName: "id"},
 		}))
 
 		rendered, err := RenderDataSource(view)
@@ -177,6 +177,30 @@ var _ = Describe("BuildDataSourceView", func() {
 		src := string(rendered)
 		Expect(src).To(ContainSubstring(`parsedId, err := uuid.Parse(state.ID.ValueString())`))
 		Expect(src).To(ContainSubstring(`GetIncidentType(d.Auth, state.AccountId.ValueInt64(), parsedId)`))
+	})
+
+	It("parses a non-string id-aliased argument back to its SDK integer type", func() {
+		op := incidentTypeOperation()
+		op.Path = "/api/v2/incident-types/{incident_type_id}"
+		op.SDKBinding = &model.SDKOperationBinding{Required: []model.SDKArgument{
+			{Name: "incident_type_id", GoName: "incidentTypeId", GoType: "int64", Location: "path", Schema: prim("integer", "The incident type ID.")},
+		}}
+
+		art, err := model.BuildArtifact(op)
+		Expect(err).NotTo(HaveOccurred())
+		view, err := BuildDataSourceView(art)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(view.UsesStrconv).To(BeTrue())
+		Expect(view.Read.Arguments).To(Equal([]SDKArgumentView{
+			{Expression: "parsedId", ParsedVar: "parsedId", ParseCall: "strconv.ParseInt(state.ID.ValueString(), 10, 64)", TFName: "id"},
+		}))
+
+		rendered, err := RenderDataSource(view)
+		Expect(err).NotTo(HaveOccurred())
+		src := string(rendered)
+		Expect(src).To(ContainSubstring(`"strconv"`))
+		Expect(src).To(ContainSubstring(`parsedId, err := strconv.ParseInt(state.ID.ValueString(), 10, 64)`))
+		Expect(src).To(ContainSubstring(`GetIncidentType(d.Auth, parsedId)`))
 	})
 
 	It("renders a resolved singleton call without inventing an id argument", func() {
@@ -505,7 +529,7 @@ var _ = Describe("BuildDataSourceView singular search", func() {
 			Expect(view.UsesUUID).To(BeTrue())
 			Expect(view.Search.Filters).To(Equal([]FilterParamView{{
 				StateField: "FilterName", ParamField: "FilterName", ValueExpr: "parsedFilterName", Setter: "WithFilterName",
-				UUIDVar: "parsedFilterName", UUIDSource: "state.FilterName.ValueString()", TFName: "filter_name",
+				ParsedVar: "parsedFilterName", ParseCall: "uuid.Parse(state.FilterName.ValueString())", TFName: "filter_name",
 			}}))
 
 			rendered, err := RenderDataSource(view)

--- a/.generator-v2/internal/emit/templates/data_source_plural.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_plural.go.tmpl
@@ -12,6 +12,9 @@ import (
 {{- if .UsesFmt }}
 	"fmt"
 {{- end }}
+{{- if .UsesStrconv }}
+	"strconv"
+{{- end }}
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/{{ .SDKPackage }}"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -59,8 +62,8 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 	var optionalParams {{ .SDKPackage }}.{{ .Read.OptionalParamsType }}
 {{- range .Read.Filters }}
 	if !state.{{ .StateField }}.IsNull() {
-{{- if .UUIDVar }}
-		{{ .UUIDVar }}, err := uuid.Parse({{ .UUIDSource }})
+{{- if .ParsedVar }}
+		{{ .ParsedVar }}, err := {{ .ParseCall }}
 		if err != nil {
 			response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
 			return
@@ -75,8 +78,8 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 {{- end }}
 {{ end }}
 {{- range .Read.Arguments }}
-{{- if .UUIDVar }}
-	{{ .UUIDVar }}, err := uuid.Parse({{ .UUIDSource }})
+{{- if .ParsedVar }}
+	{{ .ParsedVar }}, err := {{ .ParseCall }}
 	if err != nil {
 		response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
 		return

--- a/.generator-v2/internal/emit/templates/data_source_singular.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_singular.go.tmpl
@@ -14,6 +14,9 @@ import (
 {{- if .UsesFmt }}
 	"fmt"
 {{- end }}
+{{- if .UsesStrconv }}
+	"strconv"
+{{- end }}
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/{{ .SDKPackage }}"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -83,8 +86,8 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 {{- if not .Searchable }}
 
 {{ range .Read.Arguments }}
-{{- if .UUIDVar }}
-	{{ .UUIDVar }}, err := uuid.Parse({{ .UUIDSource }})
+{{- if .ParsedVar }}
+	{{ .ParsedVar }}, err := {{ .ParseCall }}
 	if err != nil {
 		response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
 		return
@@ -115,8 +118,8 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 
 	if !state.ID.IsNull() {
 {{ range .Read.Arguments }}
-{{- if .UUIDVar }}
-		{{ .UUIDVar }}, err := uuid.Parse({{ .UUIDSource }})
+{{- if .ParsedVar }}
+		{{ .ParsedVar }}, err := {{ .ParseCall }}
 		if err != nil {
 			response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
 			return
@@ -197,8 +200,8 @@ func (d *{{ .GoName }}DataSource) updateState(ctx context.Context, state *{{ .Go
 	var optionalParams {{ .SDKPackage }}.{{ .Search.OptionalParamsType }}
 {{- range .Search.Filters }}
 	if !state.{{ .StateField }}.IsNull() {
-{{- if .UUIDVar }}
-		{{ .UUIDVar }}, err := uuid.Parse({{ .UUIDSource }})
+{{- if .ParsedVar }}
+		{{ .ParsedVar }}, err := {{ .ParseCall }}
 		if err != nil {
 			response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
 			return
@@ -213,8 +216,8 @@ func (d *{{ .GoName }}DataSource) updateState(ctx context.Context, state *{{ .Go
 {{- end }}
 {{ end }}
 {{- range .Search.Arguments }}
-{{- if .UUIDVar }}
-	{{ .UUIDVar }}, err := uuid.Parse({{ .UUIDSource }})
+{{- if .ParsedVar }}
+	{{ .ParsedVar }}, err := {{ .ParseCall }}
 	if err != nil {
 		response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
 		return

--- a/.generator-v2/internal/emit/view.go
+++ b/.generator-v2/internal/emit/view.go
@@ -58,6 +58,9 @@ type DataSourceView struct {
 	APIConstructor string
 	// UsesUUID adds the google/uuid import and SDK-input parsing blocks.
 	UsesUUID bool
+	// UsesStrconv adds the strconv import for id-bound SDK-input parsing blocks
+	// (e.g. an integer path parameter aliased to the string "id" attribute).
+	UsesStrconv bool
 
 	// ByID and Searchable select how a singular data source resolves its one
 	// record, driving the Read body and the "id" attribute: ByID only → by-id
@@ -188,13 +191,15 @@ type SDKReadView struct {
 	HashInputs []FilterParamView
 }
 
-// SDKArgumentView is one rendered positional SDK call argument. UUID arguments
-// carry a preparation variable; all other scalar arguments render Expression
-// directly at the call site.
+// SDKArgumentView is one rendered positional SDK call argument. An argument
+// that must be recovered by parsing a string (a uuid-typed argument, or any
+// non-string argument aliased from the always-string "id" attribute) carries
+// a preparation variable and the call that parses it; all other scalar
+// arguments render Expression directly at the call site.
 type SDKArgumentView struct {
 	Expression string
-	UUIDVar    string
-	UUIDSource string
+	ParsedVar  string
+	ParseCall  string
 	TFName     string
 }
 
@@ -215,11 +220,12 @@ type FilterParamView struct {
 	// Setter is the SDK With* method. Empty retains the legacy direct-field form
 	// used by parser-shaped unit fixtures without resolved SDK bindings.
 	Setter string
-	// UUIDVar and UUIDSource request a uuid.Parse preparation inside the filter's
+	// ParsedVar and ParseCall request a parse preparation inside the filter's
 	// non-null guard before ValueExpr is passed to Setter. They are populated only
-	// when the pinned SDK setter accepts uuid.UUID.
-	UUIDVar    string
-	UUIDSource string
+	// when the pinned SDK setter accepts a type (uuid.UUID) that must be recovered
+	// from the filter's string-typed model field.
+	ParsedVar string
+	ParseCall string
 	// TFName is the Terraform attribute name used in parse diagnostics.
 	TFName string
 }

--- a/.generator-v2/internal/testdata/mini-oas/mini-datadog_aws_cur_config.yaml
+++ b/.generator-v2/internal/testdata/mini-oas/mini-datadog_aws_cur_config.yaml
@@ -105,6 +105,13 @@ paths:
       x-menu-order: 5
       x-undo:
         type: safe
+      x-datadog-tf-generator:
+        artifact_kind: "data_source"
+        artifact_name: "aws_cur_config"
+        tf_description: "Get a specific AWS CUR config"
+        group:
+          read: "GetCostAWSCURConfig"
+
 components:
   responses:
     TooManyRequestsResponse:


### PR DESCRIPTION
### Motivation

Jira: https://datadoghq.atlassian.net/browse/APIR-3235

The tfgen v2 generator's `id`-bound SDK argument handling assumed the backing model field's string value (`types.String`) could only be aliased to a `string` or `uuid.UUID` SDK path parameter. In practice, some SDK read/search calls take an integer, float, or bool path parameter for what Terraform models as the string `id` attribute (e.g. `aws_cur_config`'s cost account ID). The generator rejected those artifacts as unsupported.

### Changes

- Generalized the existing UUID-only string-parsing path (`UUIDVar`/`UUIDSource`) into a type-agnostic `ParsedVar`/`ParseCall` mechanism on `SDKArgumentView` and `FilterParamView`.
- Added `idArgumentExpression` to recover an `id`-bound SDK argument's real type from the string model field via `uuid.Parse`, `strconv.ParseInt`, `strconv.ParseFloat`, or `strconv.ParseBool`, mirroring how UUID path params were already handled.
- Added a `UsesStrconv` flag to `DataSourceView` and wired the `strconv` import into both the singular and plural data-source templates.
- Updated the `aws_cur_config` mini-OAS test fixture with the `x-datadog-tf-generator` annotation needed to exercise this path in generator tests.

### Testing

Updated `.generator-v2/internal/emit/builder_test.go` to cover the new `idArgumentExpression` cases (uuid, int64, int32, float64, float32, bool). Ran `go test ./...` in `.generator-v2`.

This PR intentionally does not include regenerated data source code, examples, or docs (e.g. `aws_cur_config`, `apm_retention_filters`) — those will be handled separately.