### PR TITLE
[CODEOWNERS] Make metrics-experience sole owner of metric_tag_configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,6 +52,7 @@ datadog/**/*datadog_downtime*                     @api-reliability @DataDog/moni
 datadog/**/*datadog_domain_allowlist*             @api-reliability @DataDog/team-aaa
 datadog/**/*datadog_logs*                         @api-reliability @DataDog/logs-backend @DataDog/logs-core @DataDog/logs-forwarding @DataDog/logs-app
 datadog/**/*datadog_metric*                       @api-reliability @DataDog/metrics-intake @DataDog/timeseries-query @DataDog/metrics-storage-platform
+datadog/**/*datadog_metric_tag_configuration*     @api-reliability @DataDog/metrics-experience
 datadog/**/*datadog_monitor*                      @api-reliability @DataDog/monitor-app
 datadog/**/*datadog_appsec*                       @api-reliability @DataDog/asm-backend
 datadog/**/*datadog_azure_integration*            @api-reliability @DataDog/azure-integrations

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,7 +52,7 @@ datadog/**/*datadog_downtime*                     @api-reliability @DataDog/moni
 datadog/**/*datadog_domain_allowlist*             @api-reliability @DataDog/team-aaa
 datadog/**/*datadog_logs*                         @api-reliability @DataDog/logs-backend @DataDog/logs-core @DataDog/logs-forwarding @DataDog/logs-app
 datadog/**/*datadog_metric*                       @api-reliability @DataDog/metrics-intake @DataDog/timeseries-query @DataDog/metrics-storage-platform
-datadog/**/*datadog_metric_tag_configuration*     @api-reliability @DataDog/metrics-experience
+datadog/**/*datadog_metric_tag_configuration*     @DataDog/api-reliability @DataDog/metrics-experience
 datadog/**/*datadog_monitor*                      @api-reliability @DataDog/monitor-app
 datadog/**/*datadog_appsec*                       @api-reliability @DataDog/asm-backend
 datadog/**/*datadog_azure_integration*            @api-reliability @DataDog/azure-integrations


### PR DESCRIPTION
## What

Adds a specific `datadog/**/*datadog_metric_tag_configuration*` entry in the Plugin Framework section of CODEOWNERS, immediately after the broad `datadog/**/*datadog_metric*` rule.

## Why

The broad `datadog/**/*datadog_metric*` pattern (which assigns metrics-intake, timeseries-query, and metrics-storage-platform) was overriding the more specific SDKv2 entry on line 27 that correctly assigned `metric_tag_configuration` to metrics-experience. GitHub uses last-match-wins, so the broader rule won.

The metric tag configuration resource wraps the Metrics API tag configuration endpoint — controlling which tags are indexed/queryable for a metric. This is squarely metrics-experience's domain; the other metrics teams are not involved in this surface.

The new entry follows the same `@api-reliability @DataDog/<team>` pattern used by all other Plugin Framework entries in this file.

Generated with [Claude Code](https://claude.com/claude-code)