### PR TITLE
[TF Generator] (v2) Derive the SDK API receiver with the Go generator's rule

### DIFF
--- a/.generator-v2/internal/model/artifact.go
+++ b/.generator-v2/internal/model/artifact.go
@@ -3,7 +3,6 @@ package model
 import (
 	"fmt"
 	"strings"
-	"unicode"
 )
 
 // BuildArtifact wraps a tracked Operation into an *Artifact and resolves its SDK
@@ -369,7 +368,7 @@ func SDKPackageForPath(path string) string {
 func sdkCall(op *Operation, aliasTerminalID bool) *SDKCall {
 	call := &SDKCall{
 		GoPackage:      SDKPackageForPath(op.Path),
-		GoApiStruct:    tagToClassName(op.Tag) + "Api",
+		GoApiStruct:    SdkClassName(op.Tag),
 		GoMethod:       op.OperationId,
 		GoResponseType: op.ResponseRefName,
 	}
@@ -561,21 +560,4 @@ func versionSegment(path string) string {
 		}
 	}
 	return ""
-}
-
-// tagToClassName converts an OpenAPI tag into the datadog-api-client-go API
-// struct base name: non-alphanumeric runs become word breaks, each word is
-// capitalized on its first rune, and in-word casing is preserved. So "org
-// groups" → "OrgGroups" and "APM" → "APM". This deliberately differs from
-// SdkName, which lower-cases acronyms ("APM" → "Apm").
-func tagToClassName(tag string) string {
-	var b strings.Builder
-	for _, word := range strings.FieldsFunc(tag, func(r rune) bool {
-		return !unicode.IsLetter(r) && !unicode.IsNumber(r)
-	}) {
-		runes := []rune(word)
-		b.WriteRune(unicode.ToUpper(runes[0]))
-		b.WriteString(string(runes[1:]))
-	}
-	return b.String()
 }

--- a/.generator-v2/internal/model/artifact_test.go
+++ b/.generator-v2/internal/model/artifact_test.go
@@ -8,14 +8,6 @@ import (
 )
 
 var _ = Describe("BuildArtifact", func() {
-	DescribeTable("tagToClassName capitalizes each word and preserves in-word casing",
-		func(tag, want string) { Expect(tagToClassName(tag)).To(Equal(want)) },
-		Entry("a single word passes through", "Incidents", "Incidents"),
-		Entry("a space-separated tag joins into PascalCase", "org groups", "OrgGroups"),
-		Entry("an acronym is preserved, not lower-cased", "APM", "APM"),
-		Entry("mixed punctuation becomes word breaks", "cloud-cost.management", "CloudCostManagement"),
-	)
-
 	DescribeTable("versionSegment returns the path segment after /api/",
 		func(path, want string) { Expect(versionSegment(path)).To(Equal(want)) },
 		Entry("a v2 path", "/api/v2/incidents/config/types/{id}", "v2"),

--- a/.generator-v2/internal/model/identifier.go
+++ b/.generator-v2/internal/model/identifier.go
@@ -14,15 +14,37 @@ var (
 	patternFollowingAlpha   = regexp.MustCompile(`([a-z0-9])([A-Z])`)
 	patternWhitespace       = regexp.MustCompile(`\W`)
 	patternDoubleUnderscore = regexp.MustCompile(`__+`)
+	patternNonAlphanumeric  = regexp.MustCompile(`[^a-zA-Z0-9]`)
 )
 
-// SnakeCase converts a camelCase or PascalCase identifier to snake_case.
+// SnakeCase converts a camelCase or PascalCase identifier to snake_case. It is
+// a port of utils.snake_case from datadog-api-client-go's bundled generator,
+// applying the same five operations in the same order.
 func SnakeCase(value string) string {
 	value = patternLeadingAlpha.ReplaceAllString(value, "${1}_${2}")
 	value = strings.ToLower(patternFollowingAlpha.ReplaceAllString(value, "${1}_${2}"))
 	value = patternWhitespace.ReplaceAllString(value, "_")
 	value = strings.TrimRight(value, "_")
 	return patternDoubleUnderscore.ReplaceAllString(value, "_")
+}
+
+// SdkClassName is a port of utils.class_name from datadog-api-client-go's
+// bundled generator (.generator/src/generator/utils.py):
+//
+//	value = re.sub(r'[^a-zA-Z0-9]', '', value)
+//	return value + "Api"
+//
+// It strips non-alphanumerics and does not re-capitalize, because the SDK relies
+// on tags already being PascalCase: "Org Groups" → "OrgGroupsApi" and "APM" →
+// "APMApi", while a lower-cased word stays lower ("org groups" → "orggroupsApi").
+// That last case is the point — capitalizing it would name a Go type the SDK
+// never generated.
+//
+// Deliberately not the TypeScript generator's tag_to_class_name (word-break, then
+// capitalize each word), which agrees on every PascalCase tag and diverges on any
+// other. Contrast SdkName, which lower-cases acronyms ("APM" → "Apm").
+func SdkClassName(tag string) string {
+	return patternNonAlphanumeric.ReplaceAllString(tag, "") + "Api"
 }
 
 // goKeywords is Go's full reserved-word set, the same list the SDK generator

--- a/.generator-v2/internal/model/identifier_test.go
+++ b/.generator-v2/internal/model/identifier_test.go
@@ -1,6 +1,11 @@
 package model
 
-import "testing"
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
 
 // TestSdkName locks in the naive PascalCase translation: split on underscores,
 // Title-case each segment (first rune upper, the rest lower), and never
@@ -71,3 +76,23 @@ func TestSdkNameIdempotent(t *testing.T) {
 		})
 	}
 }
+
+// The sdkClassName table is a Ginkgo spec in an otherwise stdlib-testing file:
+// the package's bootstrap already runs both, and colocating it with the function
+// it covers matters more than uniformity here (research §9 tracks migrating the
+// rest of this file).
+var _ = Describe("SdkClassName", func() {
+	// Every expectation is the output datadog-api-client-go's utils.class_name
+	// produces for the same input, so a maintainer can verify against the Python.
+	DescribeTable("strips non-alphanumerics and appends Api without re-capitalizing",
+		func(tag, want string) { Expect(SdkClassName(tag)).To(Equal(want)) },
+		Entry("a single word gains only the suffix", "Incidents", "IncidentsApi"),
+		Entry("a PascalCase multi-word tag loses its spaces", "Org Groups", "OrgGroupsApi"),
+		Entry("an acronym is preserved, not folded", "APM", "APMApi"),
+		Entry("a lower-cased word stays lower-cased", "org groups", "orggroupsApi"),
+		Entry("punctuation is stripped without creating a capital",
+			"cloud-cost.management", "cloudcostmanagementApi"),
+		Entry("digits survive", "AWS Logs Integration v2", "AWSLogsIntegrationv2Api"),
+		Entry("an empty tag still yields the suffix", "", "Api"),
+	)
+})

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -612,9 +612,9 @@ type LifecycleBindings struct {
 	// Search is the list call a singular data source uses to resolve one record
 	// by filter. It carries the list-call fields (ItemType/OptionalParamsType/
 	// Paginated), same as a plural Read.
-	Search     *SDKCall
-	Update     *SDKCall
-	Delete     *SDKCall
+	Search *SDKCall
+	Update *SDKCall
+	Delete *SDKCall
 	// UpdateUnsupported records that the tracking group declares no update role,
 	// so no endpoint can modify this resource in place (spec Edge Case). It states
 	// the lifecycle fact rather than the Terraform consequence — deciding that the
@@ -637,10 +637,8 @@ type SDKCall struct {
 	// segment after /api/ in Operation.Path (e.g. /api/v2/... → "datadogV2").
 	GoPackage string
 	// GoApiStruct is the API client struct name, e.g. "OrgGroupsApi".
-	// Rule: tag_to_class_name(Operation.Tag): replaces every non-alphanumeric
-	// character with a space, capitalizes each word and joins, then appends
-	// "Api". Preserves original casing within each word (so "APM" → "APMApi",
-	// not "ApmApi").
+	// Rule: SdkClassName(Operation.Tag) — strip every non-alphanumeric
+	// character, then append "Api", with no re-capitalization.
 	GoApiStruct string
 	// GoMethod is the method name on GoApiStruct, e.g. "CreateOrgGroup".
 	// Rule: Operation.OperationId, no transformation applied.

--- a/.generator-v2/internal/sdkbinding/bindings.go
+++ b/.generator-v2/internal/sdkbinding/bindings.go
@@ -20,6 +20,12 @@ import (
 type methodSignature struct {
 	arguments []argumentSignature
 	options   string
+	// receiver is the API struct the method hangs off in the pinned SDK, e.g.
+	// "IncidentsApi". Retained so corroborate can check the derived receiver
+	// name, not just the argument list: a tag whose spelling defeats
+	// model.SdkClassName yields a plausible name for a type the SDK never
+	// generated, and nothing else in the pipeline notices (FR-005a).
+	receiver string
 }
 
 type argumentSignature struct {
@@ -84,6 +90,7 @@ func Load(dir string) (*Inventory, error) {
 					args = args[:len(args)-1]
 				}
 				sig.arguments = args
+				sig.receiver = receiver
 				inv.methods[fn.Name.Name] = sig
 			}
 		}
@@ -288,6 +295,15 @@ func (i *Inventory) corroborate(op *model.Operation) []model.Diagnostic {
 	}
 	var differences []string
 	derived := op.SDKBinding
+	// Skipped for an untagged operation: SdkClassName would derive the useless
+	// "Api" and drown out the real problem, which is the missing tag. Nothing
+	// currently rejects an empty Tag (parser.firstTag returns ""), despite
+	// data-model.md's validation table claiming the parser enforces it.
+	if op.Tag != "" {
+		if got := model.SdkClassName(op.Tag); got != pinned.receiver {
+			differences = append(differences, fmt.Sprintf("API struct derived %q from tag %q, pinned %q", got, op.Tag, pinned.receiver))
+		}
+	}
 	if got, want := renderArguments(derived.Required), renderArgumentSignatures(pinned.arguments); got != want {
 		differences = append(differences, fmt.Sprintf("required arguments derived [%s], pinned [%s]", got, want))
 	}


### PR DESCRIPTION
## Motivation

The Datadog Go SDK derives an API receiver name with `utils.class_name` from the generator bundled inside the pinned module:

```python
def class_name(value):
    value = re.sub(r'[^a-zA-Z0-9]', '', value)
    return value + "Api"
```

It **strips** non-alphanumerics and does **not** re-capitalize — it relies on OpenAPI tags already being PascalCase. tfgen was instead using the *TypeScript* generator's `tag_to_class_name` rule: replace non-alphanumerics with a space, then capitalize each word.

The two agree on every Title Case Datadog tag, which is why this survived unnoticed. They diverge the moment a tag word starts lower-case, where the old rule named a Go type the SDK never generated — and nothing in the pipeline would have caught it, because no test compiles generated output.

## Changes

Before: `tagToClassName` word-broke on non-alphanumerics and capitalized each word, and `SDKCall.GoApiStruct`'s doc comment documented that (wrong) rule. A wrong derivation was invisible until someone compiled the generated provider.

Now:

- **`model.SdkClassName`** replaces `tagToClassName`, in `internal/model/identifier.go` beside the other four ports of the same two Python modules (`SnakeCase`, `UpperFirst`, `SdkName`, `EscapeReservedKeyword`). It is expressed as `patternNonAlphanumeric.ReplaceAllString(tag, "") + "Api"` — the regexp literal *is* the Python character class — following that file's existing one-var-per-upstream-pattern convention. It folds in the `"Api"` suffix, as `class_name` does, so a caller cannot omit it.
- **`SDKCall.GoApiStruct`'s doc comment** now describes the rule the code follows, in the struct's own 3-line house shape rather than restating the function's doc.
- **`SnakeCase`** gained the upstream citation its three neighbours already had.
- **Kept correct, not just corrected.** `sdkbinding.Load` already computed the pinned receiver name and used it solely as a `HasSuffix` filter before discarding it. `methodSignature` now retains it, and `corroborate` compares it against `SdkClassName(op.Tag)` on **every** generate — so this divergence class surfaces as a per-operation warning instead of waiting on a human re-reading `utils.py` (FR-005a step 2). It warns rather than fails, since the pinned SDK may legitimately lag the spec.

Two things found on the way, worth a reviewer's attention:

- Nothing rejects an empty `Operation.Tag` — `parser.firstTag` returns `""` — despite the spec's validation table recording it as parser-enforced. An empty tag derives the useless receiver `Api` and the package `datadog`. The new corroboration deliberately **skips** an untagged operation rather than report the derived name when the real problem is the missing tag. The guard itself is not added here.
- The recorded SDK pin in the spec's plan was two versions behind what `go list -m` resolves. That matters here because every identifier translator is a port of the generator *inside* that module, so the version and the naming rules move together.

## Testing

- Test tables repinned to `class_name` output, with the divergent cases (`org groups` → `orggroupsApi`, `cloud-cost.management` → `cloudcostmanagementApi`) as regression pins.
- **Differentially verified against the upstream Python**: extracted `PATTERN_*`, `snake_case`, `upperfirst`, `camel_case` and `class_name` from `$(go list -m -f '{{.Dir}}' github.com/DataDog/datadog-api-client-go/v2)/.generator/src/generator/utils.py` and re-ran them over every expectation. All 15 `SdkName` cases and all 7 `SdkClassName` cases agree exactly.
- Corroborated that the emitted receiver exists in the pinned SDK: `type CloudCostManagementApi datadog.Service`.
- Full generator suite green; `gofmt` and `go vet` clean.
- **Generated output and normalized run reports are byte-identical to the parent commit** for both annotated corpus slices — the meaningful check, since this changes a naming rule. No new corroboration warning fires, i.e. the derived receiver already matched the pinned SDK everywhere.

<details>
<summary>Corpus verification output</summary>

```
IDENTICAL: generated .go/.tf unchanged
=== any new corroboration warning? ===
none — derived receiver matches the pinned SDK on every corpus operation
  aws_cur_config: report IDENTICAL
  integration_elastic_cloud_account: report IDENTICAL
```

</details>
