### PR TITLE
[tfgen] Intersect object oneOf constraints

### DIFF
--- a/.generator-v2/internal/parser/schema.go
+++ b/.generator-v2/internal/parser/schema.go
@@ -1013,6 +1013,14 @@ func mergeNormalizedSchemas(variant, common *model.Schema) *model.Schema {
 	if common == nil {
 		return variant
 	}
+	// A bare type: object sibling constrains every oneOf alternative to an
+	// object without adding any fields. A normalized free-form object uses the
+	// JSON kind, but an explicitly shaped object alternative is already a
+	// narrower representation of that constraint.
+	if common.Kind == model.SchemaKindJSON && common.Type == "object" && variant.Kind == model.SchemaKindObject {
+		variant.Sensitive = variant.Sensitive || common.Sensitive
+		return variant
+	}
 	if common.Kind == model.SchemaKindUnsupported {
 		out := cloneSchema(common)
 		if out.Description == "" {

--- a/.generator-v2/internal/parser/schema_test.go
+++ b/.generator-v2/internal/parser/schema_test.go
@@ -388,6 +388,22 @@ var _ = Describe("NormalizeSchemas oneOf metadata", func() {
 		))
 	})
 
+	It("treats a bare object type adjacent to oneOf as an object constraint", func() {
+		union := oneOfFor("CreateOneOfWithObjectTypeSibling")
+		Expect(union.Variants).To(HaveLen(2))
+
+		Expect(union.Variants).To(ConsistOf(
+			SatisfyAll(
+				HaveField("Schema.Kind", model.SchemaKindObject),
+				HaveField("Schema.Properties", HaveKey("alpha")),
+			),
+			SatisfyAll(
+				HaveField("Schema.Kind", model.SchemaKindObject),
+				HaveField("Schema.Properties", HaveKey("beta")),
+			),
+		))
+	})
+
 	It("normalizes one adjacent allOf and merges it into every oneOf alternative", func() {
 		union := oneOfFor("CreateOneOfWithAllOfSibling")
 		Expect(union.Variants).To(HaveLen(2))

--- a/.generator-v2/internal/testdata/parser/schema_normalize_oneof.yaml
+++ b/.generator-v2/internal/testdata/parser/schema_normalize_oneof.yaml
@@ -141,6 +141,28 @@ paths:
       responses:
         "204":
           description: no content
+  /object-type-sibling:
+    post:
+      operationId: CreateOneOfWithObjectTypeSibling
+      tags: [OneOf]
+      x-datadog-tf-generator:
+        artifact_kind: resource
+        artifact_name: oneof_with_object_type_sibling
+        group:
+          create: CreateOneOfWithObjectTypeSibling
+          read: CreateOneOfWithObjectTypeSibling
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              oneOf:
+                - $ref: "#/components/schemas/AlphaVariant"
+                - $ref: "#/components/schemas/BetaVariant"
+      responses:
+        "204":
+          description: no content
   /required-only-sibling:
     post:
       operationId: CreateOneOfWithRequiredOnlySibling


### PR DESCRIPTION
## Summary

Intersect a bare `type: object` sibling constraint with object-shaped `oneOf` alternatives without converting the alternatives into unsupported kind conflicts.

## Motivation

A typed object alternative is already a narrower representation of a free-form object constraint, so the intersection is valid and lossless.

## Coverage impact

- Singular: 144/156 → 145/156 (+1)
- Plural: 188/194 → 189/194 (+1)
- Paired: 88/96 → 89/96 (+1)

## Testing

- `make tfgen-test`
- `make fmtcheck`
- `make test`
- Fresh full-spec build-verified sweep

## Stack

- Base: `jason.tenczar/generator-v2/allof-identity-branches`
- Next: `jason.tenczar/generator-v2/nested-state-vars`

## Reviewer notes

- The rule is restricted to object constraint plus object variant; heterogeneous alternatives continue to fail rather than weakening the schema.
