### PR TITLE
ci: bound goreleaser build parallelism

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,13 @@ jobs:
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: 2.17.1
-          args: release --clean
+          # Default parallelism is NumCPU (16 here), so all 13 targets compile
+          # and link concurrently. Each target peaks near 6.2GB RSS, so the
+          # aggregate exceeds runner RAM and the VM is OOM-killed mid-build:
+          # the job reports "runner has received a shutdown signal" with no
+          # goreleaser error. 4 holds the peak near 25GB, at the cost of
+          # building in waves.
+          args: release --clean --parallelism 4
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation

Both attempts at release 4.20.0 failed in the GoReleaser step with no usable diagnostic. The job stops roughly 3m45s into `building binaries`; the first attempt logged `The runner has received a shutdown signal`, the second logged nothing beyond `Cleaning up orphan processes`. Debug logging adds nothing, because the runner agent dies together with the VM and cannot record its own death.

The cause is memory, not GoReleaser. Parallelism was never configured, and GoReleaser defaults it to the CPU count — 16 on this runner — so all 13 release targets compile and link concurrently. A single cold-cache target, built with the flags CI uses, peaks near 6.2GB RSS, putting aggregate demand around 81GB against a runner with 64GB.

The build has been sitting on that limit for a while: successful releases spent 3m37s to 4m38s in the same step, and the failures die at 3m45s. Between 4.19.0 and 4.20.0, per-target peak grew 5.4% (5.92GB to 6.24GB, roughly 4GB in aggregate) from the datadog-api-client-go bump and 35 new provider source files. That was enough to turn a marginal build into a consistently failing one.

Pinning GoReleaser to 2.17.1 did not help and was not expected to: 2.17.0 was already in use earlier and its default parallelism is identical.

## Overview of changes

Caps GoReleaser at four concurrent build tasks, which holds peak memory near 25GB and leaves headroom as the provider keeps growing. Parallelism is settable only on the command line, so it goes in the action's `args` rather than `.goreleaser.yml`. A comment records the failure signature so the next person does not have to rediscover it.

Release outputs are unchanged — the same targets, archives, checksums and signature. The trade-off is wall-clock time in that step, since the targets now build in waves rather than all at once.

## Validation

Re-run the release for 4.20.0. The `v4.20.0` tag already exists at `25a87a9f9` and must be deleted first, otherwise the `Create tag` step fails with a 422 on the existing ref.

Confirm the GoReleaser step runs to completion and that the resulting draft release carries all 13 platform archives, the `SHA256SUMS` file, its detached signature and the registry manifest. Expect that step to take longer than the previous 3-4 minutes.
