### PR TITLE
[TF Generator] (v2) Resolve the resource CRUD lifecycle

### DIFF
--- a/.generator-v2/internal/model/artifact.go
+++ b/.generator-v2/internal/model/artifact.go
@@ -6,16 +6,18 @@ import (
 	"unicode"
 )
 
-// BuildArtifact wraps a tracked Operation's response tree into an *Artifact and
-// resolves its SDK call bindings. It sets Name/Kind/SourceFile/Schema and the
-// data-source SDK calls (Lifecycle.Read for by-id, Lifecycle.Search for the list
-// call) plus Lifecycle.IdStrategy. The request side (Create/Update/Delete,
-// GoRequestType) stays empty.
+// BuildArtifact wraps a tracked Operation into an *Artifact and resolves its SDK
+// call bindings. It sets Name/Kind/SourceFile plus Lifecycle.IdStrategy, and the
+// SDK calls its kind implies.
 //
 // A singular data source resolves its one record three ways, selected by which
 // group operations are declared: read only (by-id, the original behavior),
 // search only (find one in a list), or both (by-id when an id is given, else
-// search). Plural is unchanged.
+// search). Plural is unchanged. Each sets Schema from the response tree.
+//
+// A resource instead resolves the full CRUD set (Create/Read/Update/Delete, with
+// GoRequestType on the two that send a body) and leaves Schema nil until the
+// request/response merge lands — see buildResourceArtifact.
 func BuildArtifact(op *Operation) (*Artifact, error) {
 	if op == nil || op.Tracking == nil {
 		return nil, fmt.Errorf("model: BuildArtifact requires a tracked operation")
@@ -33,8 +35,13 @@ func BuildArtifact(op *Operation) (*Artifact, error) {
 	return artifact, nil
 }
 
-// buildArtifact selects the builder for op's cardinality and lookup shape.
+// buildArtifact selects the builder for op's kind, cardinality and lookup shape.
+// Kind is tested first: cardinality describes how a data source resolves its
+// records and says nothing about a resource, which always maps to exactly one.
 func buildArtifact(op *Operation) (*Artifact, error) {
+	if op.Tracking.ArtifactKind == ArtifactKindResource {
+		return buildResourceArtifact(op)
+	}
 	if op.Tracking.Cardinality == CardinalityPlural {
 		return buildPluralArtifact(op)
 	}
@@ -53,6 +60,40 @@ func buildArtifact(op *Operation) (*Artifact, error) {
 	}
 }
 
+// buildResourceArtifact builds a full-CRUD resource from the tracking group (see
+// buildResourceLifecycle).
+//
+// Schema is deliberately left nil. A resource's tree is the union of the Create
+// request, Update request and Read response bodies (FR-034/FR-034b), which
+// T120-T124 build; there is no correct single-body tree to put here in the
+// meantime, and populating one from the response alone would mark every
+// attribute Computed and read as a working resource. The CLI still skips
+// kind=resource, so nothing consumes this artifact yet.
+func buildResourceArtifact(op *Operation) (*Artifact, error) {
+	// Create and Read are load-bearing for the schema, not the lifecycle: without
+	// Create nothing is ever Required and the whole schema silently becomes
+	// Optional, without Read nothing is ever Computed and refresh can never
+	// reconcile state (FR-034b). Delete is load-bearing for the lifecycle, since
+	// Terraform must be able to destroy what it created. Two of the three are
+	// therefore preconditions of the merge T124 will add here, so the guard runs
+	// before any sub-builder rather than inside one of them.
+	if err := requireResolvedRoles(op, GroupRoleCreate, GroupRoleRead, GroupRoleDelete); err != nil {
+		return nil, err
+	}
+	lifecycle, diags, err := buildResourceLifecycle(op)
+	if err != nil {
+		return nil, err
+	}
+	return &Artifact{
+		Name:        op.Tracking.ArtifactName,
+		Kind:        ArtifactKindResource,
+		Description: op.Tracking.TfDescription,
+		SourceFile:  sourceFileFor(ArtifactKindResource, op.Tracking.ArtifactName),
+		Lifecycle:   lifecycle,
+		Diagnostics: diags,
+	}, nil
+}
+
 // buildSingularByIdArtifact resolves the one record by direct id lookup: its
 // Schema is the by-id response tree and Lifecycle.Read the get-by-id call.
 func buildSingularByIdArtifact(op *Operation) (*Artifact, error) {
@@ -60,7 +101,7 @@ func buildSingularByIdArtifact(op *Operation) (*Artifact, error) {
 	if err != nil {
 		return nil, err
 	}
-	read := readCall(op, true)
+	read := sdkCall(op, true)
 	inputs, err := buildRequiredInputLeaves(read.Arguments)
 	if err != nil {
 		return nil, err
@@ -72,7 +113,7 @@ func buildSingularByIdArtifact(op *Operation) (*Artifact, error) {
 		Cardinality: CardinalitySingular,
 		Description: op.Tracking.TfDescription,
 		Schema:      schema,
-		SourceFile:  sourceFileFor(op.Tracking.ArtifactName),
+		SourceFile:  sourceFileFor(op.Tracking.ArtifactKind, op.Tracking.ArtifactName),
 		Lifecycle: &LifecycleBindings{
 			Read:       read,
 			IdStrategy: op.Tracking.IdStrategy,
@@ -108,7 +149,7 @@ func buildSingularSearchArtifact(op *Operation) (*Artifact, error) {
 		Cardinality: CardinalitySingular,
 		Description: op.Tracking.TfDescription,
 		Schema:      &AttributeTree{Attributes: append(append(inputs, filters...), record.Attributes...)},
-		SourceFile:  sourceFileFor(op.Tracking.ArtifactName),
+		SourceFile:  sourceFileFor(op.Tracking.ArtifactKind, op.Tracking.ArtifactName),
 		Lifecycle: &LifecycleBindings{
 			Search:     search,
 			IdStrategy: op.Tracking.IdStrategy,
@@ -122,11 +163,10 @@ func buildSingularSearchArtifact(op *Operation) (*Artifact, error) {
 // same element shape the search returns); the search side adds Optional filters
 // from the list op's query parameters and the list call, alongside the by-id Read.
 func buildSingularBothArtifact(op *Operation) (*Artifact, error) {
-	searchOp := op.ResolvedGroup.Op(GroupRoleSearch)
-	if searchOp == nil {
-		return nil, fmt.Errorf("model: data source %q declares group.search %q but no such operation exists",
-			op.Tracking.ArtifactName, op.Tracking.Group.Search)
+	if err := requireResolvedRoles(op, GroupRoleSearch); err != nil {
+		return nil, err
 	}
+	searchOp := op.ResolvedGroup.Op(GroupRoleSearch)
 
 	// One state mapper serves both lookups only when the by-id record and the
 	// list element are the same shape. Stay "both" only when both $ref names are
@@ -153,7 +193,7 @@ func buildSingularBothArtifact(op *Operation) (*Artifact, error) {
 	if err != nil {
 		return nil, err
 	}
-	read := readCall(op, true)
+	read := sdkCall(op, true)
 	search := listCall(searchOp)
 	inputs, err := mergeRequiredInputLeaves(read.Arguments, search.Arguments)
 	if err != nil {
@@ -167,7 +207,7 @@ func buildSingularBothArtifact(op *Operation) (*Artifact, error) {
 		Cardinality: CardinalitySingular,
 		Description: op.Tracking.TfDescription,
 		Schema:      &AttributeTree{Attributes: append(append(inputs, filters...), record.Attributes...)},
-		SourceFile:  sourceFileFor(op.Tracking.ArtifactName),
+		SourceFile:  sourceFileFor(op.Tracking.ArtifactKind, op.Tracking.ArtifactName),
 		Lifecycle: &LifecycleBindings{
 			Read:       read,
 			Search:     search,
@@ -182,10 +222,8 @@ func buildSingularBothArtifact(op *Operation) (*Artifact, error) {
 // silently.
 //
 // It reports rather than fails, because whether a dangling reference is fatal
-// depends on the role: a builder that cannot proceed without one fails the
-// artifact itself with a message naming the role (buildSingularBothArtifact
-// does exactly that for a dangling group.search, and the resource lifecycle
-// builder will for the CRUD roles), and those returns never reach here. What is
+// depends on the shape: a shape that cannot proceed without a role rejects it up
+// front via requireResolvedRoles, and those returns never reach here. What is
 // left for this to surface is the remainder — a reference to a role this
 // artifact shape does not consume, which would otherwise vanish unnoticed.
 func unresolvedGroupDiagnostics(op *Operation) []Diagnostic {
@@ -203,9 +241,15 @@ func unresolvedGroupDiagnostics(op *Operation) []Diagnostic {
 	return diags
 }
 
-// sourceFileFor is the output path for a data-source artifact name.
-func sourceFileFor(name string) string {
-	return "datadog/fwprovider/data_source_datadog_" + name + ".go"
+// sourceFileFor is the output path for an artifact, keyed on kind so the two
+// prefixes stay in one place. Note the CLI overwrites SourceFile with a path
+// under --output-root, so the directory here is a default rather than a promise.
+func sourceFileFor(kind ArtifactKind, name string) string {
+	prefix := "data_source_datadog_"
+	if kind == ArtifactKindResource {
+		prefix = "resource_datadog_"
+	}
+	return "datadog/fwprovider/" + prefix + name + ".go"
 }
 
 // singularEnvelope wraps a list element schema in a one-property {data: element}
@@ -265,7 +309,7 @@ func buildPluralArtifact(op *Operation) (*Artifact, error) {
 		Cardinality: CardinalityPlural,
 		Description: op.Tracking.TfDescription,
 		Schema:      &AttributeTree{Attributes: attrs},
-		SourceFile:  "datadog/fwprovider/data_source_datadog_" + name + ".go",
+		SourceFile:  sourceFileFor(ArtifactKindDataSource, name),
 		Lifecycle: &LifecycleBindings{
 			Read:       read,
 			IdStrategy: op.Tracking.IdStrategy,
@@ -319,8 +363,10 @@ func SDKPackageForPath(path string) string {
 	return "datadog" + strings.ToUpper(versionSegment(path))
 }
 
-// readCall resolves the datadog-api-client-go binding for op's read.
-func readCall(op *Operation, aliasTerminalID bool) *SDKCall {
+// sdkCall resolves the datadog-api-client-go binding shared by every call shape:
+// package, API struct, method, response type and bound arguments. aliasTerminalID
+// renames a trailing path-id argument to "id".
+func sdkCall(op *Operation, aliasTerminalID bool) *SDKCall {
 	call := &SDKCall{
 		GoPackage:      SDKPackageForPath(op.Path),
 		GoApiStruct:    tagToClassName(op.Tag) + "Api",
@@ -337,7 +383,7 @@ func readCall(op *Operation, aliasTerminalID bool) *SDKCall {
 // params are query parameters), and the pagination flag. Shared by the plural
 // path and the singular search path.
 func listCall(op *Operation) *SDKCall {
-	c := readCall(op, false)
+	c := sdkCall(op, false)
 	c.ItemType = op.ItemRefName
 	c.Paginated = op.Pagination != nil
 	if op.SDKBinding == nil && len(op.QueryParams) > 0 {

--- a/.generator-v2/internal/model/lifecycle.go
+++ b/.generator-v2/internal/model/lifecycle.go
@@ -1,0 +1,107 @@
+package model
+
+import "fmt"
+
+// MissingRoleError reports an artifact whose tracking group does not resolve a
+// role its shape cannot do without. It names the role, and the operationId when
+// the annotation declared one, so a typo reads differently from an omission.
+type MissingRoleError struct {
+	// Artifact is the Terraform artifact name from the tracking field.
+	Artifact string
+	// Kind selects the noun the message uses. Which roles are mandatory depends
+	// on the artifact's shape, so the error has to say which shape it judged.
+	Kind ArtifactKind
+	// Role is the group role that did not resolve.
+	Role GroupRole
+	// OperationId is the unresolved reference when the annotation named one, and
+	// empty when the role was never declared. The two are different author
+	// errors and read differently.
+	OperationId string
+}
+
+func (e *MissingRoleError) Error() string {
+	cause := "is not declared"
+	if e.OperationId != "" {
+		cause = fmt.Sprintf("names operationId %q, which no operation in the spec declares", e.OperationId)
+	}
+	noun := "resource"
+	if e.Kind == ArtifactKindDataSource {
+		noun = "data source"
+	}
+	return fmt.Sprintf("model: %s %q: group.%s %s; a %s cannot be generated without that operation",
+		noun, e.Artifact, e.Role, cause, noun)
+}
+
+// requireResolvedRoles fails op's artifact unless every listed role resolves to
+// an operation, whether it was omitted or named an operationId that matched
+// nothing. Callers name the roles their shape cannot do without, which is a
+// property of the shape rather than of any one sub-builder — so this runs before
+// the schema and the lifecycle are built, not inside either.
+func requireResolvedRoles(op *Operation, roles ...GroupRole) error {
+	for _, role := range roles {
+		if op.ResolvedGroup.Op(role) != nil {
+			continue
+		}
+		return &MissingRoleError{
+			Artifact:    op.Tracking.ArtifactName,
+			Kind:        op.Tracking.ArtifactKind,
+			Role:        role,
+			OperationId: op.ResolvedGroup.UnresolvedId(role),
+		}
+	}
+	return nil
+}
+
+// buildResourceLifecycle resolves the CRUD SDK calls for a resource and reports
+// how a missing update role was handled. It assumes Create, Read and Delete are
+// already known to resolve; buildResourceArtifact enforces that before calling.
+//
+// Update is the one role whose absence is a lifecycle decision rather than a
+// precondition, which is why it is settled here. An undeclared update degrades:
+// the resource is still generated, and UpdateUnsupported tells the schema builder
+// to force replacement on every practitioner-settable attribute (FR-034d, T123).
+// A declared-but-dangling update fails instead — treating a typo as an absence
+// would silently make every subsequent change destructive.
+func buildResourceLifecycle(op *Operation) (*LifecycleBindings, []Diagnostic, error) {
+	g := op.ResolvedGroup
+	bindings := &LifecycleBindings{
+		Create: bodyCall(g.Create, false),
+		Read:   sdkCall(g.Read, true),
+		// A delete takes the terminal path id and sends no body; a 204 response
+		// leaves GoResponseType empty.
+		Delete:     sdkCall(g.Delete, true),
+		IdStrategy: op.Tracking.IdStrategy,
+	}
+
+	var diags []Diagnostic
+	switch dangling := g.UnresolvedId(GroupRoleUpdate); {
+	case g.Update != nil:
+		bindings.Update = bodyCall(g.Update, true)
+	case dangling != "":
+		return nil, nil, &MissingRoleError{
+			Artifact:    op.Tracking.ArtifactName,
+			Kind:        op.Tracking.ArtifactKind,
+			Role:        GroupRoleUpdate,
+			OperationId: dangling,
+		}
+	default:
+		bindings.UpdateUnsupported = true
+		diags = append(diags, Diagnostic{
+			Severity: SeverityWarning,
+			Message: fmt.Sprintf(
+				"resource %q: group.update is not declared, so no endpoint can modify this resource in place; every practitioner-settable attribute forces replacement, and any change to one destroys and recreates the resource",
+				op.Tracking.ArtifactName),
+		})
+	}
+
+	return bindings, diags, nil
+}
+
+// bodyCall resolves the SDK binding for an operation that sends a request body,
+// which a read or a delete never does. aliasTerminalID is false for a create,
+// which has no id yet, and true for an update, whose path names the record.
+func bodyCall(op *Operation, aliasTerminalID bool) *SDKCall {
+	call := sdkCall(op, aliasTerminalID)
+	call.GoRequestType = op.RequestRefName
+	return call
+}

--- a/.generator-v2/internal/model/lifecycle_test.go
+++ b/.generator-v2/internal/model/lifecycle_test.go
@@ -1,0 +1,142 @@
+package model
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("buildResourceLifecycle", func() {
+	It("resolves all four CRUD calls, with a request type only where a body is sent", func() {
+		art, err := BuildArtifact(incidentTypeResourceOp())
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(art.Kind).To(Equal(ArtifactKindResource))
+		Expect(art.SourceFile).To(Equal("datadog/fwprovider/resource_datadog_incident_type.go"))
+		Expect(art.Cardinality).To(BeEmpty(), "cardinality describes a data source, not a resource")
+
+		Expect(art.Lifecycle.Create).To(Equal(&SDKCall{
+			GoPackage: "datadogV2", GoApiStruct: "IncidentsApi", GoMethod: "CreateIncidentType",
+			GoRequestType: "IncidentTypeCreateRequest", GoResponseType: "IncidentTypeResponse",
+		}))
+		Expect(art.Lifecycle.Read).To(Equal(&SDKCall{
+			GoPackage: "datadogV2", GoApiStruct: "IncidentsApi", GoMethod: "GetIncidentType",
+			GoResponseType: "IncidentTypeResponse",
+		}))
+		Expect(art.Lifecycle.Update).To(Equal(&SDKCall{
+			GoPackage: "datadogV2", GoApiStruct: "IncidentsApi", GoMethod: "UpdateIncidentType",
+			GoRequestType: "IncidentTypeUpdateRequest", GoResponseType: "IncidentTypeResponse",
+		}))
+		// Deep equality pins GoRequestType to "" here: a delete sends no body.
+		Expect(art.Lifecycle.Delete).To(Equal(&SDKCall{
+			GoPackage: "datadogV2", GoApiStruct: "IncidentsApi", GoMethod: "DeleteIncidentType",
+		}))
+		Expect(art.Lifecycle.IdStrategy).To(Equal(IdStrategyDataID))
+		Expect(art.Lifecycle.UpdateUnsupported).To(BeFalse())
+		Expect(art.Diagnostics).To(BeEmpty())
+	})
+
+	It("leaves Schema nil until the request/response merge lands", func() {
+		art, err := BuildArtifact(incidentTypeResourceOp())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(art.Schema).To(BeNil())
+	})
+
+	DescribeTable("a role the resource cannot do without fails the artifact by name",
+		func(clear func(*ResolvedGroup), wantRole GroupRole, wantMessage string) {
+			op := incidentTypeResourceOp()
+			clear(op.ResolvedGroup)
+
+			art, err := BuildArtifact(op)
+			Expect(art).To(BeNil())
+			Expect(err).To(HaveOccurred())
+
+			var missing *MissingRoleError
+			Expect(errors.As(err, &missing)).To(BeTrue(), "want a *MissingRoleError, got %T", err)
+			Expect(missing.Role).To(Equal(wantRole))
+			Expect(missing.Artifact).To(Equal("incident_type"))
+			Expect(missing.Kind).To(Equal(ArtifactKindResource))
+			Expect(err.Error()).To(Equal(wantMessage))
+		},
+		Entry("create omitted", func(g *ResolvedGroup) { g.Create = nil }, GroupRoleCreate,
+			`model: resource "incident_type": group.create is not declared; a resource cannot be generated without that operation`),
+		Entry("read omitted", func(g *ResolvedGroup) { g.Read = nil }, GroupRoleRead,
+			`model: resource "incident_type": group.read is not declared; a resource cannot be generated without that operation`),
+		Entry("delete omitted", func(g *ResolvedGroup) { g.Delete = nil }, GroupRoleDelete,
+			`model: resource "incident_type": group.delete is not declared; a resource cannot be generated without that operation`),
+		Entry("create dangling", func(g *ResolvedGroup) {
+			g.Create = nil
+			g.Unresolved = []GroupReference{{Role: GroupRoleCreate, OperationId: "CreateIncidentTypeTypo"}}
+		}, GroupRoleCreate,
+			`model: resource "incident_type": group.create names operationId "CreateIncidentTypeTypo", `+
+				`which no operation in the spec declares; a resource cannot be generated without that operation`),
+		Entry("update dangling — a typo must not silently become forced replacement", func(g *ResolvedGroup) {
+			g.Update = nil
+			g.Unresolved = []GroupReference{{Role: GroupRoleUpdate, OperationId: "UpdateIncidentTypeTypo"}}
+		}, GroupRoleUpdate,
+			`model: resource "incident_type": group.update names operationId "UpdateIncidentTypeTypo", `+
+				`which no operation in the spec declares; a resource cannot be generated without that operation`),
+	)
+
+	It("degrades to forced replacement when update is simply undeclared", func() {
+		op := incidentTypeResourceOp()
+		op.ResolvedGroup.Update = nil
+
+		art, err := BuildArtifact(op)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(art.Lifecycle.Update).To(BeNil())
+		Expect(art.Lifecycle.UpdateUnsupported).To(BeTrue())
+		Expect(art.Diagnostics).To(ContainElement(Diagnostic{
+			Severity: SeverityWarning,
+			Message: `resource "incident_type": group.update is not declared, so no endpoint can modify ` +
+				`this resource in place; every practitioner-settable attribute forces replacement, and any ` +
+				`change to one destroys and recreates the resource`,
+		}))
+	})
+
+	It("fails a groupless resource on create rather than panicking", func() {
+		op := incidentTypeResourceOp()
+		op.ResolvedGroup = nil
+
+		_, err := BuildArtifact(op)
+		Expect(err).To(MatchError(ContainSubstring("group.create is not declared")))
+	})
+})
+
+// incidentTypeResourceOp is the annotated Create operation of a full-CRUD
+// incident-type resource, with its group already resolved as the parser would
+// leave it.
+func incidentTypeResourceOp() *Operation {
+	create := &Operation{
+		Path: "/api/v2/incidents/config/types", Method: "POST",
+		OperationId: "CreateIncidentType", Tag: "Incidents",
+		RequestRefName: "IncidentTypeCreateRequest", ResponseRefName: "IncidentTypeResponse",
+	}
+	read := &Operation{
+		Path: "/api/v2/incidents/config/types/{incident_type_id}", Method: "GET",
+		OperationId: "GetIncidentType", Tag: "Incidents",
+		ResponseRefName: "IncidentTypeResponse",
+	}
+	update := &Operation{
+		Path: "/api/v2/incidents/config/types/{incident_type_id}", Method: "PATCH",
+		OperationId: "UpdateIncidentType", Tag: "Incidents",
+		RequestRefName: "IncidentTypeUpdateRequest", ResponseRefName: "IncidentTypeResponse",
+	}
+	del := &Operation{
+		Path: "/api/v2/incidents/config/types/{incident_type_id}", Method: "DELETE",
+		OperationId: "DeleteIncidentType", Tag: "Incidents",
+	}
+	create.Tracking = &TrackingFieldMetadata{
+		ArtifactKind:  ArtifactKindResource,
+		ArtifactName:  "incident_type",
+		TfDescription: "Provides a Datadog incident type resource.",
+		IdStrategy:    IdStrategyDataID,
+		Group: &OperationGroup{
+			Create: "CreateIncidentType", Read: "GetIncidentType",
+			Update: "UpdateIncidentType", Delete: "DeleteIncidentType",
+		},
+	}
+	create.ResolvedGroup = &ResolvedGroup{Create: create, Read: read, Update: update, Delete: del}
+	return create
+}

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -228,6 +228,23 @@ func (g *ResolvedGroup) Op(role GroupRole) *Operation {
 	return nil
 }
 
+// UnresolvedId returns the operationId the annotation declared for role when that
+// reference resolved to nothing, and "" when the role was simply never declared.
+// It is the counterpart to Op: Op answers "which operation", this answers "and if
+// none, what did the author write". Both are nil-safe on the receiver for the
+// same reason — the safety seam belongs to the group.
+func (g *ResolvedGroup) UnresolvedId(role GroupRole) string {
+	if g == nil {
+		return ""
+	}
+	for _, ref := range g.Unresolved {
+		if ref.Role == role {
+			return ref.OperationId
+		}
+	}
+	return ""
+}
+
 // Operations returns every distinct operation the group resolved to, in
 // create/read/search/update/delete order. An operation filling two roles — a
 // group whose read and search name the same endpoint, say — appears once.
@@ -426,7 +443,9 @@ type Artifact struct {
 	// tracking extension's tf_description field; empty when the author omits it.
 	Description string
 	// Schema is the Terraform schema derived from the response (and request,
-	// for resources).
+	// for resources). It is nil on a resource until the request/response merge
+	// lands (FR-034, T120-T124): the lifecycle builds without it, and nothing
+	// consumes a resource artifact yet.
 	Schema *AttributeTree
 	// Lifecycle holds the SDK call bindings. For data sources only Read is set
 	Lifecycle *LifecycleBindings
@@ -596,7 +615,16 @@ type LifecycleBindings struct {
 	Search     *SDKCall
 	Update     *SDKCall
 	Delete     *SDKCall
-	IdStrategy IdStrategy
+	// UpdateUnsupported records that the tracking group declares no update role,
+	// so no endpoint can modify this resource in place (spec Edge Case). It states
+	// the lifecycle fact rather than the Terraform consequence — deciding that the
+	// consequence is RequiresReplace on every practitioner-settable attribute is
+	// the schema builder's job (FR-034d, T123).
+	//
+	// It is not derivable from Update == nil, which is also true of every data
+	// source; the flag is false there, which is the honest answer.
+	UpdateUnsupported bool
+	IdStrategy        IdStrategy
 }
 
 // SDKCall represents a single datadog-api-client-go invocation.


### PR DESCRIPTION
Implements T046 and T052: a tracked resource operation now builds an Artifact
carrying its four CRUD SDK calls.

- buildArtifact dispatches on ArtifactKind before Cardinality. Cardinality
  describes how a data source resolves records and says nothing about a
  resource, which always maps to exactly one.
- New internal/model/lifecycle.go resolves Create/Read/Update/Delete. bodyCall
  carries GoRequestType from Operation.RequestRefName for the two roles that
  send a body; Read and Delete use the shared sdkCall, renamed from readCall
  now that it serves all four roles.
- requireResolvedRoles rejects a resource whose group does not resolve Create,
  Read or Delete, and any role the annotation declares but that matches no
  operation. It runs before any sub-builder, because Create and Read are
  preconditions of the schema merge rather than of the lifecycle. The
  pre-existing dangling group.search check in buildSingularBothArtifact now
  reports through the same typed MissingRoleError.
- An undeclared update sets LifecycleBindings.UpdateUnsupported and records a
  warning; a declared-but-dangling update fails instead, since treating a typo
  as an absence would silently make every later change destructive.

Artifact.Schema is deliberately nil for a resource until the request/response
merge lands (FR-034, T120-T124). The CLI still skips kind=resource, so nothing
consumes a resource artifact yet.

Generated output and run reports are byte-identical to the parent commit for
both annotated corpus slices.