### PR TITLE
[tfgen] Ignore identity branches in allOf

### DIFF
--- a/.generator-v2/internal/parser/schema.go
+++ b/.generator-v2/internal/parser/schema.go
@@ -1114,9 +1114,10 @@ func oneOfValueWrapped(schema *model.Schema) bool {
 // normalizeAllOf flattens the bounded allOf subset used by the Datadog API
 // spec. A single structural branch is a metadata overlay; multiple structural
 // branches must all be objects with disjoint properties. Annotation-only
-// branches are ignored structurally but may supply a local description or
-// sensitive marker. Anything outside that subset becomes an Unsupported schema
-// with a reason so only the affected artifact fails later in the model layer.
+// branches and empty identity branches are ignored structurally; annotations may
+// still supply a local description or sensitive marker. Anything outside that
+// subset becomes an Unsupported schema with a reason so only the affected
+// artifact fails later in the model layer.
 func (n *schemaNormalizer) normalizeAllOf(s *base.Schema, depth int, ctx schemaContext) (*model.Schema, error) {
 	if reason := unsupportedAllOfOuterStructure(s); reason != "" {
 		return unsupportedSchema(reason), nil
@@ -1143,8 +1144,10 @@ func (n *schemaNormalizer) normalizeAllOf(s *base.Schema, depth int, ctx schemaC
 		if err != nil {
 			return nil, err
 		}
-		if (branch.Kind == model.SchemaKindUnsupported || branch.Kind == model.SchemaKindJSON) &&
-			branch.UnsupportedReason == "" && n.isAnnotationOnlySchema(raw) {
+		// An unconstrained schema is the identity element of allOf intersection.
+		// This is context-specific: the same {} used as a property value remains
+		// arbitrary JSON, but inside allOf it adds no structural constraint.
+		if branch.UnsupportedReason == "" && !hasStructuralOrConstraintKeywords(raw) {
 			if annotationDescription == "" && raw.Description != "" {
 				annotationDescription = raw.Description
 			}

--- a/.generator-v2/internal/parser/schema_test.go
+++ b/.generator-v2/internal/parser/schema_test.go
@@ -617,6 +617,18 @@ var _ = Describe("NormalizeSchemas allOf normalization", func() {
 		Expect(status.Description).To(Equal("Authored single-branch description."))
 	})
 
+	It("ignores empty and nullable-only identity branches inside allOf", func() {
+		status := schemaProperty(request, "empty_identity")
+		Expect(status.Kind).To(Equal(model.SchemaKindPrimitive))
+		Expect(status.Type).To(Equal("string"))
+		Expect(status.Enum).To(Equal([]string{"active", "inactive"}))
+
+		object := schemaProperty(request, "nullable_identity")
+		Expect(object.Kind).To(Equal(model.SchemaKindObject))
+		Expect(object.Properties).To(HaveKey("alpha"))
+		Expect(object.Properties).To(HaveKey("zeta"))
+	})
+
 	DescribeTable("merges object branches with deterministic properties and required fields",
 		func(property string, wantProperties, wantRequired []string) {
 			composed := schemaProperty(request, property)

--- a/.generator-v2/internal/testdata/parser/schema_normalize_allof.yaml
+++ b/.generator-v2/internal/testdata/parser/schema_normalize_allof.yaml
@@ -30,6 +30,14 @@ paths:
                   description: Authored single-branch description.
                   allOf:
                     - $ref: '#/components/schemas/Status'
+                empty_identity:
+                  allOf:
+                    - {}
+                    - $ref: '#/components/schemas/Status'
+                nullable_identity:
+                  allOf:
+                    - nullable: true
+                    - $ref: '#/components/schemas/ObjectA'
                 two_objects:
                   allOf:
                     - $ref: '#/components/schemas/ObjectA'


### PR DESCRIPTION
## Summary

Treat empty, nullable-only, and annotation-only `allOf` branches as identity elements during schema normalization.

## Motivation

These branches add no structural or value constraint, but previously turned otherwise representable schemas into unsupported compositions.

## Coverage impact

- Singular: 142/156 → 144/156 (+2)
- Plural: 187/194 → 188/194 (+1)
- Paired: 87/96 → 88/96 (+1)

## Testing

- `make tfgen-test`
- `make fmtcheck`
- `make test`
- Fresh full-spec build-verified sweep

## Stack

- Base: `jason.tenczar/generator-v2/empty-list-items`
- Next: `jason.tenczar/generator-v2/object-oneof-constraints`

## Reviewer notes

- Standalone free-form `{}` schemas remain normalized JSON.
- Only non-structural branches inside `allOf` are ignored; actual constraints still merge or fail explicitly.
