### PR TITLE
[datadog_dashboard] Fix list_stream clustering_pattern_field_path and group_by not read into state

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -10051,6 +10051,18 @@ func buildTerraformListStreamWidgetRequests(datadogListStreamRequests *[]datadog
 		if eventSize, ok := q.GetEventSizeOk(); ok && q.GetDataSource() == datadogV1.LISTSTREAMSOURCE_EVENT_STREAM {
 			queryRequest["event_size"] = eventSize
 		}
+		if clusteringPatternFieldPath, ok := q.GetClusteringPatternFieldPathOk(); ok {
+			queryRequest["clustering_pattern_field_path"] = clusteringPatternFieldPath
+		}
+		if groupBy, ok := q.GetGroupByOk(); ok && groupBy != nil && len(*groupBy) > 0 {
+			terraformGroupBys := make([]map[string]interface{}, len(*groupBy))
+			for i, g := range *groupBy {
+				terraformGroupBys[i] = map[string]interface{}{
+					"facet": g.GetFacet(),
+				}
+			}
+			queryRequest["group_by"] = terraformGroupBys
+		}
 		if v, ok := q.GetSortOk(); ok {
 			terraformSort := map[string]interface{}{}
 			if v, ok := v.GetColumnOk(); ok {

--- a/datadog/resource_datadog_dashboard_list_stream_unit_test.go
+++ b/datadog/resource_datadog_dashboard_list_stream_unit_test.go
@@ -1,0 +1,74 @@
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBuildTerraformListStreamWidgetRequests verifies that the list_stream read
+// path flattens clustering_pattern_field_path and group_by from the API response
+// back into Terraform state. Both fields have schema and write paths but were
+// never mapped back on read, producing a perpetual diff.
+// Regression test for https://github.com/DataDog/terraform-provider-datadog/issues/4149.
+func TestBuildTerraformListStreamWidgetRequests(t *testing.T) {
+	query := datadogV1.NewListStreamQuery(datadogV1.LISTSTREAMSOURCE_LOGS_PATTERN_STREAM, "service:foo")
+	query.SetClusteringPatternFieldPath("message")
+	query.SetGroupBy([]datadogV1.ListStreamGroupByItems{
+		*datadogV1.NewListStreamGroupByItems("service"),
+		*datadogV1.NewListStreamGroupByItems("status"),
+	})
+
+	column := datadogV1.NewListStreamColumn("details", datadogV1.LISTSTREAMCOLUMNWIDTH_AUTO)
+	request := datadogV1.NewListStreamWidgetRequest(
+		[]datadogV1.ListStreamColumn{*column},
+		*query,
+		datadogV1.LISTSTREAMRESPONSEFORMAT_EVENT_LIST,
+	)
+
+	result := buildTerraformListStreamWidgetRequests(&[]datadogV1.ListStreamWidgetRequest{*request})
+
+	assert.Len(t, *result, 1)
+	terraformQuery := (*result)[0]["query"].([]map[string]interface{})[0]
+
+	// clustering_pattern_field_path must round-trip into state.
+	clustering, ok := terraformQuery["clustering_pattern_field_path"].(*string)
+	assert.True(t, ok, "clustering_pattern_field_path should be present in state")
+	if assert.NotNil(t, clustering) {
+		assert.Equal(t, "message", *clustering)
+	}
+
+	// group_by must round-trip into state as a list of {facet} maps.
+	groupBy, ok := terraformQuery["group_by"].([]map[string]interface{})
+	assert.True(t, ok, "group_by should be present in state")
+	assert.Equal(t, []map[string]interface{}{
+		{"facet": "service"},
+		{"facet": "status"},
+	}, groupBy)
+}
+
+// TestBuildTerraformListStreamWidgetRequestsOmitsUnsetFields ensures the new
+// flatten blocks do not inject empty clustering_pattern_field_path/group_by keys
+// for list stream sources that don't use them (e.g. event_stream), avoiding a
+// spurious diff in the other direction.
+func TestBuildTerraformListStreamWidgetRequestsOmitsUnsetFields(t *testing.T) {
+	query := datadogV1.NewListStreamQuery(datadogV1.LISTSTREAMSOURCE_EVENT_STREAM, "example.metric")
+
+	column := datadogV1.NewListStreamColumn("source", datadogV1.LISTSTREAMCOLUMNWIDTH_AUTO)
+	request := datadogV1.NewListStreamWidgetRequest(
+		[]datadogV1.ListStreamColumn{*column},
+		*query,
+		datadogV1.LISTSTREAMRESPONSEFORMAT_EVENT_LIST,
+	)
+
+	result := buildTerraformListStreamWidgetRequests(&[]datadogV1.ListStreamWidgetRequest{*request})
+
+	assert.Len(t, *result, 1)
+	terraformQuery := (*result)[0]["query"].([]map[string]interface{})[0]
+
+	_, hasClustering := terraformQuery["clustering_pattern_field_path"]
+	assert.False(t, hasClustering, "clustering_pattern_field_path should be absent when unset")
+	_, hasGroupBy := terraformQuery["group_by"]
+	assert.False(t, hasGroupBy, "group_by should be absent when unset")
+}


### PR DESCRIPTION
### What does this PR do?

Fixes the `datadog_dashboard` `list_stream` read path so `clustering_pattern_field_path` and `group_by` converge after apply.

Both attributes are declared on `list_stream_definition.request.query` and sent on write, but `buildTerraformListStreamWidgetRequests` (the read/flatten path) never mapped either back into state. State recorded them as absent while the API held the correct values, so every `terraform plan` re-added them and every apply was a no-op that never converged.

This adds the two missing flatten mappings, placed after `event_size` / before `sort` to mirror the adjacent fields in the same function. The write path is unchanged.

### Description of the Change

In `buildTerraformListStreamWidgetRequests` (`datadog/resource_datadog_dashboard.go`):

```go
if clusteringPatternFieldPath, ok := q.GetClusteringPatternFieldPathOk(); ok {
    queryRequest["clustering_pattern_field_path"] = clusteringPatternFieldPath
}
if groupBy, ok := q.GetGroupByOk(); ok && groupBy != nil && len(*groupBy) > 0 {
    terraformGroupBys := make([]map[string]interface{}, len(*groupBy))
    for i, g := range *groupBy {
        terraformGroupBys[i] = map[string]interface{}{
            "facet": g.GetFacet(),
        }
    }
    queryRequest["group_by"] = terraformGroupBys
}
```

This was introduced by #2869 (v3.57.0), which added the schema and `buildDatadogListStreamRequests` (write) but not the read path.

### Test coverage

Added `datadog/resource_datadog_dashboard_list_stream_unit_test.go`, a unit test of the `buildTerraformListStreamWidgetRequests` flatten round-trip (no cassette / no live API needed):

- `TestBuildTerraformListStreamWidgetRequests` — a `logs_pattern_stream` query with `clustering_pattern_field_path` + multiple `group_by` items flattens both back into the state map.
- `TestBuildTerraformListStreamWidgetRequestsOmitsUnsetFields` — an `event_stream` query that sets neither leaves both keys absent (no spurious diff in the other direction).

Locally: `go build ./...`, `go vet ./datadog/...`, and `gofmt -l` are clean; both unit tests pass. The existing cassette-based `list_stream` acceptance tests were not modified; they can't be recorded offline, so no cassette re-record is required for this change.

### Related issues

Fixes #4149
