### PR TITLE
[datadog_incident_postmortem_template] Enable unstable operations so the resource works

### DIFF
--- a/datadog/fwprovider/framework_provider.go
+++ b/datadog/fwprovider/framework_provider.go
@@ -734,6 +734,12 @@ func defaultConfigureFunc(p *FrameworkProvider, request *provider.ConfigureReque
 	ddClientConfig.SetUnstableOperationEnabled("v2.DeleteIncidentNotificationTemplate", true)
 	ddClientConfig.SetUnstableOperationEnabled("v2.ListIncidentNotificationTemplates", true)
 
+	// Enable IncidentPostmortemTemplate
+	ddClientConfig.SetUnstableOperationEnabled("v2.CreateIncidentPostmortemTemplate", true)
+	ddClientConfig.SetUnstableOperationEnabled("v2.GetIncidentPostmortemTemplate", true)
+	ddClientConfig.SetUnstableOperationEnabled("v2.UpdateIncidentPostmortemTemplate", true)
+	ddClientConfig.SetUnstableOperationEnabled("v2.DeleteIncidentPostmortemTemplate", true)
+
 	// Enable OrgGroup
 	ddClientConfig.SetUnstableOperationEnabled("v2.CreateOrgGroup", true)
 	ddClientConfig.SetUnstableOperationEnabled("v2.GetOrgGroup", true)


### PR DESCRIPTION
### Summary

`datadog_incident_postmortem_template` (added in #4026, shipped in `v4.17.0`) is currently unusable: **every** apply fails, regardless of the org's feature flags.

```
Error: Error creating incident postmortem template

Could not create incident postmortem template, unexpected error: Unstable
operation 'v2.CreateIncidentPostmortemTemplate' is disabled. HTTP Response: <nil>
```

Note `HTTP Response: <nil>` — the request is rejected client-side by `datadog-api-client-go` and never reaches the API.

### Root cause

The `v2.*IncidentPostmortemTemplate` operations are declared in the API client's `unstable_operations` map defaulting to `false` (`api/datadog/configuration.go` in `datadog-api-client-go v2.62.1-0.20260724190103-95e5c326c65e`):

```go
"v2.CreateIncidentPostmortemTemplate": false,
"v2.DeleteIncidentPostmortemTemplate": false,
"v2.GetIncidentPostmortemTemplate":    false,
"v2.ListIncidentPostmortemTemplates":  false,
"v2.UpdateIncidentPostmortemTemplate": false,
```

`NewIncidentPostmortemTemplateResource` is registered in `framework_provider.go`, but `defaultConfigureFunc` never enables the corresponding operations — unlike every sibling incident resource (`IncidentType`, `IncidentNotificationTemplate`, `IncidentNotificationRule`, `IncidentUserDefinedField`, `IncidentUserDefinedRole`), each of which has an `// Enable <Thing>` block in that function. The resource's `r.Api` is `DatadogApiInstances.GetIncidentsApiV2()`, built from the very `ddClientConfig` those calls mutate, so the omission disables the resource outright.

This is **not** an org-level/account gate — nothing an operator can configure works around it, since the client short-circuits before making a request.

### Fix

Enable the four operations the resource actually calls, following the existing pattern:

```go
// Enable IncidentPostmortemTemplate
ddClientConfig.SetUnstableOperationEnabled("v2.CreateIncidentPostmortemTemplate", true)
ddClientConfig.SetUnstableOperationEnabled("v2.GetIncidentPostmortemTemplate", true)
ddClientConfig.SetUnstableOperationEnabled("v2.UpdateIncidentPostmortemTemplate", true)
ddClientConfig.SetUnstableOperationEnabled("v2.DeleteIncidentPostmortemTemplate", true)
```

`v2.ListIncidentPostmortemTemplates` is deliberately left out — there is no postmortem-template data source yet, so nothing calls it. Happy to add it if you'd prefer to pre-empt that.

### Reproduction

Against `v4.17.0` (or current `master`), any config using the resource fails:

```hcl
resource "datadog_incident_postmortem_template" "example" {
  name = "example-postmortem-template"

  content {
    type = "doc"
    content {
      type = "heading"
      attrs = jsonencode({ level = 1 })
      content {
        type = "text"
        text = "Timeline"
      }
    }
  }
}
```

### Why CI didn't catch it

There is no acceptance test or cassette for this resource — #4026 added it without one, so the create path was never exercised. Separately, `buildFrameworkDatadogClient` in `datadog/tests/framework_provider_test.go` maintains its own parallel list of ~113 `SetUnstableOperationEnabled` calls that also omits the postmortem operations; whoever adds an acceptance test will need the same four lines there. I left that file untouched since no test references it today.

I did not add an acceptance test here because recording cassettes requires a Datadog org with these Preview endpoints enabled, which I don't have. Glad to add one if a maintainer can record, or to follow up.

### Validation

- `make fmtcheck` — passes
- `make test` — passes (240 tests)
- `make vet` — passes
- `go build ./...` — passes

Not run: `make testacc` (no cassette for this resource, and no test exists to record), and `make docs` (no schema change, so generated docs are unaffected).

### PR labels

Suggest `changelog/bugfix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
