### PR TITLE
[tfgen] Compile empty list item projections

### DIFF
--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -1190,6 +1190,22 @@ var _ = Describe("BuildDataSourceView plural", func() {
 		Expect(view).To(Equal(pluralFixture()))
 	})
 
+	It("does not name an unused SDK item for an empty result projection", func() {
+		op := teamsOperation()
+		item := op.ResponseSchema.Properties["data"].Items
+		delete(item.Properties, "id")
+		delete(item.Properties, "attributes")
+
+		view := mustView(op)
+		Expect(view.State.ItemFields).To(BeEmpty())
+		Expect(view.State.ItemLists).To(BeEmpty())
+		rendered, err := RenderDataSource(view)
+		Expect(err).NotTo(HaveOccurred())
+		src := string(rendered)
+		Expect(src).To(ContainSubstring("for range *data {"))
+		Expect(src).NotTo(ContainSubstring("for _, item := range *data {"))
+	})
+
 	It("renders unconstrained result-item values as normalized JSON", func() {
 		op := teamsOperation()
 		attributes := op.ResponseSchema.Properties["data"].Items.Properties["attributes"].Properties

--- a/.generator-v2/internal/emit/templates/data_source_plural.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_plural.go.tmpl
@@ -152,7 +152,11 @@ func (d *{{ .GoName }}DataSource) Read(ctx context.Context, request datasource.R
 func (d *{{ .GoName }}DataSource) updateState(ctx context.Context, state *{{ .GoName }}DataSourceModel, data *[]{{ .SDKPackage }}.{{ .Read.ItemType }}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	results := make([]*{{ .State.ItemStruct }}, 0, len(*data))
+{{- if or .State.ItemFields .State.ItemLists }}
 	for _, item := range *data {
+{{- else }}
+	for range *data {
+{{- end }}
 		r := {{ .State.ItemStruct }}{
 {{- range .State.ItemFields }}
 			{{ .LHS }}: {{ .RHS }},


### PR DESCRIPTION
## Summary

Generate compiling plural data sources when collection items expose no projected fields.

## Motivation

The plural template always named the SDK loop item, producing an unused variable when the projection was intentionally empty.

## Coverage impact

- Singular: unchanged at 142/156
- Plural: 183/194 → 187/194 (+4)
- Paired: unchanged at 87/96

## Testing

- `make tfgen-test`
- `make fmtcheck`
- `make test`
- Fresh full-spec build-verified sweep

## Stack

- Base: `jason.tenczar/generator-v2/flat-data`
- Next: `jason.tenczar/generator-v2/allof-identity-branches`

## Reviewer notes

- The unnamed `for range` form is used only when neither scalar fields nor nested assignments reference the item.
