### PR TITLE
[datadog_security_monitoring_rule] Only read decrease_criticality_based_on_env for log_detection rules

### DIFF
--- a/datadog/fwprovider/resource_datadog_security_monitoring_rule.go
+++ b/datadog/fwprovider/resource_datadog_security_monitoring_rule.go
@@ -968,7 +968,7 @@ type securityMonitoringRuleResponseInterface interface {
 //   - Optional-only string / list: pass API value through; reconcileEmpty*
 //     helpers reconcile empty API responses against prior plan/state.
 //   - Optional-only int64: preserve prior when API returns zero or omits.
-func updateCommonResourceDataFromResponse(ctx context.Context, state *securityMonitoringRuleResourceModel, ruleResponse securityMonitoringRuleResponseInterface) diag.Diagnostics {
+func updateCommonResourceDataFromResponse(ctx context.Context, state *securityMonitoringRuleResourceModel, ruleResponse securityMonitoringRuleResponseInterface, ruleType string) diag.Diagnostics {
 	var diags diag.Diagnostics
 	priorOptions := state.Options
 
@@ -983,7 +983,7 @@ func updateCommonResourceDataFromResponse(ctx context.Context, state *securityMo
 	}
 
 	var optsDiags diag.Diagnostics
-	state.Options, optsDiags = extractTfOptions(ctx, ruleResponse.GetOptions(), priorOptions)
+	state.Options, optsDiags = extractTfOptions(ctx, ruleResponse.GetOptions(), priorOptions, ruleType)
 	diags.Append(optsDiags...)
 
 	return diags
@@ -1016,7 +1016,7 @@ func extractThirdPartyCases(ctx context.Context, responseThirdPartyCases []datad
 func updateStandardResourceDataFromResponse(ctx context.Context, state *securityMonitoringRuleResourceModel, ruleResponse *datadogV2.SecurityMonitoringStandardRuleResponse) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	diags.Append(updateCommonResourceDataFromResponse(ctx, state, ruleResponse)...)
+	diags.Append(updateCommonResourceDataFromResponse(ctx, state, ruleResponse, string(ruleResponse.GetType()))...)
 
 	opts := ruleResponse.GetOptions()
 	if opts.GetDetectionMethod() == datadogV2.SECURITYMONITORINGRULEDETECTIONMETHOD_THIRD_PARTY {
@@ -1140,7 +1140,7 @@ func extractStandardRuleQueries(ctx context.Context, responseRuleQueries []datad
 func updateSignalResourceDataFromResponse(ctx context.Context, state *securityMonitoringRuleResourceModel, resp *datadogV2.SecurityMonitoringSignalRuleResponse) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	diags.Append(updateCommonResourceDataFromResponse(ctx, state, resp)...)
+	diags.Append(updateCommonResourceDataFromResponse(ctx, state, resp, string(resp.GetType()))...)
 
 	var caseDiags diag.Diagnostics
 	state.Cases, caseDiags = extractRuleCases(ctx, resp.GetCases())
@@ -1265,7 +1265,7 @@ func extractRuleCaseActions(apiActions []datadogV2.SecurityMonitoringRuleCaseAct
 	return tfActions
 }
 
-func extractTfOptions(ctx context.Context, options datadogV2.SecurityMonitoringRuleOptions, priorOptions []ruleOptionsModel) ([]ruleOptionsModel, diag.Diagnostics) {
+func extractTfOptions(ctx context.Context, options datadogV2.SecurityMonitoringRuleOptions, priorOptions []ruleOptionsModel, ruleType string) ([]ruleOptionsModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	tfOptions := ruleOptionsModel{
@@ -1281,8 +1281,16 @@ func extractTfOptions(ctx context.Context, options datadogV2.SecurityMonitoringR
 	if detectionMethod, ok := options.GetDetectionMethodOk(); ok {
 		tfOptions.DetectionMethod = types.StringValue(string(*detectionMethod))
 	}
-	if decreaseCriticalityBasedOnEnv, ok := options.GetDecreaseCriticalityBasedOnEnvOk(); ok {
-		tfOptions.DecreaseCriticalityBasedOnEnv = types.BoolValue(*decreaseCriticalityBasedOnEnv)
+	// buildPayloadOptions only sends decrease_criticality_based_on_env for log_detection
+	// rules, so for any other rule type the API value is not one the provider can manage.
+	// Reading it back would plan a change that can never be applied, so keep the
+	// configured value instead.
+	if ruleType == string(datadogV2.SECURITYMONITORINGRULETYPECREATE_LOG_DETECTION) {
+		if decreaseCriticalityBasedOnEnv, ok := options.GetDecreaseCriticalityBasedOnEnvOk(); ok {
+			tfOptions.DecreaseCriticalityBasedOnEnv = types.BoolValue(*decreaseCriticalityBasedOnEnv)
+		}
+	} else if !priorOption.DecreaseCriticalityBasedOnEnv.IsNull() && !priorOption.DecreaseCriticalityBasedOnEnv.IsUnknown() {
+		tfOptions.DecreaseCriticalityBasedOnEnv = priorOption.DecreaseCriticalityBasedOnEnv
 	}
 
 	// Optional-only int64. Preserve prior explicit values when the API returns

--- a/datadog/fwprovider/resource_datadog_security_monitoring_rule_test.go
+++ b/datadog/fwprovider/resource_datadog_security_monitoring_rule_test.go
@@ -1,0 +1,78 @@
+package fwprovider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// newRuleOptionsWithDecreaseCriticality builds rule options carrying
+// decreaseCriticalityBasedOnEnv, mimicking a rule that has the option enabled
+// in Datadog.
+func newRuleOptionsWithDecreaseCriticality(decrease bool) datadogV2.SecurityMonitoringRuleOptions {
+	options := datadogV2.NewSecurityMonitoringRuleOptions()
+	options.SetDecreaseCriticalityBasedOnEnv(decrease)
+	return *options
+}
+
+// TestSecurityMonitoringRuleDecreaseCriticalityReadMatchesWrite guards the fix
+// for the "inconsistent result after apply" error on rules that are not
+// log_detection. buildPayloadOptions only sends
+// decrease_criticality_based_on_env for log_detection rules, so reading the API
+// value back for any other type plans a change the provider can never apply.
+func TestSecurityMonitoringRuleDecreaseCriticalityReadMatchesWrite(t *testing.T) {
+	ctx := context.Background()
+	logDetection := string(datadogV2.SECURITYMONITORINGRULETYPECREATE_LOG_DETECTION)
+	applicationSecurity := string(datadogV2.SECURITYMONITORINGRULETYPECREATE_APPLICATION_SECURITY)
+
+	// log_detection is the one type the provider writes the option for, so the
+	// API value is authoritative.
+	t.Run("log_detection follows the api", func(t *testing.T) {
+		got, diags := extractTfOptions(ctx, newRuleOptionsWithDecreaseCriticality(true), nil, logDetection)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if !got[0].DecreaseCriticalityBasedOnEnv.ValueBool() {
+			t.Fatal("expected decrease_criticality_based_on_env to follow the API value true")
+		}
+	})
+
+	// Importing an application_security rule that has the option enabled must not
+	// overwrite the configured false, which is a value the provider cannot change.
+	t.Run("application_security keeps configured false", func(t *testing.T) {
+		prior := []ruleOptionsModel{{DecreaseCriticalityBasedOnEnv: types.BoolValue(false)}}
+		got, diags := extractTfOptions(ctx, newRuleOptionsWithDecreaseCriticality(true), prior, applicationSecurity)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if got[0].DecreaseCriticalityBasedOnEnv.ValueBool() {
+			t.Fatal("expected decrease_criticality_based_on_env to stay false, the API value is not manageable for this rule type")
+		}
+	})
+
+	// A fresh import has no prior state, so the schema default applies.
+	t.Run("application_security without prior state defaults to false", func(t *testing.T) {
+		got, diags := extractTfOptions(ctx, newRuleOptionsWithDecreaseCriticality(true), nil, applicationSecurity)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if got[0].DecreaseCriticalityBasedOnEnv.ValueBool() {
+			t.Fatal("expected decrease_criticality_based_on_env to default to false")
+		}
+	})
+
+	// The same holds in the other direction: the API drops the option when it
+	// creates an application_security rule, and the configured value must survive.
+	t.Run("application_security keeps configured true", func(t *testing.T) {
+		prior := []ruleOptionsModel{{DecreaseCriticalityBasedOnEnv: types.BoolValue(true)}}
+		got, diags := extractTfOptions(ctx, *datadogV2.NewSecurityMonitoringRuleOptions(), prior, applicationSecurity)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if !got[0].DecreaseCriticalityBasedOnEnv.ValueBool() {
+			t.Fatal("expected decrease_criticality_based_on_env to stay true when the API omits it")
+		}
+	})
+}


### PR DESCRIPTION
Fixes #4204.

`options.decrease_criticality_based_on_env` is sent to the API for `log_detection` rules only, but it was read back into state for every rule type. A rule of any other type that has the option enabled in Datadog plans a `true -> false` change, sends nothing, reads back `true`, and fails:

```
Error: Provider produced inconsistent result after apply
  .options[0].decrease_criticality_based_on_env: was cty.False, but now cty.True.
```

The plan repeats on every run and no configuration resolves it, since `false` is also the schema default. Adopting such a rule with an `import` block leaves it unmanageable.

The write gate has been there since #1483 and carried over to the framework migration in #3716. This change gates the read on the same rule type, and for the types the provider does not write the option for it keeps the configured value rather than the API value. That covers both directions: a configured `false` survives a remote `true`, and a configured `true` survives the API dropping the option on create.

The attribute description already documents the option as "Only available when the rule type is `log_detection`", so this makes the read path match both the write path and the documented behaviour.

### Testing

Added `TestSecurityMonitoringRuleDecreaseCriticalityReadMatchesWrite` covering the four cases: `log_detection` follows the API, and `application_security` keeps a configured `false`, defaults to `false` with no prior state, and keeps a configured `true`. The three `application_security` subtests fail without the fix.

- `make test` passes (337 tests)
- `make fmtcheck` and `make vet` pass
- `make docs && make check-docs` reports no generated documentation changes

No cassettes were re-recorded: the change is in the response-to-state mapping and I do not have sandbox credentials for the acceptance suite. Happy to add acceptance coverage if you would prefer it.

### Note for maintainers

I cannot set labels on this PR. It needs `changelog/bugfix` per the contributing guide.
