### PR TITLE
[CCV-4685] Add cud_metadata_config to datadog_gcp_uc_config

### DIFF
--- a/datadog/fwprovider/resource_datadog_gcp_uc_config.go
+++ b/datadog/fwprovider/resource_datadog_gcp_uc_config.go
@@ -10,6 +10,7 @@ import (
 	frameworkPath "github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -27,14 +28,21 @@ type gcpUcConfigResource struct {
 	Auth context.Context
 }
 
+type cudMetadataConfigModel struct {
+	ProjectId types.String `tfsdk:"project_id"`
+	DatasetId types.String `tfsdk:"dataset_id"`
+	TableId   types.String `tfsdk:"table_id"`
+}
+
 type gcpUcConfigModel struct {
-	ID                types.String `tfsdk:"id"`
-	BillingAccountId  types.String `tfsdk:"billing_account_id"`
-	BucketName        types.String `tfsdk:"bucket_name"`
-	ExportDatasetName types.String `tfsdk:"export_dataset_name"`
-	ExportPrefix      types.String `tfsdk:"export_prefix"`
-	ExportProjectName types.String `tfsdk:"export_project_name"`
-	ServiceAccount    types.String `tfsdk:"service_account"`
+	ID                types.String            `tfsdk:"id"`
+	BillingAccountId  types.String            `tfsdk:"billing_account_id"`
+	BucketName        types.String            `tfsdk:"bucket_name"`
+	CudMetadataConfig *cudMetadataConfigModel `tfsdk:"cud_metadata_config"`
+	ExportDatasetName types.String            `tfsdk:"export_dataset_name"`
+	ExportPrefix      types.String            `tfsdk:"export_prefix"`
+	ExportProjectName types.String            `tfsdk:"export_project_name"`
+	ServiceAccount    types.String            `tfsdk:"service_account"`
 	// Computed fields
 	CreatedAt       types.String `tfsdk:"created_at"`
 	Dataset         types.String `tfsdk:"dataset"`
@@ -72,6 +80,35 @@ func (r *gcpUcConfigResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Required:      true,
 				Description:   "The Google Cloud bucket name used to store the Usage Cost export.",
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			// Deliberately NOT RequiresReplace, unlike its siblings above. Adding a
+			// CUD metadata export to an existing account is purely additive, and
+			// replacement would delete and recreate the cost config, costing the
+			// customer an ingestion gap and a full revalidation. Update() maps this
+			// attribute onto the PATCH endpoint instead.
+			//
+			// Computed as well as Optional so that an export configured in the
+			// Datadog UI, with no block in the customer's configuration, is left
+			// alone rather than proposed for deletion on the next plan.
+			"cud_metadata_config": schema.SingleNestedAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "The location of the committed use discount (CUD) metadata export. Google publishes commitment terms, amounts and expiration dates to this BigQuery table, and Datadog reads it to show commitment details in Cloud Cost Management.",
+				Attributes: map[string]schema.Attribute{
+					"project_id": schema.StringAttribute{
+						Required:    true,
+						Description: "The Google Cloud project that hosts the CUD metadata export dataset. Not necessarily the project holding the Usage Cost export.",
+					},
+					"dataset_id": schema.StringAttribute{
+						Required:    true,
+						Description: "The BigQuery dataset holding the CUD metadata export.",
+					},
+					"table_id": schema.StringAttribute{
+						Required:    true,
+						Description: "The BigQuery table holding the CUD metadata export. Google names this table, so it is always `cud_subscriptions_export`.",
+					},
+				},
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
 			},
 			"export_dataset_name": schema.StringAttribute{
 				Required:      true,
@@ -189,11 +226,61 @@ func (r *gcpUcConfigResource) Create(ctx context.Context, request resource.Creat
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
+// Update only ever handles cud_metadata_config. Every other writable attribute
+// carries RequiresReplace, so the framework recreates the resource instead of
+// routing those changes here.
 func (r *gcpUcConfigResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
-	response.Diagnostics.AddError(
-		"Update Not Supported",
-		"GCP UC Config resources do not support updates. Changes require resource recreation.",
-	)
+	var plan gcpUcConfigModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	var state gcpUcConfigModel
+	response.Diagnostics.Append(request.State.Get(ctx, &state)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	if plan.CudMetadataConfig == nil {
+		// Optional + Computed: an attribute absent from the configuration means
+		// "leave the remote value alone", not "clear it". Carry the prior value
+		// forward so the plan stays empty instead of proposing a deletion the
+		// customer never asked for.
+		plan.CudMetadataConfig = state.CudMetadataConfig
+		response.Diagnostics.Append(response.State.Set(ctx, &plan)...)
+		return
+	}
+
+	id, _ := strconv.ParseInt(state.ID.ValueString(), 10, 64)
+
+	attributes := datadogV2.NewGCPUsageCostConfigPatchRequestAttributesWithDefaults()
+	cudMetadataConfig := datadogV2.NewGCPUsageCostConfigCudMetadataConfigWithDefaults()
+	cudMetadataConfig.SetProjectId(plan.CudMetadataConfig.ProjectId.ValueString())
+	cudMetadataConfig.SetDatasetId(plan.CudMetadataConfig.DatasetId.ValueString())
+	cudMetadataConfig.SetTableId(plan.CudMetadataConfig.TableId.ValueString())
+	attributes.SetCudMetadataConfig(*cudMetadataConfig)
+
+	// is_enabled is deliberately not set: the API rejects a PATCH carrying both
+	// it and cud_metadata_config.
+	body := datadogV2.NewGCPUsageCostConfigPatchRequestWithDefaults()
+	body.Data = *datadogV2.NewGCPUsageCostConfigPatchDataWithDefaults()
+	body.Data.SetAttributes(*attributes)
+
+	resp, _, err := r.Api.UpdateCostGCPUsageCostConfig(r.Auth, id, *body)
+	if err != nil {
+		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating GcpUcConfig"))
+		return
+	}
+	if err := utils.CheckForUnparsed(resp); err != nil {
+		response.Diagnostics.AddError("response contains unparsedObject", err.Error())
+		return
+	}
+
+	responseData := resp.GetData()
+	r.updateStateFromResponseData(ctx, &plan, &responseData)
+
+	response.Diagnostics.Append(response.State.Set(ctx, &plan)...)
 }
 
 func (r *gcpUcConfigResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
@@ -226,6 +313,19 @@ func (r *gcpUcConfigResource) updateStateFromResponseData(ctx context.Context, s
 		state.ExportProjectName = types.StringValue(attributes.GetExportProjectName())
 		state.ServiceAccount = types.StringValue(attributes.GetServiceAccount())
 
+		// Reading this back is what makes Optional + Computed work: without it
+		// the provider cannot tell a UI-configured export from an absent one,
+		// and would propose removing it on every plan.
+		if cudMetadataConfig, ok := attributes.GetCudMetadataConfigOk(); ok && cudMetadataConfig != nil {
+			state.CudMetadataConfig = &cudMetadataConfigModel{
+				ProjectId: types.StringValue(cudMetadataConfig.GetProjectId()),
+				DatasetId: types.StringValue(cudMetadataConfig.GetDatasetId()),
+				TableId:   types.StringValue(cudMetadataConfig.GetTableId()),
+			}
+		} else {
+			state.CudMetadataConfig = nil
+		}
+
 		// Set computed fields
 		state.CreatedAt = types.StringValue(attributes.GetCreatedAt())
 		state.Dataset = types.StringValue(attributes.GetDataset())
@@ -252,6 +352,19 @@ func (r *gcpUcConfigResource) updateStateFromGcpUcConfigResponseData(ctx context
 		state.ExportProjectName = types.StringValue(attributes.GetExportProjectName())
 		state.ServiceAccount = types.StringValue(attributes.GetServiceAccount())
 
+		// Reading this back is what makes Optional + Computed work: without it
+		// the provider cannot tell a UI-configured export from an absent one,
+		// and would propose removing it on every plan.
+		if cudMetadataConfig, ok := attributes.GetCudMetadataConfigOk(); ok && cudMetadataConfig != nil {
+			state.CudMetadataConfig = &cudMetadataConfigModel{
+				ProjectId: types.StringValue(cudMetadataConfig.GetProjectId()),
+				DatasetId: types.StringValue(cudMetadataConfig.GetDatasetId()),
+				TableId:   types.StringValue(cudMetadataConfig.GetTableId()),
+			}
+		} else {
+			state.CudMetadataConfig = nil
+		}
+
 		// Set computed fields
 		state.CreatedAt = types.StringValue(attributes.GetCreatedAt())
 		state.Dataset = types.StringValue(attributes.GetDataset())
@@ -276,6 +389,13 @@ func (r *gcpUcConfigResource) buildGcpUcConfigRequestBody(ctx context.Context, s
 	}
 	if !state.BucketName.IsNull() {
 		attributes.SetBucketName(state.BucketName.ValueString())
+	}
+	if state.CudMetadataConfig != nil {
+		cudMetadataConfig := datadogV2.NewGCPUsageCostConfigCudMetadataConfigWithDefaults()
+		cudMetadataConfig.SetProjectId(state.CudMetadataConfig.ProjectId.ValueString())
+		cudMetadataConfig.SetDatasetId(state.CudMetadataConfig.DatasetId.ValueString())
+		cudMetadataConfig.SetTableId(state.CudMetadataConfig.TableId.ValueString())
+		attributes.SetCudMetadataConfig(*cudMetadataConfig)
 	}
 	if !state.ExportDatasetName.IsNull() {
 		attributes.SetExportDatasetName(state.ExportDatasetName.ValueString())

--- a/datadog/tests/resource_datadog_gcp_uc_config_test.go
+++ b/datadog/tests/resource_datadog_gcp_uc_config_test.go
@@ -6,7 +6,9 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/fwprovider"
@@ -84,6 +86,179 @@ func TestAccGcpUcConfigImport(t *testing.T) {
 			},
 		},
 	})
+}
+
+// Adding a CUD metadata export to an account already managed in Terraform is
+// purely additive. If cud_metadata_config ever regains RequiresReplace, this
+// plan becomes a destroy-and-create, which costs the customer an ingestion gap
+// and a full revalidation. The plan check is the guard against that.
+func TestAccGcpUcConfigCudMetadataAddedInPlace(t *testing.T) {
+	t.Parallel()
+	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
+	uniq := uniqueEntityName(ctx, t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: accProviders,
+		CheckDestroy:             testAccCheckDatadogGcpUcConfigDestroy(providers.frameworkProvider),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDatadogGcpUcConfigBasic(uniq),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogGcpUcConfigExists(providers.frameworkProvider),
+					resource.TestCheckNoResourceAttr(
+						"datadog_gcp_uc_config.foo", "cud_metadata_config.dataset_id"),
+				),
+			},
+			{
+				Config: testAccCheckDatadogGcpUcConfigWithCudMetadata(uniq),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							"datadog_gcp_uc_config.foo", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogGcpUcConfigExists(providers.frameworkProvider),
+					resource.TestCheckResourceAttr(
+						"datadog_gcp_uc_config.foo", "cud_metadata_config.project_id", "test-gcp-project"),
+					resource.TestCheckResourceAttr(
+						"datadog_gcp_uc_config.foo", "cud_metadata_config.dataset_id", "committed_usage_discounts"),
+					resource.TestCheckResourceAttr(
+						"datadog_gcp_uc_config.foo", "cud_metadata_config.table_id", "cud_subscriptions_export"),
+				),
+			},
+		},
+	})
+}
+
+// A customer can configure their CUD metadata export in the Datadog UI, leaving
+// no block in their configuration. Optional + Computed has to read that value
+// back and leave it alone. Without Computed, Terraform reads a value the config
+// does not declare and proposes deleting it, so the next apply silently reverts
+// the customer's setup.
+//
+// ExpectNonEmptyPlan is false (the default, stated here because it *is* the
+// assertion): the framework plans after the step and fails on any diff.
+func TestAccGcpUcConfigCudMetadataConfiguredOutOfBand(t *testing.T) {
+	t.Parallel()
+	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
+	uniq := uniqueEntityName(ctx, t)
+
+	var cloudAccountID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: accProviders,
+		CheckDestroy:             testAccCheckDatadogGcpUcConfigDestroy(providers.frameworkProvider),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDatadogGcpUcConfigBasic(uniq),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogGcpUcConfigExists(providers.frameworkProvider),
+					func(s *terraform.State) error {
+						res, ok := s.RootModule().Resources["datadog_gcp_uc_config.foo"]
+						if !ok {
+							return fmt.Errorf("datadog_gcp_uc_config.foo not found in state")
+						}
+						cloudAccountID = res.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Configure the export behind Terraform's back, the way the
+				// Datadog UI would.
+				PreConfig: func() {
+					if err := setGcpCudMetadataConfigOutOfBand(providers.frameworkProvider, cloudAccountID); err != nil {
+						t.Fatalf("failed to set CUD metadata config out of band: %s", err)
+					}
+				},
+				// Unchanged, and deliberately still carries no cud_metadata_config.
+				Config:             testAccCheckDatadogGcpUcConfigBasic(uniq),
+				ExpectNonEmptyPlan: false,
+				Check: resource.ComposeTestCheckFunc(
+					// Read back into state rather than ignored.
+					resource.TestCheckResourceAttr(
+						"datadog_gcp_uc_config.foo", "cud_metadata_config.dataset_id", "committed_usage_discounts"),
+				),
+			},
+		},
+	})
+}
+
+// Optional + Computed cannot distinguish "the customer removed this block" from
+// "the customer never wrote one", so removing it is a no-op rather than an
+// opt-out. That is the accepted trade for not clobbering UI-configured accounts
+// above. Pinned here so it reads as intended behaviour and not a bug.
+func TestAccGcpUcConfigCudMetadataBlockRemovalIsNoop(t *testing.T) {
+	t.Parallel()
+	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
+	uniq := uniqueEntityName(ctx, t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: accProviders,
+		CheckDestroy:             testAccCheckDatadogGcpUcConfigDestroy(providers.frameworkProvider),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDatadogGcpUcConfigWithCudMetadata(uniq),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogGcpUcConfigExists(providers.frameworkProvider),
+					resource.TestCheckResourceAttr(
+						"datadog_gcp_uc_config.foo", "cud_metadata_config.dataset_id", "committed_usage_discounts"),
+				),
+			},
+			{
+				Config: testAccCheckDatadogGcpUcConfigBasic(uniq),
+				Check: resource.ComposeTestCheckFunc(
+					// Still configured. To opt out, PATCH an empty config or use
+					// the Datadog UI.
+					resource.TestCheckResourceAttr(
+						"datadog_gcp_uc_config.foo", "cud_metadata_config.dataset_id", "committed_usage_discounts"),
+				),
+			},
+		},
+	})
+}
+
+// setGcpCudMetadataConfigOutOfBand PATCHes a CUD metadata config directly,
+// bypassing Terraform, to simulate a customer configuring it in the Datadog UI.
+func setGcpCudMetadataConfigOutOfBand(accProvider *fwprovider.FrameworkProvider, cloudAccountID string) error {
+	id, err := strconv.ParseInt(cloudAccountID, 10, 64)
+	if err != nil {
+		return err
+	}
+
+	cudMetadataConfig := datadogV2.NewGCPUsageCostConfigCudMetadataConfigWithDefaults()
+	cudMetadataConfig.SetProjectId("test-gcp-project")
+	cudMetadataConfig.SetDatasetId("committed_usage_discounts")
+	cudMetadataConfig.SetTableId("cud_subscriptions_export")
+
+	attributes := datadogV2.NewGCPUsageCostConfigPatchRequestAttributesWithDefaults()
+	attributes.SetCudMetadataConfig(*cudMetadataConfig)
+
+	body := datadogV2.NewGCPUsageCostConfigPatchRequestWithDefaults()
+	body.Data = *datadogV2.NewGCPUsageCostConfigPatchDataWithDefaults()
+	body.Data.SetAttributes(*attributes)
+
+	_, _, err = accProvider.DatadogApiInstances.GetCloudCostManagementApiV2().
+		UpdateCostGCPUsageCostConfig(accProvider.Auth, id, *body)
+	return err
+}
+
+func testAccCheckDatadogGcpUcConfigWithCudMetadata(uniq string) string {
+	return `resource "datadog_gcp_uc_config" "foo" {
+    billing_account_id = "123456_ABCDEF_123456"
+    bucket_name = "test-gcp-bucket"
+    export_dataset_name = "billing"
+    export_prefix = "datadog_cloud_cost_detailed_usage_export"
+    export_project_name = "test-gcp-project"
+    service_account = "test-service-account@test-project.iam.gserviceaccount.com"
+
+    cud_metadata_config {
+        project_id = "test-gcp-project"
+        dataset_id = "committed_usage_discounts"
+        table_id   = "cud_subscriptions_export"
+    }
+}`
 }
 
 func testAccCheckDatadogGcpUcConfigBasic(uniq string) string {


### PR DESCRIPTION
> ## ⚠️ Draft — CI will be red, and that's expected
>
> This does not compile. Every error is a missing generated type, because [datadog-api-spec#6372](https://github.com/DataDog/datadog-api-spec/pull/6372) hasn't merged and `datadog-api-client-go` hasn't been regenerated. **Nothing here has been built or tested.**
>
> Open early so the design can be reviewed, since this is where the expensive mistakes live.

## Why

Google Cloud customers can commit to a year or more of spend in exchange for a discount — a **committed use discount**, or CUD. Datadog already ingests their cost export, which is enough to see that a CUD exists but carries little more than its ID. The details customers actually want — commitment amount, term, start and end dates — are only in a **separate** CUD metadata export, which Datadog has to read on its own. So we need the customer to tell us where that export lives.

Customers adding a GCP account expect to do it with Terraform. This adds the attribute so they can, instead of finishing `terraform apply` and then configuring the export by hand in the Datadog UI.

```hcl
resource "datadog_gcp_uc_config" "gcp_uc_config" {
  billing_account_id = "123456_A123BC_12AB34"
  # ...
  cud_metadata_config {
    project_id = "my-project-123"
    dataset_id = "committed_usage_discounts"
    table_id   = "cud_subscriptions_export"
  }
}
```

## Tests pin both decisions

Three acceptance tests, each guarding one thing:

| Test | Guards |
| --- | --- |
| `…CudMetadataAddedInPlace` | `plancheck.ExpectResourceAction(..., ResourceActionUpdate)` — **fails if this ever becomes a replace** |
| `…CudMetadataConfiguredOutOfBand` | PATCHes a config behind Terraform's back, then plans against a config with no block. `ExpectNonEmptyPlan: false` is the assertion — without `Computed`, Terraform proposes deleting the customer's export here |
| `…CudMetadataBlockRemovalIsNoop` | Removing the block leaves the export in place, recording the trade-off as intended rather than leaving it to be rediscovered as a bug |

The middle one is the load-bearing check. It's the only way to prove `UseStateForUnknown` on a `SingleNestedAttribute` actually behaves as intended for a UI-configured account, which is currently an assumption.

## Before this can merge

1. **[datadog-api-spec#6372](https://github.com/DataDog/datadog-api-spec/pull/6372) merges**, which in turn needs [dd-source#50475](https://github.com/ddoghq/dd-source/pull/50475) — the field currently 400s for orgs without a feature flag.
2. `datadog-api-client-go` regenerates. **No tagged release needed** — this repo pins a pseudo-version, so an unreleased commit works.
3. Bump `go.mod` to a client commit containing the type. That's part of this PR, not a separate one.
4. Then: build, docs regeneration, and cassettes.

Jira: [CCV-4685](https://datadoghq.atlassian.net/browse/CCV-4685) · unblocks web-ui#334731

---

## The chain

Enabling CUD metadata setup in Terraform spans four repos. Strictly sequential — each step needs the one above it merged and released.

| Step | Change | State |
| --- | --- | --- |
| 1 | [dd-source#50475](https://github.com/ddoghq/dd-source/pull/50475) — remove the feature-flag gate from the API | open, needs 0 |
| 2 | [datadog-api-spec#6372](https://github.com/DataDog/datadog-api-spec/pull/6372) — declare `cud_metadata_config` | draft, needs 1 |
| 3 | `datadog-api-client-go` — regenerate | automatic once 2 merges; no tagged release needed |
| **4** | [terraform-provider-datadog#4123](https://github.com/DataDog/terraform-provider-datadog/pull/4123) — add the HCL attribute | draft, needs 3 |
| 5 | [web-ui#334731](https://github.com/DataDog/web-ui/pull/334731) — emit the HCL block in the setup wizard | draft, needs 4 |

Tracked by [CCV-4685](https://datadoghq.atlassian.net/browse/CCV-4685) and [CCV-4687](https://datadoghq.atlassian.net/browse/CCV-4687).

**This PR is step 4.**


[CCV-4685]: https://datadoghq.atlassian.net/browse/CCV-4685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ