### PR TITLE
[tfgen] Support flat data response objects

### DIFF
--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -692,11 +692,10 @@ type flattenedEnvelope struct {
 }
 
 // flattenEnvelope recognizes the singular JSON:API envelope at the response root
-// and reshapes it for the walk. It expects a top-level "data" object whose members
-// are a subset of {id, type, attributes}, with "attributes" an object of leaves
-// only. It hoists each attribute leaf to a top-level path ("response.<leaf>"),
-// surfaces "id" from id_strategy (data.id only), and drops "type". Anything outside
-// the recognized envelope is appended to b.unsupported and the result is nil.
+// and reshapes it for the walk. The usual {data:{id,type,attributes}} form hoists
+// attributes; APIs using a flat {data:{id,type,...}} object hoist its non-envelope
+// members directly. In both forms id supplies Terraform identity, while type and
+// relationships are metadata and are dropped.
 func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrategy model.IdStrategy, rootExpr string) *flattenedEnvelope {
 	// A JSON:API response carries sideloading and request metadata beside the
 	// primary resource: "included" (the hydrated targets of data.relationships),
@@ -721,8 +720,10 @@ func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrat
 		return nil
 	}
 
-	// data members must be a subset of {id, type, attributes}.
+	// Find the standard envelope members, retaining other members in case this is
+	// one of the flat data objects used by a small set of APIs.
 	var id, attributes *model.Attribute
+	var flatChildren []*model.Attribute
 	ok := true
 	for _, child := range data.Children {
 		switch tfNameOf(child.Path) {
@@ -732,21 +733,14 @@ func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrat
 			// type is the discriminator and is not surfaced.
 		case "attributes":
 			attributes = child
-		default:
-			// Members outside {id, type, attributes} (e.g. relationships) have no
-			// place in the attributes-only view; drop them rather than failing.
+		case "relationships":
 			b.dropped = append(b.dropped, droppedEnvelopeMember(child.Path))
+		default:
+			flatChildren = append(flatChildren, child)
 		}
 	}
 
-	if attributes == nil {
-		b.unsupported = append(b.unsupported, UnsupportedNode{
-			Path:   data.Path,
-			Reason: "envelope data is missing an attributes object",
-		})
-		return nil
-	}
-	if attributes.TfType != "schema.SingleNestedBlock" {
+	if attributes != nil && attributes.TfType != "schema.SingleNestedBlock" {
 		b.unsupported = append(b.unsupported, UnsupportedNode{
 			Path:   attributes.Path,
 			Reason: "envelope attributes must be an object",
@@ -754,10 +748,21 @@ func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrat
 		return nil
 	}
 
-	// Hoist the attribute children to top-level paths: scalar leaves, typed list/map
+	children := flatChildren
+	if attributes != nil {
+		for _, child := range flatChildren {
+			b.dropped = append(b.dropped, droppedEnvelopeMember(child.Path))
+		}
+		children = attributes.Children
+	} else {
+		// Direct getters live on data instead of its attributes object.
+		b.receiver = rootExpr
+	}
+
+	// Hoist the selected children to top-level paths: scalar leaves, typed list/map
 	// attributes, list-of-object blocks, and bare nested objects are in scope.
-	leaves := make([]*model.Attribute, 0, len(attributes.Children))
-	for _, child := range attributes.Children {
+	leaves := make([]*model.Attribute, 0, len(children))
+	for _, child := range children {
 		if isAuditField(tfNameOf(child.Path)) {
 			b.dropped = append(b.dropped, droppedAuditField(child.Path))
 			continue
@@ -771,7 +776,7 @@ func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrat
 		if !isLeafType(child.TfType) && !isArrayType(child.TfType) && !isMapType(child.TfType) && !isObjectType(child.TfType) {
 			b.unsupported = append(b.unsupported, UnsupportedNode{
 				Path:   child.Path,
-				Reason: "nesting under attributes is not supported",
+				Reason: "nested response shape is not supported",
 			})
 			ok = false
 			continue
@@ -804,7 +809,7 @@ func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrat
 		}
 	}
 	var preamble []string
-	if len(leaves) > 0 {
+	if attributes != nil && len(leaves) > 0 {
 		preamble = []string{"attributes := " + rootExpr + ".GetAttributes()"}
 	}
 	return &flattenedEnvelope{

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -146,6 +146,36 @@ var _ = Describe("BuildDataSourceView", func() {
 		}))
 	})
 
+	It("hoists fields from a flat data object without an attributes wrapper", func() {
+		op := incidentTypeOperation()
+		data := op.ResponseSchema.Properties["data"]
+		name := data.Properties["attributes"].Properties["name"]
+		delete(data.Properties, "attributes")
+		data.Properties["name"] = name
+		data.Properties["relationships"] = obj(map[string]*model.Schema{
+			"owner": prim("string", "Relationship metadata."),
+		})
+
+		view := mustView(op)
+		Expect(view.State.Preamble).To(BeEmpty())
+		Expect(view.Schema.Attributes).To(ContainElement(HaveField("TFName", "name")))
+		Expect(view.State.Assignments).To(ContainElement(StateAssignment{
+			Var: "name", GetterOk: "resp.Data.GetNameOk()", LHS: "state.Name", RHS: "types.StringValue(*name)",
+		}))
+		Expect(view.Dropped).To(ContainElement(HaveField("Message", ContainSubstring("response.data.relationships"))))
+	})
+
+	It("supports an identity-only flat data object", func() {
+		op := incidentTypeOperation()
+		data := op.ResponseSchema.Properties["data"]
+		delete(data.Properties, "attributes")
+
+		view := mustView(op)
+		Expect(view.Schema.Attributes).To(BeEmpty())
+		Expect(view.Models[0].Fields).To(HaveLen(1))
+		Expect(view.State.Assignments).To(ContainElement(HaveField("LHS", "state.ID")))
+	})
+
 	It("produces a deeply-equal view across two runs", func() {
 		first, err := BuildDataSourceView(incidentTypeArtifact())
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

Support JSON:API-like responses whose `data` object stores resource fields directly instead of beneath an `attributes` object.

## Motivation

Several APIs use a flat data object while retaining `id` and `type`. The generator previously required the canonical nested `attributes` shape.

## Coverage impact

- Singular: 138/156 → 142/156 (+4)
- Plural: unchanged at 183/194
- Paired: 86/96 → 87/96 (+1)

## Testing

- `make tfgen-test`
- `make fmtcheck`
- `make test`
- Fresh full-spec build-verified sweep

## Stack

- Base: `jason.tenczar/generator-v2/lookup-output-fields`
- Next: `jason.tenczar/generator-v2/empty-list-items`

## Reviewer notes

- `relationships` and JSON:API metadata remain intentionally dropped with diagnostics.
- Direct resource fields use getters on `data` rather than a synthetic attributes receiver.
