### PR TITLE
[datadog_metric_tag_configuration] Retry tag configuration create on 409 conflict

### DIFF
--- a/datadog/resource_datadog_metric_tag_configuration.go
+++ b/datadog/resource_datadog_metric_tag_configuration.go
@@ -3,13 +3,16 @@ package datadog
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"regexp"
+	"time"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/validators"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -250,6 +253,33 @@ func buildDatadogMetricTagConfigurationUpdate(d *schema.ResourceData, existingMe
 	return result, nil
 }
 
+// createTagConfigurationRetryError classifies the outcome of a
+// CreateTagConfiguration call for retry.RetryContext.
+//
+// A ForceNew change to metric_type makes Terraform do destroy-then-create. The
+// create is issued milliseconds after the delete, but Datadog's tag-config
+// conflict check reads an eventually-consistent store that can still show the
+// just-deleted config for several seconds (minutes when the CDC pipeline is
+// degraded), so the create is rejected with HTTP 409 ("conflicts with existing
+// tag configuration, use PATCH to update"). We retry ONLY on 409 until the
+// delete becomes visible; every other error (and success) is terminal.
+//
+// We intentionally do NOT GET-before-retry: right after a delete the GET reads
+// the same stale store and would return 200, masking the transient race as a
+// real conflict.
+func createTagConfigurationRetryError(metricName string, err error, httpResponse *http.Response) *retry.RetryError {
+	if err == nil {
+		return nil
+	}
+	if httpResponse != nil && httpResponse.StatusCode == http.StatusConflict {
+		return retry.RetryableError(fmt.Errorf(
+			"tag configuration for %q still conflicts with a recently deleted configuration, retrying: %w",
+			metricName, err))
+	}
+	return retry.NonRetryableError(
+		utils.TranslateClientError(err, httpResponse, "error creating MetricTagConfiguration"))
+}
+
 func resourceDatadogMetricTagConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConf := meta.(*ProviderConfiguration)
 	apiInstances := providerConf.DatadogApiInstances
@@ -263,9 +293,18 @@ func resourceDatadogMetricTagConfigurationCreate(ctx context.Context, d *schema.
 	ddObject.SetData(*resultMetricTagConfigurationData)
 	metricName := d.Get("metric_name").(string)
 
-	response, httpResponse, err := apiInstances.GetMetricsApiV2().CreateTagConfiguration(auth, metricName, *ddObject)
+	// Retry the create on HTTP 409: after a destroy-then-create (ForceNew on
+	// metric_type), Datadog's eventually-consistent conflict check can still see
+	// the just-deleted config and reject the create. Retry only the 409 until the
+	// delete becomes visible; 30s ceiling with the SDK's built-in backoff.
+	var response datadogV2.MetricTagConfigurationResponse
+	var httpResponse *http.Response
+	err = retry.RetryContext(ctx, 30*time.Second, func() *retry.RetryError {
+		response, httpResponse, err = apiInstances.GetMetricsApiV2().CreateTagConfiguration(auth, metricName, *ddObject)
+		return createTagConfigurationRetryError(metricName, err, httpResponse)
+	})
 	if err != nil {
-		return utils.TranslateClientErrorDiag(err, httpResponse, "error creating MetricTagConfiguration")
+		return diag.FromErr(err)
 	}
 	if err := utils.CheckForUnparsed(response); err != nil {
 		return diag.FromErr(err)

--- a/datadog/resource_datadog_metric_tag_configuration_unit_test.go
+++ b/datadog/resource_datadog_metric_tag_configuration_unit_test.go
@@ -1,0 +1,63 @@
+package datadog
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateTagConfigurationRetryError(t *testing.T) {
+	apiErr := errors.New("boom")
+
+	tests := []struct {
+		name          string
+		err           error
+		httpResponse  *http.Response
+		wantNil       bool // classifier returned nil (success)
+		wantRetryable bool // only meaningful when wantNil == false
+	}{
+		{
+			name:    "success (nil error) is terminal",
+			err:     nil,
+			wantNil: true,
+		},
+		{
+			name:          "409 conflict is retryable",
+			err:           apiErr,
+			httpResponse:  &http.Response{StatusCode: http.StatusConflict},
+			wantRetryable: true,
+		},
+		{
+			name:          "400 bad request is not retryable",
+			err:           apiErr,
+			httpResponse:  &http.Response{StatusCode: http.StatusBadRequest},
+			wantRetryable: false,
+		},
+		{
+			name:          "500 is not retryable here",
+			err:           apiErr,
+			httpResponse:  &http.Response{StatusCode: http.StatusInternalServerError},
+			wantRetryable: false,
+		},
+		{
+			name:          "nil http response (network error) is not retryable",
+			err:           apiErr,
+			httpResponse:  nil,
+			wantRetryable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := createTagConfigurationRetryError("test.metric.name", tt.err, tt.httpResponse)
+			if tt.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			assert.NotNil(t, got)
+			assert.Equal(t, tt.wantRetryable, got.Retryable)
+		})
+	}
+}


### PR DESCRIPTION
## What

Wrap the `datadog_metric_tag_configuration` create call in `retry.RetryContext` to retry on HTTP 409, with a 30-second ceiling.

## Why

`metric_type` is `ForceNew`. Any change to it triggers a Terraform destroy-then-create. The create is issued milliseconds after the delete, but Datadog's tag-config conflict check reads an eventually-consistent store that can still show the just-deleted config for several seconds (minutes when the CDC pipeline is degraded). The create then returns **HTTP 409** ("New gauge/count/rate conflicts with existing tag configuration, use PATCH to update"), the apply fails, and the resource is left absent — which has caused metric-cost spikes.

## Scope

- **Create handler only.** Read, update, and delete are untouched.
- **409-only retry.** Every other error (400, 5xx, network) is returned immediately. The existing provider-level retry (`http_client_retry_enabled`) covers 429 and 5xx; this is additive.
- **30-second hardcoded ceiling.** `d.Timeout(schema.TimeoutCreate)` without a `Timeouts` block silently defaults to 20 minutes, which would block `terraform apply` on a genuine pre-existing conflict. Hardcoding 30s keeps the PR minimal and avoids a schema change. A follow-up can add a user-tunable `Timeouts` block if the team wants an escape hatch for prolonged CDC outages.
- **No GET-before-retry.** Right after a delete, the GET reads the same stale store and returns 200, masking the transient race as a real conflict.

## Tests

- **New deterministic unit test** (`resource_datadog_metric_tag_configuration_unit_test.go`) exercises `createTagConfigurationRetryError` directly: nil error → nil, 409 → retryable, 400/500/nil response → non-retryable. No API or cassette needed.
- **Existing cassettes unchanged.** On the healthy path the closure returns `nil` on the first attempt (one create call, same as before), so all existing recorded tests replay correctly.

Generated with [Claude Code](https://claude.com/claude-code)