### PR TITLE
[tfgen] Parse date filters for SDK calls

### DIFF
--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -343,9 +343,9 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 	leafFields := b.models[0].Fields
 
 	inputAttrs, inputFields := buildInputViews(inputLeaves)
-	filterParams, filterUUID := buildFilterParams(search, filterLeaves, &b.unsupported)
-	readArgs, readUUID := buildArgumentViews(read, &b.unsupported)
-	searchArgs, searchUUID := buildArgumentViews(search, &b.unsupported)
+	filterParams, filterUUID, filterTime := buildFilterParams(search, filterLeaves, &b.unsupported)
+	readArgs, readUUID, readTime := buildArgumentViews(read, &b.unsupported)
+	searchArgs, searchUUID, searchTime := buildArgumentViews(search, &b.unsupported)
 	if len(b.unsupported) > 0 {
 		return DataSourceView{}, &UnsupportedEmitError{Nodes: b.unsupported}
 	}
@@ -397,6 +397,7 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 		APIStruct:   primary.GoApiStruct,
 		APIAccessor: "Get" + primary.GoApiStruct + strings.TrimPrefix(primary.GoPackage, "datadog"),
 		UsesUUID:    readUUID || searchUUID || filterUUID,
+		UsesTime:    readTime || searchTime || filterTime,
 		UsesJSON:    b.usesJSON,
 		ByID:        byID,
 		Searchable:  searchable,
@@ -465,31 +466,35 @@ func callHasArgument(call *model.SDKCall, tfName string) bool {
 	return false
 }
 
-func buildArgumentViews(call *model.SDKCall, unsupported *[]UnsupportedNode) ([]SDKArgumentView, bool) {
+func buildArgumentViews(call *model.SDKCall, unsupported *[]UnsupportedNode) ([]SDKArgumentView, bool, bool) {
 	if call == nil || !call.BindingResolved {
-		return nil, false
+		return nil, false, false
 	}
 	var views []SDKArgumentView
 	usesUUID := false
+	usesTime := false
 	for _, arg := range call.Arguments {
-		expr, uuidVar, uuidSource, reason := sdkArgumentExpression(call.GoPackage, arg)
-		if reason != "" {
+		expr := sdkArgumentExpression(call.GoPackage, arg)
+		if expr.reason != "" {
 			*unsupported = append(*unsupported, UnsupportedNode{
-				Path: "sdk." + call.GoMethod + "." + arg.Name, Reason: reason,
+				Path: "sdk." + call.GoMethod + "." + arg.Name, Reason: expr.reason,
 			})
 			continue
 		}
 		views = append(views, SDKArgumentView{
-			Expression: expr, UUIDVar: uuidVar, UUIDSource: uuidSource, TFName: arg.TFName,
+			Expression: expr.value, UUIDVar: expr.uuidVar, UUIDSource: expr.uuidSource,
+			TimeVar: expr.timeVar, TimeSource: expr.timeSource, TimeLayout: expr.timeLayout,
+			TFName: arg.TFName,
 		})
-		usesUUID = usesUUID || uuidVar != ""
+		usesUUID = usesUUID || expr.uuidVar != ""
+		usesTime = usesTime || expr.timeVar != ""
 	}
-	return views, usesUUID
+	return views, usesUUID, usesTime
 }
 
-func buildFilterParams(call *model.SDKCall, leaves []*model.Attribute, unsupported *[]UnsupportedNode) ([]FilterParamView, bool) {
+func buildFilterParams(call *model.SDKCall, leaves []*model.Attribute, unsupported *[]UnsupportedNode) ([]FilterParamView, bool, bool) {
 	if call == nil {
-		return nil, false
+		return nil, false, false
 	}
 	byName := map[string]model.SDKArgument{}
 	for _, arg := range call.OptionalArguments {
@@ -497,6 +502,7 @@ func buildFilterParams(call *model.SDKCall, leaves []*model.Attribute, unsupport
 	}
 	var params []FilterParamView
 	usesUUID := false
+	usesTime := false
 	for _, leaf := range leaves {
 		tfName := tfNameOf(leaf.Path)
 		if !call.BindingResolved {
@@ -513,26 +519,40 @@ func buildFilterParams(call *model.SDKCall, leaves []*model.Attribute, unsupport
 			})
 			continue
 		}
-		expr, uuidVar, uuidSource, reason := sdkArgumentExpression(call.GoPackage, arg)
-		if reason != "" {
-			*unsupported = append(*unsupported, UnsupportedNode{Path: "sdk." + call.GoMethod + "." + arg.Name, Reason: reason})
+		expr := sdkArgumentExpression(call.GoPackage, arg)
+		if expr.reason != "" {
+			*unsupported = append(*unsupported, UnsupportedNode{Path: "sdk." + call.GoMethod + "." + arg.Name, Reason: expr.reason})
 			continue
 		}
 		param := FilterParamView{
-			StateField: model.SdkName(tfName), ParamField: model.SdkName(tfName), ValueExpr: expr, Setter: arg.Setter,
+			StateField: model.SdkName(tfName), ParamField: model.SdkName(tfName), ValueExpr: expr.value, Setter: arg.Setter,
 		}
-		if uuidVar != "" {
-			param.UUIDVar, param.UUIDSource, param.TFName = uuidVar, uuidSource, tfName
+		if expr.uuidVar != "" {
+			param.UUIDVar, param.UUIDSource, param.TFName = expr.uuidVar, expr.uuidSource, tfName
 			usesUUID = true
+		}
+		if expr.timeVar != "" {
+			param.TimeVar, param.TimeSource, param.TimeLayout, param.TFName = expr.timeVar, expr.timeSource, expr.timeLayout, tfName
+			usesTime = true
 		}
 		params = append(params, param)
 	}
-	return params, usesUUID
+	return params, usesUUID, usesTime
 }
 
-func sdkArgumentExpression(sdkPackage string, arg model.SDKArgument) (expr, uuidVar, uuidSource, reason string) {
+type sdkArgumentExpressionView struct {
+	value      string
+	uuidVar    string
+	uuidSource string
+	timeVar    string
+	timeSource string
+	timeLayout string
+	reason     string
+}
+
+func sdkArgumentExpression(sdkPackage string, arg model.SDKArgument) sdkArgumentExpressionView {
 	if arg.Schema == nil || arg.Schema.Kind != model.SchemaKindPrimitive {
-		return "", "", "", fmt.Sprintf("SDK argument type %s is outside scalar-first support", arg.GoType)
+		return sdkArgumentExpressionView{reason: fmt.Sprintf("SDK argument type %s is outside scalar-first support", arg.GoType)}
 	}
 	field := goFieldName(arg.TFName)
 	source := "state." + field
@@ -547,22 +567,31 @@ func sdkArgumentExpression(sdkPackage string, arg model.SDKArgument) (expr, uuid
 	case "number":
 		value = source + ".ValueFloat64()"
 	default:
-		return "", "", "", fmt.Sprintf("OpenAPI scalar type %q is not supported", arg.Schema.Type)
+		return sdkArgumentExpressionView{reason: fmt.Sprintf("OpenAPI scalar type %q is not supported", arg.Schema.Type)}
 	}
 
 	switch arg.GoType {
 	case "string", "bool", "int64", "float64":
-		return value, "", "", ""
+		return sdkArgumentExpressionView{value: value}
 	case "int", "int32", "float32":
-		return arg.GoType + "(" + value + ")", "", "", ""
+		return sdkArgumentExpressionView{value: arg.GoType + "(" + value + ")"}
 	case "uuid.UUID":
 		name := "parsed" + model.SdkName(arg.TFName)
-		return name, name, value, ""
+		return sdkArgumentExpressionView{value: name, uuidVar: name, uuidSource: value}
+	case "time.Time":
+		layout := "time.RFC3339"
+		if arg.Schema.Format == "date" {
+			layout = "time.DateOnly"
+		} else if arg.Schema.Format != "date-time" {
+			return sdkArgumentExpressionView{reason: fmt.Sprintf("SDK time.Time argument has unsupported OpenAPI format %q", arg.Schema.Format)}
+		}
+		name := "parsed" + model.SdkName(arg.TFName)
+		return sdkArgumentExpressionView{value: name, timeVar: name, timeSource: value, timeLayout: layout}
 	}
 	if strings.ContainsAny(arg.GoType, "[]*{}.") || arg.GoType == "interface{}" {
-		return "", "", "", fmt.Sprintf("SDK argument type %s is outside scalar-first support", arg.GoType)
+		return sdkArgumentExpressionView{reason: fmt.Sprintf("SDK argument type %s is outside scalar-first support", arg.GoType)}
 	}
-	return sdkPackage + "." + arg.GoType + "(" + value + ")", "", "", ""
+	return sdkArgumentExpressionView{value: sdkPackage + "." + arg.GoType + "(" + value + ")"}
 }
 
 // flattenedEnvelope is the result of recognizing a singular JSON:API envelope:
@@ -1150,8 +1179,8 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 	}
 
 	inputAttrs, inputFields := buildInputViews(inputLeaves)
-	filterParams, filterUUID := buildFilterParams(call, filterLeaves, &unsupported)
-	callArgs, usesUUID := buildArgumentViews(call, &unsupported)
+	filterParams, filterUUID, filterTime := buildFilterParams(call, filterLeaves, &unsupported)
+	callArgs, usesUUID, usesTime := buildArgumentViews(call, &unsupported)
 	goName := dsGoName(a.Name)
 
 	// b hosts walk so list-of-object item fields generate their element structs.
@@ -1325,6 +1354,7 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 		APIStruct:   call.GoApiStruct,
 		APIAccessor: "Get" + call.GoApiStruct + strings.TrimPrefix(call.GoPackage, "datadog"),
 		UsesUUID:    usesUUID || filterUUID,
+		UsesTime:    usesTime || filterTime,
 		UsesJSON:    b.usesJSON,
 		Read: SDKReadView{
 			Method:             call.GoMethod,

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -516,6 +516,32 @@ var _ = Describe("BuildDataSourceView singular search", func() {
 			Expect(src).To(ContainSubstring(`optionalParams.WithFilterName(parsedFilterName)`))
 		})
 
+		It("parses an RFC3339 filter before calling a time.Time SDK setter", func() {
+			op := powerpackSearchOperation()
+			op.QueryParams[0].Schema.Format = "date-time"
+			op.SDKBinding = &model.SDKOperationBinding{
+				OptionalParamsType: "ListPowerpacksOptionalParameters",
+				Optional: []model.SDKArgument{{
+					Name: "filter[name]", GoName: "filterName", GoType: "time.Time", Location: "query",
+					Schema: op.QueryParams[0].Schema, Setter: "WithFilterName",
+				}},
+			}
+
+			view := mustView(op)
+			Expect(view.UsesTime).To(BeTrue())
+			Expect(view.Search.Filters).To(Equal([]FilterParamView{{
+				StateField: "FilterName", ParamField: "FilterName", ValueExpr: "parsedFilterName", Setter: "WithFilterName",
+				TimeVar: "parsedFilterName", TimeSource: "state.FilterName.ValueString()", TimeLayout: "time.RFC3339", TFName: "filter_name",
+			}}))
+
+			rendered, err := RenderDataSource(view)
+			Expect(err).NotTo(HaveOccurred())
+			src := string(rendered)
+			Expect(src).To(ContainSubstring(`"time"`))
+			Expect(src).To(ContainSubstring(`parsedFilterName, err := time.Parse(time.RFC3339, state.FilterName.ValueString())`))
+			Expect(src).To(ContainSubstring(`optionalParams.WithFilterName(parsedFilterName)`))
+		})
+
 		It("hashes the search inputs when the selected record has no id", func() {
 			op := powerpackSearchOperation()
 			delete(op.ResponseSchema.Properties["data"].Items.Properties, "id")
@@ -1150,6 +1176,27 @@ var _ = Describe("BuildDataSourceView plural", func() {
 		Expect(err).NotTo(HaveOccurred())
 		src := string(rendered)
 		Expect(src).To(ContainSubstring(`parsedFilterKeyword, err := uuid.Parse(state.FilterKeyword.ValueString())`))
+		Expect(src).To(ContainSubstring(`optionalParams.WithFilterKeyword(parsedFilterKeyword)`))
+	})
+
+	It("parses a date filter in the plural Read path", func() {
+		op := teamsOperation()
+		filter := op.QueryParams[0]
+		filter.Schema.Format = "date"
+		op.SDKBinding = &model.SDKOperationBinding{
+			OptionalParamsType: "ListTeamsOptionalParameters",
+			Optional: []model.SDKArgument{
+				{Name: filter.Name, GoName: "filterKeyword", GoType: "time.Time", Location: "query", Schema: filter.Schema, Setter: "WithFilterKeyword"},
+				{Name: "filter[me]", GoName: "filterMe", GoType: "bool", Location: "query", Schema: op.QueryParams[1].Schema, Setter: "WithFilterMe"},
+			},
+		}
+
+		view := mustView(op)
+		Expect(view.UsesTime).To(BeTrue())
+		rendered, err := RenderDataSource(view)
+		Expect(err).NotTo(HaveOccurred())
+		src := string(rendered)
+		Expect(src).To(ContainSubstring(`parsedFilterKeyword, err := time.Parse(time.DateOnly, state.FilterKeyword.ValueString())`))
 		Expect(src).To(ContainSubstring(`optionalParams.WithFilterKeyword(parsedFilterKeyword)`))
 	})
 

--- a/.generator-v2/internal/emit/templates/data_source_plural.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_plural.go.tmpl
@@ -15,6 +15,9 @@ import (
 {{- if .UsesFmt }}
 	"fmt"
 {{- end }}
+{{- if .UsesTime }}
+	"time"
+{{- end }}
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/{{ .SDKPackage }}"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -72,6 +75,13 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 			return
 		}
 {{- end }}
+{{- if .TimeVar }}
+		{{ .TimeVar }}, err := time.Parse({{ .TimeLayout }}, {{ .TimeSource }})
+		if err != nil {
+			response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
+			return
+		}
+{{- end }}
 {{- if .Setter }}
 		optionalParams.{{ .Setter }}({{ .ValueExpr }})
 {{- else }}
@@ -83,6 +93,13 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 {{- range .Read.Arguments }}
 {{- if .UUIDVar }}
 	{{ .UUIDVar }}, err := uuid.Parse({{ .UUIDSource }})
+	if err != nil {
+		response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
+		return
+	}
+{{- end }}
+{{- if .TimeVar }}
+	{{ .TimeVar }}, err := time.Parse({{ .TimeLayout }}, {{ .TimeSource }})
 	if err != nil {
 		response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
 		return

--- a/.generator-v2/internal/emit/templates/data_source_singular.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_singular.go.tmpl
@@ -17,6 +17,9 @@ import (
 {{- if .UsesFmt }}
 	"fmt"
 {{- end }}
+{{- if .UsesTime }}
+	"time"
+{{- end }}
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/{{ .SDKPackage }}"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -96,6 +99,13 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 		return
 	}
 {{- end }}
+{{- if .TimeVar }}
+	{{ .TimeVar }}, err := time.Parse({{ .TimeLayout }}, {{ .TimeSource }})
+	if err != nil {
+		response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
+		return
+	}
+{{- end }}
 {{- end }}
 	resp, httpResp, err := d.Api.{{ .Read.Method }}(d.Auth{{ range .Read.Arguments }}, {{ .Expression }}{{ end }}{{ if and .ByID (not .Read.Arguments) }}, state.ID.ValueString(){{ end }})
 	if err != nil {
@@ -123,6 +133,13 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 {{ range .Read.Arguments }}
 {{- if .UUIDVar }}
 		{{ .UUIDVar }}, err := uuid.Parse({{ .UUIDSource }})
+		if err != nil {
+			response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
+			return
+		}
+{{- end }}
+{{- if .TimeVar }}
+		{{ .TimeVar }}, err := time.Parse({{ .TimeLayout }}, {{ .TimeSource }})
 		if err != nil {
 			response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
 			return
@@ -210,6 +227,13 @@ func (d *{{ .GoName }}DataSource) updateState(ctx context.Context, state *{{ .Go
 			return
 		}
 {{- end }}
+{{- if .TimeVar }}
+		{{ .TimeVar }}, err := time.Parse({{ .TimeLayout }}, {{ .TimeSource }})
+		if err != nil {
+			response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
+			return
+		}
+{{- end }}
 {{- if .Setter }}
 		optionalParams.{{ .Setter }}({{ .ValueExpr }})
 {{- else }}
@@ -221,6 +245,13 @@ func (d *{{ .GoName }}DataSource) updateState(ctx context.Context, state *{{ .Go
 {{- range .Search.Arguments }}
 {{- if .UUIDVar }}
 	{{ .UUIDVar }}, err := uuid.Parse({{ .UUIDSource }})
+	if err != nil {
+		response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
+		return
+	}
+{{- end }}
+{{- if .TimeVar }}
+	{{ .TimeVar }}, err := time.Parse({{ .TimeLayout }}, {{ .TimeSource }})
 	if err != nil {
 		response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
 		return

--- a/.generator-v2/internal/emit/view.go
+++ b/.generator-v2/internal/emit/view.go
@@ -58,6 +58,8 @@ type DataSourceView struct {
 	APIConstructor string
 	// UsesUUID adds the google/uuid import and SDK-input parsing blocks.
 	UsesUUID bool
+	// UsesTime adds the time import and SDK-input date parsing blocks.
+	UsesTime bool
 	// UsesJSON adds encoding/json and normalized JSON custom-type imports.
 	UsesJSON bool
 
@@ -197,6 +199,9 @@ type SDKArgumentView struct {
 	Expression string
 	UUIDVar    string
 	UUIDSource string
+	TimeVar    string
+	TimeSource string
+	TimeLayout string
 	TFName     string
 }
 
@@ -222,6 +227,11 @@ type FilterParamView struct {
 	// when the pinned SDK setter accepts uuid.UUID.
 	UUIDVar    string
 	UUIDSource string
+	// TimeVar, TimeSource, and TimeLayout request a time.Parse preparation for
+	// SDK setters accepting time.Time.
+	TimeVar    string
+	TimeSource string
+	TimeLayout string
 	// TFName is the Terraform attribute name used in parse diagnostics.
 	TFName string
 }


### PR DESCRIPTION
## Summary

Parse OpenAPI `date` and `date-time` Terraform strings into `time.Time` values when SDK methods require time-typed optional or positional arguments.

## Motivation

The Terraform schema correctly exposes dates as strings, but generated SDK calls previously passed those strings directly to `time.Time` parameters and failed to compile.

## Coverage impact

- Singular: 125/156 → 126/156 (+1)
- Plural: 177/194 → 183/194 (+6)
- Paired: 75/96 → 76/96 (+1)

## Testing

- `make tfgen-test`
- `make fmtcheck`
- `make test`
- Fresh full-spec build-verified sweep

## Stack

- Base: `jason.tenczar/generator-v2/free-form-map-values`
- Next: `jason.tenczar/generator-v2/numeric-ids`

## Reviewer notes

- Invalid date input now produces an explicit Terraform diagnostic before the SDK call.
