### PR TITLE
Allow unsigned external contributor commits

### DIFF
--- a/repository.datadog.yaml
+++ b/repository.datadog.yaml
@@ -2,3 +2,9 @@
 schema-version: v1
 kind: mergequeue
 skip_labels: true
+---
+schema-version: v1
+kind: mergegate
+rules:
+  - require: commit-signatures
+    allow_unsigned_external: true


### PR DESCRIPTION
## Motivation

External contributors to this public repository do not consistently sign commits, requiring maintainers to request history rewrites or sign those commits on their behalf. Datadog contributors should remain subject to verified-signature enforcement without imposing that workflow on community contributors.

## Overview of changes

Configure MergeGate to allow unsigned commits from external contributors while continuing to require verified signatures from Datadog committers.