### PR TITLE
[TF Generator] (v2) Implement the resource schema merge

### DIFF
--- a/.generator-v2/internal/model/merge.go
+++ b/.generator-v2/internal/model/merge.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ----------------------------------------------------------------------------
-// Generic schema combination, lifted from the parser package (T120). It was
+// Generic schema combination, lifted from the parser package. It was
 // originally private to parser's oneOf-sibling merge, but the resource schema
 // merge below needs the same primitives (CloneSchema, the sorted/intersect
 // helpers) and model cannot import parser — so this is the one place they
@@ -202,7 +202,7 @@ func intersectStrings(left, right []string) []string {
 }
 
 // ----------------------------------------------------------------------------
-// Resource schema merge (T120, T121, FR-034)
+// Resource schema merge
 // ----------------------------------------------------------------------------
 
 // SchemaMergeError reports a structural disagreement among the Create request,
@@ -215,7 +215,7 @@ func intersectStrings(left, right []string) []string {
 //
 // It fails only the artifact being merged, mirroring OneOfProjectionError's
 // scope: MergeResourceSchema aborts and the caller fails that one artifact
-// while unrelated artifacts continue (FR-034c).
+// while unrelated artifacts continue.
 type SchemaMergeError struct {
 	// Path is the schema path where the bodies disagree, dot-delimited from
 	// the merged tree's root, with "[]"/"{}" for an array/map element.
@@ -237,19 +237,18 @@ func (e *SchemaMergeError) Error() string {
 // at equal depth from each body's root, so a JSON:API data.attributes.<field>
 // lines up across all three even though the enclosing request/response
 // components differ by name; every correlated position is stamped with
-// Provenance (FR-034, FR-034b). The one exception is a OneOf/Unsupported/
-// RefCycle/DepthExceeded node (see mergeVerbatim): its own position is
-// stamped, but its subtree is cloned verbatim from the preferred side rather
-// than walked, so nodes inside it carry whatever Provenance (typically none)
-// they already had.
+// Provenance. The one exception is a OneOf/Unsupported/RefCycle/DepthExceeded
+// node (see mergeVerbatim): its own position is stamped, but its subtree is
+// cloned verbatim from the preferred side rather than walked, so nodes inside
+// it carry whatever Provenance (typically none) they already had.
 //
 // group.Search and the Create/Update *response* bodies are never read: a
 // field only they carry would become Computed state that refresh can never
-// repopulate (FR-034b) — the search element can be a narrower shape than the
-// by-id record, and a create-response-only field is never seen again.
+// repopulate — the search element can be a narrower shape than the by-id
+// record, and a create-response-only field is never seen again.
 //
-// Callers must guard for a missing or dangling Create/Read role before calling
-// (T124) — that failure needs the operationId to name a useful diagnostic,
+// Callers must guard for a missing or dangling Create/Read role before
+// calling — that failure needs the operationId to name a useful diagnostic,
 // which this function does not have. MergeResourceSchema only guards against
 // the degenerate case of a nil group or missing Create/Read operation, and
 // returns a plain error for it.
@@ -294,9 +293,9 @@ func (m *resourceMerger) mergeNode(create, update, read *Schema, createRequired 
 	case SchemaKindPrimitive:
 		return m.mergePrimitive(create, update, read, createRequired, path)
 	default:
-		// OneOf, Unsupported, RefCycle, DepthExceeded: FR-034c's cosmetic list
-		// names RefName/Description/Enum/Sensitive, not oneOf-specific fields, so
-		// these kinds are not deep-merged — the merged node is the preferred
+		// OneOf, Unsupported, RefCycle, DepthExceeded: the cosmetic-reconciliation
+		// list names RefName/Description/Enum/Sensitive, not oneOf-specific fields,
+		// so these kinds are not deep-merged — the merged node is the preferred
 		// side's clone with those four fields reconciled the same way as every
 		// other kind.
 		return m.mergeVerbatim(create, update, read, createRequired, path)
@@ -400,7 +399,7 @@ func (m *resourceMerger) mergeVerbatim(create, update, read *Schema, createRequi
 	return out, nil
 }
 
-// cosmeticFields reconciles the four fields FR-034c treats as cosmetic —
+// cosmeticFields reconciles the four fields treated as cosmetic —
 // RefName and Description favoring the Read response, Enum members unioned
 // (never intersected: a validator must accept everything the response can
 // return, or refresh fails on a value the practitioner never chose), Sensitive
@@ -513,14 +512,10 @@ func requiredFromCreate(create *Schema) []string {
 	return sortedUniqueStrings(append([]string(nil), create.Required...))
 }
 
-// pickString returns get's value, preferring the Read side, then Create, then
-// Update, skipping an empty value even from the preferred side. disagreed
-// reports whether the present sides actually carried more than one distinct
-// non-empty value, so the caller knows whether a reconciliation happened or
-// every side already agreed.
-// preferenceOrder is the Read, Create, Update order FR-034c's cosmetic
-// reconciliation prefers throughout — read wins a disagreement, else create,
-// else update. Entries are nil when that side is absent; callers filter.
+// preferenceOrder is the Read, Create, Update order the cosmetic
+// reconciliation below prefers throughout — read wins a disagreement, else
+// create, else update. Entries are nil when that side is absent; callers
+// filter.
 func preferenceOrder(create, update, read *Schema) [3]*Schema {
 	return [3]*Schema{read, create, update}
 }
@@ -535,6 +530,11 @@ func preferredSchema(create, update, read *Schema) *Schema {
 	return nil
 }
 
+// pickString returns get's value, preferring the Read side, then Create, then
+// Update, skipping an empty value even from the preferred side. disagreed
+// reports whether the present sides actually carried more than one distinct
+// non-empty value, so the caller knows whether a reconciliation happened or
+// every side already agreed.
 func pickString(get func(*Schema) string, create, update, read *Schema) (value string, disagreed bool) {
 	seen := map[string]bool{}
 	for _, s := range presentSchemas(create, update, read) {

--- a/.generator-v2/internal/model/merge.go
+++ b/.generator-v2/internal/model/merge.go
@@ -7,12 +7,7 @@ import (
 )
 
 // ----------------------------------------------------------------------------
-// Generic schema combination, lifted from the parser package. It was
-// originally private to parser's oneOf-sibling merge, but the resource schema
-// merge below needs the same primitives (CloneSchema, the sorted/intersect
-// helpers) and model cannot import parser — so this is the one place they
-// live, and parser now calls the exported names instead of holding its own
-// copy.
+// Schema combination helpers
 // ----------------------------------------------------------------------------
 
 // MergeNormalizedSchemas intersects the subset of OpenAPI constraints retained
@@ -21,11 +16,6 @@ import (
 // simultaneously, so enums intersect and a kind/type/format conflict makes the
 // alternative Unsupported rather than erroring, letting the affected variant
 // alone report that precise failure instead of the whole union being dropped.
-//
-// This is a different operation from MergeResourceSchema below, which unions
-// (rather than intersects) three independently-normalized bodies and raises
-// SchemaMergeError on a structural conflict rather than swallowing it — the two
-// merges answer different questions and intentionally do not share a policy.
 func MergeNormalizedSchemas(variant, common *Schema) *Schema {
 	if variant == nil {
 		return common
@@ -135,8 +125,8 @@ func OneOfValueWrapped(schema *Schema) bool {
 	}
 }
 
-// CloneSchema returns a deep copy so combining or reconciling schemas never
-// mutates a normalized branch, or any child reachable from it, in place.
+// CloneSchema returns a deep copy of s, including Items, Properties, Variants
+// and OneOf.
 func CloneSchema(s *Schema) *Schema {
 	if s == nil {
 		return nil
@@ -212,10 +202,6 @@ func intersectStrings(left, right []string) []string {
 // deeper, at the "[]"/"{}" path, since Items disagreement is just a Kind (or
 // Type/Format) mismatch one recursion step further down — no separate check
 // is needed for it.
-//
-// It fails only the artifact being merged, mirroring OneOfProjectionError's
-// scope: MergeResourceSchema aborts and the caller fails that one artifact
-// while unrelated artifacts continue.
 type SchemaMergeError struct {
 	// Path is the schema path where the bodies disagree, dot-delimited from
 	// the merged tree's root, with "[]"/"{}" for an array/map element.
@@ -232,26 +218,23 @@ func (e *SchemaMergeError) Error() string {
 }
 
 // MergeResourceSchema unions the Create request, Update request and Read
-// response bodies of group into one Schema tree, the input BuildResourceTree
-// turns into a resource AttributeTree. Nodes are correlated by property name
-// at equal depth from each body's root, so a JSON:API data.attributes.<field>
-// lines up across all three even though the enclosing request/response
-// components differ by name; every correlated position is stamped with
-// Provenance. The one exception is a OneOf/Unsupported/RefCycle/DepthExceeded
-// node (see mergeVerbatim): its own position is stamped, but its subtree is
-// cloned verbatim from the preferred side rather than walked, so nodes inside
-// it carry whatever Provenance (typically none) they already had.
+// response bodies of group into one Schema tree, stamping Provenance at every
+// correlated position. Nodes are correlated by property name at equal depth
+// from each body's root, so a JSON:API data.attributes.<field> lines up
+// across all three even though the enclosing request/response components
+// differ by name. The one exception is a OneOf/Unsupported/RefCycle/
+// DepthExceeded node (see mergeVerbatim): its own position is stamped, but
+// its subtree is cloned verbatim from the preferred side rather than walked,
+// so nodes inside it carry whatever Provenance (typically none) they already
+// had.
 //
 // group.Search and the Create/Update *response* bodies are never read: a
 // field only they carry would become Computed state that refresh can never
 // repopulate — the search element can be a narrower shape than the by-id
 // record, and a create-response-only field is never seen again.
 //
-// Callers must guard for a missing or dangling Create/Read role before
-// calling — that failure needs the operationId to name a useful diagnostic,
-// which this function does not have. MergeResourceSchema only guards against
-// the degenerate case of a nil group or missing Create/Read operation, and
-// returns a plain error for it.
+// It returns a plain error when group is nil or is missing a Create or Read
+// operation.
 func MergeResourceSchema(group *ResolvedGroup) (*Schema, []Diagnostic, error) {
 	if group == nil || group.Create == nil || group.Read == nil {
 		return nil, nil, fmt.Errorf("model: MergeResourceSchema requires a resolved Create and Read operation")
@@ -270,8 +253,8 @@ func MergeResourceSchema(group *ResolvedGroup) (*Schema, []Diagnostic, error) {
 	return merged, m.diagnostics, nil
 }
 
-// resourceMerger accumulates the info diagnostics MergeResourceSchema raises
-// while walking the three bodies.
+// resourceMerger accumulates the info diagnostics raised while walking the
+// three bodies.
 type resourceMerger struct {
 	diagnostics []Diagnostic
 }
@@ -492,9 +475,7 @@ func unionObjectKeys(create, update, read *Schema) []string {
 
 // ChildPath joins parent and child into a dot-delimited schema path, e.g.
 // "data.attributes.name", except when child is the array/map element marker
-// ("[]"/"{}"), which appends without a dot. Shared by the parser's path
-// tracking, the SDK binding walk, and the resource schema merge below, so the
-// three stay spelled identically.
+// ("[]"/"{}"), which appends without a dot.
 func ChildPath(parent, child string) string {
 	if parent == "" {
 		return child
@@ -512,10 +493,9 @@ func requiredFromCreate(create *Schema) []string {
 	return sortedUniqueStrings(append([]string(nil), create.Required...))
 }
 
-// preferenceOrder is the Read, Create, Update order the cosmetic
-// reconciliation below prefers throughout — read wins a disagreement, else
-// create, else update. Entries are nil when that side is absent; callers
-// filter.
+// preferenceOrder returns Read, Create, Update in that order — read wins a
+// disagreement, else create, else update. An entry is nil when that side is
+// absent.
 func preferenceOrder(create, update, read *Schema) [3]*Schema {
 	return [3]*Schema{read, create, update}
 }

--- a/.generator-v2/internal/model/merge.go
+++ b/.generator-v2/internal/model/merge.go
@@ -232,12 +232,16 @@ func (e *SchemaMergeError) Error() string {
 }
 
 // MergeResourceSchema unions the Create request, Update request and Read
-// response bodies of group into one Schema tree stamped with Provenance at
-// every node (FR-034, FR-034b), the input BuildResourceTree turns into a
-// resource AttributeTree. Nodes are correlated by property name at equal
-// depth from each body's root, so a JSON:API data.attributes.<field> lines up
-// across all three even though the enclosing request/response components
-// differ by name.
+// response bodies of group into one Schema tree, the input BuildResourceTree
+// turns into a resource AttributeTree. Nodes are correlated by property name
+// at equal depth from each body's root, so a JSON:API data.attributes.<field>
+// lines up across all three even though the enclosing request/response
+// components differ by name; every correlated position is stamped with
+// Provenance (FR-034, FR-034b). The one exception is a OneOf/Unsupported/
+// RefCycle/DepthExceeded node (see mergeVerbatim): its own position is
+// stamped, but its subtree is cloned verbatim from the preferred side rather
+// than walked, so nodes inside it carry whatever Provenance (typically none)
+// they already had.
 //
 // group.Search and the Create/Update *response* bodies are never read: a
 // field only they carry would become Computed state that refresh can never
@@ -314,7 +318,7 @@ func (m *resourceMerger) mergeObject(create, update, read *Schema, createRequire
 		if read != nil {
 			childRead = read.Properties[key]
 		}
-		child, err := m.mergeNode(childCreate, childUpdate, childRead, childRequired, mergePath(path, key))
+		child, err := m.mergeNode(childCreate, childUpdate, childRead, childRequired, ChildPath(path, key))
 		if err != nil {
 			return nil, err
 		}
@@ -350,7 +354,7 @@ func (m *resourceMerger) mergeCollection(kind SchemaKind, create, update, read *
 	}
 	// An array/map element has no name of its own to appear in a parent's
 	// Required list, so it is never itself request-required.
-	items, err := m.mergeNode(childCreate, childUpdate, childRead, false, path+suffix)
+	items, err := m.mergeNode(childCreate, childUpdate, childRead, false, ChildPath(path, suffix))
 	if err != nil {
 		return nil, err
 	}
@@ -368,22 +372,13 @@ func (m *resourceMerger) mergeCollection(kind SchemaKind, create, update, read *
 
 func (m *resourceMerger) mergePrimitive(create, update, read *Schema, createRequired bool, path string) (*Schema, error) {
 	present := presentSchemas(create, update, read)
-	typ, format := present[0].Type, present[0].Format
-	for _, s := range present[1:] {
-		switch {
-		case s.Type == "":
-		case typ == "":
-			typ = s.Type
-		case s.Type != typ:
-			return nil, &SchemaMergeError{Path: path, Aspect: "type", Left: typ, Right: s.Type}
-		}
-		switch {
-		case s.Format == "":
-		case format == "":
-			format = s.Format
-		case s.Format != format:
-			return nil, &SchemaMergeError{Path: path, Aspect: "format", Left: format, Right: s.Format}
-		}
+	typ, err := reconcileField(path, "type", present, func(s *Schema) string { return s.Type })
+	if err != nil {
+		return nil, err
+	}
+	format, err := reconcileField(path, "format", present, func(s *Schema) string { return s.Format })
+	if err != nil {
+		return nil, err
 	}
 	refName, description, enum, sensitive := m.cosmeticFields(create, update, read, path)
 	return &Schema{
@@ -399,14 +394,7 @@ func (m *resourceMerger) mergePrimitive(create, update, read *Schema, createRequ
 }
 
 func (m *resourceMerger) mergeVerbatim(create, update, read *Schema, createRequired bool, path string) (*Schema, error) {
-	var preferred *Schema
-	for _, s := range []*Schema{read, create, update} {
-		if s != nil {
-			preferred = s
-			break
-		}
-	}
-	out := CloneSchema(preferred)
+	out := CloneSchema(preferredSchema(create, update, read))
 	out.RefName, out.Description, out.Enum, out.Sensitive = m.cosmeticFields(create, update, read, path)
 	out.Provenance = stampProvenance(create, update, read, createRequired)
 	return out, nil
@@ -449,13 +437,29 @@ func stampProvenance(create, update, read *Schema, createRequired bool) *SchemaP
 // SchemaMergeError naming the two conflicting spellings.
 func kindConflict(create, update, read *Schema, path string) (SchemaKind, error) {
 	present := presentSchemas(create, update, read)
-	kind := present[0].Kind
-	for _, s := range present[1:] {
-		if s.Kind != kind {
-			return "", &SchemaMergeError{Path: path, Aspect: "kind", Left: string(kind), Right: string(s.Kind)}
+	kind, err := reconcileField(path, "kind", present, func(s *Schema) string { return string(s.Kind) })
+	if err != nil {
+		return "", err
+	}
+	return SchemaKind(kind), nil
+}
+
+// reconcileField picks the one value every present body that sets it agrees
+// on for a structural aspect ("kind", "type", or "format") — skipping a body
+// that doesn't set it at all — and returns a SchemaMergeError naming both
+// spellings the moment two present bodies disagree.
+func reconcileField(path, aspect string, present []*Schema, get func(*Schema) string) (string, error) {
+	var value string
+	for _, s := range present {
+		switch v := get(s); {
+		case v == "":
+		case value == "":
+			value = v
+		case v != value:
+			return "", &SchemaMergeError{Path: path, Aspect: aspect, Left: value, Right: v}
 		}
 	}
-	return kind, nil
+	return value, nil
 }
 
 func presentSchemas(create, update, read *Schema) []*Schema {
@@ -487,9 +491,17 @@ func unionObjectKeys(create, update, read *Schema) []string {
 	return keys
 }
 
-func mergePath(parent, child string) string {
+// ChildPath joins parent and child into a dot-delimited schema path, e.g.
+// "data.attributes.name", except when child is the array/map element marker
+// ("[]"/"{}"), which appends without a dot. Shared by the parser's path
+// tracking, the SDK binding walk, and the resource schema merge below, so the
+// three stay spelled identically.
+func ChildPath(parent, child string) string {
 	if parent == "" {
 		return child
+	}
+	if child == "[]" || child == "{}" {
+		return parent + child
 	}
 	return parent + "." + child
 }
@@ -506,6 +518,23 @@ func requiredFromCreate(create *Schema) []string {
 // reports whether the present sides actually carried more than one distinct
 // non-empty value, so the caller knows whether a reconciliation happened or
 // every side already agreed.
+// preferenceOrder is the Read, Create, Update order FR-034c's cosmetic
+// reconciliation prefers throughout — read wins a disagreement, else create,
+// else update. Entries are nil when that side is absent; callers filter.
+func preferenceOrder(create, update, read *Schema) [3]*Schema {
+	return [3]*Schema{read, create, update}
+}
+
+// preferredSchema returns the first present side in preferenceOrder.
+func preferredSchema(create, update, read *Schema) *Schema {
+	for _, s := range preferenceOrder(create, update, read) {
+		if s != nil {
+			return s
+		}
+	}
+	return nil
+}
+
 func pickString(get func(*Schema) string, create, update, read *Schema) (value string, disagreed bool) {
 	seen := map[string]bool{}
 	for _, s := range presentSchemas(create, update, read) {
@@ -514,7 +543,7 @@ func pickString(get func(*Schema) string, create, update, read *Schema) (value s
 		}
 	}
 	disagreed = len(seen) > 1
-	for _, s := range []*Schema{read, create, update} {
+	for _, s := range preferenceOrder(create, update, read) {
 		if s == nil {
 			continue
 		}

--- a/.generator-v2/internal/model/merge.go
+++ b/.generator-v2/internal/model/merge.go
@@ -1,0 +1,568 @@
+package model
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+)
+
+// ----------------------------------------------------------------------------
+// Generic schema combination, lifted from the parser package (T120). It was
+// originally private to parser's oneOf-sibling merge, but the resource schema
+// merge below needs the same primitives (CloneSchema, the sorted/intersect
+// helpers) and model cannot import parser — so this is the one place they
+// live, and parser now calls the exported names instead of holding its own
+// copy.
+// ----------------------------------------------------------------------------
+
+// MergeNormalizedSchemas intersects the subset of OpenAPI constraints retained
+// by Schema. It combines a oneOf alternative with the constraints declared
+// adjacent to the oneOf keyword (its "sibling" schema) — both must hold
+// simultaneously, so enums intersect and a kind/type/format conflict makes the
+// alternative Unsupported rather than erroring, letting the affected variant
+// alone report that precise failure instead of the whole union being dropped.
+//
+// This is a different operation from MergeResourceSchema below, which unions
+// (rather than intersects) three independently-normalized bodies and raises
+// SchemaMergeError on a structural conflict rather than swallowing it — the two
+// merges answer different questions and intentionally do not share a policy.
+func MergeNormalizedSchemas(variant, common *Schema) *Schema {
+	if variant == nil {
+		return common
+	}
+	if common == nil {
+		return variant
+	}
+	if common.Kind == SchemaKindUnsupported {
+		out := CloneSchema(common)
+		if out.Description == "" {
+			out.Description = variant.Description
+		}
+		return out
+	}
+	if variant.Kind == SchemaKindOneOf && variant.OneOf != nil {
+		for i := range variant.OneOf.Variants {
+			variant.OneOf.Variants[i].Schema = MergeNormalizedSchemas(variant.OneOf.Variants[i].Schema, common)
+			variant.OneOf.Variants[i].ValueWrapped = OneOfValueWrapped(variant.OneOf.Variants[i].Schema)
+		}
+		return variant
+	}
+	if variant.Kind == SchemaKindUnsupported {
+		if variant.UnsupportedReason != "" {
+			return variant
+		}
+		if common.Description == "" {
+			common.Description = variant.Description
+		}
+		return common
+	}
+	if variant.Kind != common.Kind {
+		return &Schema{
+			Kind:              SchemaKindUnsupported,
+			Description:       variant.Description,
+			UnsupportedReason: fmt.Sprintf("oneOf alternative kind %q conflicts with adjacent schema kind %q", variant.Kind, common.Kind),
+		}
+	}
+
+	switch variant.Kind {
+	case SchemaKindObject:
+		if variant.Properties == nil {
+			variant.Properties = make(map[string]*Schema)
+		}
+		for key, commonProperty := range common.Properties {
+			if property, exists := variant.Properties[key]; exists {
+				variant.Properties[key] = MergeNormalizedSchemas(property, commonProperty)
+			} else {
+				variant.Properties[key] = commonProperty
+			}
+		}
+		variant.Required = sortedUniqueStrings(append(variant.Required, common.Required...))
+	case SchemaKindArray, SchemaKindMap:
+		variant.Items = MergeNormalizedSchemas(variant.Items, common.Items)
+	case SchemaKindPrimitive:
+		if variant.Type != "" && common.Type != "" && variant.Type != common.Type {
+			return &Schema{
+				Kind:              SchemaKindUnsupported,
+				Description:       variant.Description,
+				UnsupportedReason: fmt.Sprintf("oneOf alternative type %q conflicts with adjacent type %q", variant.Type, common.Type),
+			}
+		}
+		if variant.Type == "" {
+			variant.Type = common.Type
+		}
+		if variant.Format != "" && common.Format != "" && variant.Format != common.Format {
+			return &Schema{
+				Kind:              SchemaKindUnsupported,
+				Description:       variant.Description,
+				UnsupportedReason: fmt.Sprintf("oneOf alternative format %q conflicts with adjacent format %q", variant.Format, common.Format),
+			}
+		}
+		if variant.Format == "" {
+			variant.Format = common.Format
+		}
+		switch {
+		case len(variant.Enum) == 0:
+			variant.Enum = append([]string(nil), common.Enum...)
+		case len(common.Enum) > 0:
+			intersection := intersectStrings(variant.Enum, common.Enum)
+			if len(intersection) == 0 {
+				return &Schema{
+					Kind:              SchemaKindUnsupported,
+					Description:       variant.Description,
+					UnsupportedReason: "oneOf alternative enum has no values in common with adjacent enum",
+				}
+			}
+			variant.Enum = intersection
+		}
+	}
+	variant.Sensitive = variant.Sensitive || common.Sensitive
+	return variant
+}
+
+// OneOfValueWrapped reports whether a oneOf alternative's Terraform variant
+// model wraps its value in a single "value" field (every primitive, array and
+// map alternative) rather than exposing its own fields directly (every object
+// alternative).
+func OneOfValueWrapped(schema *Schema) bool {
+	if schema == nil {
+		return false
+	}
+	switch schema.Kind {
+	case SchemaKindPrimitive, SchemaKindArray, SchemaKindMap:
+		return true
+	default:
+		return false
+	}
+}
+
+// CloneSchema returns a deep copy so combining or reconciling schemas never
+// mutates a normalized branch, or any child reachable from it, in place.
+func CloneSchema(s *Schema) *Schema {
+	if s == nil {
+		return nil
+	}
+	out := *s
+	out.Enum = append([]string(nil), s.Enum...)
+	out.Required = append([]string(nil), s.Required...)
+	out.Items = CloneSchema(s.Items)
+	if s.Properties != nil {
+		out.Properties = make(map[string]*Schema, len(s.Properties))
+		for name, child := range s.Properties {
+			out.Properties[name] = CloneSchema(child)
+		}
+	}
+	if s.Variants != nil {
+		out.Variants = make([]*Schema, len(s.Variants))
+		for i, variant := range s.Variants {
+			out.Variants[i] = CloneSchema(variant)
+		}
+	}
+	if s.OneOf != nil {
+		oneOf := *s.OneOf
+		oneOf.Variants = make([]OneOfVariant, len(s.OneOf.Variants))
+		for i, variant := range s.OneOf.Variants {
+			oneOf.Variants[i] = variant
+			oneOf.Variants[i].Schema = CloneSchema(variant.Schema)
+		}
+		if s.OneOf.Discriminator != nil {
+			discriminator := *s.OneOf.Discriminator
+			if s.OneOf.Discriminator.Mapping != nil {
+				discriminator.Mapping = make(map[string]string, len(s.OneOf.Discriminator.Mapping))
+				for key, value := range s.OneOf.Discriminator.Mapping {
+					discriminator.Mapping[key] = value
+				}
+			}
+			oneOf.Discriminator = &discriminator
+		}
+		out.OneOf = &oneOf
+	}
+	return &out
+}
+
+func sortedUniqueStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	sort.Strings(values)
+	return slices.Compact(values)
+}
+
+func intersectStrings(left, right []string) []string {
+	allowed := make(map[string]struct{}, len(right))
+	for _, value := range right {
+		allowed[value] = struct{}{}
+	}
+	var intersection []string
+	for _, value := range left {
+		if _, ok := allowed[value]; ok {
+			intersection = append(intersection, value)
+		}
+	}
+	return sortedUniqueStrings(intersection)
+}
+
+// ----------------------------------------------------------------------------
+// Resource schema merge (T120, T121, FR-034)
+// ----------------------------------------------------------------------------
+
+// SchemaMergeError reports a structural disagreement among the Create request,
+// Update request and Read response bodies at one schema path: a differing
+// Kind, primitive Type, or Format. An element/value shape conflict (an array
+// or map whose element disagrees) surfaces as this same error one level
+// deeper, at the "[]"/"{}" path, since Items disagreement is just a Kind (or
+// Type/Format) mismatch one recursion step further down — no separate check
+// is needed for it.
+//
+// It fails only the artifact being merged, mirroring OneOfProjectionError's
+// scope: MergeResourceSchema aborts and the caller fails that one artifact
+// while unrelated artifacts continue (FR-034c).
+type SchemaMergeError struct {
+	// Path is the schema path where the bodies disagree, dot-delimited from
+	// the merged tree's root, with "[]"/"{}" for an array/map element.
+	Path string
+	// Aspect names what disagreed: "kind", "type", or "format".
+	Aspect string
+	// Left and Right are the two conflicting spellings, e.g. "object" and
+	// "primitive", or "string" and "integer".
+	Left, Right string
+}
+
+func (e *SchemaMergeError) Error() string {
+	return fmt.Sprintf("model: resource schema merge conflict at %q: %s %q vs %q", e.Path, e.Aspect, e.Left, e.Right)
+}
+
+// MergeResourceSchema unions the Create request, Update request and Read
+// response bodies of group into one Schema tree stamped with Provenance at
+// every node (FR-034, FR-034b), the input BuildResourceTree turns into a
+// resource AttributeTree. Nodes are correlated by property name at equal
+// depth from each body's root, so a JSON:API data.attributes.<field> lines up
+// across all three even though the enclosing request/response components
+// differ by name.
+//
+// group.Search and the Create/Update *response* bodies are never read: a
+// field only they carry would become Computed state that refresh can never
+// repopulate (FR-034b) — the search element can be a narrower shape than the
+// by-id record, and a create-response-only field is never seen again.
+//
+// Callers must guard for a missing or dangling Create/Read role before calling
+// (T124) — that failure needs the operationId to name a useful diagnostic,
+// which this function does not have. MergeResourceSchema only guards against
+// the degenerate case of a nil group or missing Create/Read operation, and
+// returns a plain error for it.
+func MergeResourceSchema(group *ResolvedGroup) (*Schema, []Diagnostic, error) {
+	if group == nil || group.Create == nil || group.Read == nil {
+		return nil, nil, fmt.Errorf("model: MergeResourceSchema requires a resolved Create and Read operation")
+	}
+
+	var updateRequest *Schema
+	if group.Update != nil {
+		updateRequest = group.Update.RequestSchema
+	}
+
+	m := &resourceMerger{}
+	merged, err := m.mergeNode(group.Create.RequestSchema, updateRequest, group.Read.ResponseSchema, false, "")
+	if err != nil {
+		return nil, nil, err
+	}
+	return merged, m.diagnostics, nil
+}
+
+// resourceMerger accumulates the info diagnostics MergeResourceSchema raises
+// while walking the three bodies.
+type resourceMerger struct {
+	diagnostics []Diagnostic
+}
+
+// mergeNode combines the three bodies' schemas at one correlated tree
+// position. create/update/read are nil when that body does not reach this
+// position; createRequired is fixed by the caller from the enclosing object's
+// Create-body Required list (a node cannot answer this about itself).
+func (m *resourceMerger) mergeNode(create, update, read *Schema, createRequired bool, path string) (*Schema, error) {
+	kind, err := kindConflict(create, update, read, path)
+	if err != nil {
+		return nil, err
+	}
+	switch kind {
+	case SchemaKindObject:
+		return m.mergeObject(create, update, read, createRequired, path)
+	case SchemaKindArray, SchemaKindMap:
+		return m.mergeCollection(kind, create, update, read, createRequired, path)
+	case SchemaKindPrimitive:
+		return m.mergePrimitive(create, update, read, createRequired, path)
+	default:
+		// OneOf, Unsupported, RefCycle, DepthExceeded: FR-034c's cosmetic list
+		// names RefName/Description/Enum/Sensitive, not oneOf-specific fields, so
+		// these kinds are not deep-merged — the merged node is the preferred
+		// side's clone with those four fields reconciled the same way as every
+		// other kind.
+		return m.mergeVerbatim(create, update, read, createRequired, path)
+	}
+}
+
+func (m *resourceMerger) mergeObject(create, update, read *Schema, createRequired bool, path string) (*Schema, error) {
+	properties := make(map[string]*Schema)
+	for _, key := range unionObjectKeys(create, update, read) {
+		var childCreate, childUpdate, childRead *Schema
+		childRequired := false
+		if create != nil {
+			childCreate = create.Properties[key]
+			childRequired = slices.Contains(create.Required, key)
+		}
+		if update != nil {
+			childUpdate = update.Properties[key]
+		}
+		if read != nil {
+			childRead = read.Properties[key]
+		}
+		child, err := m.mergeNode(childCreate, childUpdate, childRead, childRequired, mergePath(path, key))
+		if err != nil {
+			return nil, err
+		}
+		properties[key] = child
+	}
+	refName, description, enum, sensitive := m.cosmeticFields(create, update, read, path)
+	return &Schema{
+		Kind:        SchemaKindObject,
+		Properties:  properties,
+		Required:    requiredFromCreate(create),
+		RefName:     refName,
+		Description: description,
+		Enum:        enum,
+		Sensitive:   sensitive,
+		Provenance:  stampProvenance(create, update, read, createRequired),
+	}, nil
+}
+
+func (m *resourceMerger) mergeCollection(kind SchemaKind, create, update, read *Schema, createRequired bool, path string) (*Schema, error) {
+	var childCreate, childUpdate, childRead *Schema
+	if create != nil {
+		childCreate = create.Items
+	}
+	if update != nil {
+		childUpdate = update.Items
+	}
+	if read != nil {
+		childRead = read.Items
+	}
+	suffix := "[]"
+	if kind == SchemaKindMap {
+		suffix = "{}"
+	}
+	// An array/map element has no name of its own to appear in a parent's
+	// Required list, so it is never itself request-required.
+	items, err := m.mergeNode(childCreate, childUpdate, childRead, false, path+suffix)
+	if err != nil {
+		return nil, err
+	}
+	refName, description, enum, sensitive := m.cosmeticFields(create, update, read, path)
+	return &Schema{
+		Kind:        kind,
+		Items:       items,
+		RefName:     refName,
+		Description: description,
+		Enum:        enum,
+		Sensitive:   sensitive,
+		Provenance:  stampProvenance(create, update, read, createRequired),
+	}, nil
+}
+
+func (m *resourceMerger) mergePrimitive(create, update, read *Schema, createRequired bool, path string) (*Schema, error) {
+	present := presentSchemas(create, update, read)
+	typ, format := present[0].Type, present[0].Format
+	for _, s := range present[1:] {
+		switch {
+		case s.Type == "":
+		case typ == "":
+			typ = s.Type
+		case s.Type != typ:
+			return nil, &SchemaMergeError{Path: path, Aspect: "type", Left: typ, Right: s.Type}
+		}
+		switch {
+		case s.Format == "":
+		case format == "":
+			format = s.Format
+		case s.Format != format:
+			return nil, &SchemaMergeError{Path: path, Aspect: "format", Left: format, Right: s.Format}
+		}
+	}
+	refName, description, enum, sensitive := m.cosmeticFields(create, update, read, path)
+	return &Schema{
+		Kind:        SchemaKindPrimitive,
+		Type:        typ,
+		Format:      format,
+		Enum:        enum,
+		RefName:     refName,
+		Description: description,
+		Sensitive:   sensitive,
+		Provenance:  stampProvenance(create, update, read, createRequired),
+	}, nil
+}
+
+func (m *resourceMerger) mergeVerbatim(create, update, read *Schema, createRequired bool, path string) (*Schema, error) {
+	var preferred *Schema
+	for _, s := range []*Schema{read, create, update} {
+		if s != nil {
+			preferred = s
+			break
+		}
+	}
+	out := CloneSchema(preferred)
+	out.RefName, out.Description, out.Enum, out.Sensitive = m.cosmeticFields(create, update, read, path)
+	out.Provenance = stampProvenance(create, update, read, createRequired)
+	return out, nil
+}
+
+// cosmeticFields reconciles the four fields FR-034c treats as cosmetic —
+// RefName and Description favoring the Read response, Enum members unioned
+// (never intersected: a validator must accept everything the response can
+// return, or refresh fails on a value the practitioner never chose), Sensitive
+// the disjunction — and records one info Diagnostic when the present bodies
+// actually disagreed on any of them.
+func (m *resourceMerger) cosmeticFields(create, update, read *Schema, path string) (refName, description string, enum []string, sensitive bool) {
+	var refDisagree, descDisagree, enumDisagree, sensDisagree bool
+	refName, refDisagree = pickString(func(s *Schema) string { return s.RefName }, create, update, read)
+	description, descDisagree = pickString(func(s *Schema) string { return s.Description }, create, update, read)
+	enum, enumDisagree = unionEnum(create, update, read)
+	sensitive, sensDisagree = anySensitive(create, update, read)
+
+	if refDisagree || descDisagree || enumDisagree || sensDisagree {
+		m.diagnostics = append(m.diagnostics, Diagnostic{
+			Severity: SeverityInfo,
+			Message: fmt.Sprintf(
+				"resource schema merge: reconciled a cosmetic difference between the create/update/read bodies at %q — favoring the read response for name/description, unioning enum members, OR-ing sensitive",
+				path,
+			),
+		})
+	}
+	return refName, description, enum, sensitive
+}
+
+func stampProvenance(create, update, read *Schema, createRequired bool) *SchemaProvenance {
+	return &SchemaProvenance{
+		InRequest:       create != nil || update != nil,
+		RequestRequired: createRequired,
+		InResponse:      read != nil,
+	}
+}
+
+// kindConflict reports the Kind every present (non-nil) body agrees on, or a
+// SchemaMergeError naming the two conflicting spellings.
+func kindConflict(create, update, read *Schema, path string) (SchemaKind, error) {
+	present := presentSchemas(create, update, read)
+	kind := present[0].Kind
+	for _, s := range present[1:] {
+		if s.Kind != kind {
+			return "", &SchemaMergeError{Path: path, Aspect: "kind", Left: string(kind), Right: string(s.Kind)}
+		}
+	}
+	return kind, nil
+}
+
+func presentSchemas(create, update, read *Schema) []*Schema {
+	var out []*Schema
+	if create != nil {
+		out = append(out, create)
+	}
+	if update != nil {
+		out = append(out, update)
+	}
+	if read != nil {
+		out = append(out, read)
+	}
+	return out
+}
+
+func unionObjectKeys(create, update, read *Schema) []string {
+	seen := make(map[string]struct{})
+	for _, s := range presentSchemas(create, update, read) {
+		for key := range s.Properties {
+			seen[key] = struct{}{}
+		}
+	}
+	keys := make([]string, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func mergePath(parent, child string) string {
+	if parent == "" {
+		return child
+	}
+	return parent + "." + child
+}
+
+func requiredFromCreate(create *Schema) []string {
+	if create == nil {
+		return nil
+	}
+	return sortedUniqueStrings(append([]string(nil), create.Required...))
+}
+
+// pickString returns get's value, preferring the Read side, then Create, then
+// Update, skipping an empty value even from the preferred side. disagreed
+// reports whether the present sides actually carried more than one distinct
+// non-empty value, so the caller knows whether a reconciliation happened or
+// every side already agreed.
+func pickString(get func(*Schema) string, create, update, read *Schema) (value string, disagreed bool) {
+	seen := map[string]bool{}
+	for _, s := range presentSchemas(create, update, read) {
+		if v := get(s); v != "" {
+			seen[v] = true
+		}
+	}
+	disagreed = len(seen) > 1
+	for _, s := range []*Schema{read, create, update} {
+		if s == nil {
+			continue
+		}
+		if v := get(s); v != "" {
+			return v, disagreed
+		}
+	}
+	return "", disagreed
+}
+
+// unionEnum unions the Enum members of every present side. disagreed reports
+// whether at least two sides carried enum members and at least one of them
+// was missing a member another side had — a side whose own deduped enum is
+// already the same size as the union necessarily equals it, since it is a
+// subset by construction.
+func unionEnum(create, update, read *Schema) (values []string, disagreed bool) {
+	present := presentSchemas(create, update, read)
+	var all []string
+	withEnum := 0
+	for _, s := range present {
+		if len(s.Enum) > 0 {
+			withEnum++
+			all = append(all, s.Enum...)
+		}
+	}
+	values = sortedUniqueStrings(all)
+	if withEnum < 2 {
+		return values, false
+	}
+	for _, s := range present {
+		if len(s.Enum) == 0 {
+			continue
+		}
+		if len(sortedUniqueStrings(append([]string(nil), s.Enum...))) != len(values) {
+			return values, true
+		}
+	}
+	return values, false
+}
+
+func anySensitive(create, update, read *Schema) (sensitive, disagreed bool) {
+	var sawTrue, sawFalse bool
+	for _, s := range presentSchemas(create, update, read) {
+		if s.Sensitive {
+			sawTrue = true
+		} else {
+			sawFalse = true
+		}
+	}
+	return sawTrue, sawTrue && sawFalse
+}

--- a/.generator-v2/internal/model/merge_test.go
+++ b/.generator-v2/internal/model/merge_test.go
@@ -1,0 +1,222 @@
+package model
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// jsonAPIBody builds a JSON:API-shaped body — data.attributes.<field> — under
+// its own top-level component name, so tests can give the Create request, the
+// Update request and the Read response three different enclosing component
+// names while still correlating by property position underneath them.
+func jsonAPIBody(refName string, attributes map[string]*Schema, required []string) *Schema {
+	return &Schema{
+		Kind:    SchemaKindObject,
+		RefName: refName,
+		Properties: map[string]*Schema{
+			"data": {
+				Kind: SchemaKindObject,
+				Properties: map[string]*Schema{
+					"attributes": {
+						Kind:       SchemaKindObject,
+						Properties: attributes,
+						Required:   required,
+					},
+				},
+			},
+		},
+	}
+}
+
+func attributesOf(s *Schema) map[string]*Schema {
+	return s.Properties["data"].Properties["attributes"].Properties
+}
+
+var _ = Describe("MergeResourceSchema", func() {
+	It("correlates by property position across three differently-named components and stamps the FR-034a provenance bits", func() {
+		createReq := jsonAPIBody("IncidentTypeCreateRequest", map[string]*Schema{
+			"name":          {Kind: SchemaKindPrimitive, Type: "string", Description: "name (create)"},
+			"is_default":    {Kind: SchemaKindPrimitive, Type: "boolean"},
+			"internal_note": {Kind: SchemaKindPrimitive, Type: "string"},
+			"priority":      {Kind: SchemaKindPrimitive, Type: "string", Enum: []string{"low", "high"}},
+			"status":        {Kind: SchemaKindPrimitive, Type: "string", Enum: []string{"open", "closed"}},
+		}, []string{"name"})
+
+		// A PATCH body marking "priority" required is deliberately unusual: it
+		// proves RequestRequired reads the Create body's Required list only.
+		updateReq := jsonAPIBody("IncidentTypeUpdateRequest", map[string]*Schema{
+			"name":       {Kind: SchemaKindPrimitive, Type: "string"},
+			"is_default": {Kind: SchemaKindPrimitive, Type: "boolean"},
+			"priority":   {Kind: SchemaKindPrimitive, Type: "string", Enum: []string{"low", "high"}},
+		}, []string{"priority"})
+
+		readResp := jsonAPIBody("IncidentTypeResponse", map[string]*Schema{
+			"name":       {Kind: SchemaKindPrimitive, Type: "string", Description: "The incident type name."},
+			"is_default": {Kind: SchemaKindPrimitive, Type: "boolean"},
+			"created_at": {Kind: SchemaKindPrimitive, Type: "string", Format: "date-time"},
+			"status":     {Kind: SchemaKindPrimitive, Type: "string", Enum: []string{"open", "closed", "archived"}, Sensitive: true},
+		}, nil)
+
+		group := &ResolvedGroup{
+			Create: &Operation{OperationId: "CreateIncidentType", RequestSchema: createReq},
+			Update: &Operation{OperationId: "UpdateIncidentType", RequestSchema: updateReq},
+			Read:   &Operation{OperationId: "GetIncidentType", ResponseSchema: readResp},
+		}
+
+		merged, diags, err := MergeResourceSchema(group)
+		Expect(err).NotTo(HaveOccurred())
+
+		attrs := attributesOf(merged)
+
+		By("required in Create, present in Update, present in response -> Required")
+		Expect(attrs["name"].Provenance).To(Equal(&SchemaProvenance{InRequest: true, RequestRequired: true, InResponse: true}))
+		// Cosmetic: descriptions differ, Read response wins.
+		Expect(attrs["name"].Description).To(Equal("The incident type name."))
+
+		By("optional in Create, present in Update, present in response -> Optional+Computed")
+		Expect(attrs["is_default"].Provenance).To(Equal(&SchemaProvenance{InRequest: true, RequestRequired: false, InResponse: true}))
+
+		By("Create-only, absent from Update and the response -> write-only Optional")
+		Expect(attrs["internal_note"].Provenance).To(Equal(&SchemaProvenance{InRequest: true, RequestRequired: false, InResponse: false}))
+
+		By("response-only -> Computed-only, and Format carries through untouched")
+		Expect(attrs["created_at"].Provenance).To(Equal(&SchemaProvenance{InRequest: false, RequestRequired: false, InResponse: true}))
+		Expect(attrs["created_at"].Format).To(Equal("date-time"))
+
+		By("Update's Required entry is ignored: RequestRequired reads Create's Required list only")
+		Expect(attrs["priority"].Provenance.RequestRequired).To(BeFalse())
+		// Enum agrees everywhere it appears, so no cosmetic reconciliation is needed.
+		Expect(attrs["priority"].Enum).To(Equal([]string{"high", "low"}))
+
+		By("Enum members union (never intersect) and Sensitive is the disjunction")
+		Expect(attrs["status"].Enum).To(Equal([]string{"archived", "closed", "open"}))
+		Expect(attrs["status"].Sensitive).To(BeTrue())
+
+		By("the root's own RefName differs across all three bodies; the Read response wins")
+		Expect(merged.RefName).To(Equal("IncidentTypeResponse"))
+
+		By("every reconciled cosmetic difference is recorded as an info diagnostic")
+		Expect(diags).NotTo(BeEmpty())
+		for _, d := range diags {
+			Expect(d.Severity).To(Equal(SeverityInfo))
+		}
+	})
+
+	It("merges with no Update operation at all", func() {
+		createReq := jsonAPIBody("XCreateRequest", map[string]*Schema{
+			"name": {Kind: SchemaKindPrimitive, Type: "string"},
+		}, []string{"name"})
+		readResp := jsonAPIBody("XResponse", map[string]*Schema{
+			"name": {Kind: SchemaKindPrimitive, Type: "string"},
+		}, nil)
+
+		group := &ResolvedGroup{
+			Create: &Operation{OperationId: "CreateX", RequestSchema: createReq},
+			Read:   &Operation{OperationId: "GetX", ResponseSchema: readResp},
+		}
+
+		merged, _, err := MergeResourceSchema(group)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(attributesOf(merged)["name"].Provenance).To(Equal(&SchemaProvenance{InRequest: true, RequestRequired: true, InResponse: true}))
+	})
+
+	It("never reads group.Search or a Create/Update response body", func() {
+		createReq := jsonAPIBody("XCreateRequest", map[string]*Schema{
+			"name": {Kind: SchemaKindPrimitive, Type: "string"},
+		}, nil)
+		readResp := jsonAPIBody("XResponse", map[string]*Schema{
+			"name": {Kind: SchemaKindPrimitive, Type: "string"},
+		}, nil)
+
+		group := &ResolvedGroup{
+			Create: &Operation{
+				OperationId:   "CreateX",
+				RequestSchema: createReq,
+				// A response-only field must never surface as Computed state.
+				ResponseSchema: jsonAPIBody("XCreateResponse", map[string]*Schema{
+					"name":            {Kind: SchemaKindPrimitive, Type: "string"},
+					"create_response": {Kind: SchemaKindPrimitive, Type: "string"},
+				}, nil),
+			},
+			Read: &Operation{OperationId: "GetX", ResponseSchema: readResp},
+			Search: &Operation{
+				OperationId: "ListX",
+				// A field only the search element carries must not leak in either.
+				ResponseSchema: jsonAPIBody("XListItem", map[string]*Schema{
+					"name":          {Kind: SchemaKindPrimitive, Type: "string"},
+					"search_narrow": {Kind: SchemaKindPrimitive, Type: "string"},
+				}, nil),
+			},
+		}
+
+		merged, _, err := MergeResourceSchema(group)
+		Expect(err).NotTo(HaveOccurred())
+		attrs := attributesOf(merged)
+		Expect(attrs).To(HaveKey("name"))
+		Expect(attrs).NotTo(HaveKey("create_response"))
+		Expect(attrs).NotTo(HaveKey("search_narrow"))
+	})
+
+	It("fails with SchemaMergeError naming the path and both spellings on a primitive type conflict", func() {
+		createReq := jsonAPIBody("XCreateRequest", map[string]*Schema{
+			"count": {Kind: SchemaKindPrimitive, Type: "integer"},
+		}, nil)
+		readResp := jsonAPIBody("XResponse", map[string]*Schema{
+			"count": {Kind: SchemaKindPrimitive, Type: "string"},
+		}, nil)
+
+		group := &ResolvedGroup{
+			Create: &Operation{OperationId: "CreateX", RequestSchema: createReq},
+			Read:   &Operation{OperationId: "GetX", ResponseSchema: readResp},
+		}
+
+		_, _, err := MergeResourceSchema(group)
+		Expect(err).To(HaveOccurred())
+		var mergeErr *SchemaMergeError
+		Expect(errors.As(err, &mergeErr)).To(BeTrue())
+		Expect(mergeErr.Path).To(Equal("data.attributes.count"))
+		Expect(mergeErr.Aspect).To(Equal("type"))
+		Expect([]string{mergeErr.Left, mergeErr.Right}).To(ConsistOf("integer", "string"))
+	})
+
+	It("fails with SchemaMergeError on a Kind conflict, at the deeper path when it is inside an array element", func() {
+		createReq := jsonAPIBody("XCreateRequest", map[string]*Schema{
+			"tags": {
+				Kind:  SchemaKindArray,
+				Items: &Schema{Kind: SchemaKindPrimitive, Type: "string"},
+			},
+		}, nil)
+		readResp := jsonAPIBody("XResponse", map[string]*Schema{
+			"tags": {
+				Kind: SchemaKindArray,
+				Items: &Schema{
+					Kind:       SchemaKindObject,
+					Properties: map[string]*Schema{"value": {Kind: SchemaKindPrimitive, Type: "string"}},
+				},
+			},
+		}, nil)
+
+		group := &ResolvedGroup{
+			Create: &Operation{OperationId: "CreateX", RequestSchema: createReq},
+			Read:   &Operation{OperationId: "GetX", ResponseSchema: readResp},
+		}
+
+		_, _, err := MergeResourceSchema(group)
+		Expect(err).To(HaveOccurred())
+		var mergeErr *SchemaMergeError
+		Expect(errors.As(err, &mergeErr)).To(BeTrue())
+		Expect(mergeErr.Path).To(Equal("data.attributes.tags[]"))
+		Expect(mergeErr.Aspect).To(Equal("kind"))
+		Expect([]string{mergeErr.Left, mergeErr.Right}).To(ConsistOf(string(SchemaKindPrimitive), string(SchemaKindObject)))
+	})
+
+	It("requires a resolved Create and Read operation", func() {
+		_, _, err := MergeResourceSchema(&ResolvedGroup{})
+		Expect(err).To(HaveOccurred())
+
+		_, _, err = MergeResourceSchema(&ResolvedGroup{Create: &Operation{}})
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/.generator-v2/internal/model/merge_test.go
+++ b/.generator-v2/internal/model/merge_test.go
@@ -35,7 +35,7 @@ func attributesOf(s *Schema) map[string]*Schema {
 }
 
 var _ = Describe("MergeResourceSchema", func() {
-	It("correlates by property position across three differently-named components and stamps the FR-034a provenance bits", func() {
+	It("correlates by property position across three differently-named components and stamps the provenance bits", func() {
 		createReq := jsonAPIBody("IncidentTypeCreateRequest", map[string]*Schema{
 			"name":          {Kind: SchemaKindPrimitive, Type: "string", Description: "name (create)"},
 			"is_default":    {Kind: SchemaKindPrimitive, Type: "boolean"},

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -354,19 +354,15 @@ type Schema struct {
 	// carrying one — mirroring how the SDK generator's child_models() prefers a
 	// $ref name over the parent-derived alternative name.
 	RefName string
-	// Provenance is non-nil only on a node of the schema MergeResourceSchema
-	// produces by unioning the Create request, Update request and Read response
-	// bodies; nil everywhere else. That nil-ness is what distinguishes a
-	// merged schema from a single-direction one, so BuildResourceTree can reject
-	// an unmerged input rather than silently flag every node Computed.
+	// Provenance is non-nil only on a node produced by unioning the Create
+	// request, Update request and Read response bodies; nil on any
+	// single-direction schema.
 	Provenance *SchemaProvenance
 }
 
-// SchemaProvenance records which of the three bodies a resource schema merge
-// reads — Create request, Update request, Read response — contributed a node,
-// so BuildResourceTree can derive Terraform presence flags as a total function
-// of these three bits alone, with no further OpenAPI signal consulted. Set
-// only by MergeResourceSchema.
+// SchemaProvenance records which of the three bodies — Create request,
+// Update request, Read response — contributed a given node during a resource
+// schema merge.
 type SchemaProvenance struct {
 	// InRequest is true when the node is present in the Create or Update
 	// request body.
@@ -517,13 +513,12 @@ type Attribute struct {
 	Default *Literal
 	// Validators is the fingerprintable validator list for this attribute.
 	Validators []ValidatorSpec
-	// PlanModifiers is populated only by BuildResourceTree; empty for
-	// both data-source tree shapes. UseStateForUnknown() lands on an Optional +
-	// Computed attribute, RequiresReplace() on a request-settable one when the
-	// group resolves no Update role. Never populated on a Computed-only
-	// attribute — the server may change such a value during apply, so either
-	// modifier there produces an inconsistent-result error or a spurious
-	// replacement.
+	// PlanModifiers holds this attribute's plan modifiers: UseStateForUnknown()
+	// on an Optional+Computed attribute, RequiresReplace() on a
+	// request-settable one when no Update role exists. Never set on a
+	// Computed-only attribute — the server may change such a value during
+	// apply, so either modifier there would produce an inconsistent-result
+	// error or a spurious replacement.
 	PlanModifiers []PlanModifierSpec
 	// Description is always populated from the OpenAPI description (repo convention).
 	Description string
@@ -634,9 +629,7 @@ type ValidatorSpec struct {
 }
 
 // PlanModifierSpec is one plan modifier attached to a resource attribute,
-// rendered as a Go constructor call. Populated only by
-// BuildResourceTree, from the same resource flag matrix that derives
-// Required/Optional/Computed, and typed per framework value kind
+// rendered as a Go constructor call and typed per framework value kind
 // (planmodifier.Bool, planmodifier.Object, ...) derived from Attribute.GoType.
 type PlanModifierSpec struct {
 	// Name is the plan modifier constructor, e.g.

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -354,6 +354,29 @@ type Schema struct {
 	// carrying one — mirroring how the SDK generator's child_models() prefers a
 	// $ref name over the parent-derived alternative name.
 	RefName string
+	// Provenance is non-nil only on a node of the schema MergeResourceSchema
+	// produces by unioning the Create request, Update request and Read response
+	// bodies (FR-034); nil everywhere else. That nil-ness is what distinguishes a
+	// merged schema from a single-direction one, so BuildResourceTree can reject
+	// an unmerged input rather than silently flag every node Computed.
+	Provenance *SchemaProvenance
+}
+
+// SchemaProvenance records which of the three bodies a resource schema merge
+// reads — Create request, Update request, Read response — contributed a node,
+// so BuildResourceTree can derive Terraform presence flags as a total function
+// of these three bits alone (FR-034a), with no further OpenAPI signal
+// consulted. Set only by MergeResourceSchema.
+type SchemaProvenance struct {
+	// InRequest is true when the node is present in the Create or Update
+	// request body.
+	InRequest bool
+	// RequestRequired is true when the node is named in the Create body's
+	// Required list. The Update body is never consulted for requiredness — a
+	// PATCH body marks everything optional.
+	RequestRequired bool
+	// InResponse is true when the node is present in the Read response body.
+	InResponse bool
 }
 
 // OneOfSpec is the normalized representation of an OpenAPI oneOf. The envelope
@@ -494,6 +517,14 @@ type Attribute struct {
 	Default *Literal
 	// Validators is the fingerprintable validator list for this attribute.
 	Validators []ValidatorSpec
+	// PlanModifiers is populated only by BuildResourceTree (FR-034d); empty for
+	// both data-source tree shapes. UseStateForUnknown() lands on an Optional +
+	// Computed attribute, RequiresReplace() on a request-settable one when the
+	// group resolves no Update role. Never populated on a Computed-only
+	// attribute — the server may change such a value during apply, so either
+	// modifier there produces an inconsistent-result error or a spurious
+	// replacement.
+	PlanModifiers []PlanModifierSpec
 	// Description is always populated from the OpenAPI description (repo convention).
 	Description string
 	// Children holds nested attributes for nested blocks.
@@ -597,6 +628,19 @@ type Literal struct {
 // validator: the constructor plus its Go-source-rendered arguments.
 type ValidatorSpec struct {
 	// Name is the validator constructor, e.g. stringvalidator.LengthAtLeast.
+	Name string
+	// Args are the constructor arguments rendered as Go source expressions.
+	Args []string
+}
+
+// PlanModifierSpec is one plan modifier attached to a resource attribute
+// (FR-034d), rendered as a Go constructor call. Populated only by
+// BuildResourceTree, from the same resource flag matrix that derives
+// Required/Optional/Computed, and typed per framework value kind
+// (planmodifier.Bool, planmodifier.Object, ...) derived from Attribute.GoType.
+type PlanModifierSpec struct {
+	// Name is the plan modifier constructor, e.g.
+	// stringplanmodifier.UseStateForUnknown or boolplanmodifier.RequiresReplace.
 	Name string
 	// Args are the constructor arguments rendered as Go source expressions.
 	Args []string

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -356,7 +356,7 @@ type Schema struct {
 	RefName string
 	// Provenance is non-nil only on a node of the schema MergeResourceSchema
 	// produces by unioning the Create request, Update request and Read response
-	// bodies (FR-034); nil everywhere else. That nil-ness is what distinguishes a
+	// bodies; nil everywhere else. That nil-ness is what distinguishes a
 	// merged schema from a single-direction one, so BuildResourceTree can reject
 	// an unmerged input rather than silently flag every node Computed.
 	Provenance *SchemaProvenance
@@ -365,8 +365,8 @@ type Schema struct {
 // SchemaProvenance records which of the three bodies a resource schema merge
 // reads — Create request, Update request, Read response — contributed a node,
 // so BuildResourceTree can derive Terraform presence flags as a total function
-// of these three bits alone (FR-034a), with no further OpenAPI signal
-// consulted. Set only by MergeResourceSchema.
+// of these three bits alone, with no further OpenAPI signal consulted. Set
+// only by MergeResourceSchema.
 type SchemaProvenance struct {
 	// InRequest is true when the node is present in the Create or Update
 	// request body.
@@ -517,7 +517,7 @@ type Attribute struct {
 	Default *Literal
 	// Validators is the fingerprintable validator list for this attribute.
 	Validators []ValidatorSpec
-	// PlanModifiers is populated only by BuildResourceTree (FR-034d); empty for
+	// PlanModifiers is populated only by BuildResourceTree; empty for
 	// both data-source tree shapes. UseStateForUnknown() lands on an Optional +
 	// Computed attribute, RequiresReplace() on a request-settable one when the
 	// group resolves no Update role. Never populated on a Computed-only
@@ -633,8 +633,8 @@ type ValidatorSpec struct {
 	Args []string
 }
 
-// PlanModifierSpec is one plan modifier attached to a resource attribute
-// (FR-034d), rendered as a Go constructor call. Populated only by
+// PlanModifierSpec is one plan modifier attached to a resource attribute,
+// rendered as a Go constructor call. Populated only by
 // BuildResourceTree, from the same resource flag matrix that derives
 // Required/Optional/Computed, and typed per framework value kind
 // (planmodifier.Bool, planmodifier.Object, ...) derived from Attribute.GoType.

--- a/.generator-v2/internal/parser/schema.go
+++ b/.generator-v2/internal/parser/schema.go
@@ -652,7 +652,7 @@ func (n *schemaNormalizer) normalizeSchema(s *base.Schema, depth int, ctx schema
 		// Sorted iteration keeps recursion (and any surfaced error) deterministic.
 		for _, key := range sortedPropertyKeys(s) {
 			child, err := n.normalizeProxyAt(s.Properties.GetOrZero(key), depth, schemaContext{
-				path:     childPath(ctx.path, key),
+				path:     model.ChildPath(ctx.path, key),
 				required: slices.Contains(s.Required, key),
 			})
 			if err != nil {
@@ -666,7 +666,7 @@ func (n *schemaNormalizer) normalizeSchema(s *base.Schema, depth int, ctx schema
 		// Array: a single element schema, carried in out.Items.
 		if s.Items != nil && s.Items.IsA() {
 			item, err := n.normalizeProxyAt(s.Items.A, depth, schemaContext{
-				path:     childPath(ctx.path, "[]"),
+				path:     model.ChildPath(ctx.path, "[]"),
 				required: true,
 			})
 			if err != nil {
@@ -682,7 +682,7 @@ func (n *schemaNormalizer) normalizeSchema(s *base.Schema, depth int, ctx schema
 		// represent, so carry an Unsupported sentinel for the check to reject.
 		if s.AdditionalProperties != nil && s.AdditionalProperties.IsA() {
 			value, err := n.normalizeProxyAt(s.AdditionalProperties.A, depth, schemaContext{
-				path:     childPath(ctx.path, "{}"),
+				path:     model.ChildPath(ctx.path, "{}"),
 				required: true,
 			})
 			if err != nil {
@@ -762,7 +762,7 @@ func (n *schemaNormalizer) normalizeOneOf(s *base.Schema, depth int, ctx schemaC
 		if err != nil {
 			return nil, fmt.Errorf("parser: %w", err)
 		}
-		variantPath := childPath(ctx.path, tfName)
+		variantPath := model.ChildPath(ctx.path, tfName)
 		variantSchema, err := n.normalizeProxyAt(proxy, depth, schemaContext{
 			path:     variantPath,
 			required: true,
@@ -1324,16 +1324,6 @@ func nonNullTypes(types []string) []string {
 		}
 	}
 	return out
-}
-
-func childPath(parent, child string) string {
-	if parent == "" {
-		return child
-	}
-	if child == "[]" || child == "{}" {
-		return parent + child
-	}
-	return parent + "." + child
 }
 
 // classifyKind derives the SchemaKind from structure, not type alone. Precedence

--- a/.generator-v2/internal/parser/schema.go
+++ b/.generator-v2/internal/parser/schema.go
@@ -784,7 +784,7 @@ func (n *schemaNormalizer) normalizeOneOf(s *base.Schema, depth int, ctx schemaC
 			GoName:       model.SdkName(tfName),
 			Schema:       variantSchema,
 			RefName:      source.refName,
-			ValueWrapped: oneOfValueWrapped(variantSchema),
+			ValueWrapped: model.OneOfValueWrapped(variantSchema),
 		})
 	}
 
@@ -926,7 +926,7 @@ func (n *schemaNormalizer) mergeOneOfSiblings(
 	// A type:object sibling carrying only required names is a constraint
 	// carrier, not a standalone Terraform object. General schema normalization
 	// correctly classifies an object with no properties as Unsupported, but
-	// retaining that sentinel here would cause mergeNormalizedSchemas to discard
+	// retaining that sentinel here would cause MergeNormalizedSchemas to discard
 	// the required constraint. Give this merge-only schema an empty object shape
 	// so its required names are applied to every object alternative.
 	if common.Kind == model.SchemaKindUnsupported && isRequiredOnlyObjectConstraint(commonRaw) {
@@ -934,7 +934,7 @@ func (n *schemaNormalizer) mergeOneOfSiblings(
 		common.Properties = make(map[string]*model.Schema)
 		common.Required = sortedRequired(commonRaw)
 	}
-	return mergeNormalizedSchemas(variant, common), nil
+	return model.MergeNormalizedSchemas(variant, common), nil
 }
 
 func isRequiredOnlyObjectConstraint(s *base.Schema) bool {
@@ -969,114 +969,6 @@ func oneOfSiblingSchema(s *base.Schema) (*base.Schema, bool) {
 		len(common.Enum) > 0 ||
 		common.Format != ""
 	return &common, hasConstraints
-}
-
-// mergeNormalizedSchemas intersects the subset of OpenAPI constraints retained
-// by model.Schema. A kind mismatch remains present as an Unsupported variant so
-// later validation can report that precise alternative instead of dropping it.
-func mergeNormalizedSchemas(variant, common *model.Schema) *model.Schema {
-	if variant == nil {
-		return common
-	}
-	if common == nil {
-		return variant
-	}
-	if common.Kind == model.SchemaKindUnsupported {
-		out := cloneSchema(common)
-		if out.Description == "" {
-			out.Description = variant.Description
-		}
-		return out
-	}
-	if variant.Kind == model.SchemaKindOneOf && variant.OneOf != nil {
-		for i := range variant.OneOf.Variants {
-			variant.OneOf.Variants[i].Schema = mergeNormalizedSchemas(variant.OneOf.Variants[i].Schema, common)
-			variant.OneOf.Variants[i].ValueWrapped = oneOfValueWrapped(variant.OneOf.Variants[i].Schema)
-		}
-		return variant
-	}
-	if variant.Kind == model.SchemaKindUnsupported {
-		if variant.UnsupportedReason != "" {
-			return variant
-		}
-		if common.Description == "" {
-			common.Description = variant.Description
-		}
-		return common
-	}
-	if variant.Kind != common.Kind {
-		return &model.Schema{
-			Kind:              model.SchemaKindUnsupported,
-			Description:       variant.Description,
-			UnsupportedReason: fmt.Sprintf("oneOf alternative kind %q conflicts with adjacent schema kind %q", variant.Kind, common.Kind),
-		}
-	}
-
-	switch variant.Kind {
-	case model.SchemaKindObject:
-		if variant.Properties == nil {
-			variant.Properties = make(map[string]*model.Schema)
-		}
-		for key, commonProperty := range common.Properties {
-			if property, exists := variant.Properties[key]; exists {
-				variant.Properties[key] = mergeNormalizedSchemas(property, commonProperty)
-			} else {
-				variant.Properties[key] = commonProperty
-			}
-		}
-		variant.Required = sortedUniqueStrings(append(variant.Required, common.Required...))
-	case model.SchemaKindArray, model.SchemaKindMap:
-		variant.Items = mergeNormalizedSchemas(variant.Items, common.Items)
-	case model.SchemaKindPrimitive:
-		if variant.Type != "" && common.Type != "" && variant.Type != common.Type {
-			return &model.Schema{
-				Kind:              model.SchemaKindUnsupported,
-				Description:       variant.Description,
-				UnsupportedReason: fmt.Sprintf("oneOf alternative type %q conflicts with adjacent type %q", variant.Type, common.Type),
-			}
-		}
-		if variant.Type == "" {
-			variant.Type = common.Type
-		}
-		if variant.Format != "" && common.Format != "" && variant.Format != common.Format {
-			return &model.Schema{
-				Kind:              model.SchemaKindUnsupported,
-				Description:       variant.Description,
-				UnsupportedReason: fmt.Sprintf("oneOf alternative format %q conflicts with adjacent format %q", variant.Format, common.Format),
-			}
-		}
-		if variant.Format == "" {
-			variant.Format = common.Format
-		}
-		switch {
-		case len(variant.Enum) == 0:
-			variant.Enum = append([]string(nil), common.Enum...)
-		case len(common.Enum) > 0:
-			intersection := intersectStrings(variant.Enum, common.Enum)
-			if len(intersection) == 0 {
-				return &model.Schema{
-					Kind:              model.SchemaKindUnsupported,
-					Description:       variant.Description,
-					UnsupportedReason: "oneOf alternative enum has no values in common with adjacent enum",
-				}
-			}
-			variant.Enum = intersection
-		}
-	}
-	variant.Sensitive = variant.Sensitive || common.Sensitive
-	return variant
-}
-
-func oneOfValueWrapped(schema *model.Schema) bool {
-	if schema == nil {
-		return false
-	}
-	switch schema.Kind {
-	case model.SchemaKindPrimitive, model.SchemaKindArray, model.SchemaKindMap:
-		return true
-	default:
-		return false
-	}
 }
 
 // normalizeAllOf flattens the bounded allOf subset used by the Datadog API
@@ -1139,7 +1031,7 @@ func (n *schemaNormalizer) normalizeAllOf(s *base.Schema, depth int, ctx schemaC
 	}
 
 	if len(branches) == 1 {
-		out := cloneSchema(branches[0].schema)
+		out := model.CloneSchema(branches[0].schema)
 		if outerType != "" && !schemaKindMatchesType(out, outerType) {
 			return unsupportedSchema(fmt.Sprintf("allOf outer type %q conflicts with branch %d schema kind %q", outerType, branches[0].index, out.Kind)), nil
 		}
@@ -1202,7 +1094,7 @@ func (n *schemaNormalizer) normalizeAllOf(s *base.Schema, depth int, ctx schemaC
 				)), nil
 			}
 			propertyBranch[name] = branch.index
-			out.Properties[name] = cloneSchema(child)
+			out.Properties[name] = model.CloneSchema(child)
 		}
 		for _, name := range branch.schema.Required {
 			required[name] = true
@@ -1442,72 +1334,6 @@ func childPath(parent, child string) string {
 		return parent + child
 	}
 	return parent + "." + child
-}
-
-func sortedUniqueStrings(values []string) []string {
-	if len(values) == 0 {
-		return nil
-	}
-	sort.Strings(values)
-	return slices.Compact(values)
-}
-
-func intersectStrings(left, right []string) []string {
-	allowed := make(map[string]struct{}, len(right))
-	for _, value := range right {
-		allowed[value] = struct{}{}
-	}
-	var intersection []string
-	for _, value := range left {
-		if _, ok := allowed[value]; ok {
-			intersection = append(intersection, value)
-		}
-	}
-	return sortedUniqueStrings(intersection)
-}
-
-// cloneSchema returns a deep copy so applying allOf metadata never mutates a
-// normalized branch or any child reachable from it.
-func cloneSchema(s *model.Schema) *model.Schema {
-	if s == nil {
-		return nil
-	}
-	out := *s
-	out.Enum = append([]string(nil), s.Enum...)
-	out.Required = append([]string(nil), s.Required...)
-	out.Items = cloneSchema(s.Items)
-	if s.Properties != nil {
-		out.Properties = make(map[string]*model.Schema, len(s.Properties))
-		for name, child := range s.Properties {
-			out.Properties[name] = cloneSchema(child)
-		}
-	}
-	if s.Variants != nil {
-		out.Variants = make([]*model.Schema, len(s.Variants))
-		for i, variant := range s.Variants {
-			out.Variants[i] = cloneSchema(variant)
-		}
-	}
-	if s.OneOf != nil {
-		oneOf := *s.OneOf
-		oneOf.Variants = make([]model.OneOfVariant, len(s.OneOf.Variants))
-		for i, variant := range s.OneOf.Variants {
-			oneOf.Variants[i] = variant
-			oneOf.Variants[i].Schema = cloneSchema(variant.Schema)
-		}
-		if s.OneOf.Discriminator != nil {
-			discriminator := *s.OneOf.Discriminator
-			if s.OneOf.Discriminator.Mapping != nil {
-				discriminator.Mapping = make(map[string]string, len(s.OneOf.Discriminator.Mapping))
-				for key, value := range s.OneOf.Discriminator.Mapping {
-					discriminator.Mapping[key] = value
-				}
-			}
-			oneOf.Discriminator = &discriminator
-		}
-		out.OneOf = &oneOf
-	}
-	return &out
 }
 
 // classifyKind derives the SchemaKind from structure, not type alone. Precedence

--- a/.generator-v2/internal/parser/schema_test.go
+++ b/.generator-v2/internal/parser/schema_test.go
@@ -484,7 +484,7 @@ var _ = Describe("NormalizeSchemas oneOf naming failures", func() {
 			Properties: map[string]*model.Schema{"shared": {Kind: model.SchemaKindPrimitive, Type: "string"}},
 		}
 
-		Expect(mergeNormalizedSchemas(unsupported, common)).To(BeIdenticalTo(unsupported))
+		Expect(model.MergeNormalizedSchemas(unsupported, common)).To(BeIdenticalTo(unsupported))
 		Expect(unsupported.UnsupportedReason).To(ContainSubstring("colliding variant name"))
 	})
 })

--- a/.generator-v2/internal/sdkbind/bind.go
+++ b/.generator-v2/internal/sdkbind/bind.go
@@ -125,17 +125,17 @@ func (b *binder) walk(s *model.Schema, sdkName, path string) {
 
 	case model.SchemaKindObject:
 		for _, name := range sortedKeys(s.Properties) {
-			b.walk(s.Properties[name], childModelName(sdkName, model.SdkName(name)), childPath(path, name))
+			b.walk(s.Properties[name], childModelName(sdkName, model.SdkName(name)), model.ChildPath(path, name))
 		}
 
 	case model.SchemaKindArray:
-		b.walk(s.Items, childModelName(sdkName, "Item"), childPath(path, "[]"))
+		b.walk(s.Items, childModelName(sdkName, "Item"), model.ChildPath(path, "[]"))
 
 	case model.SchemaKindMap:
 		// child_models only recurses into additionalProperties when the value is a
 		// $ref, so a map value is nameable through its own component name or not at
 		// all: pass no accumulated name and let the $ref rule above supply one.
-		b.walk(s.Items, "", childPath(path, "{}"))
+		b.walk(s.Items, "", model.ChildPath(path, "{}"))
 	}
 }
 
@@ -196,7 +196,7 @@ func (b *binder) bindUnion(spec *model.OneOfSpec, sdkName, path string) {
 		}
 
 		// An alternative may itself be a union, or contain one.
-		b.walk(v.Schema, v.RefName, childPath(unionPath, v.TFName))
+		b.walk(v.Schema, v.RefName, model.ChildPath(unionPath, v.TFName))
 	}
 }
 
@@ -208,18 +208,6 @@ func childModelName(parent, step string) string {
 		return ""
 	}
 	return parent + step
-}
-
-// childPath mirrors the parser's path spelling so a binding diagnostic points at
-// the same node a normalization diagnostic would.
-func childPath(parent, child string) string {
-	if parent == "" {
-		return child
-	}
-	if child == "[]" || child == "{}" {
-		return parent + child
-	}
-	return parent + "." + child
 }
 
 func sortedKeys(m map[string]*model.Schema) []string {


### PR DESCRIPTION
## Motivation

Continues the generator-v2 resource-support work: a resource's Terraform schema has to be derived from three different OpenAPI bodies (the Create request, the Update request, and the Read response), not from a single response tree the way a data source is. Nothing in the generator built that merged schema yet, so a resource artifact's `Schema` field was left `nil`.

## Changes

- Added `SchemaProvenance` (`InRequest`, `RequestRequired`, `InResponse`) and `PlanModifierSpec`, plus the corresponding `Schema.Provenance` and `Attribute.PlanModifiers` fields, in `internal/model/types.go`.
- Added `internal/model/merge.go`:
  - `MergeResourceSchema` unions the Create request, Update request and Read response bodies, correlating nodes by property name at equal depth from each body's root, and stamps `Provenance` on every node.
  - `SchemaMergeError` for a structural disagreement (differing Kind/Type/Format) between the three bodies, naming the path and both spellings.
  - Cosmetic disagreements (RefName/Description/Enum/Sensitive) reconcile instead of erroring, favoring the Read response, and record an info diagnostic.
- Lifted `mergeNormalizedSchemas`/`cloneSchema`/`oneOfValueWrapped`, previously private to `internal/parser`, into `model` as exported `MergeNormalizedSchemas`/`CloneSchema`/`OneOfValueWrapped` (unchanged behavior) so the new merge can reuse them instead of duplicating; `parser` now calls the `model` versions. Also lifted `childPath` (byte-identical in `parser` and `sdkbind`) into `model` as `ChildPath` for the same reason.
- A few follow-up passes on the same code: collapsed repeated reconciliation/preference-order logic into shared helpers, and trimmed code comments down to describing each function's own behavior rather than cross-referencing other parts of the generator or naming spec task IDs.

## Testing

Added `internal/model/merge_test.go`: covers all provenance combinations, a JSON:API fixture where the Create/Update/Read bodies each have a different root component name, the rule that `RequestRequired` reads only the Create body's `Required` list, `Update == nil`, and both structural-conflict shapes (primitive type, and a Kind conflict nested inside an array). Full `go test ./internal/...`, `go vet`, and `gofmt` are green.
