### PR TITLE
datadog_datastore_item: fix the ignored item key filter and JSON column rendering

### DIFF
--- a/datadog/fwprovider/data_source_datadog_datastore_item.go
+++ b/datadog/fwprovider/data_source_datadog_datastore_item.go
@@ -107,9 +107,10 @@ func (d *datastoreItemDataSource) Read(ctx context.Context, request datasource.R
 	datastoreID := state.DatastoreID.ValueString()
 	itemKey := state.ItemKey.ValueString()
 
-	// Use ListDatastoreItems with item_key query parameter to get specific item
-	optionalParams := datadogV2.NewListDatastoreItemsOptionalParameters()
-	optionalParams.ItemKey = &itemKey
+	// Filter with `filter`, not `ItemKey`: the client sends the latter as
+	// `item_key` while the API reads `itemKey`, so it is ignored and the
+	// response is the whole datastore.
+	optionalParams := datadogV2.NewListDatastoreItemsOptionalParameters().WithFilter(itemKey)
 
 	resp, _, err := d.Api.ListDatastoreItems(d.Auth, datastoreID, *optionalParams)
 	if err != nil {
@@ -122,8 +123,8 @@ func (d *datastoreItemDataSource) Read(ctx context.Context, request datasource.R
 	}
 
 	// Check if item was found
-	items := resp.GetData()
-	if len(items) == 0 {
+	item := datastoreItemByKey(resp.GetData(), itemKey)
+	if item == nil {
 		response.Diagnostics.AddError(
 			"Item not found",
 			fmt.Sprintf("No item found with key '%s' in datastore '%s'", itemKey, datastoreID),
@@ -131,7 +132,7 @@ func (d *datastoreItemDataSource) Read(ctx context.Context, request datasource.R
 		return
 	}
 
-	d.updateState(ctx, &state, &items[0])
+	d.updateState(ctx, &state, item)
 
 	// Save data into Terraform state
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)

--- a/datadog/fwprovider/data_source_datadog_datastore_item.go
+++ b/datadog/fwprovider/data_source_datadog_datastore_item.go
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -71,7 +72,7 @@ func (d *datastoreItemDataSource) Schema(_ context.Context, _ datasource.SchemaR
 			"value": schema.MapAttribute{
 				Computed:    true,
 				ElementType: types.StringType,
-				Description: "The data content (as key-value pairs) of the datastore item.",
+				Description: "The data content (as key-value pairs) of the datastore item. A column of the datastore's JSON type is returned as a JSON string, so `jsondecode` can read it.",
 			},
 			"created_at": schema.StringAttribute{
 				Computed:    true,
@@ -132,13 +133,17 @@ func (d *datastoreItemDataSource) Read(ctx context.Context, request datasource.R
 		return
 	}
 
-	d.updateState(ctx, &state, item)
+	response.Diagnostics.Append(d.updateState(ctx, &state, item)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 
 	// Save data into Terraform state
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
-func (d *datastoreItemDataSource) updateState(ctx context.Context, state *datastoreItemDataSourceModel, resp *datadogV2.ItemApiPayloadData) {
+func (d *datastoreItemDataSource) updateState(ctx context.Context, state *datastoreItemDataSourceModel, resp *datadogV2.ItemApiPayloadData) diag.Diagnostics {
+	diags := diag.Diagnostics{}
 	datastoreID := state.DatastoreID.ValueString()
 	itemKey := state.ItemKey.ValueString()
 
@@ -170,13 +175,17 @@ func (d *datastoreItemDataSource) updateState(ctx context.Context, state *datast
 
 	// Convert value map to types.Map
 	if value, ok := attributes.GetValueOk(); ok && value != nil {
-		valueMap := make(map[string]string)
-		for k, v := range *value {
-			valueMap[k] = fmt.Sprintf("%v", v)
+		valueMap, err := datastoreItemValueToMap(*value)
+		if err != nil {
+			diags.AddError("error rendering datastore item value", err.Error())
+			return diags
 		}
-		mapValue, diags := types.MapValueFrom(ctx, types.StringType, valueMap)
-		if !diags.HasError() {
+		mapValue, mapDiags := types.MapValueFrom(ctx, types.StringType, valueMap)
+		diags.Append(mapDiags...)
+		if !mapDiags.HasError() {
 			state.Value = mapValue
 		}
 	}
+
+	return diags
 }

--- a/datadog/fwprovider/datastore_item.go
+++ b/datadog/fwprovider/datastore_item.go
@@ -1,6 +1,7 @@
 package fwprovider
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
@@ -23,4 +24,29 @@ func datastoreItemByKey(items []datadogV2.ItemApiPayloadData, key string) *datad
 		}
 	}
 	return nil
+}
+
+// datastoreItemValueToMap flattens an item's columns to strings, the element
+// type of the `value` attribute.
+//
+// A column of the datastore's JSON type arrives as a Go map or slice and is
+// rendered as JSON, so jsondecode() can read it. Scalars keep their fmt
+// rendering, and a string column is passed through unquoted.
+func datastoreItemValueToMap(value map[string]interface{}) (map[string]string, error) {
+	out := make(map[string]string, len(value))
+	for column, raw := range value {
+		switch typed := raw.(type) {
+		case string:
+			out[column] = typed
+		case map[string]interface{}, []interface{}:
+			encoded, err := json.Marshal(typed)
+			if err != nil {
+				return nil, fmt.Errorf("column %q: %w", column, err)
+			}
+			out[column] = string(encoded)
+		default:
+			out[column] = fmt.Sprintf("%v", typed)
+		}
+	}
+	return out, nil
 }

--- a/datadog/fwprovider/datastore_item.go
+++ b/datadog/fwprovider/datastore_item.go
@@ -1,0 +1,26 @@
+package fwprovider
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+// datastoreItemByKey returns the item whose primary key column equals key, or
+// nil when the listing holds no such item.
+//
+// The listing is filtered server-side, but nothing guarantees the response is a
+// single row, so the key is checked here as well.
+func datastoreItemByKey(items []datadogV2.ItemApiPayloadData, key string) *datadogV2.ItemApiPayloadData {
+	for i := range items {
+		attributes := items[i].GetAttributes()
+		column := attributes.GetPrimaryColumnName()
+		if column == "" {
+			continue
+		}
+		if value, ok := attributes.GetValue()[column]; ok && fmt.Sprintf("%v", value) == key {
+			return &items[i]
+		}
+	}
+	return nil
+}

--- a/datadog/fwprovider/datastore_item_test.go
+++ b/datadog/fwprovider/datastore_item_test.go
@@ -1,0 +1,54 @@
+package fwprovider
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func datastoreItem(primaryColumn string, value map[string]interface{}) datadogV2.ItemApiPayloadData {
+	attributes := datadogV2.NewItemApiPayloadDataAttributesWithDefaults()
+	attributes.SetPrimaryColumnName(primaryColumn)
+	attributes.SetValue(value)
+
+	item := datadogV2.NewItemApiPayloadDataWithDefaults()
+	item.SetAttributes(*attributes)
+	return *item
+}
+
+func TestDatastoreItemByKey(t *testing.T) {
+	items := []datadogV2.ItemApiPayloadData{
+		datastoreItem("product", map[string]interface{}{"product": "aaa"}),
+		datastoreItem("product", map[string]interface{}{"product": "apm"}),
+		datastoreItem("id", map[string]interface{}{"id": float64(42)}),
+	}
+
+	for _, tc := range []struct {
+		name string
+		key  string
+		want string
+	}{
+		{"first item", "aaa", "aaa"},
+		{"later item", "apm", "apm"},
+		{"non-string key", "42", "42"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			item := datastoreItemByKey(items, tc.key)
+			if item == nil {
+				t.Fatalf("no item for key %q", tc.key)
+			}
+			attributes := item.GetAttributes()
+			got := attributes.GetValue()[attributes.GetPrimaryColumnName()]
+			if got != tc.want && got != float64(42) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	if item := datastoreItemByKey(items, "missing"); item != nil {
+		t.Fatalf("got an item for a key that is not in the listing")
+	}
+	if item := datastoreItemByKey(nil, "aaa"); item != nil {
+		t.Fatalf("got an item from an empty listing")
+	}
+}

--- a/datadog/fwprovider/datastore_item_test.go
+++ b/datadog/fwprovider/datastore_item_test.go
@@ -52,3 +52,29 @@ func TestDatastoreItemByKey(t *testing.T) {
 		t.Fatalf("got an item from an empty listing")
 	}
 }
+
+func TestDatastoreItemValueToMap(t *testing.T) {
+	got, err := datastoreItemValueToMap(map[string]interface{}{
+		"product": "apm",
+		"object":  map[string]interface{}{"threshold": float64(10)},
+		"list":    []interface{}{"a", "b"},
+		"number":  float64(10),
+		"bool":    true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	want := map[string]string{
+		"product": "apm",
+		"object":  `{"threshold":10}`,
+		"list":    `["a","b"]`,
+		"number":  "10",
+		"bool":    "true",
+	}
+	for column, expected := range want {
+		if got[column] != expected {
+			t.Errorf("column %q: got %q, want %q", column, got[column], expected)
+		}
+	}
+}

--- a/datadog/fwprovider/resource_datadog_datastore_item.go
+++ b/datadog/fwprovider/resource_datadog_datastore_item.go
@@ -95,9 +95,11 @@ func (r *datastoreItemResource) Read(ctx context.Context, request resource.ReadR
 	datastoreID := state.DatastoreID.ValueString()
 	itemKey := state.ItemKey.ValueString()
 
-	// Use ListDatastoreItems with item_key query parameter to get specific item
-	optionalParams := datadogV2.NewListDatastoreItemsOptionalParameters()
-	optionalParams.ItemKey = &itemKey
+	// Filter with `filter`, not `ItemKey`: the client sends the latter as
+	// `item_key` while the API reads `itemKey`, so it is ignored and the
+	// response is the whole datastore. Without this, a deleted item is still
+	// found — as some other item — and the deletion is never detected.
+	optionalParams := datadogV2.NewListDatastoreItemsOptionalParameters().WithFilter(itemKey)
 
 	resp, httpResp, err := r.Api.ListDatastoreItems(r.Auth, datastoreID, *optionalParams)
 	if err != nil {
@@ -114,13 +116,13 @@ func (r *datastoreItemResource) Read(ctx context.Context, request resource.ReadR
 	}
 
 	// Check if item was found
-	items := resp.GetData()
-	if len(items) == 0 {
+	item := datastoreItemByKey(resp.GetData(), itemKey)
+	if item == nil {
 		response.State.RemoveResource(ctx)
 		return
 	}
 
-	r.updateState(ctx, &state, &items[0])
+	r.updateState(ctx, &state, item)
 
 	// Save data into Terraform state
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)

--- a/datadog/tests/resource_datadog_datastore_item_test.go
+++ b/datadog/tests/resource_datadog_datastore_item_test.go
@@ -84,9 +84,9 @@ func datastoreItemDestroyHelper(auth context.Context, s *terraform.State, apiIns
 		datastoreID := parts[0]
 		itemKey := parts[1]
 
-		// Try to read the item
-		optionalParams := datadogV2.NewListDatastoreItemsOptionalParameters()
-		optionalParams.ItemKey = &itemKey
+		// Try to read the item. `filter` is the parameter the API reads; ItemKey
+		// is sent as `item_key` and silently ignored, which returns every item.
+		optionalParams := datadogV2.NewListDatastoreItemsOptionalParameters().WithFilter(itemKey)
 
 		resp, httpResp, err := apiInstances.GetActionsDatastoresApiV2().ListDatastoreItems(auth, datastoreID, *optionalParams)
 		if err != nil {
@@ -133,9 +133,9 @@ func datastoreItemExistsHelper(auth context.Context, s *terraform.State, apiInst
 		datastoreID := parts[0]
 		itemKey := parts[1]
 
-		// Try to read the item
-		optionalParams := datadogV2.NewListDatastoreItemsOptionalParameters()
-		optionalParams.ItemKey = &itemKey
+		// Try to read the item. `filter` is the parameter the API reads; ItemKey
+		// is sent as `item_key` and silently ignored, which returns every item.
+		optionalParams := datadogV2.NewListDatastoreItemsOptionalParameters().WithFilter(itemKey)
 
 		resp, httpResp, err := apiInstances.GetActionsDatastoresApiV2().ListDatastoreItems(auth, datastoreID, *optionalParams)
 		if err != nil {

--- a/docs/data-sources/datastore_item.md
+++ b/docs/data-sources/datastore_item.md
@@ -28,4 +28,4 @@ Use this data source to retrieve information about an existing Datadog datastore
 - `org_id` (Number) The ID of the organization that owns this item.
 - `signature` (String) A unique signature identifying this item version.
 - `store_id` (String) The unique identifier of the datastore containing this item.
-- `value` (Map of String) The data content (as key-value pairs) of the datastore item.
+- `value` (Map of String) The data content (as key-value pairs) of the datastore item. A column of the datastore's JSON type is returned as a JSON string, so `jsondecode` can read it.


### PR DESCRIPTION
Two bugs in `datadog_datastore_item`. Each is independent and has its own commit.

### 1. The item listing was never filtered

The data source and the resource both filtered with `ItemKey`, which the generated client sends as the query parameter `item_key`. The API reads `itemKey` and ignores unknown parameters, so no filter was applied — the call returned the whole datastore and the code took `items[0]`.

Measured against a 30-item datastore:

```
GET .../items?itemKey=apm    ->  1 row  (apm)
GET .../items?item_key=apm   -> 30 rows (items[0] = aaa)
```

So the data source resolved every `item_key` to the first row in the store, with no error and a clean plan. The resource's `Read` never detected an out-of-band deletion, because some other item was always there to find.

Fixed by using `filter`, which the API reads and which matches on the primary key, and by selecting the item whose primary key column equals the requested key instead of trusting the position in the response.

### 2. A JSON column was unreadable

A column of the datastore's JSON type arrives as a Go map or slice. `updateState` rendered every column with `fmt "%v"`, so it reached Terraform as Go map syntax:

```
map[tags:[a b] threshold:10 window:map[seconds:300]]
```

No Terraform function can parse that — `jsondecode` fails with `invalid character 'm' looking for beginning of value` — so the only workaround was to store the column as a JSON string.

Fixed by rendering composite columns with `encoding/json`. Strings still pass through unquoted and scalars keep their `fmt` rendering, so no existing configuration changes.

### Test

`make test`: 337 pass, 0 fail. New unit tests cover key selection (including a non-string key and a key not in the listing) and column rendering.

Verified against the live API with a locally built provider, reading two real datastores:

```
a_apm_row_key           = "apm"      # was "aaa"
f_rum_row_key           = "rum"      # was "aaa"
d_nested_object_column  = "{\"tags\":[\"a\",\"b\"],\"threshold\":10,\"window\":{\"seconds\":300}}"
e_nested_object_decoded = 300        # jsondecode of that column, previously an error
```

`make docs` regenerated only the `value` description.
