### PR TITLE
[datadog_datastore] Fix inconsistent result when primary_key_generation_strategy is omitted

### DIFF
--- a/datadog/fwprovider/resource_datadog_datastore.go
+++ b/datadog/fwprovider/resource_datadog_datastore.go
@@ -8,6 +8,7 @@ import (
 	frameworkPath "github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -74,6 +75,8 @@ func (r *datastoreResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 			},
 			"primary_key_generation_strategy": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("none"),
 				Description: "Can be set to `uuid` to automatically generate primary keys when new items are added. Default value is `none`, which requires you to supply a primary key for each new item.",
 			},
 			"created_at": schema.StringAttribute{

--- a/datadog/fwprovider/resource_datadog_datastore_unit_test.go
+++ b/datadog/fwprovider/resource_datadog_datastore_unit_test.go
@@ -1,0 +1,45 @@
+package fwprovider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDatastoreSchemaPrimaryKeyGenerationStrategyDefault guards against a
+// regression of https://github.com/DataDog/terraform-provider-datadog/issues/3610.
+//
+// When `primary_key_generation_strategy` is omitted, the API reads back "none",
+// which previously produced a "Provider produced inconsistent result after apply"
+// error (plan held null, apply yielded "none"). Marking the attribute
+// Optional+Computed with a static default of "none" makes the planned value
+// resolve to "none" so it matches the post-apply state.
+func TestDatastoreSchemaPrimaryKeyGenerationStrategyDefault(t *testing.T) {
+	ctx := context.Background()
+
+	resp := &resource.SchemaResponse{}
+	NewDatastoreResource().Schema(ctx, resource.SchemaRequest{}, resp)
+	require.False(t, resp.Diagnostics.HasError(), "schema should not produce diagnostics")
+
+	attr, ok := resp.Schema.Attributes["primary_key_generation_strategy"]
+	require.True(t, ok, "primary_key_generation_strategy attribute should exist")
+
+	strAttr, ok := attr.(schema.StringAttribute)
+	require.True(t, ok, "primary_key_generation_strategy should be a StringAttribute")
+
+	// A Default may only be set on a Computed attribute in the plugin framework,
+	// and the attribute must stay Optional so users can still override it.
+	assert.True(t, strAttr.Optional, "attribute should remain Optional")
+	assert.True(t, strAttr.Computed, "attribute must be Computed for a Default to apply")
+	require.NotNil(t, strAttr.Default, "attribute should declare a Default")
+
+	defResp := defaults.StringResponse{}
+	strAttr.Default.DefaultString(ctx, defaults.StringRequest{}, &defResp)
+	require.False(t, defResp.Diagnostics.HasError(), "default should not produce diagnostics")
+	assert.Equal(t, "none", defResp.PlanValue.ValueString(), "default value should be \"none\"")
+}

--- a/docs/resources/datastore.md
+++ b/docs/resources/datastore.md
@@ -45,7 +45,7 @@ resource "datadog_datastore" "auto_uuid" {
 
 - `description` (String) A human-readable description about the datastore.
 - `org_access` (String) The organization access level for the datastore. For example, 'contributor'.
-- `primary_key_generation_strategy` (String) Can be set to `uuid` to automatically generate primary keys when new items are added. Default value is `none`, which requires you to supply a primary key for each new item.
+- `primary_key_generation_strategy` (String) Can be set to `uuid` to automatically generate primary keys when new items are added. Default value is `none`, which requires you to supply a primary key for each new item. Defaults to `"none"`.
 
 ### Read-Only
 


### PR DESCRIPTION
### Fixes #3610

When `primary_key_generation_strategy` is omitted from a `datadog_datastore` resource, `tofu apply` / `terraform apply` fails with:

```
Error: Provider produced inconsistent result after apply
.primary_key_generation_strategy: was null, but now cty.StringVal("none")
```

#### Root cause

The attribute is `Optional` with a documented default of `none`, but nothing supplies that default at plan time. The plan therefore holds `null`, while apply reads the value back from the API as `none` — Terraform flags the mismatch as an inconsistent result.

#### Fix

Mark the attribute `Optional` + `Computed` and add `Default: stringdefault.StaticString("none")`. The plugin framework now resolves the planned value to `none` when the config omits it, so the plan matches the post-apply state. Users can still set `uuid` (or any value) explicitly. `updateState` already maps the API's `primary_key_generation_strategy` back consistently, so no read-path change is needed.

#### Testing

- Added an offline unit test (`datadog/fwprovider/resource_datadog_datastore_unit_test.go`) asserting the schema attribute is Optional+Computed and defaults to `none`.
- `go build ./...`, `go vet ./datadog/...`, and `gofmt -l` are clean.
- Acceptance tests for this resource run against recorded cassettes and are unchanged.

Docs are unchanged: an Optional+Computed attribute continues to render under the "Optional" section.