### PR TITLE
[fwutils] Support write-only secrets inside nested blocks

### DIFF
--- a/datadog/internal/fwutils/README.md
+++ b/datadog/internal/fwutils/README.md
@@ -29,6 +29,22 @@ Attributes: fwutils.MergeAttributes(
 )
 ```
 
+### Secrets in Nested Blocks
+
+The three attributes live at the resource root by default. Set `ParentBlocks` to scope them under static nested blocks, so that both the generated validators and the handler lookups target the right paths:
+
+```go
+var secretConfig = fwutils.WriteOnlySecretConfig{
+    OriginalAttr:  "password",
+    WriteOnlyAttr: "password_wo",
+    TriggerAttr:   "password_wo_version",
+    ParentBlocks:  []string{"authentication", "basic"},
+    // ...descriptions
+}
+```
+
+The attributes are then addressed as `authentication.basic.password`. Only single-nested blocks are supported: attributes inside list- or set-nested blocks need index-aware paths, which a list of block names cannot express.
+
 ### CRUD Operations
 
 `WriteOnlySecretHandler` retrieves the secret from whichever mode the user chose:

--- a/datadog/internal/fwutils/writeonly_helpers.go
+++ b/datadog/internal/fwutils/writeonly_helpers.go
@@ -35,6 +35,31 @@ type WriteOnlySecretConfig struct {
 	OriginalDescription  string
 	WriteOnlyDescription string
 	TriggerDescription   string
+	// ParentBlocks scopes the three attributes under static nested blocks, e.g.
+	// []string{"authentication", "basic"}. Empty means the resource root.
+	ParentBlocks []string
+}
+
+func (secretConfig WriteOnlySecretConfig) attrPath(attributeName string) frameworkPath.Path {
+	if len(secretConfig.ParentBlocks) == 0 {
+		return frameworkPath.Root(attributeName)
+	}
+	attributePath := frameworkPath.Root(secretConfig.ParentBlocks[0])
+	for _, blockName := range secretConfig.ParentBlocks[1:] {
+		attributePath = attributePath.AtName(blockName)
+	}
+	return attributePath.AtName(attributeName)
+}
+
+func (secretConfig WriteOnlySecretConfig) attrExpression(attributeName string) frameworkPath.Expression {
+	if len(secretConfig.ParentBlocks) == 0 {
+		return frameworkPath.MatchRoot(attributeName)
+	}
+	attributeExpression := frameworkPath.MatchRoot(secretConfig.ParentBlocks[0])
+	for _, blockName := range secretConfig.ParentBlocks[1:] {
+		attributeExpression = attributeExpression.AtName(blockName)
+	}
+	return attributeExpression.AtName(attributeName)
 }
 
 // CreateWriteOnlySecretAttributes generates three attributes for dual-mode secret support:
@@ -50,11 +75,11 @@ func CreateWriteOnlySecretAttributes(config WriteOnlySecretConfig) map[string]sc
 			Sensitive:   true,
 			Validators: []validator.String{
 				stringvalidator.ExactlyOneOf(
-					frameworkPath.MatchRoot(config.OriginalAttr),
-					frameworkPath.MatchRoot(config.WriteOnlyAttr),
+					config.attrExpression(config.OriginalAttr),
+					config.attrExpression(config.WriteOnlyAttr),
 				),
 				stringvalidator.PreferWriteOnlyAttribute(
-					frameworkPath.MatchRoot(config.WriteOnlyAttr),
+					config.attrExpression(config.WriteOnlyAttr),
 				),
 			},
 		},
@@ -65,11 +90,11 @@ func CreateWriteOnlySecretAttributes(config WriteOnlySecretConfig) map[string]sc
 			WriteOnly:   true,
 			Validators: []validator.String{
 				stringvalidator.ExactlyOneOf(
-					frameworkPath.MatchRoot(config.OriginalAttr),
-					frameworkPath.MatchRoot(config.WriteOnlyAttr),
+					config.attrExpression(config.OriginalAttr),
+					config.attrExpression(config.WriteOnlyAttr),
 				),
 				stringvalidator.AlsoRequires(
-					frameworkPath.MatchRoot(config.TriggerAttr),
+					config.attrExpression(config.TriggerAttr),
 				),
 			},
 		},
@@ -79,7 +104,7 @@ func CreateWriteOnlySecretAttributes(config WriteOnlySecretConfig) map[string]sc
 			Validators: []validator.String{
 				stringvalidator.LengthAtLeast(1),
 				stringvalidator.AlsoRequires(frameworkPath.Expressions{
-					frameworkPath.MatchRoot(config.WriteOnlyAttr),
+					config.attrExpression(config.WriteOnlyAttr),
 				}...),
 			},
 		},
@@ -116,7 +141,7 @@ func (h *WriteOnlySecretHandler) GetSecretForCreate(ctx context.Context, config 
 
 	// Check write-only attribute first (only exists in config, never in plan/state)
 	var writeOnlySecret types.String
-	result.Diagnostics.Append(config.GetAttribute(ctx, frameworkPath.Root(h.Config.WriteOnlyAttr), &writeOnlySecret)...)
+	result.Diagnostics.Append(config.GetAttribute(ctx, h.Config.attrPath(h.Config.WriteOnlyAttr), &writeOnlySecret)...)
 	if result.Diagnostics.HasError() {
 		return result
 	}
@@ -129,7 +154,7 @@ func (h *WriteOnlySecretHandler) GetSecretForCreate(ctx context.Context, config 
 
 	// Fall back to plaintext attribute
 	var plaintextSecret types.String
-	result.Diagnostics.Append(config.GetAttribute(ctx, frameworkPath.Root(h.Config.OriginalAttr), &plaintextSecret)...)
+	result.Diagnostics.Append(config.GetAttribute(ctx, h.Config.attrPath(h.Config.OriginalAttr), &plaintextSecret)...)
 	if result.Diagnostics.HasError() {
 		return result
 	}
@@ -159,7 +184,7 @@ func (h *WriteOnlySecretHandler) GetSecretForUpdate(ctx context.Context, config 
 
 	// Check if write-only secret is present in config
 	var writeOnlySecret types.String
-	result.Diagnostics.Append(config.GetAttribute(ctx, frameworkPath.Root(h.Config.WriteOnlyAttr), &writeOnlySecret)...)
+	result.Diagnostics.Append(config.GetAttribute(ctx, h.Config.attrPath(h.Config.WriteOnlyAttr), &writeOnlySecret)...)
 	if result.Diagnostics.HasError() {
 		return result
 	}
@@ -176,8 +201,8 @@ func (h *WriteOnlySecretHandler) GetSecretForUpdate(ctx context.Context, config 
 		// Pattern 1: API supports partial updates
 		// Only return secret if version trigger changed
 		var planVersion, priorVersion types.String
-		result.Diagnostics.Append(req.Plan.GetAttribute(ctx, frameworkPath.Root(h.Config.TriggerAttr), &planVersion)...)
-		result.Diagnostics.Append(req.State.GetAttribute(ctx, frameworkPath.Root(h.Config.TriggerAttr), &priorVersion)...)
+		result.Diagnostics.Append(req.Plan.GetAttribute(ctx, h.Config.attrPath(h.Config.TriggerAttr), &planVersion)...)
+		result.Diagnostics.Append(req.State.GetAttribute(ctx, h.Config.attrPath(h.Config.TriggerAttr), &priorVersion)...)
 		if result.Diagnostics.HasError() {
 			return result
 		}
@@ -195,7 +220,7 @@ func (h *WriteOnlySecretHandler) GetSecretForUpdate(ctx context.Context, config 
 
 	// Fall back to plaintext attribute
 	var plaintextSecret types.String
-	result.Diagnostics.Append(config.GetAttribute(ctx, frameworkPath.Root(h.Config.OriginalAttr), &plaintextSecret)...)
+	result.Diagnostics.Append(config.GetAttribute(ctx, h.Config.attrPath(h.Config.OriginalAttr), &plaintextSecret)...)
 	if result.Diagnostics.HasError() {
 		return result
 	}

--- a/datadog/internal/fwutils/writeonly_helpers_test.go
+++ b/datadog/internal/fwutils/writeonly_helpers_test.go
@@ -2,6 +2,8 @@ package fwutils
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -296,6 +298,192 @@ func TestGetSecretForUpdate(t *testing.T) {
 			}
 			if tt.wantShouldSet && result.Value != tt.wantValue {
 				t.Errorf("Value = %q, want %q", result.Value, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestWriteOnlySecretConfigPaths(t *testing.T) {
+	root := WriteOnlySecretConfig{
+		OriginalAttr:  "password",
+		WriteOnlyAttr: "password_wo",
+		TriggerAttr:   "password_wo_version",
+	}
+	if got, want := root.attrPath("password_wo").String(), "password_wo"; got != want {
+		t.Errorf("root attrPath = %q, want %q", got, want)
+	}
+	if got, want := root.attrExpression("password_wo").String(), "password_wo"; got != want {
+		t.Errorf("root attrExpression = %q, want %q", got, want)
+	}
+
+	nested := root
+	nested.ParentBlocks = []string{"authentication", "basic"}
+	if got, want := nested.attrPath("password_wo").String(), "authentication.basic.password_wo"; got != want {
+		t.Errorf("nested attrPath = %q, want %q", got, want)
+	}
+	if got, want := nested.attrExpression("password_wo").String(), "authentication.basic.password_wo"; got != want {
+		t.Errorf("nested attrExpression = %q, want %q", got, want)
+	}
+}
+
+// validatorDescriptions joins the descriptions of an attribute's validators.
+// The validators render their path expressions into those descriptions, which is
+// the only way to observe the paths from outside the validators package.
+func validatorDescriptions(t *testing.T, attr schema.Attribute) string {
+	t.Helper()
+	stringAttr, ok := attr.(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("expected schema.StringAttribute, got %T", attr)
+	}
+	var descriptions []string
+	for _, attrValidator := range stringAttr.Validators {
+		descriptions = append(descriptions, attrValidator.Description(context.Background()))
+	}
+	return strings.Join(descriptions, "\n")
+}
+
+func TestCreateWriteOnlySecretAttributesPaths(t *testing.T) {
+	root := WriteOnlySecretConfig{
+		OriginalAttr:  "password",
+		WriteOnlyAttr: "password_wo",
+		TriggerAttr:   "password_wo_version",
+	}
+	nested := root
+	nested.ParentBlocks = []string{"authentication", "basic"}
+
+	cases := []struct {
+		name   string
+		config WriteOnlySecretConfig
+		prefix string
+	}{
+		{name: "root keeps unprefixed paths", config: root},
+		{name: "nested block prefixes paths", config: nested, prefix: "authentication.basic."},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			attrs := CreateWriteOnlySecretAttributes(tc.config)
+			original := validatorDescriptions(t, attrs["password"])
+			writeOnly := validatorDescriptions(t, attrs["password_wo"])
+			trigger := validatorDescriptions(t, attrs["password_wo_version"])
+
+			// Validators render a path collection as "[first,second]". Keeping the
+			// brackets in the expectation makes each token unambiguous: "[password_wo]"
+			// cannot match inside "[password_wo_version]", and an unprefixed
+			// expectation cannot match a prefixed path.
+			pathList := func(attrs ...string) string {
+				prefixed := make([]string, 0, len(attrs))
+				for _, attr := range attrs {
+					prefixed = append(prefixed, tc.prefix+attr)
+				}
+				return fmt.Sprintf("%q", "["+strings.Join(prefixed, ",")+"]")
+			}
+			wantPair := pathList("password", "password_wo")
+
+			// Both members of the ExactlyOneOf pair reference each other.
+			for attr, got := range map[string]string{"password": original, "password_wo": writeOnly} {
+				if !strings.Contains(got, wantPair) {
+					t.Errorf("%s validators should reference %s, got:\n%s", attr, wantPair, got)
+				}
+			}
+			// The write-only attribute requires its version trigger, and vice versa.
+			if want := pathList("password_wo_version"); !strings.Contains(writeOnly, want) {
+				t.Errorf("password_wo validators should reference %s, got:\n%s", want, writeOnly)
+			}
+			if want := pathList("password_wo"); !strings.Contains(trigger, want) {
+				t.Errorf("password_wo_version validators should reference %s, got:\n%s", want, trigger)
+			}
+			// PreferWriteOnlyAttribute renders its path unquoted.
+			if want := "attribute " + tc.prefix + "password_wo should be preferred"; !strings.Contains(original, want) {
+				t.Errorf("password validators should contain %q, got:\n%s", want, original)
+			}
+		})
+	}
+}
+
+func testNestedWriteOnlySchema() schema.Schema {
+	return schema.Schema{
+		Blocks: map[string]schema.Block{
+			"authentication": schema.SingleNestedBlock{
+				Blocks: map[string]schema.Block{
+					"basic": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"username":            schema.StringAttribute{Optional: true},
+							"password":            schema.StringAttribute{Optional: true, Sensitive: true},
+							"password_wo":         schema.StringAttribute{Optional: true, Sensitive: true, WriteOnly: true},
+							"password_wo_version": schema.StringAttribute{Optional: true},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func makeNestedConfigValue(password, passwordWo *string) tftypes.Value {
+	basicType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"username":            tftypes.String,
+		"password":            tftypes.String,
+		"password_wo":         tftypes.String,
+		"password_wo_version": tftypes.String,
+	}}
+	authType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{"basic": basicType}}
+	rootType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{"authentication": authType}}
+
+	strVal := func(s *string) tftypes.Value {
+		if s == nil {
+			return tftypes.NewValue(tftypes.String, nil)
+		}
+		return tftypes.NewValue(tftypes.String, *s)
+	}
+
+	basic := tftypes.NewValue(basicType, map[string]tftypes.Value{
+		"username":            tftypes.NewValue(tftypes.String, "datadog"),
+		"password":            strVal(password),
+		"password_wo":         strVal(passwordWo),
+		"password_wo_version": tftypes.NewValue(tftypes.String, nil),
+	})
+	auth := tftypes.NewValue(authType, map[string]tftypes.Value{"basic": basic})
+	return tftypes.NewValue(rootType, map[string]tftypes.Value{"authentication": auth})
+}
+
+func TestGetSecretForCreateFromNestedBlock(t *testing.T) {
+	handler := &WriteOnlySecretHandler{
+		Config: WriteOnlySecretConfig{
+			OriginalAttr:  "password",
+			WriteOnlyAttr: "password_wo",
+			TriggerAttr:   "password_wo_version",
+			ParentBlocks:  []string{"authentication", "basic"},
+		},
+	}
+
+	cases := []struct {
+		name       string
+		password   *string
+		passwordWo *string
+		wantSet    bool
+		wantValue  string
+	}{
+		{name: "write-only wins", passwordWo: ptr("wo-secret"), wantSet: true, wantValue: "wo-secret"},
+		{name: "plaintext fallback", password: ptr("plain-secret"), wantSet: true, wantValue: "plain-secret"},
+		{name: "neither set", wantSet: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := &tfsdk.Config{
+				Schema: testNestedWriteOnlySchema(),
+				Raw:    makeNestedConfigValue(tc.password, tc.passwordWo),
+			}
+			result := handler.GetSecretForCreate(context.Background(), config)
+			if result.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", result.Diagnostics)
+			}
+			if result.ShouldSetValue != tc.wantSet {
+				t.Errorf("ShouldSetValue = %v, want %v", result.ShouldSetValue, tc.wantSet)
+			}
+			if result.Value != tc.wantValue {
+				t.Errorf("Value = %q, want %q", result.Value, tc.wantValue)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
The write-only secret helpers in `datadog/internal/fwutils` assumed the three generated attributes (`<secret>`, `<secret>_wo`, `<secret>_wo_version`) always lived at the resource root, so they built every validator expression and state lookup with `path.Root(...)`. That made the helpers unusable for resources where the secret sits inside a nested block, such as `authentication.basic.password`. This change lets callers declare the enclosing blocks so the helpers resolve the correct paths.

## Changes
- Add a `ParentBlocks []string` field to `WriteOnlySecretConfig` that scopes the generated attributes under static nested blocks (empty keeps the existing root behaviour)
- Add `attrPath` and `attrExpression` helpers that build `path.Path` / `path.Expression` values from `ParentBlocks`, and use them in `CreateWriteOnlySecretAttributes`, `GetSecretForCreate`, and `GetSecretForUpdate` in place of the hardcoded `path.Root` / `path.MatchRoot` calls
- Add unit tests covering path construction, the paths rendered by the generated `ExactlyOneOf`, `AlsoRequires`, and `PreferWriteOnlyAttribute` validators, and secret resolution from a nested-block config (write-only wins, plaintext fallback, neither set)
- Document `ParentBlocks` in `datadog/internal/fwutils/README.md`, including the single-nested-block limitation

## Testing
- [ ] `make test` passes
- [ ] `make fmtcheck` and `make vet` pass
- [ ] Existing callers (`datadog_integration_fastly_account`, `datadog_synthetics_global_variable`) are unaffected, since they leave `ParentBlocks` empty

## Notes
- Backwards compatible: no schema or behaviour change for existing callers.
- `ParentBlocks` only supports static nested blocks (single-nested). Secrets inside list- or set-nested blocks would need index-aware paths and are not covered here.
