### PR TITLE
[datadog_provider] Honor framework retry settings

### DIFF
--- a/datadog/fwprovider/framework_provider.go
+++ b/datadog/fwprovider/framework_provider.go
@@ -855,9 +855,13 @@ func defaultConfigureFunc(p *FrameworkProvider, request *provider.ConfigureReque
 	if httpClientRetryEnabled {
 		ddClientConfig.RetryConfiguration.EnableRetry = httpClientRetryEnabled
 
-		if !config.HttpClientRetryBackoffMultiplier.IsNull() {
-			timeout := time.Duration(config.HttpClientRetryBackoffMultiplier.ValueInt64()) * time.Second
+		if !config.HttpClientRetryTimeout.IsNull() {
+			timeout := time.Duration(config.HttpClientRetryTimeout.ValueInt64()) * time.Second
 			ddClientConfig.RetryConfiguration.HTTPRetryTimeout = timeout
+		}
+
+		if !config.HttpClientRetryBackoffMultiplier.IsNull() {
+			ddClientConfig.RetryConfiguration.BackOffMultiplier = float64(config.HttpClientRetryBackoffMultiplier.ValueInt64())
 		}
 
 		if !config.HttpClientRetryBackoffBase.IsNull() {

--- a/datadog/fwprovider/framework_provider_test.go
+++ b/datadog/fwprovider/framework_provider_test.go
@@ -1,0 +1,44 @@
+package fwprovider
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestDefaultConfigureFuncRetryConfiguration(t *testing.T) {
+	p := New().(*FrameworkProvider)
+	config := &ProviderSchema{
+		ApiUrl:                           types.StringValue("https://api.datadoghq.com"),
+		Validate:                         types.StringValue("false"),
+		HttpClientRetryEnabled:           types.StringValue("true"),
+		HttpClientRetryTimeout:           types.Int64Value(300),
+		HttpClientRetryBackoffMultiplier: types.Int64Value(7),
+		HttpClientRetryBackoffBase:       types.Int64Value(4),
+		HttpClientRetryMaxRetries:        types.Int64Value(5),
+	}
+
+	diags := defaultConfigureFunc(p, &provider.ConfigureRequest{}, config)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	retryConfig := p.DatadogApiInstances.HttpClient.GetConfig().RetryConfiguration
+	if !retryConfig.EnableRetry {
+		t.Error("expected retries to be enabled")
+	}
+	if got, want := retryConfig.HTTPRetryTimeout, 300*time.Second; got != want {
+		t.Errorf("HTTPRetryTimeout = %s, want %s", got, want)
+	}
+	if got, want := retryConfig.BackOffMultiplier, float64(7); got != want {
+		t.Errorf("BackOffMultiplier = %v, want %v", got, want)
+	}
+	if got, want := retryConfig.BackOffBase, float64(4); got != want {
+		t.Errorf("BackOffBase = %v, want %v", got, want)
+	}
+	if got, want := retryConfig.MaxRetries, 5; got != want {
+		t.Errorf("MaxRetries = %d, want %d", got, want)
+	}
+}


### PR DESCRIPTION
## Motivation

Fixes #4120. The Plugin Framework provider maps `http_client_retry_backoff_multiplier` to the retry timeout and does not apply `http_client_retry_timeout`.

## Overview of changes

Map the retry timeout and backoff multiplier to their corresponding Datadog API client configuration fields. Add unit coverage for the effective retry configuration.