### PR TITLE
[datadog_dataset] Remove `synthetics` from supported product types

### DIFF
--- a/datadog/fwprovider/resource_datadog_dataset.go
+++ b/datadog/fwprovider/resource_datadog_dataset.go
@@ -87,7 +87,7 @@ func (r *DatasetResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"product": schema.StringAttribute{
-							Description: "The product type of the dataset. Supported types: `apm`, `rum`, `synthetics`, `metrics` (Custom Metrics), `logs`, `sd_repoinfo`, `error_tracking`, `cloud_cost`, and `ml_obs`.",
+							Description: "The product type of the dataset. Supported types: `apm`, `rum`, `metrics` (Custom Metrics), `logs`, `sd_repoinfo`, `error_tracking`, `cloud_cost`, and `ml_obs`.",
 							Required:    true,
 						},
 						"filters": schema.SetAttribute{

--- a/docs/resources/dataset.md
+++ b/docs/resources/dataset.md
@@ -51,7 +51,7 @@ resource "datadog_dataset" "foo" {
 Required:
 
 - `filters` (Set of String) A list of tag-based filters used to restrict access to the product type. Each filter is formatted as `@tag.key:value`.
-- `product` (String) The product type of the dataset. Supported types: `apm`, `rum`, `synthetics`, `metrics` (Custom Metrics), `logs`, `sd_repoinfo`, `error_tracking`, `cloud_cost`, and `ml_obs`.
+- `product` (String) The product type of the dataset. Supported types: `apm`, `rum`, `metrics` (Custom Metrics), `logs`, `sd_repoinfo`, `error_tracking`, `cloud_cost`, and `ml_obs`.
 
 ## Import
 


### PR DESCRIPTION
synthetics isn't a valid DAC product type, hence removing it