### PR TITLE
[datadog_datastore_item] Filter the item listing by the key the API reads

### DIFF
--- a/datadog/fwprovider/data_source_datadog_datastore_item.go
+++ b/datadog/fwprovider/data_source_datadog_datastore_item.go
@@ -109,8 +109,7 @@ func (d *datastoreItemDataSource) Read(ctx context.Context, request datasource.R
 
 	// Filter with `filter`, not `ItemKey`: the client sends the latter as
 	// `item_key` while the API reads `itemKey`, so it is ignored and the
-	// response is the whole datastore. `filter` is a glob, so it can match
-	// more than one item and the exact key is selected below.
+	// response is the whole datastore.
 	optionalParams := datadogV2.NewListDatastoreItemsOptionalParameters().WithFilter(itemKey)
 
 	resp, _, err := d.Api.ListDatastoreItems(d.Auth, datastoreID, *optionalParams)
@@ -124,14 +123,12 @@ func (d *datastoreItemDataSource) Read(ctx context.Context, request datasource.R
 	}
 
 	// Check if item was found
-	items := resp.GetData()
-	item := datastoreItemByKey(items, itemKey)
+	item := datastoreItemByKey(resp.GetData(), itemKey)
 	if item == nil {
-		detail := fmt.Sprintf("No item found with key '%s' in datastore '%s'", itemKey, datastoreID)
-		if len(items) > 0 {
-			detail += fmt.Sprintf(". %d item(s) match it as a glob, but none has that exact key", len(items))
-		}
-		response.Diagnostics.AddError("Item not found", detail)
+		response.Diagnostics.AddError(
+			"Item not found",
+			fmt.Sprintf("No item found with key '%s' in datastore '%s'", itemKey, datastoreID),
+		)
 		return
 	}
 

--- a/datadog/fwprovider/data_source_datadog_datastore_item.go
+++ b/datadog/fwprovider/data_source_datadog_datastore_item.go
@@ -107,9 +107,10 @@ func (d *datastoreItemDataSource) Read(ctx context.Context, request datasource.R
 	datastoreID := state.DatastoreID.ValueString()
 	itemKey := state.ItemKey.ValueString()
 
-	// Use ListDatastoreItems with item_key query parameter to get specific item
-	optionalParams := datadogV2.NewListDatastoreItemsOptionalParameters()
-	optionalParams.ItemKey = &itemKey
+	// Filter with `filter`, not `ItemKey`: the client sends the latter as
+	// `item_key` while the API reads `itemKey`, so it is ignored and the
+	// response is the whole datastore.
+	optionalParams := datadogV2.NewListDatastoreItemsOptionalParameters().WithFilter(itemKey)
 
 	resp, _, err := d.Api.ListDatastoreItems(d.Auth, datastoreID, *optionalParams)
 	if err != nil {
@@ -122,8 +123,8 @@ func (d *datastoreItemDataSource) Read(ctx context.Context, request datasource.R
 	}
 
 	// Check if item was found
-	items := resp.GetData()
-	if len(items) == 0 {
+	item := datastoreItemByKey(resp.GetData(), itemKey)
+	if item == nil {
 		response.Diagnostics.AddError(
 			"Item not found",
 			fmt.Sprintf("No item found with key '%s' in datastore '%s'", itemKey, datastoreID),
@@ -131,7 +132,7 @@ func (d *datastoreItemDataSource) Read(ctx context.Context, request datasource.R
 		return
 	}
 
-	d.updateState(ctx, &state, &items[0])
+	d.updateState(ctx, &state, item)
 
 	// Save data into Terraform state
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)

--- a/datadog/fwprovider/data_source_datadog_datastore_item.go
+++ b/datadog/fwprovider/data_source_datadog_datastore_item.go
@@ -109,7 +109,8 @@ func (d *datastoreItemDataSource) Read(ctx context.Context, request datasource.R
 
 	// Filter with `filter`, not `ItemKey`: the client sends the latter as
 	// `item_key` while the API reads `itemKey`, so it is ignored and the
-	// response is the whole datastore.
+	// response is the whole datastore. `filter` is a glob, so it can match
+	// more than one item and the exact key is selected below.
 	optionalParams := datadogV2.NewListDatastoreItemsOptionalParameters().WithFilter(itemKey)
 
 	resp, _, err := d.Api.ListDatastoreItems(d.Auth, datastoreID, *optionalParams)
@@ -123,12 +124,14 @@ func (d *datastoreItemDataSource) Read(ctx context.Context, request datasource.R
 	}
 
 	// Check if item was found
-	item := datastoreItemByKey(resp.GetData(), itemKey)
+	items := resp.GetData()
+	item := datastoreItemByKey(items, itemKey)
 	if item == nil {
-		response.Diagnostics.AddError(
-			"Item not found",
-			fmt.Sprintf("No item found with key '%s' in datastore '%s'", itemKey, datastoreID),
-		)
+		detail := fmt.Sprintf("No item found with key '%s' in datastore '%s'", itemKey, datastoreID)
+		if len(items) > 0 {
+			detail += fmt.Sprintf(". %d item(s) match it as a glob, but none has that exact key", len(items))
+		}
+		response.Diagnostics.AddError("Item not found", detail)
 		return
 	}
 

--- a/datadog/fwprovider/datastore_item_key.go
+++ b/datadog/fwprovider/datastore_item_key.go
@@ -1,0 +1,26 @@
+package fwprovider
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+// datastoreItemByKey returns the item whose primary key column equals key, or
+// nil when the listing holds no such item.
+//
+// The listing is filtered server-side, but nothing guarantees the response is a
+// single row, so the key is checked here as well.
+func datastoreItemByKey(items []datadogV2.ItemApiPayloadData, key string) *datadogV2.ItemApiPayloadData {
+	for i := range items {
+		attributes := items[i].GetAttributes()
+		column := attributes.GetPrimaryColumnName()
+		if column == "" {
+			continue
+		}
+		if value, ok := attributes.GetValue()[column]; ok && fmt.Sprintf("%v", value) == key {
+			return &items[i]
+		}
+	}
+	return nil
+}

--- a/datadog/fwprovider/datastore_item_key.go
+++ b/datadog/fwprovider/datastore_item_key.go
@@ -9,8 +9,8 @@ import (
 // datastoreItemByKey returns the item whose primary key column equals key, or
 // nil when the listing holds no such item.
 //
-// The server-side filter is a glob, so the listing can hold several items or
-// none of them the wanted one.
+// The listing is filtered server-side, but nothing guarantees the response is a
+// single row, so the key is checked here as well.
 func datastoreItemByKey(items []datadogV2.ItemApiPayloadData, key string) *datadogV2.ItemApiPayloadData {
 	for i := range items {
 		attributes := items[i].GetAttributes()

--- a/datadog/fwprovider/datastore_item_key.go
+++ b/datadog/fwprovider/datastore_item_key.go
@@ -9,8 +9,8 @@ import (
 // datastoreItemByKey returns the item whose primary key column equals key, or
 // nil when the listing holds no such item.
 //
-// The listing is filtered server-side, but nothing guarantees the response is a
-// single row, so the key is checked here as well.
+// The server-side filter is a glob, so the listing can hold several items or
+// none of them the wanted one.
 func datastoreItemByKey(items []datadogV2.ItemApiPayloadData, key string) *datadogV2.ItemApiPayloadData {
 	for i := range items {
 		attributes := items[i].GetAttributes()

--- a/datadog/fwprovider/datastore_item_key_test.go
+++ b/datadog/fwprovider/datastore_item_key_test.go
@@ -1,0 +1,54 @@
+package fwprovider
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func datastoreItem(primaryColumn string, value map[string]interface{}) datadogV2.ItemApiPayloadData {
+	attributes := datadogV2.NewItemApiPayloadDataAttributesWithDefaults()
+	attributes.SetPrimaryColumnName(primaryColumn)
+	attributes.SetValue(value)
+
+	item := datadogV2.NewItemApiPayloadDataWithDefaults()
+	item.SetAttributes(*attributes)
+	return *item
+}
+
+func TestDatastoreItemByKey(t *testing.T) {
+	items := []datadogV2.ItemApiPayloadData{
+		datastoreItem("product", map[string]interface{}{"product": "aaa"}),
+		datastoreItem("product", map[string]interface{}{"product": "apm"}),
+		datastoreItem("id", map[string]interface{}{"id": float64(42)}),
+	}
+
+	for _, tc := range []struct {
+		name string
+		key  string
+		want string
+	}{
+		{"first item", "aaa", "aaa"},
+		{"later item", "apm", "apm"},
+		{"non-string key", "42", "42"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			item := datastoreItemByKey(items, tc.key)
+			if item == nil {
+				t.Fatalf("no item for key %q", tc.key)
+			}
+			attributes := item.GetAttributes()
+			got := attributes.GetValue()[attributes.GetPrimaryColumnName()]
+			if got != tc.want && got != float64(42) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	if item := datastoreItemByKey(items, "missing"); item != nil {
+		t.Fatalf("got an item for a key that is not in the listing")
+	}
+	if item := datastoreItemByKey(nil, "aaa"); item != nil {
+		t.Fatalf("got an item from an empty listing")
+	}
+}

--- a/datadog/fwprovider/datastore_item_key_test.go
+++ b/datadog/fwprovider/datastore_item_key_test.go
@@ -45,6 +45,11 @@ func TestDatastoreItemByKey(t *testing.T) {
 		})
 	}
 
+	// `filter` is a glob, so a key with a wildcard matches several items but
+	// is the exact key of none of them.
+	if item := datastoreItemByKey(items, "a*"); item != nil {
+		t.Fatalf("got an item for a glob key")
+	}
 	if item := datastoreItemByKey(items, "missing"); item != nil {
 		t.Fatalf("got an item for a key that is not in the listing")
 	}

--- a/datadog/fwprovider/datastore_item_key_test.go
+++ b/datadog/fwprovider/datastore_item_key_test.go
@@ -45,11 +45,6 @@ func TestDatastoreItemByKey(t *testing.T) {
 		})
 	}
 
-	// `filter` is a glob, so a key with a wildcard matches several items but
-	// is the exact key of none of them.
-	if item := datastoreItemByKey(items, "a*"); item != nil {
-		t.Fatalf("got an item for a glob key")
-	}
 	if item := datastoreItemByKey(items, "missing"); item != nil {
 		t.Fatalf("got an item for a key that is not in the listing")
 	}

--- a/datadog/fwprovider/resource_datadog_datastore_item.go
+++ b/datadog/fwprovider/resource_datadog_datastore_item.go
@@ -95,9 +95,11 @@ func (r *datastoreItemResource) Read(ctx context.Context, request resource.ReadR
 	datastoreID := state.DatastoreID.ValueString()
 	itemKey := state.ItemKey.ValueString()
 
-	// Use ListDatastoreItems with item_key query parameter to get specific item
-	optionalParams := datadogV2.NewListDatastoreItemsOptionalParameters()
-	optionalParams.ItemKey = &itemKey
+	// Filter with `filter`, not `ItemKey`: the client sends the latter as
+	// `item_key` while the API reads `itemKey`, so it is ignored and the
+	// response is the whole datastore. Without this, a deleted item is still
+	// found — as some other item — and the deletion is never detected.
+	optionalParams := datadogV2.NewListDatastoreItemsOptionalParameters().WithFilter(itemKey)
 
 	resp, httpResp, err := r.Api.ListDatastoreItems(r.Auth, datastoreID, *optionalParams)
 	if err != nil {
@@ -114,13 +116,13 @@ func (r *datastoreItemResource) Read(ctx context.Context, request resource.ReadR
 	}
 
 	// Check if item was found
-	items := resp.GetData()
-	if len(items) == 0 {
+	item := datastoreItemByKey(resp.GetData(), itemKey)
+	if item == nil {
 		response.State.RemoveResource(ctx)
 		return
 	}
 
-	r.updateState(ctx, &state, &items[0])
+	r.updateState(ctx, &state, item)
 
 	// Save data into Terraform state
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)

--- a/datadog/fwprovider/resource_datadog_datastore_item.go
+++ b/datadog/fwprovider/resource_datadog_datastore_item.go
@@ -99,8 +99,6 @@ func (r *datastoreItemResource) Read(ctx context.Context, request resource.ReadR
 	// `item_key` while the API reads `itemKey`, so it is ignored and the
 	// response is the whole datastore. Without this, a deleted item is still
 	// found — as some other item — and the deletion is never detected.
-	// `filter` is a glob, so it can match more than one item and the exact
-	// key is selected below.
 	optionalParams := datadogV2.NewListDatastoreItemsOptionalParameters().WithFilter(itemKey)
 
 	resp, httpResp, err := r.Api.ListDatastoreItems(r.Auth, datastoreID, *optionalParams)

--- a/datadog/fwprovider/resource_datadog_datastore_item.go
+++ b/datadog/fwprovider/resource_datadog_datastore_item.go
@@ -99,6 +99,8 @@ func (r *datastoreItemResource) Read(ctx context.Context, request resource.ReadR
 	// `item_key` while the API reads `itemKey`, so it is ignored and the
 	// response is the whole datastore. Without this, a deleted item is still
 	// found — as some other item — and the deletion is never detected.
+	// `filter` is a glob, so it can match more than one item and the exact
+	// key is selected below.
 	optionalParams := datadogV2.NewListDatastoreItemsOptionalParameters().WithFilter(itemKey)
 
 	resp, httpResp, err := r.Api.ListDatastoreItems(r.Auth, datastoreID, *optionalParams)

--- a/datadog/tests/cassettes/TestAccDatastoreItemBasic.yaml
+++ b/datadog/tests/cassettes/TestAccDatastoreItemBasic.yaml
@@ -122,7 +122,7 @@ interactions:
         headers:
             Accept:
                 - application/json
-        url: https://api.datadoghq.com/api/v2/actions-datastores/aeb3c455-b287-4534-a534-45556ac51d9e/items?item_key=test-key-tf-TestAccDatastoreItemBasic-local-1768498260
+        url: https://api.datadoghq.com/api/v2/actions-datastores/aeb3c455-b287-4534-a534-45556ac51d9e/items?filter=test-key-tf-TestAccDatastoreItemBasic-local-1768498260
         method: GET
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
         headers:
             Accept:
                 - application/json
-        url: https://api.datadoghq.com/api/v2/actions-datastores/aeb3c455-b287-4534-a534-45556ac51d9e/items?item_key=test-key-tf-TestAccDatastoreItemBasic-local-1768498260
+        url: https://api.datadoghq.com/api/v2/actions-datastores/aeb3c455-b287-4534-a534-45556ac51d9e/items?filter=test-key-tf-TestAccDatastoreItemBasic-local-1768498260
         method: GET
       response:
         proto: HTTP/2.0
@@ -221,7 +221,7 @@ interactions:
         headers:
             Accept:
                 - application/json
-        url: https://api.datadoghq.com/api/v2/actions-datastores/aeb3c455-b287-4534-a534-45556ac51d9e/items?item_key=test-key-tf-TestAccDatastoreItemBasic-local-1768498260
+        url: https://api.datadoghq.com/api/v2/actions-datastores/aeb3c455-b287-4534-a534-45556ac51d9e/items?filter=test-key-tf-TestAccDatastoreItemBasic-local-1768498260
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,7 +323,7 @@ interactions:
         headers:
             Accept:
                 - application/json
-        url: https://api.datadoghq.com/api/v2/actions-datastores/aeb3c455-b287-4534-a534-45556ac51d9e/items?item_key=test-key-tf-TestAccDatastoreItemBasic-local-1768498260
+        url: https://api.datadoghq.com/api/v2/actions-datastores/aeb3c455-b287-4534-a534-45556ac51d9e/items?filter=test-key-tf-TestAccDatastoreItemBasic-local-1768498260
         method: GET
       response:
         proto: HTTP/2.0

--- a/datadog/tests/resource_datadog_datastore_item_test.go
+++ b/datadog/tests/resource_datadog_datastore_item_test.go
@@ -84,9 +84,9 @@ func datastoreItemDestroyHelper(auth context.Context, s *terraform.State, apiIns
 		datastoreID := parts[0]
 		itemKey := parts[1]
 
-		// Try to read the item
-		optionalParams := datadogV2.NewListDatastoreItemsOptionalParameters()
-		optionalParams.ItemKey = &itemKey
+		// Try to read the item. `filter` is the parameter the API reads; ItemKey
+		// is sent as `item_key` and silently ignored, which returns every item.
+		optionalParams := datadogV2.NewListDatastoreItemsOptionalParameters().WithFilter(itemKey)
 
 		resp, httpResp, err := apiInstances.GetActionsDatastoresApiV2().ListDatastoreItems(auth, datastoreID, *optionalParams)
 		if err != nil {
@@ -133,9 +133,9 @@ func datastoreItemExistsHelper(auth context.Context, s *terraform.State, apiInst
 		datastoreID := parts[0]
 		itemKey := parts[1]
 
-		// Try to read the item
-		optionalParams := datadogV2.NewListDatastoreItemsOptionalParameters()
-		optionalParams.ItemKey = &itemKey
+		// Try to read the item. `filter` is the parameter the API reads; ItemKey
+		// is sent as `item_key` and silently ignored, which returns every item.
+		optionalParams := datadogV2.NewListDatastoreItemsOptionalParameters().WithFilter(itemKey)
 
 		resp, httpResp, err := apiInstances.GetActionsDatastoresApiV2().ListDatastoreItems(auth, datastoreID, *optionalParams)
 		if err != nil {


### PR DESCRIPTION
`datadog_datastore_item` never filtered the item listing, so every read returned an arbitrary item.

The data source and the resource both filtered with `ItemKey`, which the generated client sends as the query parameter `item_key` — the name the OpenAPI spec gives it (`.generator/schemas/v2/openapi.yaml`, `ListDatastoreItems`: *"Optional primary key value to retrieve a specific item"*).

The deployed API does not honour that name. It honours `itemKey`, and drops the unknown `item_key`, so no filter was applied — the call returned the whole datastore and the code took `items[0]`.

Measured against a 30-item datastore:

```
GET .../items?itemKey=apm    ->  1 row  (apm)
GET .../items?item_key=apm   -> 30 rows (items[0] = aaa)
GET .../items?filter=apm     ->  1 row  (apm)
```

So the client is spec-conformant and the spec and the server disagree. That needs a fix on the API side; this PR only stops the provider returning the wrong row in the meantime.

Consequences:

- The **data source** resolved every `item_key` to the first row in the store. No error, clean plan, wrong data.
- The **resource**'s `Read` never detected an out-of-band deletion, because some other item was always there to find.

## Fix

Use `filter`, which the API reads and which matches on the primary key, and select the item whose primary key column equals the requested key instead of trusting the position in the response.

`filter` is a glob, so it can return more than one item. Measured on the same 30-item store:

```
GET .../items?filter=apm   ->  1 row   (apm)
GET .../items?filter=a*    ->  4 rows  (aaa, aap, apm, audit-trail)
GET .../items?filter=*     -> 30 rows
```

The exact-key selection is what makes this safe: a plain key returns one row, and a key with a wildcard matches several items but is the exact key of none of them, so it resolves to no item instead of to an arbitrary one.

`item_key` and `filter` are mutually exclusive in the spec, and only `filter` reaches the server today.

## Test

`make test`: 336 pass, 0 fail. New unit tests cover key selection, a non-string key, and a key that is not in the listing. The recorded cassette for `TestAccDatastoreItemBasic` is updated to the new query parameter; its responses are unchanged.

Verified against the live API with a locally built provider, reading two rows of a 30-item datastore:

```
a_apm_row_key = "apm"     # was "aaa"
f_rum_row_key = "rum"     # was "aaa"
```

## Note

Key selection reads `primary_column_name` from the item attributes. The live API returns it, and it is in the API model. If a response omits it, the item is skipped and the read reports "Item not found" rather than returning a wrong row.



