### PR TITLE
[datadog_observability_pipeline] fix SDS processor fields schema

### DIFF
--- a/datadog/fwprovider/resource_datadog_observability_pipeline.go
+++ b/datadog/fwprovider/resource_datadog_observability_pipeline.go
@@ -1588,7 +1588,7 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 																			NestedObject: schema.NestedBlockObject{
 																				Blocks: map[string]schema.Block{
 																					"custom": schema.ListNestedBlock{
-																						Description: "Pattern detection using a custom regular expression.",
+																						Description: "Pattern detection using a custom regular expression. Exactly one of `custom` or `library` must be specified.",
 																						NestedObject: schema.NestedBlockObject{
 																							Attributes: map[string]schema.Attribute{
 																								"rule": schema.StringAttribute{
@@ -1603,6 +1603,7 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 																						},
 																						Validators: []validator.List{
 																							listvalidator.SizeAtMost(1),
+																							listvalidator.ExactlyOneOf(frameworkPath.MatchRelative().AtParent().AtName("library")),
 																						},
 																					},
 																					"library": schema.ListNestedBlock{
@@ -1631,6 +1632,7 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 																				},
 																			},
 																			Validators: []validator.List{
+																				listvalidator.IsRequired(),
 																				listvalidator.SizeAtMost(1),
 																			},
 																		},
@@ -1639,7 +1641,7 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 																			NestedObject: schema.NestedBlockObject{
 																				Blocks: map[string]schema.Block{
 																					"include": schema.ListNestedBlock{
-																						Description: "Explicitly include these fields for scanning.",
+																						Description: "Explicitly include these fields for scanning. Exactly one of `include`, `exclude`, or `all` must be specified.",
 																						NestedObject: schema.NestedBlockObject{
 																							Attributes: map[string]schema.Attribute{
 																								"fields": schema.ListAttribute{
@@ -1651,6 +1653,10 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 																						},
 																						Validators: []validator.List{
 																							listvalidator.SizeAtMost(1),
+																							listvalidator.ExactlyOneOf(
+																								frameworkPath.MatchRelative().AtParent().AtName("exclude"),
+																								frameworkPath.MatchRelative().AtParent().AtName("all"),
+																							),
 																						},
 																					},
 																					"exclude": schema.ListNestedBlock{
@@ -1677,6 +1683,7 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 																				},
 																			},
 																			Validators: []validator.List{
+																				listvalidator.IsRequired(),
 																				listvalidator.SizeAtMost(1),
 																			},
 																		},
@@ -1685,7 +1692,7 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 																			NestedObject: schema.NestedBlockObject{
 																				Blocks: map[string]schema.Block{
 																					"redact": schema.ListNestedBlock{
-																						Description: "Redacts the matched value.",
+																						Description: "Redacts the matched value. Exactly one of `redact`, `hash`, or `partial_redact` must be specified.",
 																						NestedObject: schema.NestedBlockObject{
 																							Attributes: map[string]schema.Attribute{
 																								"replace": schema.StringAttribute{
@@ -1696,6 +1703,10 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 																						},
 																						Validators: []validator.List{
 																							listvalidator.SizeAtMost(1),
+																							listvalidator.ExactlyOneOf(
+																								frameworkPath.MatchRelative().AtParent().AtName("hash"),
+																								frameworkPath.MatchRelative().AtParent().AtName("partial_redact"),
+																							),
 																						},
 																					},
 																					"hash": schema.ListNestedBlock{
@@ -1728,6 +1739,7 @@ func (r *observabilityPipelineResource) Schema(_ context.Context, _ resource.Sch
 																				},
 																			},
 																			Validators: []validator.List{
+																				listvalidator.IsRequired(),
 																				listvalidator.SizeAtMost(1),
 																			},
 																		},

--- a/docs/resources/observability_pipeline.md
+++ b/docs/resources/observability_pipeline.md
@@ -2439,7 +2439,7 @@ Optional:
 
 - `hash` (Block List) Hashes the matched value. (see [below for nested schema](#nestedblock--config--processor_group--processor--sensitive_data_scanner--rule--on_match--hash))
 - `partial_redact` (Block List) Redacts part of the matched value (e.g., keep last 4 characters). (see [below for nested schema](#nestedblock--config--processor_group--processor--sensitive_data_scanner--rule--on_match--partial_redact))
-- `redact` (Block List) Redacts the matched value. (see [below for nested schema](#nestedblock--config--processor_group--processor--sensitive_data_scanner--rule--on_match--redact))
+- `redact` (Block List) Redacts the matched value. Exactly one of `redact`, `hash`, or `partial_redact` must be specified. (see [below for nested schema](#nestedblock--config--processor_group--processor--sensitive_data_scanner--rule--on_match--redact))
 
 <a id="nestedblock--config--processor_group--processor--sensitive_data_scanner--rule--on_match--hash"></a>
 ### Nested Schema for `config.processor_group.processor.sensitive_data_scanner.rule.on_match.hash`
@@ -2468,7 +2468,7 @@ Optional:
 
 Optional:
 
-- `custom` (Block List) Pattern detection using a custom regular expression. (see [below for nested schema](#nestedblock--config--processor_group--processor--sensitive_data_scanner--rule--pattern--custom))
+- `custom` (Block List) Pattern detection using a custom regular expression. Exactly one of `custom` or `library` must be specified. (see [below for nested schema](#nestedblock--config--processor_group--processor--sensitive_data_scanner--rule--pattern--custom))
 - `library` (Block List) Pattern detection using a predefined pattern from the Sensitive Data Scanner library. For Terraform setup (standard pattern data source and library rules), see the [Sensitive Data Scanner processor documentation](https://docs.datadoghq.com/observability_pipelines/processors/sensitive_data_scanner/?tab=libraryrules#set-up-the-processor-using-terraform). (see [below for nested schema](#nestedblock--config--processor_group--processor--sensitive_data_scanner--rule--pattern--library))
 
 <a id="nestedblock--config--processor_group--processor--sensitive_data_scanner--rule--pattern--custom"></a>
@@ -2498,7 +2498,7 @@ Optional:
 
 - `all` (Boolean) Scan all fields.
 - `exclude` (Block List) Explicitly exclude these fields from scanning. (see [below for nested schema](#nestedblock--config--processor_group--processor--sensitive_data_scanner--rule--scope--exclude))
-- `include` (Block List) Explicitly include these fields for scanning. (see [below for nested schema](#nestedblock--config--processor_group--processor--sensitive_data_scanner--rule--scope--include))
+- `include` (Block List) Explicitly include these fields for scanning. Exactly one of `include`, `exclude`, or `all` must be specified. (see [below for nested schema](#nestedblock--config--processor_group--processor--sensitive_data_scanner--rule--scope--include))
 
 <a id="nestedblock--config--processor_group--processor--sensitive_data_scanner--rule--scope--exclude"></a>
 ### Nested Schema for `config.processor_group.processor.sensitive_data_scanner.rule.scope.exclude`


### PR DESCRIPTION
The SDS schema was too permissive, which allowed invalid configurations to be sent to the API, which correctly rejected them, resulting in a scary plugin error instead of a helpful schema error

- `pattern`, `scope`, `on_match` are now required
- add `ExactlyOneOf` constraints on `pattern`, `scope` and `on_match` variants