### PR TITLE
[datadog_datastore_item] Return JSON columns as JSON, not Go map syntax

### DIFF
--- a/datadog/fwprovider/data_source_datadog_datastore_item.go
+++ b/datadog/fwprovider/data_source_datadog_datastore_item.go
@@ -71,7 +71,7 @@ func (d *datastoreItemDataSource) Schema(_ context.Context, _ datasource.SchemaR
 			"value": schema.MapAttribute{
 				Computed:    true,
 				ElementType: types.StringType,
-				Description: "The data content (as key-value pairs) of the datastore item.",
+				Description: "The data content (as key-value pairs) of the datastore item. A column of the datastore's JSON type is returned as a JSON string, so `jsondecode` can read it.",
 			},
 			"created_at": schema.StringAttribute{
 				Computed:    true,
@@ -169,10 +169,7 @@ func (d *datastoreItemDataSource) updateState(ctx context.Context, state *datast
 
 	// Convert value map to types.Map
 	if value, ok := attributes.GetValueOk(); ok && value != nil {
-		valueMap := make(map[string]string)
-		for k, v := range *value {
-			valueMap[k] = fmt.Sprintf("%v", v)
-		}
+		valueMap := datastoreItemValueToMap(*value)
 		mapValue, diags := types.MapValueFrom(ctx, types.StringType, valueMap)
 		if !diags.HasError() {
 			state.Value = mapValue

--- a/datadog/fwprovider/datastore_item_value.go
+++ b/datadog/fwprovider/datastore_item_value.go
@@ -1,0 +1,32 @@
+package fwprovider
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// datastoreItemValueToMap flattens an item's columns to strings, the element
+// type of the `value` attribute.
+//
+// A column of the datastore's JSON type arrives as a Go map or slice and is
+// rendered as JSON, so jsondecode() can read it. Scalars keep their fmt
+// rendering, and a string column is passed through unquoted.
+func datastoreItemValueToMap(value map[string]interface{}) map[string]string {
+	out := make(map[string]string, len(value))
+	for column, raw := range value {
+		switch typed := raw.(type) {
+		case string:
+			out[column] = typed
+		case map[string]interface{}, []interface{}:
+			// The value was decoded from the API's JSON, so it encodes back.
+			if encoded, err := json.Marshal(typed); err == nil {
+				out[column] = string(encoded)
+				continue
+			}
+			out[column] = fmt.Sprintf("%v", typed)
+		default:
+			out[column] = fmt.Sprintf("%v", typed)
+		}
+	}
+	return out
+}

--- a/datadog/fwprovider/datastore_item_value.go
+++ b/datadog/fwprovider/datastore_item_value.go
@@ -3,6 +3,7 @@ package fwprovider
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 )
 
 // datastoreItemValueToMap flattens an item's columns to strings, the element
@@ -19,11 +20,13 @@ func datastoreItemValueToMap(value map[string]interface{}) map[string]string {
 			out[column] = typed
 		case map[string]interface{}, []interface{}:
 			// The value was decoded from the API's JSON, so it encodes back.
-			if encoded, err := json.Marshal(typed); err == nil {
-				out[column] = string(encoded)
-				continue
+			encoded, err := json.Marshal(typed)
+			if err != nil {
+				log.Printf("[WARN] datadog_datastore_item: column %q is not encodable to JSON (%v); returning its Go rendering", column, err)
+				out[column] = fmt.Sprintf("%v", typed)
+				break
 			}
-			out[column] = fmt.Sprintf("%v", typed)
+			out[column] = string(encoded)
 		default:
 			out[column] = fmt.Sprintf("%v", typed)
 		}

--- a/datadog/fwprovider/datastore_item_value_test.go
+++ b/datadog/fwprovider/datastore_item_value_test.go
@@ -1,0 +1,28 @@
+package fwprovider
+
+import (
+	"testing"
+)
+
+func TestDatastoreItemValueToMap(t *testing.T) {
+	got := datastoreItemValueToMap(map[string]interface{}{
+		"product": "apm",
+		"object":  map[string]interface{}{"threshold": float64(10)},
+		"list":    []interface{}{"a", "b"},
+		"number":  float64(10),
+		"bool":    true,
+	})
+
+	want := map[string]string{
+		"product": "apm",
+		"object":  `{"threshold":10}`,
+		"list":    `["a","b"]`,
+		"number":  "10",
+		"bool":    "true",
+	}
+	for column, expected := range want {
+		if got[column] != expected {
+			t.Errorf("column %q: got %q, want %q", column, got[column], expected)
+		}
+	}
+}

--- a/docs/data-sources/datastore_item.md
+++ b/docs/data-sources/datastore_item.md
@@ -28,4 +28,4 @@ Use this data source to retrieve information about an existing Datadog datastore
 - `org_id` (Number) The ID of the organization that owns this item.
 - `signature` (String) A unique signature identifying this item version.
 - `store_id` (String) The unique identifier of the datastore containing this item.
-- `value` (Map of String) The data content (as key-value pairs) of the datastore item.
+- `value` (Map of String) The data content (as key-value pairs) of the datastore item. A column of the datastore's JSON type is returned as a JSON string, so `jsondecode` can read it.


### PR DESCRIPTION
A `datadog_datastore_item` column of the datastore's JSON type is unreadable in Terraform.

Such a column arrives from the API as a Go map or slice. The data source rendered every column with `fmt "%v"`, so it reached Terraform as Go map syntax:

```
map[tags:[a b] threshold:10 window:map[seconds:300]]
```

No Terraform function can parse that. `jsondecode` fails with `invalid character 'm' looking for beginning of value`, so the only workaround is to store the column as a JSON string instead of using the datastore's JSON type.

## Fix

Render composite columns with `encoding/json`. Strings still pass through unquoted and scalars keep their `fmt` rendering, so no existing configuration changes.

## Test

`make test`: 333 pass, 0 fail. A new unit test covers an object column, a list column, a string, a number, and a boolean.

Verified against the live API with a locally built provider, reading a datastore whose `nested` column is a JSON object:

```
# before
d_nested_object_column  = "map[tags:[a b] threshold:10 window:map[seconds:300]]"

# after
d_nested_object_column  = "{\"tags\":[\"a\",\"b\"],\"threshold\":10,\"window\":{\"seconds\":300}}"
e_nested_object_decoded = 300     # jsondecode(...).window.seconds, previously an error
```

`make docs` regenerated only the `value` description.
