### PR TITLE
[tfgen] Preserve structured response maps as JSON

### DIFF
--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -773,7 +773,7 @@ func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrat
 			b.dropped = append(b.dropped, droppedIDCollision(child.Path))
 			continue
 		}
-		if !isLeafType(child.TfType) && !isArrayType(child.TfType) && !isMapType(child.TfType) && !isObjectType(child.TfType) {
+		if !isLeafType(child.TfType) && !isArrayType(child.TfType) && !isMapType(child.TfType) && !isObjectType(child.TfType) && !isOpaqueJSONType(child.TfType) {
 			b.unsupported = append(b.unsupported, UnsupportedNode{
 				Path:   child.Path,
 				Reason: "nested response shape is not supported",
@@ -997,6 +997,18 @@ func (b *dataSourceBuilder) walk(structName, stem, receiver, lhsPrefix string, a
 				ElementType:   a.ElementType,
 			})
 
+		case "schema.MapNestedAttribute":
+			// Dynamic keys whose values are structured objects cannot be expressed
+			// as blocks. Preserve the complete SDK map as canonical JSON instead of
+			// dropping either its keys or its nested values.
+			b.usesJSON = true
+			attrViews = append(attrViews, opaqueJSONView(a))
+			fields = append(fields, ModelFieldView{GoField: field, GoType: "jsontypes.Normalized", TFName: tfName})
+			lists = append(lists, ListAssignment{
+				Kind: "json", LHS: lhsPrefix + "." + field,
+				GetterOk: getterOk(receiver, tfName), Var: leafVar(tfName), Path: a.Path,
+			})
+
 		case "schema.ListNestedBlock":
 			elemStruct, childStem := b.namer.nested(stem, a)
 			base := nestedStateBase(tfName, childStem, receiver, lhsPrefix)
@@ -1115,6 +1127,19 @@ func isArrayType(tfType string) bool {
 
 // isMapType reports whether tfType is a typed dynamic-key map attribute.
 func isMapType(tfType string) bool { return tfType == "schema.MapAttribute" }
+
+// isOpaqueJSONType identifies a response shape that Terraform can retain but
+// the generator cannot safely model as nested blocks. A structured map is kept
+// as normalized JSON so its dynamic keys and complete values survive in state.
+func isOpaqueJSONType(tfType string) bool { return tfType == "schema.MapNestedAttribute" }
+
+func opaqueJSONView(a *model.Attribute) AttrView {
+	return AttrView{
+		TFName: tfNameOf(a.Path), TFType: "schema.StringAttribute",
+		CustomType: "jsontypes.NormalizedType{}", Description: a.Description,
+		Required: a.Required, Optional: a.Optional, Computed: a.Computed, Sensitive: a.Sensitive,
+	}
+}
 
 // isObjectType reports whether tfType is a bare nested object the envelope
 // hoists into single-object machinery (schema.SingleNestedBlock).
@@ -1348,6 +1373,16 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 			})
 			continue
 		}
+		if isOpaqueJSONType(n.TfType) {
+			b.usesJSON = true
+			itemAttrs = append(itemAttrs, opaqueJSONView(n))
+			itemFields = append(itemFields, ModelFieldView{GoField: field, GoType: "jsontypes.Normalized", TFName: tfName})
+			itemLists = append(itemLists, ListAssignment{
+				Kind: "json", LHS: "r." + field, GetterOk: getter,
+				Var: leafVar(tfName), Path: n.Path,
+			})
+			continue
+		}
 
 		// Same rule as walk: a union is keyed on OneOf, never on TfType.
 		if n.OneOf != nil {
@@ -1549,7 +1584,7 @@ func flattenItemElement(block *model.Attribute, unsupported *[]UnsupportedNode, 
 					nonScalars = append(nonScalars, leaf)
 				case isLeafType(leaf.TfType):
 					scalars = append(scalars, itemElementLeaf{attr: leaf, chain: itemGetter("item.Attributes", tfNameOf(leaf.Path))})
-				case isArrayType(leaf.TfType), isMapType(leaf.TfType), isObjectType(leaf.TfType):
+				case isArrayType(leaf.TfType), isMapType(leaf.TfType), isObjectType(leaf.TfType), isOpaqueJSONType(leaf.TfType):
 					nonScalars = append(nonScalars, leaf)
 				default:
 					*unsupported = append(*unsupported, UnsupportedNode{Path: leaf.Path, Reason: "nesting under item attributes is not supported"})

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -1090,6 +1090,29 @@ var _ = Describe("BuildDataSourceView singular arrays", func() {
 		Expect(src).To(ContainSubstring("state.Metadata = jsontypes.NewNormalizedValue(string(encoded))"))
 	})
 
+	It("preserves a structured response map as normalized JSON", func() {
+		op := teamSingularOperation()
+		attrs := op.ResponseSchema.Properties["data"].Properties["attributes"].Properties
+		attrs["custom_attributes"] = &model.Schema{
+			Kind: model.SchemaKindMap, Description: "Dynamic structured values.",
+			Items: obj(map[string]*model.Schema{
+				"enabled": prim("boolean", "Whether the value is enabled."),
+			}),
+		}
+
+		view := mustView(op)
+		Expect(view.UsesJSON).To(BeTrue())
+		Expect(view.Schema.Attributes).To(ContainElement(SatisfyAll(
+			HaveField("TFName", "custom_attributes"),
+			HaveField("TFType", "schema.StringAttribute"),
+			HaveField("CustomType", "jsontypes.NormalizedType{}"),
+		)))
+		Expect(view.State.Lists).To(ContainElement(ListAssignment{
+			Kind: "json", LHS: "state.CustomAttributes", GetterOk: "attributes.GetCustomAttributesOk()",
+			Var: "customAttributes", Path: "response.custom_attributes",
+		}))
+	})
+
 	It("hoists a string array under attributes into a ListAttribute carrying its element type", func() {
 		view, err := BuildDataSourceView(mustArtifact(teamSingularOperation()))
 		Expect(err).NotTo(HaveOccurred())
@@ -1247,6 +1270,24 @@ var _ = Describe("BuildDataSourceView plural", func() {
 		Expect(err).NotTo(HaveOccurred())
 		src := string(rendered)
 		Expect(src).To(ContainSubstring("r.Metadata = jsontypes.NewNormalizedValue(string(encoded))"))
+	})
+
+	It("preserves a structured result-item map as normalized JSON", func() {
+		op := teamsOperation()
+		attributes := op.ResponseSchema.Properties["data"].Items.Properties["attributes"].Properties
+		attributes["custom_attributes"] = &model.Schema{
+			Kind: model.SchemaKindMap, Description: "Dynamic structured values.",
+			Items: obj(map[string]*model.Schema{
+				"enabled": prim("boolean", "Whether the value is enabled."),
+			}),
+		}
+
+		view := mustView(op)
+		Expect(view.UsesJSON).To(BeTrue())
+		Expect(view.State.ItemLists).To(ContainElement(ListAssignment{
+			Kind: "json", LHS: "r.CustomAttributes", GetterOk: "item.Attributes.GetCustomAttributesOk()",
+			Var: "customAttributes", Path: "response.data[].attributes.custom_attributes",
+		}))
 	})
 
 	It("emits a recursively typed map on a plural result item", func() {


### PR DESCRIPTION
## Summary

Preserve computed maps with structured object values as normalized JSON in generated data-source state.

## Motivation

Dynamic map keys cannot be expressed as Terraform blocks. Canonical JSON retains every key and nested value without inventing an unstable static model.

## Coverage impact

- Singular: 146/156 → 148/156 (+2)
- Plural: 190/194 → 191/194 (+1)
- Paired: 90/96 → 91/96 (+1)

## Testing

- `make tfgen-test`
- `make fmtcheck`
- `make test`
- Focused Case API probes
- Fresh full-spec build-verified sweep

## Stack

- Base: `jason.tenczar/generator-v2/nested-state-vars`
- Next: `jason.tenczar/generator-v2/unprojectable-map-json`

## Reviewer notes

- This intentionally trades per-value Terraform typing for lossless state preservation on dynamic response maps.
