### PR TITLE
[TF Generator] (v2) Resolve tracking-group operationIds to operations

### DIFF
--- a/.generator-v2/internal/cli/generate.go
+++ b/.generator-v2/internal/cli/generate.go
@@ -324,11 +324,11 @@ func generateArtifact(op *model.Operation, outputRoot, testsOutputRoot, examples
 	if err != nil {
 		return failEntry(entry, err), nil, nil, nil
 	}
-	if op.SearchOp != nil && op.SearchOp != op {
-		if err := sdkbind.BindOperation(op.SearchOp); err != nil {
+	if searchOp := op.SearchOp(); searchOp != nil && searchOp != op {
+		if err := sdkbind.BindOperation(searchOp); err != nil {
 			return failEntry(entry, err), nil, nil, nil
 		}
-		searchDiagnostics, err := sdkbinding.Bind(op.SearchOp, sdkBindings)
+		searchDiagnostics, err := sdkbinding.Bind(searchOp, sdkBindings)
 		if err != nil {
 			return failEntry(entry, err), nil, nil, nil
 		}

--- a/.generator-v2/internal/cli/generate.go
+++ b/.generator-v2/internal/cli/generate.go
@@ -324,7 +324,7 @@ func generateArtifact(op *model.Operation, outputRoot, testsOutputRoot, examples
 	if err != nil {
 		return failEntry(entry, err), nil, nil, nil
 	}
-	if searchOp := op.SearchOp(); searchOp != nil && searchOp != op {
+	if searchOp := op.ResolvedGroup.Op(model.GroupRoleSearch); searchOp != nil && searchOp != op {
 		if err := sdkbind.BindOperation(searchOp); err != nil {
 			return failEntry(entry, err), nil, nil, nil
 		}

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -594,7 +594,7 @@ var _ = Describe("BuildDataSourceView singular search", func() {
 		It("hashes a fixed seed on the search path when the selected record has no id", func() {
 			op := datastoreBothOperation()
 			delete(op.ResponseSchema.Properties["data"].Properties, "id")
-			delete(op.SearchOp.ResponseSchema.Properties["data"].Items.Properties, "id")
+			delete(op.SearchOp().ResponseSchema.Properties["data"].Items.Properties, "id")
 
 			view := mustView(op)
 			Expect(view.Search.HashInputs).To(BeEmpty())
@@ -699,7 +699,7 @@ func datastoreBothOperation() *model.Operation {
 		Tag:                 "Actions Datastores",
 		ResponseRefName:     "Datastore",
 		ResponseDataRefName: "DatastoreData", // matches the list element → stays "both"
-		SearchOp:            listOp,
+		ResolvedGroup:       &model.ResolvedGroup{Search: listOp},
 		Tracking: &model.TrackingFieldMetadata{
 			ArtifactKind:  model.ArtifactKindDataSource,
 			ArtifactName:  "datastore",
@@ -716,7 +716,7 @@ func datastoreBothOperation() *model.Operation {
 // id field and the search filter coexist.
 func datastoreBothWithFilterOperation() *model.Operation {
 	op := datastoreBothOperation()
-	op.SearchOp.QueryParams = []model.QueryParam{
+	op.SearchOp().QueryParams = []model.QueryParam{
 		{Name: "filter[keyword]", Schema: prim("string", ""), Description: "Filter datastores by keyword."},
 	}
 	return op

--- a/.generator-v2/internal/emit/builder_test.go
+++ b/.generator-v2/internal/emit/builder_test.go
@@ -594,7 +594,7 @@ var _ = Describe("BuildDataSourceView singular search", func() {
 		It("hashes a fixed seed on the search path when the selected record has no id", func() {
 			op := datastoreBothOperation()
 			delete(op.ResponseSchema.Properties["data"].Properties, "id")
-			delete(op.SearchOp().ResponseSchema.Properties["data"].Items.Properties, "id")
+			delete(op.ResolvedGroup.Search.ResponseSchema.Properties["data"].Items.Properties, "id")
 
 			view := mustView(op)
 			Expect(view.Search.HashInputs).To(BeEmpty())
@@ -680,7 +680,7 @@ func powerpackSearchOperation() *model.Operation {
 }
 
 // datastoreBothOperation is an id-optional singular data source: the tracked op is
-// the by-id GET, and SearchOp points at the list GET (no query params, matching the
+// the by-id GET, and the resolved group's search role points at the list GET (no query params, matching the
 // real ListDatastores). Its element mirrors data_source_datadog_datastore.go.
 func datastoreBothOperation() *model.Operation {
 	listOp := &model.Operation{
@@ -716,7 +716,7 @@ func datastoreBothOperation() *model.Operation {
 // id field and the search filter coexist.
 func datastoreBothWithFilterOperation() *model.Operation {
 	op := datastoreBothOperation()
-	op.SearchOp().QueryParams = []model.QueryParam{
+	op.ResolvedGroup.Search.QueryParams = []model.QueryParam{
 		{Name: "filter[keyword]", Schema: prim("string", ""), Description: "Filter datastores by keyword."},
 	}
 	return op

--- a/.generator-v2/internal/model/artifact.go
+++ b/.generator-v2/internal/model/artifact.go
@@ -27,7 +27,9 @@ func BuildArtifact(op *Operation) (*Artifact, error) {
 	// A group reference naming an operationId the spec does not declare is an
 	// author error the run report must show, even when the artifact still builds
 	// without that role.
-	artifact.Diagnostics = append(unresolvedGroupDiagnostics(op), artifact.Diagnostics...)
+	if diags := unresolvedGroupDiagnostics(op); len(diags) > 0 {
+		artifact.Diagnostics = append(diags, artifact.Diagnostics...)
+	}
 	return artifact, nil
 }
 
@@ -120,7 +122,7 @@ func buildSingularSearchArtifact(op *Operation) (*Artifact, error) {
 // same element shape the search returns); the search side adds Optional filters
 // from the list op's query parameters and the list call, alongside the by-id Read.
 func buildSingularBothArtifact(op *Operation) (*Artifact, error) {
-	searchOp := op.SearchOp()
+	searchOp := op.ResolvedGroup.Op(GroupRoleSearch)
 	if searchOp == nil {
 		return nil, fmt.Errorf("model: data source %q declares group.search %q but no such operation exists",
 			op.Tracking.ArtifactName, op.Tracking.Group.Search)
@@ -176,10 +178,16 @@ func buildSingularBothArtifact(op *Operation) (*Artifact, error) {
 }
 
 // unresolvedGroupDiagnostics reports every group reference whose operationId
-// matches no operation in the spec. The role is nil-filled rather than fatal
-// here — a data source resolves its record from the annotated operation itself,
-// so a dangling read/search reference degrades the lookup instead of breaking
-// it — but a silent drop would leave the author's typo invisible.
+// matches no operation in the spec, so an author's typo is never dropped
+// silently.
+//
+// It reports rather than fails, because whether a dangling reference is fatal
+// depends on the role: a builder that cannot proceed without one fails the
+// artifact itself with a message naming the role (buildSingularBothArtifact
+// does exactly that for a dangling group.search, and the resource lifecycle
+// builder will for the CRUD roles), and those returns never reach here. What is
+// left for this to surface is the remainder — a reference to a role this
+// artifact shape does not consume, which would otherwise vanish unnoticed.
 func unresolvedGroupDiagnostics(op *Operation) []Diagnostic {
 	if op.ResolvedGroup == nil || len(op.ResolvedGroup.Unresolved) == 0 {
 		return nil

--- a/.generator-v2/internal/model/artifact.go
+++ b/.generator-v2/internal/model/artifact.go
@@ -20,6 +20,19 @@ func BuildArtifact(op *Operation) (*Artifact, error) {
 	if op == nil || op.Tracking == nil {
 		return nil, fmt.Errorf("model: BuildArtifact requires a tracked operation")
 	}
+	artifact, err := buildArtifact(op)
+	if err != nil {
+		return nil, err
+	}
+	// A group reference naming an operationId the spec does not declare is an
+	// author error the run report must show, even when the artifact still builds
+	// without that role.
+	artifact.Diagnostics = append(unresolvedGroupDiagnostics(op), artifact.Diagnostics...)
+	return artifact, nil
+}
+
+// buildArtifact selects the builder for op's cardinality and lookup shape.
+func buildArtifact(op *Operation) (*Artifact, error) {
 	if op.Tracking.Cardinality == CardinalityPlural {
 		return buildPluralArtifact(op)
 	}
@@ -107,7 +120,7 @@ func buildSingularSearchArtifact(op *Operation) (*Artifact, error) {
 // same element shape the search returns); the search side adds Optional filters
 // from the list op's query parameters and the list call, alongside the by-id Read.
 func buildSingularBothArtifact(op *Operation) (*Artifact, error) {
-	searchOp := op.SearchOp
+	searchOp := op.SearchOp()
 	if searchOp == nil {
 		return nil, fmt.Errorf("model: data source %q declares group.search %q but no such operation exists",
 			op.Tracking.ArtifactName, op.Tracking.Group.Search)
@@ -160,6 +173,26 @@ func buildSingularBothArtifact(op *Operation) (*Artifact, error) {
 		},
 		Diagnostics: diags,
 	}, nil
+}
+
+// unresolvedGroupDiagnostics reports every group reference whose operationId
+// matches no operation in the spec. The role is nil-filled rather than fatal
+// here — a data source resolves its record from the annotated operation itself,
+// so a dangling read/search reference degrades the lookup instead of breaking
+// it — but a silent drop would leave the author's typo invisible.
+func unresolvedGroupDiagnostics(op *Operation) []Diagnostic {
+	if op.ResolvedGroup == nil || len(op.ResolvedGroup.Unresolved) == 0 {
+		return nil
+	}
+	diags := make([]Diagnostic, 0, len(op.ResolvedGroup.Unresolved))
+	for _, ref := range op.ResolvedGroup.Unresolved {
+		diags = append(diags, Diagnostic{
+			Severity: SeverityWarning,
+			Message: fmt.Sprintf("artifact %q: group.%s names operationId %q, which no operation in the spec declares; that role is unbound",
+				op.Tracking.ArtifactName, ref.Role, ref.OperationId),
+		})
+	}
+	return diags
 }
 
 // sourceFileFor is the output path for a data-source artifact name.

--- a/.generator-v2/internal/model/artifact_test.go
+++ b/.generator-v2/internal/model/artifact_test.go
@@ -270,9 +270,24 @@ var _ = Describe("BuildArtifact singular search", func() {
 
 		It("fails when group.search names an operation that does not exist", func() {
 			op := bothDatastoreOp()
-			op.SearchOp = nil // simulate an unknown operationId
+			op.ResolvedGroup.Search = nil // simulate an unknown operationId
 			_, err := BuildArtifact(op)
 			Expect(err).To(HaveOccurred())
+		})
+
+		It("warns about a group reference the parser could not resolve", func() {
+			op := bothDatastoreOp()
+			op.ResolvedGroup.Unresolved = []GroupReference{
+				{Role: GroupRoleUpdate, OperationId: "UpdateDatastoreTypo"},
+			}
+			art, err := BuildArtifact(op)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(art.Diagnostics).To(ContainElement(Diagnostic{
+				Severity: SeverityWarning,
+				Message: `artifact "datastore": group.update names operationId "UpdateDatastoreTypo", ` +
+					`which no operation in the spec declares; that role is unbound`,
+			}))
 		})
 
 		It("produces a deeply-equal artifact across two runs", func() {
@@ -388,7 +403,7 @@ func bothDatastoreOp() *Operation {
 		Tag:                 "Datastores",
 		ResponseRefName:     "Datastore",
 		ResponseDataRefName: "Datastore", // same as the list element → stays "both"
-		SearchOp:            listOp,
+		ResolvedGroup:       &ResolvedGroup{Search: listOp},
 		Tracking: &TrackingFieldMetadata{
 			ArtifactKind: ArtifactKindDataSource,
 			ArtifactName: "datastore",
@@ -431,7 +446,7 @@ func bothApiKeyOp() *Operation {
 		Tag:                 "KeyManagement",
 		ResponseRefName:     "APIKeyResponse",
 		ResponseDataRefName: "FullAPIKey",
-		SearchOp:            listOp,
+		ResolvedGroup:       &ResolvedGroup{Search: listOp},
 		Tracking: &TrackingFieldMetadata{
 			ArtifactKind: ArtifactKindDataSource,
 			ArtifactName: "api_key",

--- a/.generator-v2/internal/model/artifact_test.go
+++ b/.generator-v2/internal/model/artifact_test.go
@@ -375,7 +375,7 @@ func searchPowerpackOp() *Operation {
 }
 
 // bothDatastoreOp is an id-optional singular data source: the tracked op is the
-// by-id GET (group.read), and SearchOp points at the list GET (group.search)
+// by-id GET (group.read), and the resolved group's search role points at the list GET (group.search)
 // carrying one scalar filter.
 func bothDatastoreOp() *Operation {
 	listOp := &Operation{

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -9,6 +9,7 @@
 package model
 
 import (
+	"slices"
 	"time"
 
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
@@ -144,17 +145,92 @@ type Operation struct {
 	// ItemRefName) or an inline data object. Lets a "both" data source detect when
 	// its by-id record shape diverges from its list element shape.
 	ResponseDataRefName string
-	// SearchOp is the operation named by Tracking.Group.Search, resolved during
-	// NormalizeSchemas: the list endpoint a singular data source searches to
-	// resolve one record. It points at the operation itself when this op is the
-	// search op (search-only), and is nil when no search is declared or the
-	// declared operationId is unknown.
-	SearchOp *Operation
+	// ResolvedGroup is Tracking.Group with every declared operationId replaced by
+	// the operation it names, filled by parser.ResolveOperationGroups. It is nil
+	// on an operation that declares no group, and on hand-built test operations
+	// that never went through the parser.
+	ResolvedGroup *ResolvedGroup
 	// SDKBinding is the call signature derived from the OpenAPI operation using
 	// the Go SDK generator's naming and ordering rules. The CLI fills it before
 	// artifact construction. Tests that build parser-shaped operations directly
 	// may leave it nil and exercise the legacy call shape.
 	SDKBinding *SDKOperationBinding
+}
+
+// SearchOp returns the list operation the group's search reference resolved to:
+// the endpoint a singular data source searches to resolve one record. It points
+// at the operation itself when this op *is* the search op (search-only), and is
+// nil when no search is declared, the declared operationId is unknown, or the
+// group was never resolved. Nil-safe, so callers need no group nil check.
+func (o *Operation) SearchOp() *Operation {
+	if o == nil || o.ResolvedGroup == nil {
+		return nil
+	}
+	return o.ResolvedGroup.Search
+}
+
+// GroupRole names one operation slot in a tracking group. The values are the
+// annotation keys themselves, so a diagnostic can quote what the author wrote.
+type GroupRole string
+
+const (
+	GroupRoleCreate GroupRole = "create"
+	GroupRoleRead   GroupRole = "read"
+	GroupRoleSearch GroupRole = "search"
+	GroupRoleUpdate GroupRole = "update"
+	GroupRoleDelete GroupRole = "delete"
+)
+
+// ResolvedGroup is an OperationGroup with every declared operationId replaced by
+// the *Operation it names — the CRUD lifecycle for a resource, the by-id read
+// and/or the list search for a data source. It is produced by
+// parser.ResolveOperationGroups once the whole spec is enumerated, because a
+// group may reference an operation that appears later in the document (or that
+// carries no tracking field of its own).
+//
+// A role is nil both when the annotation left it out and when the operationId
+// it named matches no operation in the spec; Unresolved is what distinguishes
+// the two, listing only the latter. Resolution never fails the run:
+// FR-012 requires an unrepresentable annotation to fail its own artifact while
+// unrelated artifacts continue, so the unresolved references travel with the
+// operation for the artifact and lifecycle builders to act on.
+type ResolvedGroup struct {
+	Create *Operation
+	Read   *Operation
+	// Search is the list endpoint a singular data source resolves one record
+	// through. It is the annotated operation itself for a search-only artifact.
+	Search *Operation
+	Update *Operation
+	Delete *Operation
+	// Unresolved lists the declared references whose operationId matches no
+	// operation in the spec, in create/read/search/update/delete order.
+	Unresolved []GroupReference
+}
+
+// GroupReference is one (role, operationId) pair exactly as the annotation
+// declared it, retained so a diagnostic can name both.
+type GroupReference struct {
+	Role        GroupRole
+	OperationId string
+}
+
+// Operations returns every distinct operation the group resolved to, in
+// create/read/search/update/delete order. An operation filling two roles — a
+// group whose read and search name the same endpoint, say — appears once.
+// Nil-safe, and the order is document-independent, which is what every
+// consumer needs for deterministic output.
+func (g *ResolvedGroup) Operations() []*Operation {
+	if g == nil {
+		return nil
+	}
+	ops := make([]*Operation, 0, 5)
+	for _, op := range []*Operation{g.Create, g.Read, g.Search, g.Update, g.Delete} {
+		if op == nil || slices.Contains(ops, op) {
+			continue
+		}
+		ops = append(ops, op)
+	}
+	return ops
 }
 
 // QueryParam is one normalized OpenAPI path or query parameter (the historical

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -157,18 +157,6 @@ type Operation struct {
 	SDKBinding *SDKOperationBinding
 }
 
-// SearchOp returns the list operation the group's search reference resolved to:
-// the endpoint a singular data source searches to resolve one record. It points
-// at the operation itself when this op *is* the search op (search-only), and is
-// nil when no search is declared, the declared operationId is unknown, or the
-// group was never resolved. Nil-safe, so callers need no group nil check.
-func (o *Operation) SearchOp() *Operation {
-	if o == nil || o.ResolvedGroup == nil {
-		return nil
-	}
-	return o.ResolvedGroup.Search
-}
-
 // GroupRole names one operation slot in a tracking group. The values are the
 // annotation keys themselves, so a diagnostic can quote what the author wrote.
 type GroupRole string
@@ -212,6 +200,32 @@ type ResolvedGroup struct {
 type GroupReference struct {
 	Role        GroupRole
 	OperationId string
+}
+
+// Op returns the operation resolved for role. It is nil when the annotation
+// omitted that role, when the operationId it named matched no operation, and
+// when the group was never resolved — and it is nil-safe on the receiver, so a
+// caller holding a possibly-groupless operation can write
+// op.ResolvedGroup.Op(GroupRoleSearch) with no guard of its own. Every role is
+// reached this same way: the safety seam belongs to the group, not to whichever
+// role happened to acquire callers first.
+func (g *ResolvedGroup) Op(role GroupRole) *Operation {
+	if g == nil {
+		return nil
+	}
+	switch role {
+	case GroupRoleCreate:
+		return g.Create
+	case GroupRoleRead:
+		return g.Read
+	case GroupRoleSearch:
+		return g.Search
+	case GroupRoleUpdate:
+		return g.Update
+	case GroupRoleDelete:
+		return g.Delete
+	}
+	return nil
 }
 
 // Operations returns every distinct operation the group resolved to, in

--- a/.generator-v2/internal/parser/group.go
+++ b/.generator-v2/internal/parser/group.go
@@ -1,0 +1,74 @@
+package parser
+
+import (
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+)
+
+// ResolveOperationGroups wires every tracked operation's declared group to the
+// operations it names, filling Operation.ResolvedGroup: create/read/update/
+// delete for a resource lifecycle, read (by-id) and/or search (list) for a data
+// source. An operation carrying no tracking field, or tracking metadata with no
+// group, is left with a nil ResolvedGroup.
+//
+// Resolution is a whole-spec pass rather than a per-operation one because a
+// group routinely references an operation that appears later in the document,
+// and one that carries no tracking field of its own (only the annotated
+// operation does).
+//
+// It never fails the run. An operationId matching no operation in the spec is
+// recorded in ResolvedGroup.Unresolved and leaves that role nil, so the
+// artifact and lifecycle builders can fail exactly the artifact that depends on
+// it while unrelated artifacts continue (FR-012). Calling it twice on the same
+// spec produces the same result.
+func ResolveOperationGroups(spec *model.Spec) {
+	if spec == nil {
+		return
+	}
+	byID := indexOperationsByID(spec.Operations)
+	for _, op := range spec.Operations {
+		if op == nil || op.Tracking == nil || op.Tracking.Group == nil {
+			continue
+		}
+		op.ResolvedGroup = resolveGroup(op.Tracking.Group, byID)
+	}
+}
+
+// resolveGroup replaces each operationId declared in decl with the operation it
+// names, recording the ones byID does not know. Roles are visited in
+// create/read/search/update/delete order so Unresolved is deterministic
+// regardless of how the annotation was written.
+func resolveGroup(decl *model.OperationGroup, byID map[string]*model.Operation) *model.ResolvedGroup {
+	g := &model.ResolvedGroup{}
+	resolve := func(role model.GroupRole, id string, dst **model.Operation) {
+		if id == "" {
+			return
+		}
+		if target := byID[id]; target != nil {
+			*dst = target
+			return
+		}
+		g.Unresolved = append(g.Unresolved, model.GroupReference{Role: role, OperationId: id})
+	}
+	resolve(model.GroupRoleCreate, decl.Create, &g.Create)
+	resolve(model.GroupRoleRead, decl.Read, &g.Read)
+	resolve(model.GroupRoleSearch, decl.Search, &g.Search)
+	resolve(model.GroupRoleUpdate, decl.Update, &g.Update)
+	resolve(model.GroupRoleDelete, decl.Delete, &g.Delete)
+	return g
+}
+
+// indexOperationsByID indexes operations by operationId, skipping the unnamed
+// ones (an operationId is optional in OpenAPI, but a group can only reference an
+// operation that has one). OpenAPI requires operationIds to be unique, so a
+// duplicate is a malformed document; the last of a duplicate pair wins, which
+// LoadSpec's (path, method) sort makes deterministic.
+func indexOperationsByID(ops []*model.Operation) map[string]*model.Operation {
+	byID := make(map[string]*model.Operation, len(ops))
+	for _, op := range ops {
+		if op == nil || op.OperationId == "" {
+			continue
+		}
+		byID[op.OperationId] = op
+	}
+	return byID
+}

--- a/.generator-v2/internal/parser/group.go
+++ b/.generator-v2/internal/parser/group.go
@@ -39,21 +39,21 @@ func ResolveOperationGroups(spec *model.Spec) {
 // regardless of how the annotation was written.
 func resolveGroup(decl *model.OperationGroup, byID map[string]*model.Operation) *model.ResolvedGroup {
 	g := &model.ResolvedGroup{}
-	resolve := func(role model.GroupRole, id string, dst **model.Operation) {
+	resolve := func(role model.GroupRole, id string) *model.Operation {
 		if id == "" {
-			return
+			return nil
 		}
 		if target := byID[id]; target != nil {
-			*dst = target
-			return
+			return target
 		}
 		g.Unresolved = append(g.Unresolved, model.GroupReference{Role: role, OperationId: id})
+		return nil
 	}
-	resolve(model.GroupRoleCreate, decl.Create, &g.Create)
-	resolve(model.GroupRoleRead, decl.Read, &g.Read)
-	resolve(model.GroupRoleSearch, decl.Search, &g.Search)
-	resolve(model.GroupRoleUpdate, decl.Update, &g.Update)
-	resolve(model.GroupRoleDelete, decl.Delete, &g.Delete)
+	g.Create = resolve(model.GroupRoleCreate, decl.Create)
+	g.Read = resolve(model.GroupRoleRead, decl.Read)
+	g.Search = resolve(model.GroupRoleSearch, decl.Search)
+	g.Update = resolve(model.GroupRoleUpdate, decl.Update)
+	g.Delete = resolve(model.GroupRoleDelete, decl.Delete)
 	return g
 }
 

--- a/.generator-v2/internal/parser/group_test.go
+++ b/.generator-v2/internal/parser/group_test.go
@@ -1,0 +1,224 @@
+package parser
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+)
+
+var _ = Describe("ResolveOperationGroups", func() {
+	// op builds a bare operation; groupedOp adds tracking metadata declaring a
+	// group. Both stay minimal — resolution reads only OperationId and Tracking.
+	op := func(operationId string) *model.Operation {
+		return &model.Operation{Path: "/" + operationId, Method: "GET", OperationId: operationId}
+	}
+	groupedOp := func(operationId string, group *model.OperationGroup) *model.Operation {
+		o := op(operationId)
+		o.Tracking = &model.TrackingFieldMetadata{
+			ArtifactKind: model.ArtifactKindResource,
+			ArtifactName: "thing",
+			Group:        group,
+		}
+		return o
+	}
+
+	Context("when every declared operationId exists", func() {
+		It("wires each CRUD role to the operation it names", func() {
+			create := groupedOp("CreateThing", &model.OperationGroup{
+				Create: "CreateThing",
+				Read:   "GetThing",
+				Update: "UpdateThing",
+				Delete: "DeleteThing",
+			})
+			read, update, del := op("GetThing"), op("UpdateThing"), op("DeleteThing")
+			spec := &model.Spec{Operations: []*model.Operation{create, read, update, del}}
+
+			ResolveOperationGroups(spec)
+
+			g := create.ResolvedGroup
+			Expect(g).NotTo(BeNil())
+			Expect(g.Create).To(BeIdenticalTo(create))
+			Expect(g.Read).To(BeIdenticalTo(read))
+			Expect(g.Update).To(BeIdenticalTo(update))
+			Expect(g.Delete).To(BeIdenticalTo(del))
+			Expect(g.Search).To(BeNil())
+			Expect(g.Unresolved).To(BeEmpty())
+		})
+
+		It("resolves a reference to an operation declared later in the spec", func() {
+			read := groupedOp("GetThing", &model.OperationGroup{Read: "GetThing", Search: "ListThings"})
+			list := op("ListThings")
+			spec := &model.Spec{Operations: []*model.Operation{read, list}}
+
+			ResolveOperationGroups(spec)
+
+			Expect(read.ResolvedGroup.Search).To(BeIdenticalTo(list))
+			Expect(read.SearchOp()).To(BeIdenticalTo(list))
+		})
+
+		It("resolves a search-only group to the annotated operation itself", func() {
+			list := groupedOp("ListThings", &model.OperationGroup{Search: "ListThings"})
+			spec := &model.Spec{Operations: []*model.Operation{list}}
+
+			ResolveOperationGroups(spec)
+
+			Expect(list.ResolvedGroup.Search).To(BeIdenticalTo(list))
+			Expect(list.ResolvedGroup.Read).To(BeNil())
+		})
+	})
+
+	Context("when a declared operationId matches no operation", func() {
+		It("leaves the role nil and records the reference", func() {
+			create := groupedOp("CreateThing", &model.OperationGroup{
+				Create: "CreateThing",
+				Update: "UpdateThingTypo",
+			})
+			spec := &model.Spec{Operations: []*model.Operation{create}}
+
+			ResolveOperationGroups(spec)
+
+			g := create.ResolvedGroup
+			Expect(g.Create).To(BeIdenticalTo(create))
+			Expect(g.Update).To(BeNil())
+			Expect(g.Unresolved).To(Equal([]model.GroupReference{
+				{Role: model.GroupRoleUpdate, OperationId: "UpdateThingTypo"},
+			}))
+		})
+
+		It("records several dangling references in create/read/search/update/delete order", func() {
+			create := groupedOp("CreateThing", &model.OperationGroup{
+				Delete: "DeleteTypo",
+				Update: "UpdateTypo",
+				Read:   "ReadTypo",
+				Create: "CreateTypo",
+			})
+			spec := &model.Spec{Operations: []*model.Operation{create}}
+
+			ResolveOperationGroups(spec)
+
+			Expect(create.ResolvedGroup.Unresolved).To(Equal([]model.GroupReference{
+				{Role: model.GroupRoleCreate, OperationId: "CreateTypo"},
+				{Role: model.GroupRoleRead, OperationId: "ReadTypo"},
+				{Role: model.GroupRoleUpdate, OperationId: "UpdateTypo"},
+				{Role: model.GroupRoleDelete, OperationId: "DeleteTypo"},
+			}))
+		})
+
+		It("does not fail the run, so unrelated artifacts still resolve", func() {
+			broken := groupedOp("CreateBroken", &model.OperationGroup{Read: "GoneMissing"})
+			healthy := groupedOp("GetHealthy", &model.OperationGroup{Read: "GetHealthy"})
+			healthy.Tracking.ArtifactName = "healthy"
+			spec := &model.Spec{Operations: []*model.Operation{broken, healthy}}
+
+			ResolveOperationGroups(spec)
+
+			Expect(broken.ResolvedGroup.Read).To(BeNil())
+			Expect(healthy.ResolvedGroup.Read).To(BeIdenticalTo(healthy))
+			Expect(healthy.ResolvedGroup.Unresolved).To(BeEmpty())
+		})
+	})
+
+	Context("when an operation declares no group", func() {
+		It("leaves ResolvedGroup nil for tracked and untracked operations alike", func() {
+			untracked := op("GetHealth")
+			groupless := op("GetThing")
+			groupless.Tracking = &model.TrackingFieldMetadata{
+				ArtifactKind: model.ArtifactKindDataSource,
+				ArtifactName: "thing",
+			}
+			spec := &model.Spec{Operations: []*model.Operation{untracked, groupless}}
+
+			ResolveOperationGroups(spec)
+
+			Expect(untracked.ResolvedGroup).To(BeNil())
+			Expect(groupless.ResolvedGroup).To(BeNil())
+			Expect(groupless.SearchOp()).To(BeNil())
+		})
+	})
+
+	It("tolerates a nil spec and nil operations", func() {
+		Expect(func() { ResolveOperationGroups(nil) }).NotTo(Panic())
+		spec := &model.Spec{Operations: []*model.Operation{nil, op("GetThing")}}
+		Expect(func() { ResolveOperationGroups(spec) }).NotTo(Panic())
+	})
+
+	It("is idempotent: a second pass reproduces the first result", func() {
+		build := func() *model.Spec {
+			create := groupedOp("CreateThing", &model.OperationGroup{
+				Create: "CreateThing", Read: "GetThing", Update: "Typo",
+			})
+			return &model.Spec{Operations: []*model.Operation{create, op("GetThing")}}
+		}
+		once, twice := build(), build()
+		ResolveOperationGroups(once)
+		ResolveOperationGroups(twice)
+		ResolveOperationGroups(twice)
+		Expect(twice).To(Equal(once))
+	})
+
+	Context("through LoadSpec", func() {
+		It("resolves a full CRUD group from an annotated spec", func() {
+			spec := loadSpecMust("schema_normalize_crud.yaml")
+			g := opByID(spec, "CreateThing").ResolvedGroup
+
+			Expect(g).NotTo(BeNil())
+			Expect(g.Create).To(BeIdenticalTo(opByID(spec, "CreateThing")))
+			Expect(g.Read).To(BeIdenticalTo(opByID(spec, "GetThing")))
+			Expect(g.Update).To(BeIdenticalTo(opByID(spec, "UpdateThing")))
+			Expect(g.Delete).To(BeIdenticalTo(opByID(spec, "DeleteThing")))
+			Expect(g.Unresolved).To(BeEmpty())
+		})
+
+		It("leaves Update nil when the annotation omits it", func() {
+			spec := loadSpecMust("schema_normalize_missing_update.yaml")
+			g := opByID(spec, "CreateThing").ResolvedGroup
+
+			Expect(g.Update).To(BeNil())
+			Expect(g.Delete).To(BeIdenticalTo(opByID(spec, "DeleteThing")))
+			// An omitted role is not a dangling reference.
+			Expect(g.Unresolved).To(BeEmpty())
+		})
+
+		It("records dangling references without failing the load", func() {
+			spec := loadSpecMust("group_unresolved.yaml")
+			g := opByID(spec, "CreateThing").ResolvedGroup
+
+			Expect(g.Read).To(BeIdenticalTo(opByID(spec, "GetThing")))
+			Expect(g.Update).To(BeNil())
+			Expect(g.Delete).To(BeNil())
+			Expect(g.Unresolved).To(Equal([]model.GroupReference{
+				{Role: model.GroupRoleUpdate, OperationId: "PatchThingTypo"},
+				{Role: model.GroupRoleDelete, OperationId: "DestroyThingTypo"},
+			}))
+		})
+
+		It("normalizes the bodies of every operation the group resolved to", func() {
+			spec := loadSpecMust("schema_normalize_crud.yaml")
+			for _, id := range []string{"CreateThing", "GetThing", "UpdateThing"} {
+				Expect(opByID(spec, id).ResponseSchema).NotTo(BeNil(), "response schema of %s", id)
+			}
+			// The annotated operation's own request body is normalized too.
+			Expect(opByID(spec, "CreateThing").RequestSchema).NotTo(BeNil())
+		})
+	})
+})
+
+var _ = Describe("ResolvedGroup.Operations", func() {
+	first, second := &model.Operation{OperationId: "First"}, &model.Operation{OperationId: "Second"}
+
+	It("returns the resolved operations in create/read/search/update/delete order", func() {
+		g := &model.ResolvedGroup{Create: first, Delete: second}
+		Expect(g.Operations()).To(Equal([]*model.Operation{first, second}))
+	})
+
+	It("returns an operation filling two roles exactly once", func() {
+		g := &model.ResolvedGroup{Read: first, Search: first, Delete: second}
+		Expect(g.Operations()).To(Equal([]*model.Operation{first, second}))
+	})
+
+	It("is nil-safe and skips unfilled roles", func() {
+		Expect((*model.ResolvedGroup)(nil).Operations()).To(BeEmpty())
+		Expect((&model.ResolvedGroup{}).Operations()).To(BeEmpty())
+	})
+})

--- a/.generator-v2/internal/parser/group_test.go
+++ b/.generator-v2/internal/parser/group_test.go
@@ -54,7 +54,7 @@ var _ = Describe("ResolveOperationGroups", func() {
 			ResolveOperationGroups(spec)
 
 			Expect(read.ResolvedGroup.Search).To(BeIdenticalTo(list))
-			Expect(read.SearchOp()).To(BeIdenticalTo(list))
+			Expect(read.ResolvedGroup.Op(model.GroupRoleSearch)).To(BeIdenticalTo(list))
 		})
 
 		It("resolves a search-only group to the annotated operation itself", func() {
@@ -133,7 +133,9 @@ var _ = Describe("ResolveOperationGroups", func() {
 
 			Expect(untracked.ResolvedGroup).To(BeNil())
 			Expect(groupless.ResolvedGroup).To(BeNil())
-			Expect(groupless.SearchOp()).To(BeNil())
+			// A nil group answers for every role without a guard at the call site.
+			Expect(groupless.ResolvedGroup.Op(model.GroupRoleSearch)).To(BeNil())
+			Expect(groupless.ResolvedGroup.Op(model.GroupRoleCreate)).To(BeNil())
 		})
 	})
 
@@ -207,18 +209,45 @@ var _ = Describe("ResolveOperationGroups", func() {
 var _ = Describe("ResolvedGroup.Operations", func() {
 	first, second := &model.Operation{OperationId: "First"}, &model.Operation{OperationId: "Second"}
 
-	It("returns the resolved operations in create/read/search/update/delete order", func() {
-		g := &model.ResolvedGroup{Create: first, Delete: second}
-		Expect(g.Operations()).To(Equal([]*model.Operation{first, second}))
-	})
-
-	It("returns an operation filling two roles exactly once", func() {
-		g := &model.ResolvedGroup{Read: first, Search: first, Delete: second}
-		Expect(g.Operations()).To(Equal([]*model.Operation{first, second}))
-	})
+	DescribeTable("returns the resolved operations in create/read/search/update/delete order",
+		func(g *model.ResolvedGroup, want []*model.Operation) {
+			Expect(g.Operations()).To(Equal(want))
+		},
+		Entry("distinct roles", &model.ResolvedGroup{Create: first, Delete: second},
+			[]*model.Operation{first, second}),
+		Entry("an operation filling two roles appears once", &model.ResolvedGroup{Read: first, Search: first, Delete: second},
+			[]*model.Operation{first, second}),
+	)
 
 	It("is nil-safe and skips unfilled roles", func() {
 		Expect((*model.ResolvedGroup)(nil).Operations()).To(BeEmpty())
 		Expect((&model.ResolvedGroup{}).Operations()).To(BeEmpty())
+	})
+})
+
+var _ = Describe("ResolvedGroup.Op", func() {
+	group := &model.ResolvedGroup{
+		Create: &model.Operation{OperationId: "CreateThing"},
+		Read:   &model.Operation{OperationId: "GetThing"},
+		Search: &model.Operation{OperationId: "ListThings"},
+		Update: &model.Operation{OperationId: "UpdateThing"},
+		Delete: &model.Operation{OperationId: "DeleteThing"},
+	}
+
+	DescribeTable("returns the operation resolved for each role",
+		func(role model.GroupRole, wantOperationId string) {
+			Expect(group.Op(role).OperationId).To(Equal(wantOperationId))
+		},
+		Entry("create", model.GroupRoleCreate, "CreateThing"),
+		Entry("read", model.GroupRoleRead, "GetThing"),
+		Entry("search", model.GroupRoleSearch, "ListThings"),
+		Entry("update", model.GroupRoleUpdate, "UpdateThing"),
+		Entry("delete", model.GroupRoleDelete, "DeleteThing"),
+	)
+
+	It("returns nil for an unfilled role, an unknown role, and a nil group", func() {
+		Expect((&model.ResolvedGroup{}).Op(model.GroupRoleCreate)).To(BeNil())
+		Expect(group.Op(model.GroupRole("publish"))).To(BeNil())
+		Expect((*model.ResolvedGroup)(nil).Op(model.GroupRoleRead)).To(BeNil())
 	})
 })

--- a/.generator-v2/internal/parser/parser.go
+++ b/.generator-v2/internal/parser/parser.go
@@ -66,9 +66,10 @@ func WithTrackingFieldName(name string) Option {
 // not silently produce partial output.
 //
 // LoadSpec populates Path, Method, OperationId, Tag and Tracking on each
-// Operation, then runs NormalizeSchemas to fill RequestSchema and
-// ResponseSchema for every tracked operation's CRUD group. The result is a
-// fully-populated *model.Spec or an actionable error.
+// Operation, runs ResolveOperationGroups to wire each tracking group's
+// operationIds to the operations they name, then runs NormalizeSchemas to fill
+// RequestSchema and ResponseSchema for every tracked operation and its group.
+// The result is a fully-populated *model.Spec or an actionable error.
 func LoadSpec(path string, opts ...Option) (*model.Spec, error) {
 	cfg := loadConfig{maxDepth: DefaultMaxDepth, trackingFieldName: DefaultTrackingFieldName}
 	for _, opt := range opts {
@@ -155,6 +156,10 @@ func LoadSpec(path string, opts ...Option) (*model.Spec, error) {
 	if err := CheckDuplicateArtifactNames(spec); err != nil {
 		return nil, err
 	}
+
+	// Groups are resolved before normalization: it walks the operations a group
+	// points at, which only exist as pointers once every operation is enumerated.
+	ResolveOperationGroups(spec)
 
 	if err := NormalizeSchemas(spec, rawOps, cfg.maxDepth, cfg.trackingFieldName); err != nil {
 		return nil, err

--- a/.generator-v2/internal/parser/schema.go
+++ b/.generator-v2/internal/parser/schema.go
@@ -74,8 +74,12 @@ func backtickedToken(s string) (string, bool) {
 }
 
 // NormalizeSchemas fills RequestSchema and ResponseSchema on every tracked
-// operation's CRUD group, resolving the create/read/update/delete operationIds
-// in Tracking.Group to operations and extracting their bodies from rawOps.
+// operation and on every operation its CRUD group resolved to, extracting their
+// bodies from rawOps.
+//
+// It requires ResolveOperationGroups to have run first — that pass turns the
+// group's operationIds into the *model.Operation pointers walked here. LoadSpec
+// calls the two in order.
 //
 // Request uses the application/json requestBody; response uses the
 // application/json body of the lowest-numbered 2xx code that has one. A missing
@@ -94,62 +98,33 @@ func NormalizeSchemas(spec *model.Spec, rawOps map[*model.Operation]*v3.Operatio
 		trackingFieldName: trackingFieldName,
 	}
 
-	// operationId → *model.Operation, to resolve a group's CRUD references.
-	byID := make(map[string]*model.Operation, len(spec.Operations))
-	for _, op := range spec.Operations {
-		if op == nil || op.OperationId == "" {
-			continue
-		}
-		byID[op.OperationId] = op
-	}
-
-	// Roots are tracked operations; each fills its group's operations, which may
-	// themselves be untracked. filled dedups operations shared across groups.
+	// Roots are tracked operations; each fills its own bodies and its group's,
+	// which may themselves be untracked. The tracked operation is filled whether
+	// or not its group names it, so a group that references only other operations
+	// — or no group at all — still leaves the annotated operation's own request
+	// and response trees populated. filled dedups operations shared across groups.
 	filled := make(map[*model.Operation]bool)
+	fill := func(target *model.Operation) error {
+		if filled[target] {
+			return nil
+		}
+		filled[target] = true
+		return n.fillOperation(target, rawOps[target])
+	}
 	for _, op := range spec.Operations {
 		if op == nil || op.Tracking == nil {
 			continue
 		}
-		for _, id := range groupOperationIds(op.Tracking) {
-			target := byID[id]
-			if target == nil || filled[target] {
-				continue
-			}
-			filled[target] = true
-			if err := n.fillOperation(target, rawOps[target]); err != nil {
+		if err := fill(op); err != nil {
+			return err
+		}
+		for _, target := range op.ResolvedGroup.Operations() {
+			if err := fill(target); err != nil {
 				return err
 			}
 		}
 	}
-
-	// Resolve each tracked op's search reference to the list operation it points
-	// at, so BuildArtifact can reach the search op's filters and list call. An
-	// unknown operationId leaves SearchOp nil for BuildArtifact to fail-slow on.
-	for _, op := range spec.Operations {
-		if op == nil || op.Tracking == nil || op.Tracking.Group == nil {
-			continue
-		}
-		if id := op.Tracking.Group.Search; id != "" {
-			op.SearchOp = byID[id]
-		}
-	}
 	return nil
-}
-
-// groupOperationIds returns the non-empty operationIds backing a tracking group
-// (create/read/search/update/delete), so their schemas get normalized.
-func groupOperationIds(t *model.TrackingFieldMetadata) []string {
-	if t == nil || t.Group == nil {
-		return nil
-	}
-	g := t.Group
-	ids := make([]string, 0, 5)
-	for _, id := range []string{g.Create, g.Read, g.Search, g.Update, g.Delete} {
-		if id != "" {
-			ids = append(ids, id)
-		}
-	}
-	return ids
 }
 
 // schemaNormalizer holds the per-pass state: the component set for $ref

--- a/.generator-v2/internal/testdata/parser/group_unresolved.yaml
+++ b/.generator-v2/internal/testdata/parser/group_unresolved.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: group reference resolution fixture with dangling operationIds
+  version: 1.0.0
+paths:
+  /things:
+    post:
+      operationId: CreateThing
+      x-datadog-tf-generator:
+        artifact_kind: resource
+        artifact_name: thing
+        group:
+          create: CreateThing
+          read: GetThing
+          # Neither operationId below is declared anywhere in this document.
+          update: PatchThingTypo
+          delete: DestroyThingTypo
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+  /things/{id}:
+    get:
+      operationId: GetThing
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string


### PR DESCRIPTION
### Changes 
Implements an OperationGroup decoder that wires a tracking group's create/read/search/update/delete operationIds to the *model.Operation.
- internal/parser/group.go: ResolveOperationGroups, a whole-spec pass run by LoadSpec before NormalizeSchemas 
- model.ResolvedGroup replaces the single-purpose Operation.SearchOp field, which becomes the nil-safe SearchOp() accessor over it. Group wiring now has one source of truth instead of an index rebuilt per pass.
- A dangling operationId leaves its role nil and lands in Unresolved; BuildArtifact turns each into a per-artifact warning rather than failing the run. 
- NormalizeSchemas walks ResolvedGroup.Operations() instead of re-indexing operationIds, and now also normalizes the annotated operation itself, closing a latent gap where a group naming only other operations left the annotated one's own request/response trees nil.
