### PR TITLE
[tfgen] Parse numeric lookup IDs for SDK calls

### DIFF
--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -344,8 +344,8 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 
 	inputAttrs, inputFields := buildInputViews(inputLeaves)
 	filterParams, filterUUID, filterTime := buildFilterParams(search, filterLeaves, &b.unsupported)
-	readArgs, readUUID, readTime := buildArgumentViews(read, &b.unsupported)
-	searchArgs, searchUUID, searchTime := buildArgumentViews(search, &b.unsupported)
+	readArgs, readUUID, readTime, readStrconv := buildArgumentViews(read, &b.unsupported)
+	searchArgs, searchUUID, searchTime, searchStrconv := buildArgumentViews(search, &b.unsupported)
 	if len(b.unsupported) > 0 {
 		return DataSourceView{}, &UnsupportedEmitError{Nodes: b.unsupported}
 	}
@@ -398,6 +398,7 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 		APIAccessor: "Get" + primary.GoApiStruct + strings.TrimPrefix(primary.GoPackage, "datadog"),
 		UsesUUID:    readUUID || searchUUID || filterUUID,
 		UsesTime:    readTime || searchTime || filterTime,
+		UsesStrconv: readStrconv || searchStrconv,
 		UsesJSON:    b.usesJSON,
 		ByID:        byID,
 		Searchable:  searchable,
@@ -466,13 +467,14 @@ func callHasArgument(call *model.SDKCall, tfName string) bool {
 	return false
 }
 
-func buildArgumentViews(call *model.SDKCall, unsupported *[]UnsupportedNode) ([]SDKArgumentView, bool, bool) {
+func buildArgumentViews(call *model.SDKCall, unsupported *[]UnsupportedNode) ([]SDKArgumentView, bool, bool, bool) {
 	if call == nil || !call.BindingResolved {
-		return nil, false, false
+		return nil, false, false, false
 	}
 	var views []SDKArgumentView
 	usesUUID := false
 	usesTime := false
+	usesStrconv := false
 	for _, arg := range call.Arguments {
 		expr := sdkArgumentExpression(call.GoPackage, arg)
 		if expr.reason != "" {
@@ -484,12 +486,14 @@ func buildArgumentViews(call *model.SDKCall, unsupported *[]UnsupportedNode) ([]
 		views = append(views, SDKArgumentView{
 			Expression: expr.value, UUIDVar: expr.uuidVar, UUIDSource: expr.uuidSource,
 			TimeVar: expr.timeVar, TimeSource: expr.timeSource, TimeLayout: expr.timeLayout,
+			IntVar: expr.intVar, IntSource: expr.intSource, IntBits: expr.intBits,
 			TFName: arg.TFName,
 		})
 		usesUUID = usesUUID || expr.uuidVar != ""
 		usesTime = usesTime || expr.timeVar != ""
+		usesStrconv = usesStrconv || expr.intVar != ""
 	}
-	return views, usesUUID, usesTime
+	return views, usesUUID, usesTime, usesStrconv
 }
 
 func buildFilterParams(call *model.SDKCall, leaves []*model.Attribute, unsupported *[]UnsupportedNode) ([]FilterParamView, bool, bool) {
@@ -547,6 +551,9 @@ type sdkArgumentExpressionView struct {
 	timeVar    string
 	timeSource string
 	timeLayout string
+	intVar     string
+	intSource  string
+	intBits    int
 	reason     string
 }
 
@@ -556,6 +563,23 @@ func sdkArgumentExpression(sdkPackage string, arg model.SDKArgument) sdkArgument
 	}
 	field := goFieldName(arg.TFName)
 	source := "state." + field
+	if arg.TFName == "id" && arg.Schema.Type == "integer" {
+		name := "parsed" + model.SdkName(arg.TFName)
+		value := name
+		bits := 64
+		switch arg.GoType {
+		case "int":
+			bits, value = 0, "int("+name+")"
+		case "int32":
+			bits, value = 32, "int32("+name+")"
+		case "int64":
+		default:
+			value = sdkPackage + "." + arg.GoType + "(" + name + ")"
+		}
+		return sdkArgumentExpressionView{
+			value: value, intVar: name, intSource: source + ".ValueString()", intBits: bits,
+		}
+	}
 	var value string
 	switch arg.Schema.Type {
 	case "string":
@@ -1180,7 +1204,7 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 
 	inputAttrs, inputFields := buildInputViews(inputLeaves)
 	filterParams, filterUUID, filterTime := buildFilterParams(call, filterLeaves, &unsupported)
-	callArgs, usesUUID, usesTime := buildArgumentViews(call, &unsupported)
+	callArgs, usesUUID, usesTime, usesStrconv := buildArgumentViews(call, &unsupported)
 	goName := dsGoName(a.Name)
 
 	// b hosts walk so list-of-object item fields generate their element structs.
@@ -1355,6 +1379,7 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 		APIAccessor: "Get" + call.GoApiStruct + strings.TrimPrefix(call.GoPackage, "datadog"),
 		UsesUUID:    usesUUID || filterUUID,
 		UsesTime:    usesTime || filterTime,
+		UsesStrconv: usesStrconv,
 		UsesJSON:    b.usesJSON,
 		Read: SDKReadView{
 			Method:             call.GoMethod,

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -179,6 +179,28 @@ var _ = Describe("BuildDataSourceView", func() {
 		Expect(src).To(ContainSubstring(`GetIncidentType(d.Auth, state.AccountId.ValueInt64(), parsedId)`))
 	})
 
+	It("parses a string-valued Terraform id for a numeric SDK path argument", func() {
+		op := incidentTypeOperation()
+		op.SDKBinding = &model.SDKOperationBinding{Required: []model.SDKArgument{{
+			Name: "incident_type_id", GoName: "incidentTypeId", GoType: "int64", Location: "path",
+			Schema: prim("integer", "The numeric incident type ID."),
+		}}}
+
+		view := mustView(op)
+		Expect(view.UsesStrconv).To(BeTrue())
+		Expect(view.Read.Arguments).To(Equal([]SDKArgumentView{{
+			Expression: "parsedId", IntVar: "parsedId", IntSource: "state.ID.ValueString()", IntBits: 64, TFName: "id",
+		}}))
+
+		rendered, err := RenderDataSource(view)
+		Expect(err).NotTo(HaveOccurred())
+		src := string(rendered)
+		Expect(src).To(ContainSubstring(`"strconv"`))
+		Expect(src).To(ContainSubstring(`parsedId, err := strconv.ParseInt(state.ID.ValueString(), 10, 64)`))
+		Expect(src).To(ContainSubstring(`response.Diagnostics.AddError("Invalid id", err.Error())`))
+		Expect(src).To(ContainSubstring(`GetIncidentType(d.Auth, parsedId)`))
+	})
+
 	It("renders a resolved singleton call without inventing an id argument", func() {
 		op := incidentTypeOperation()
 		op.Path = "/api/v2/incidents/config/types/default"

--- a/.generator-v2/internal/emit/templates/data_source_plural.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_plural.go.tmpl
@@ -18,6 +18,9 @@ import (
 {{- if .UsesTime }}
 	"time"
 {{- end }}
+{{- if .UsesStrconv }}
+	"strconv"
+{{- end }}
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/{{ .SDKPackage }}"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -100,6 +103,13 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 {{- end }}
 {{- if .TimeVar }}
 	{{ .TimeVar }}, err := time.Parse({{ .TimeLayout }}, {{ .TimeSource }})
+	if err != nil {
+		response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
+		return
+	}
+{{- end }}
+{{- if .IntVar }}
+	{{ .IntVar }}, err := strconv.ParseInt({{ .IntSource }}, 10, {{ .IntBits }})
 	if err != nil {
 		response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
 		return

--- a/.generator-v2/internal/emit/templates/data_source_singular.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_singular.go.tmpl
@@ -20,6 +20,9 @@ import (
 {{- if .UsesTime }}
 	"time"
 {{- end }}
+{{- if .UsesStrconv }}
+	"strconv"
+{{- end }}
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/{{ .SDKPackage }}"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -106,6 +109,13 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 		return
 	}
 {{- end }}
+{{- if .IntVar }}
+	{{ .IntVar }}, err := strconv.ParseInt({{ .IntSource }}, 10, {{ .IntBits }})
+	if err != nil {
+		response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
+		return
+	}
+{{- end }}
 {{- end }}
 	resp, httpResp, err := d.Api.{{ .Read.Method }}(d.Auth{{ range .Read.Arguments }}, {{ .Expression }}{{ end }}{{ if and .ByID (not .Read.Arguments) }}, state.ID.ValueString(){{ end }})
 	if err != nil {
@@ -140,6 +150,13 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 {{- end }}
 {{- if .TimeVar }}
 		{{ .TimeVar }}, err := time.Parse({{ .TimeLayout }}, {{ .TimeSource }})
+		if err != nil {
+			response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
+			return
+		}
+{{- end }}
+{{- if .IntVar }}
+		{{ .IntVar }}, err := strconv.ParseInt({{ .IntSource }}, 10, {{ .IntBits }})
 		if err != nil {
 			response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
 			return
@@ -252,6 +269,13 @@ func (d *{{ .GoName }}DataSource) updateState(ctx context.Context, state *{{ .Go
 {{- end }}
 {{- if .TimeVar }}
 	{{ .TimeVar }}, err := time.Parse({{ .TimeLayout }}, {{ .TimeSource }})
+	if err != nil {
+		response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
+		return
+	}
+{{- end }}
+{{- if .IntVar }}
+	{{ .IntVar }}, err := strconv.ParseInt({{ .IntSource }}, 10, {{ .IntBits }})
 	if err != nil {
 		response.Diagnostics.AddError("Invalid {{ .TFName }}", err.Error())
 		return

--- a/.generator-v2/internal/emit/view.go
+++ b/.generator-v2/internal/emit/view.go
@@ -60,6 +60,8 @@ type DataSourceView struct {
 	UsesUUID bool
 	// UsesTime adds the time import and SDK-input date parsing blocks.
 	UsesTime bool
+	// UsesStrconv adds integer parsing for string-valued Terraform IDs.
+	UsesStrconv bool
 	// UsesJSON adds encoding/json and normalized JSON custom-type imports.
 	UsesJSON bool
 
@@ -202,6 +204,9 @@ type SDKArgumentView struct {
 	TimeVar    string
 	TimeSource string
 	TimeLayout string
+	IntVar     string
+	IntSource  string
+	IntBits    int
 	TFName     string
 }
 


### PR DESCRIPTION
## Summary

Parse canonical Terraform string IDs into integer SDK path arguments while retaining string identity in Terraform state.

## Motivation

Several by-ID endpoints use numeric SDK arguments even though Terraform data-source identity is consistently represented as a string.

## Coverage impact

- Singular: 126/156 → 133/156 (+7)
- Plural: unchanged at 183/194
- Paired: 76/96 → 82/96 (+6)

## Testing

- `make tfgen-test`
- `make fmtcheck`
- `make test`
- Fresh full-spec build-verified sweep

## Stack

- Base: `jason.tenczar/generator-v2/time-filters`
- Next: `jason.tenczar/generator-v2/lookup-output-fields`

## Reviewer notes

- Parsing respects the SDK integer width and reports conversion errors as diagnostics.
