### PR TITLE
[tfgen] Preserve unprojectable response maps as JSON

### DIFF
--- a/.generator-v2/internal/model/schema.go
+++ b/.generator-v2/internal/model/schema.go
@@ -239,24 +239,42 @@ func (b *treeBuilder) attribute(s *Schema, path string, mode nestingMode, requir
 			// into attribute form regardless of the incoming mode.
 			children, err := b.children(s.Items, path+"{}.", nestAttribute)
 			if err != nil {
-				return nil, err
+				return b.responseMapFallback(attr, err)
 			}
 			attr.Children, attr.ModelRefName = children, s.Items.RefName
 		case SchemaKindOneOf:
 			variants, envelope, err := b.oneOfVariants(s.Items, path+"{}", nestAttribute)
 			if err != nil {
-				return nil, err
+				return b.responseMapFallback(attr, err)
 			}
 			attr.Children, attr.OneOf = variants, envelope
 		default:
 			elem, err := ElementType(s.Items)
 			if err != nil {
-				return nil, err
+				return b.responseMapFallback(attr, err)
 			}
 			attr.ElementType = elem
 		}
 	}
 
+	return attr, nil
+}
+
+// responseMapFallback preserves a computed dynamic map as normalized JSON when
+// one of its value descendants cannot be represented as a Terraform nested
+// attribute. The map remains lossless in state, while request trees stay strict:
+// accepting opaque practitioner input would discard the OpenAPI validation shape.
+func (b *treeBuilder) responseMapFallback(attr *Attribute, projectionErr error) (*Attribute, error) {
+	if b.kind != responseTree {
+		return nil, projectionErr
+	}
+	attr.TfType = "schema.StringAttribute"
+	attr.GoType = "jsontypes.Normalized"
+	attr.CustomType = "jsontypes.NormalizedType{}"
+	attr.ElementType = ""
+	attr.Children = nil
+	attr.OneOf = nil
+	attr.ModelRefName = ""
 	return attr, nil
 }
 

--- a/.generator-v2/internal/model/schema_test.go
+++ b/.generator-v2/internal/model/schema_test.go
@@ -300,6 +300,27 @@ var _ = Describe("BuildResponseTree type delegation and composites", func() {
 		Expect(pathsOf(configs.Children)).To(Equal([]string{"response.configs{}.x"}))
 	})
 
+	It("preserves an unprojectable response map as normalized JSON", func() {
+		schema := objSchema(map[string]*Schema{
+			"configs": mapSchema(objSchema(map[string]*Schema{
+				"value": {Kind: SchemaKindUnsupported, UnsupportedReason: "heterogeneous union"},
+			})),
+		})
+
+		tree, _, err := BuildResponseTree(schema)
+		Expect(err).NotTo(HaveOccurred())
+		configs := attrByPath(tree, "response.configs")
+		Expect(configs.TfType).To(Equal("schema.StringAttribute"))
+		Expect(configs.GoType).To(Equal("jsontypes.Normalized"))
+		Expect(configs.CustomType).To(Equal("jsontypes.NormalizedType{}"))
+		Expect(configs.Children).To(BeEmpty())
+
+		request, _, requestErr := BuildRequestTree(schema)
+		Expect(request).To(BeNil())
+		Expect(requestErr).To(HaveOccurred())
+		Expect(requestErr.Error()).To(ContainSubstring("heterogeneous union"))
+	})
+
 	It("builds a nested object (no map ancestor) as a SingleNestedBlock with .key children", func() {
 		tree, _, err := BuildResponseTree(objSchema(map[string]*Schema{
 			"options": objSchema(map[string]*Schema{"notify": primSchema("boolean")}),
@@ -462,9 +483,6 @@ var _ = Describe("BuildResponseTree defensive guard", func() {
 		Entry("inside an array-of-object element",
 			objSchema(map[string]*Schema{"list": arrSchema(objSchema(map[string]*Schema{"bad": {Kind: SchemaKindRefCycle}}))}),
 			"response.list[].bad"),
-		Entry("inside a map-of-object value",
-			objSchema(map[string]*Schema{"m": mapSchema(objSchema(map[string]*Schema{"bad": {Kind: SchemaKindRefCycle}}))}),
-			"response.m{}.bad"),
 	)
 
 	It("retains a parser-supplied reason when an unsupported node fails one artifact", func() {


### PR DESCRIPTION
## Summary

Fall back to normalized JSON when a computed structured map contains descendants that cannot be represented by Terraform's nested-attribute model.

## Motivation

The Projects settings map contains a heterogeneous value union. Failing the whole artifact loses a response value Terraform can safely retain as opaque JSON.

## Coverage impact

- Singular: 148/156 → 149/156 (+1)
- Plural: 191/194 → 192/194 (+1)
- Paired: 91/96 → 92/96 (+1)

## Testing

- `make tfgen-test`
- `make fmtcheck`
- `make test`
- Focused Projects probes
- Fresh full-spec build-verified sweep

## Stack

- Base: `jason.tenczar/generator-v2/object-map-json`
- Next: `jason.tenczar/generator-v2/opaque-envelope-attributes`

## Reviewer notes

- The fallback is response-only. Request trees remain strict so practitioner input is still validated against the OpenAPI shape.
