### PR TITLE
[datadog_integration_aws_account_ccm_config] Report Terraform setup method

### DIFF
--- a/datadog/fwprovider/resource_datadog_integration_aws_account_ccm_config.go
+++ b/datadog/fwprovider/resource_datadog_integration_aws_account_ccm_config.go
@@ -300,5 +300,13 @@ func (r *integrationAwsAccountCcmConfigResource) buildIntegrationAwsAccountCcmCo
 	req.Data = *datadogV2.NewAWSCcmConfigRequestDataWithDefaults()
 	req.Data.SetAttributes(*attributes)
 
+	// Set metadata to indicate this request is coming from Terraform.
+	if req.AdditionalProperties == nil {
+		req.AdditionalProperties = make(map[string]interface{})
+	}
+	req.AdditionalProperties["meta"] = map[string]interface{}{
+		"setup_method": "terraform",
+	}
+
 	return req, diags
 }

--- a/datadog/fwprovider/resource_datadog_integration_aws_account_ccm_config_test.go
+++ b/datadog/fwprovider/resource_datadog_integration_aws_account_ccm_config_test.go
@@ -1,0 +1,34 @@
+package fwprovider
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestIntegrationAwsAccountCcmConfigRequestIncludesTerraformSetupMethod(t *testing.T) {
+	r := &integrationAwsAccountCcmConfigResource{}
+
+	req, diags := r.buildIntegrationAwsAccountCcmConfigRequestBody(
+		context.Background(),
+		&integrationAwsAccountCcmConfigModel{},
+	)
+	if diags.HasError() {
+		t.Fatalf("building request returned diagnostics: %v", diags)
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshaling request: %v", err)
+	}
+
+	var payload struct {
+		Meta map[string]string `json:"meta"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("unmarshaling request: %v", err)
+	}
+	if got := payload.Meta["setup_method"]; got != "terraform" {
+		t.Fatalf("expected setup method %q, got %q in %s", "terraform", got, body)
+	}
+}

--- a/datadog/tests/cassettes/TestAccIntegrationAwsAccountCcmConfigBasic.yaml
+++ b/datadog/tests/cassettes/TestAccIntegrationAwsAccountCcmConfigBasic.yaml
@@ -42,14 +42,14 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 226
+        content_length: 261
         transfer_encoding: []
         trailer: {}
         host: api.datadoghq.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"data":{"attributes":{"ccm_config":{"data_export_configs":[{"bucket_name":"billing","bucket_region":"us-east-1","report_name":"cost-and-usage-report","report_prefix":"reports","report_type":"CUR2.0"}]}},"type":"ccm_config"}}
+            {"data":{"attributes":{"ccm_config":{"data_export_configs":[{"bucket_name":"billing","bucket_region":"us-east-1","report_name":"cost-and-usage-report","report_prefix":"reports","report_type":"CUR2.0"}]}},"type":"ccm_config"},"meta":{"setup_method":"terraform"}}
         form: {}
         headers:
             Accept:


### PR DESCRIPTION
## Summary

Report Terraform as the setup method when creating an AWS CUR 2 configuration. This lets the CCM account syncer attribute successful setup without coupling the AWS integrations endpoint to Terraform-specific behavior.

## Changes

- Add top-level `meta.setup_method: terraform` to CUR 2 API requests.
- Cover the serialized request and update the acceptance cassette.

## Test plan

- `make fmtcheck`
- `make test`
- `make docs && make check-docs`
- `make vet`
- `RECORD=false TESTARGS="-run TestAccIntegrationAwsAccountCcmConfigBasic" make testacc`

## Related PRs

- [dd-source #71069](https://github.com/ddoghq/dd-source/pull/71069)
- [dogweb #3542](https://github.com/ddoghq/dogweb/pull/3542)
- [web-ui #6191](https://github.com/ddoghq/web-ui/pull/6191)