### PR TITLE
[tfgen] Preserve opaque envelope attributes

### DIFF
--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -740,20 +740,27 @@ func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrat
 		}
 	}
 
-	if attributes != nil && attributes.TfType != "schema.SingleNestedBlock" {
-		b.unsupported = append(b.unsupported, UnsupportedNode{
-			Path:   attributes.Path,
-			Reason: "envelope attributes must be an object",
-		})
-		return nil
-	}
-
 	children := flatChildren
 	if attributes != nil {
 		for _, child := range flatChildren {
 			b.dropped = append(b.dropped, droppedEnvelopeMember(child.Path))
 		}
-		children = attributes.Children
+		switch {
+		case attributes.TfType == "schema.SingleNestedBlock":
+			children = attributes.Children
+		case isJSONAttribute(attributes):
+			// A few JSON:API-shaped responses define attributes as a free-form
+			// object rather than a typed property bag. Keep the member itself as
+			// normalized JSON and read it directly from data.
+			children = []*model.Attribute{attributes}
+			b.receiver = rootExpr
+		default:
+			b.unsupported = append(b.unsupported, UnsupportedNode{
+				Path:   attributes.Path,
+				Reason: "envelope attributes must be an object or normalized JSON",
+			})
+			return nil
+		}
 	} else {
 		// Direct getters live on data instead of its attributes object.
 		b.receiver = rootExpr
@@ -809,7 +816,7 @@ func (b *dataSourceBuilder) flattenEnvelope(topLevel []*model.Attribute, idStrat
 		}
 	}
 	var preamble []string
-	if attributes != nil && len(leaves) > 0 {
+	if attributes != nil && attributes.TfType == "schema.SingleNestedBlock" && len(leaves) > 0 {
 		preamble = []string{"attributes := " + rootExpr + ".GetAttributes()"}
 	}
 	return &flattenedEnvelope{

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -1059,6 +1059,27 @@ var _ = Describe("BuildDataSourceView singular nested arrays", func() {
 })
 
 var _ = Describe("BuildDataSourceView singular arrays", func() {
+	It("preserves an opaque JSON:API attributes member as normalized JSON", func() {
+		op := teamSingularOperation()
+		data := op.ResponseSchema.Properties["data"]
+		data.Properties["attributes"] = &model.Schema{
+			Kind: model.SchemaKindJSON, Description: "Free-form resource attributes.",
+		}
+
+		view := mustView(op)
+		Expect(view.UsesJSON).To(BeTrue())
+		Expect(view.Schema.Attributes).To(ContainElement(SatisfyAll(
+			HaveField("TFName", "attributes"),
+			HaveField("CustomType", "jsontypes.NormalizedType{}"),
+		)))
+		Expect(view.State.Preamble).To(BeEmpty())
+		Expect(view.State.Lists).To(ContainElement(SatisfyAll(
+			HaveField("Kind", "json"),
+			HaveField("LHS", "state.Attributes"),
+			HaveField("GetterOk", ContainSubstring(".GetAttributesOk()")),
+		)))
+	})
+
 	It("renders unconstrained response values as normalized JSON", func() {
 		op := teamSingularOperation()
 		attrs := op.ResponseSchema.Properties["data"].Properties["attributes"].Properties


### PR DESCRIPTION
## Summary

Support JSON:API-shaped responses whose `attributes` member is itself a free-form object by exposing it as normalized JSON.

## Motivation

Sensitive Data Scanner configuration uses an opaque `attributes` member rather than a typed property bag. The value is representable without pretending it has a static nested schema.

## Coverage impact

- Singular: 149/156 → 150/156 (+1)
- Plural: unchanged at 192/194
- Paired: unchanged at 92/96

Final stack coverage is 96.2% singular, 99.0% plural, and 95.8% paired.

## Testing

- `make tfgen-test`
- `make fmtcheck`
- `make test`
- Focused `ListScanningGroups` probe
- Fresh full-spec build-verified sweep

## Stack

- Base: `jason.tenczar/generator-v2/unprojectable-map-json`
- Top of stack

## Reviewer notes

- Typed JSON:API attributes continue through the existing typed projection path.
- Only an already-normalized free-form attributes member uses the opaque JSON path.
