### PR TITLE
[datadog_azure_integration] Azure Secretless Auth GA

### DIFF
--- a/datadog/fwprovider/resource_datadog_azure_integration.go
+++ b/datadog/fwprovider/resource_datadog_azure_integration.go
@@ -159,7 +159,7 @@ func (r *integrationAzureResource) Schema(_ context.Context, _ resource.SchemaRe
 				Computed:    true,
 				Default:     booldefault.StaticBool(false),
 				Optional:    true,
-				Description: "When enabled, Datadog authenticates to this app registration using federated workload identity credentials instead of a client secret. The app registration must have a Datadog federated credential for this to work. When `true`, `client_secret` should be omitted.",
+				Description: "When enabled, Datadog authenticates to this app registration using federated workload identity credentials instead of a client secret. You also need to set up a federated credential in your Azure App Registration with the proper External ID. Follow Terraform instructions in the Datadog UI to [onboard](https://app.datadoghq.com/integrations/azure/add) or [migrate](https://app.datadoghq.com/integrations/azure). Migration instructions can be found in the general tab by clicking 'Set Up Secretless Auth'. When `true`, `client_secret` should be omitted.",
 			},
 			"resource_provider_configs": schema.ListAttribute{
 				Computed: true,

--- a/datadog/fwprovider/resource_datadog_azure_integration.go
+++ b/datadog/fwprovider/resource_datadog_azure_integration.go
@@ -159,7 +159,7 @@ func (r *integrationAzureResource) Schema(_ context.Context, _ resource.SchemaRe
 				Computed:    true,
 				Default:     booldefault.StaticBool(false),
 				Optional:    true,
-				Description: "(Preview) When enabled, Datadog authenticates to this app registration using federated workload identity credentials instead of a client secret. The app registration must have a Datadog federated credential for this to work. When `true`, `client_secret` should be omitted.",
+				Description: "When enabled, Datadog authenticates to this app registration using federated workload identity credentials instead of a client secret. The app registration must have a Datadog federated credential for this to work. When `true`, `client_secret` should be omitted.",
 			},
 			"resource_provider_configs": schema.ListAttribute{
 				Computed: true,

--- a/docs/resources/integration_azure.md
+++ b/docs/resources/integration_azure.md
@@ -10,8 +10,6 @@ description: |-
 
 Provides a Datadog - Microsoft Azure integration resource. This can be used to create and manage the integrations.
 
-Note: If you are setting up a new Datadog - Azure integration using secretless auth or migrating to secretless auth, you will also need to set up a federated credential in your Azure App Registration with the proper External ID. Please follow Terraform instructions in the Datadog UI to [onboard](https://app.datadoghq.com/integrations/azure/add) or [migrate](https://app.datadoghq.com/integrations/azure). Migration instructions can be found in the general tab by clicking "Set Up Secretless Auth".
-
 ## Example Usage
 
 ```terraform
@@ -33,7 +31,6 @@ resource "datadog_integration_azure" "sandbox_secretless" {
   tenant_name             = "<azure_tenant_name>"
   client_id               = "<azure_client_id>"
   secretless_auth_enabled = true
-  ...
 }
 ```
 
@@ -59,7 +56,7 @@ Note: This requires `resource_collection_enabled` to be set to true. Defaults to
 - `metrics_enabled_default` (Boolean) Enable Azure metrics for your organization for resource providers where no resource provider config is specified. Defaults to `true`.
 - `resource_collection_enabled` (Boolean) When enabled, Datadog collects metadata and configuration info from cloud resources (such as compute instances, databases, and load balancers) monitored by this app registration.
 - `resource_provider_configs` (List of Object) Configuration settings applied to resources from the specified Azure resource providers. (see [below for nested schema](#nestedatt--resource_provider_configs))
-- `secretless_auth_enabled` (Boolean) When enabled, Datadog authenticates to this app registration using federated workload identity credentials instead of a client secret. The app registration must have a Datadog federated credential for this to work. When `true`, `client_secret` should be omitted. Defaults to `false`.
+- `secretless_auth_enabled` (Boolean) When enabled, Datadog authenticates to this app registration using federated workload identity credentials instead of a client secret. You also need to set up a federated credential in your Azure App Registration with the proper External ID. Follow Terraform instructions in the Datadog UI to [onboard](https://app.datadoghq.com/integrations/azure/add) or [migrate](https://app.datadoghq.com/integrations/azure). Migration instructions can be found in the general tab by clicking 'Set Up Secretless Auth'. When `true`, `client_secret` should be omitted. Defaults to `false`.
 - `usage_metrics_enabled` (Boolean) Enable azure.usage metrics for your organization. Defaults to `true`.
 
 ### Read-Only

--- a/docs/resources/integration_azure.md
+++ b/docs/resources/integration_azure.md
@@ -10,6 +10,8 @@ description: |-
 
 Provides a Datadog - Microsoft Azure integration resource. This can be used to create and manage the integrations.
 
+Note: If you are setting up a new Datadog - Azure integration using secretless auth or migrating to secretless auth, you will also need to set up a federated credential in your Azure App Registration with the proper External ID. Please follow Terraform instructions in the Datadog UI to [onboard](https://app.datadoghq.com/integrations/azure/add) or [migrate](https://app.datadoghq.com/integrations/azure). Migration instructions can be found in the general tab by clicking "Set Up Secretless Auth".
+
 ## Example Usage
 
 ```terraform
@@ -27,11 +29,11 @@ resource "datadog_integration_azure" "sandbox" {
 }
 
 # Or, using secretless (federated workload identity) authentication.
-# Note: secretless authentication is currently in Preview.
 resource "datadog_integration_azure" "sandbox_secretless" {
   tenant_name             = "<azure_tenant_name>"
   client_id               = "<azure_client_id>"
   secretless_auth_enabled = true
+  ...
 }
 ```
 
@@ -57,7 +59,7 @@ Note: This requires `resource_collection_enabled` to be set to true. Defaults to
 - `metrics_enabled_default` (Boolean) Enable Azure metrics for your organization for resource providers where no resource provider config is specified. Defaults to `true`.
 - `resource_collection_enabled` (Boolean) When enabled, Datadog collects metadata and configuration info from cloud resources (such as compute instances, databases, and load balancers) monitored by this app registration.
 - `resource_provider_configs` (List of Object) Configuration settings applied to resources from the specified Azure resource providers. (see [below for nested schema](#nestedatt--resource_provider_configs))
-- `secretless_auth_enabled` (Boolean) (Preview) When enabled, Datadog authenticates to this app registration using federated workload identity credentials instead of a client secret. The app registration must have a Datadog federated credential for this to work. When `true`, `client_secret` should be omitted. Defaults to `false`.
+- `secretless_auth_enabled` (Boolean) When enabled, Datadog authenticates to this app registration using federated workload identity credentials instead of a client secret. The app registration must have a Datadog federated credential for this to work. When `true`, `client_secret` should be omitted. Defaults to `false`.
 - `usage_metrics_enabled` (Boolean) Enable azure.usage metrics for your organization. Defaults to `true`.
 
 ### Read-Only

--- a/examples/resources/datadog_integration_azure/resource.tf
+++ b/examples/resources/datadog_integration_azure/resource.tf
@@ -12,7 +12,6 @@ resource "datadog_integration_azure" "sandbox" {
 }
 
 # Or, using secretless (federated workload identity) authentication.
-# Note: secretless authentication is currently in Preview.
 resource "datadog_integration_azure" "sandbox_secretless" {
   tenant_name             = "<azure_tenant_name>"
   client_id               = "<azure_client_id>"


### PR DESCRIPTION
### Motivation
On Tuesday we opened Secretless Auth to GA.

Since then we have seen a customer set up an integration incorrectly via Terraform (federated credential was missing or lacked an external id. My guess is that they just looked at the terraform provider, saw the new option, and set it without looking at our onboarding or migration UI. Regardless, we should be pointing customers to the UI if for no other reason than to get the external id, which they need and cannot get anywhere else.

### Summary
Remove a couple references to the feature being in preview.

Add a note near the top of the description directing customers to the UI and providing relevant links for convenience.

### Testing
Only documentation changes.