### PR TITLE
[tfgen] Coalesce lookup and returned fields

### DIFF
--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -343,6 +343,8 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 	leafFields := b.models[0].Fields
 
 	inputAttrs, inputFields := buildInputViews(inputLeaves)
+	inputAttrs, inputFields, recordAttrs, leafFields, collisions := coalesceLookupOutputs(inputAttrs, inputFields, recordAttrs, leafFields)
+	b.unsupported = append(b.unsupported, collisions...)
 	filterParams, filterUUID, filterTime := buildFilterParams(search, filterLeaves, &b.unsupported)
 	readArgs, readUUID, readTime, readStrconv := buildArgumentViews(read, &b.unsupported)
 	searchArgs, searchUUID, searchTime, searchStrconv := buildArgumentViews(search, &b.unsupported)
@@ -416,6 +418,67 @@ func BuildDataSourceView(a *model.Artifact) (DataSourceView, error) {
 		UsesFmt: !searchable || len(searchView.HashInputs) > 0 || len(b.oneOfRenders) > 0,
 		Dropped: b.dropped,
 	}, nil
+}
+
+// coalesceLookupOutputs merges a singular lookup input with the returned field
+// of the same name. Required path inputs remain Required; optional search inputs
+// become Optional+Computed so the configured value and refreshed API value share
+// one Terraform field. Incompatible types stay local generator diagnostics.
+func coalesceLookupOutputs(
+	inputAttrs []AttrView,
+	inputFields []ModelFieldView,
+	recordAttrs []AttrView,
+	recordFields []ModelFieldView,
+) ([]AttrView, []ModelFieldView, []AttrView, []ModelFieldView, []UnsupportedNode) {
+	attrIndex := make(map[string]int, len(inputAttrs))
+	for i := range inputAttrs {
+		attrIndex[inputAttrs[i].TFName] = i
+	}
+	fieldIndex := make(map[string]int, len(inputFields))
+	for i := range inputFields {
+		fieldIndex[inputFields[i].TFName] = i
+	}
+
+	remainingAttrs := make([]AttrView, 0, len(recordAttrs))
+	var conflicts []UnsupportedNode
+	for _, output := range recordAttrs {
+		i, found := attrIndex[output.TFName]
+		if !found {
+			remainingAttrs = append(remainingAttrs, output)
+			continue
+		}
+		input := &inputAttrs[i]
+		if input.TFType != output.TFType || input.ElementType != output.ElementType || input.CustomType != output.CustomType {
+			conflicts = append(conflicts, UnsupportedNode{
+				Path:   "schema." + output.TFName,
+				Reason: fmt.Sprintf("lookup input type %s conflicts with returned type %s", input.TFType, output.TFType),
+			})
+			continue
+		}
+		if input.Description == "" {
+			input.Description = output.Description
+		}
+		input.Sensitive = input.Sensitive || output.Sensitive
+		input.Computed = input.Optional
+	}
+
+	remainingFields := make([]ModelFieldView, 0, len(recordFields))
+	for _, output := range recordFields {
+		i, found := fieldIndex[output.TFName]
+		if !found {
+			remainingFields = append(remainingFields, output)
+			continue
+		}
+		input := inputFields[i]
+		if input.GoField != output.GoField || input.GoType != output.GoType {
+			conflicts = append(conflicts, UnsupportedNode{
+				Path:   "model." + output.TFName,
+				Reason: fmt.Sprintf("lookup input model type %s conflicts with returned type %s", input.GoType, output.GoType),
+			})
+		}
+	}
+
+	return inputAttrs, inputFields, remainingAttrs, remainingFields, conflicts
 }
 
 // buildInputViews turns Terraform input leaves into schema attributes and model

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -179,6 +179,36 @@ var _ = Describe("BuildDataSourceView", func() {
 		Expect(src).To(ContainSubstring(`GetIncidentType(d.Auth, state.AccountId.ValueInt64(), parsedId)`))
 	})
 
+	It("coalesces a required path lookup with the returned field of the same name", func() {
+		op := incidentTypeOperation()
+		op.Path = "/api/v2/accounts/{account_id}/incident-types/{incident_type_id}"
+		op.ResponseSchema.Properties["data"].Properties["attributes"].Properties["account_id"] =
+			prim("integer", "The returned account ID.")
+		op.SDKBinding = &model.SDKOperationBinding{Required: []model.SDKArgument{
+			{Name: "account_id", GoName: "accountId", GoType: "int64", Location: "path", Schema: prim("integer", "The lookup account ID.")},
+			{Name: "incident_type_id", GoName: "incidentTypeId", GoType: "string", Location: "path", Schema: prim("string", "The incident type ID.")},
+		}}
+
+		view := mustView(op)
+		var accountAttrs []AttrView
+		for _, attr := range view.Schema.Attributes {
+			if attr.TFName == "account_id" {
+				accountAttrs = append(accountAttrs, attr)
+			}
+		}
+		Expect(accountAttrs).To(Equal([]AttrView{{
+			TFName: "account_id", TFType: "schema.Int64Attribute", Description: "The account_id argument.", Required: true,
+		}}))
+		var accountFields []ModelFieldView
+		for _, field := range view.Models[0].Fields {
+			if field.TFName == "account_id" {
+				accountFields = append(accountFields, field)
+			}
+		}
+		Expect(accountFields).To(HaveLen(1))
+		Expect(view.State.Assignments).To(ContainElement(HaveField("LHS", "state.AccountId")))
+	})
+
 	It("parses a string-valued Terraform id for a numeric SDK path argument", func() {
 		op := incidentTypeOperation()
 		op.SDKBinding = &model.SDKOperationBinding{Required: []model.SDKArgument{{
@@ -510,6 +540,31 @@ var _ = Describe("BuildDataSourceView singular search", func() {
 			Expect(view.State.ParamName).To(Equal("data"))
 			Expect(view.State.ParamType).To(Equal("datadogV2.PowerpackData"))
 			Expect(view.State.Preamble).To(Equal([]string{"attributes := data.GetAttributes()"}))
+		})
+
+		It("coalesces an optional search lookup with its computed returned field", func() {
+			op := powerpackSearchOperation()
+			op.QueryParams[0].Name = "name"
+
+			view := mustView(op)
+			var nameAttrs []AttrView
+			for _, attr := range view.Schema.Attributes {
+				if attr.TFName == "name" {
+					nameAttrs = append(nameAttrs, attr)
+				}
+			}
+			Expect(nameAttrs).To(Equal([]AttrView{{
+				TFName: "name", TFType: "schema.StringAttribute", Description: "The name of the Powerpack to search for.",
+				Optional: true, Computed: true,
+			}}))
+			var nameFields []ModelFieldView
+			for _, field := range view.Models[0].Fields {
+				if field.TFName == "name" {
+					nameFields = append(nameFields, field)
+				}
+			}
+			Expect(nameFields).To(HaveLen(1))
+			Expect(view.State.Assignments).To(ContainElement(HaveField("LHS", "state.Name")))
 		})
 
 		It("parses an optional UUID filter before calling its pinned SDK setter", func() {


### PR DESCRIPTION
## Summary

Coalesce lookup inputs and returned fields that resolve to the same Terraform attribute instead of emitting duplicate model tags.

## Motivation

By-ID and filtered singular endpoints commonly return the field used for lookup. Treating input and output as separate declarations caused otherwise valid artifacts to fail generation.

## Coverage impact

- Singular: 133/156 → 138/156 (+5)
- Plural: unchanged at 183/194
- Paired: 82/96 → 86/96 (+4)

## Testing

- `make tfgen-test`
- `make fmtcheck`
- `make test`
- Fresh full-spec build-verified sweep

## Stack

- Base: `jason.tenczar/generator-v2/numeric-ids`
- Next: `jason.tenczar/generator-v2/flat-data`

## Reviewer notes

- Required lookups remain required; optional search inputs become optional and computed when also returned by the API.
- Incompatible duplicate shapes still fail with a targeted diagnostic.
