### PR TITLE
Support sensitivity on data quality monitor options

### DIFF
--- a/datadog/fwprovider/resource_datadog_monitor.go
+++ b/datadog/fwprovider/resource_datadog_monitor.go
@@ -264,11 +264,12 @@ type DataQualityQuery struct {
 }
 
 type DataQualityMonitorOptions struct {
-	CustomSql         types.String `tfsdk:"custom_sql"`
-	CustomWhere       types.String `tfsdk:"custom_where"`
-	GroupByColumns    types.List   `tfsdk:"group_by_columns"`
-	CrontabOverride   types.String `tfsdk:"crontab_override"`
-	ModelTypeOverride types.String `tfsdk:"model_type_override"`
+	CustomSql         types.String  `tfsdk:"custom_sql"`
+	CustomWhere       types.String  `tfsdk:"custom_where"`
+	GroupByColumns    types.List    `tfsdk:"group_by_columns"`
+	CrontabOverride   types.String  `tfsdk:"crontab_override"`
+	ModelTypeOverride types.String  `tfsdk:"model_type_override"`
+	Sensitivity       types.Float64 `tfsdk:"sensitivity"`
 }
 
 type DataJobsQuery struct {
@@ -1188,6 +1189,10 @@ func (r *monitorResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 													Optional:    true,
 													Description: "Override for the model type. Valid values are `freshness`, `percentage`, `any`.",
 												},
+												"sensitivity": schema.Float64Attribute{
+													Optional:    true,
+													Description: "Sensitivity of the anomaly detection model, expressed as a multiplier on the width of the predicted bounds. Higher values widen the bounds and produce fewer alerts; lower values tighten them and produce more alerts. Defaults to `3.0`.",
+												},
 											},
 										},
 									},
@@ -1950,6 +1955,7 @@ func (r *monitorResource) buildDataQualityQueryStruct(ctx context.Context, dataQ
 			if !opt.ModelTypeOverride.IsNull() {
 				monitorOptsReq.SetModelTypeOverride(datadogV1.MonitorFormulaAndFunctionDataQualityModelTypeOverride(opt.ModelTypeOverride.ValueString()))
 			}
+			fwutils.SetOptFloat64(opt.Sensitivity, monitorOptsReq.SetSensitivity)
 			dataQualityQueryReq.SetMonitorOptions(monitorOptsReq)
 		}
 		variableReq.MonitorFormulaAndFunctionDataQualityQueryDefinition = &dataQualityQueryReq
@@ -2695,6 +2701,7 @@ func (r *monitorResource) buildDataQualityQueryState(ctx context.Context, dataQu
 			CustomSql:       fwutils.ToTerraformStr(monitorOpts.GetCustomSqlOk()),
 			CustomWhere:     fwutils.ToTerraformStr(monitorOpts.GetCustomWhereOk()),
 			CrontabOverride: fwutils.ToTerraformStr(monitorOpts.GetCrontabOverrideOk()),
+			Sensitivity:     fwutils.ToTerraformFloat64(monitorOpts.GetSensitivityOk()),
 		}
 		if groupByCols, ok := monitorOpts.GetGroupByColumnsOk(); ok && groupByCols != nil {
 			monitorOptsState.GroupByColumns, _ = types.ListValueFrom(ctx, types.StringType, groupByCols)

--- a/datadog/internal/fwutils/types_utils.go
+++ b/datadog/internal/fwutils/types_utils.go
@@ -48,6 +48,13 @@ func ToTerraformInt32(v *int32, ok bool) types.Int32 {
 	return types.Int32Null()
 }
 
+func ToTerraformFloat64(v *float64, ok bool) types.Float64 {
+	if ok && v != nil {
+		return types.Float64Value(*v)
+	}
+	return types.Float64Null()
+}
+
 func ToTerraformInt64(v *int64, ok bool) types.Int64 {
 	if ok && v != nil {
 		return types.Int64Value(*v)
@@ -72,6 +79,12 @@ func SetOptString(s types.String, set func(string)) {
 func SetOptInt32(i types.Int32, set func(int32)) {
 	if !i.IsNull() && !i.IsUnknown() {
 		set(i.ValueInt32())
+	}
+}
+
+func SetOptFloat64(f types.Float64, set func(float64)) {
+	if !f.IsNull() && !f.IsUnknown() {
+		set(f.ValueFloat64())
 	}
 }
 

--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -1181,10 +1181,18 @@ func getMonitorFormulaQuerySchema() *schema.Schema {
 											Optional:    true,
 											Description: "Crontab expression to override the default schedule.",
 										},
+										// Deliberately not validated against the client enum: the API
+										// accepts values this provider version may not know about yet,
+										// and rejects bad ones with a clear error.
 										"model_type_override": {
 											Type:        schema.TypeString,
 											Optional:    true,
 											Description: "Override for the model type. Valid values are `freshness`, `percentage`, `any`.",
+										},
+										"sensitivity": {
+											Type:        schema.TypeFloat,
+											Optional:    true,
+											Description: "Sensitivity of the anomaly detection model, expressed as a multiplier on the width of the predicted bounds. Higher values widen the bounds and produce fewer alerts; lower values tighten them and produce more alerts. Defaults to `3.0`.",
 										},
 									},
 								},
@@ -1887,6 +1895,13 @@ func getOptionalString(data map[string]interface{}, fieldName string) (string, b
 	return val, ok && len(val) > 0
 }
 
+// getOptionalFloat safely extracts an optional float field from a map. A zero value is
+// treated as unset, mirroring how getOptionalString treats the empty string.
+func getOptionalFloat(data map[string]interface{}, fieldName string) (float64, bool) {
+	val, ok := data[fieldName].(float64)
+	return val, ok && val != 0
+}
+
 // getOptionalStringSlice safely extracts an optional string slice from a map, filtering out nil and empty values
 func getOptionalStringSlice(data map[string]interface{}, fieldName string) []string {
 	list, ok := data[fieldName].([]interface{})
@@ -1931,6 +1946,10 @@ func buildDataQualityMonitorOptions(data map[string]interface{}) *datadogV1.Moni
 	}
 	if v, ok := getOptionalString(data, "model_type_override"); ok {
 		opts.SetModelTypeOverride(datadogV1.MonitorFormulaAndFunctionDataQualityModelTypeOverride(v))
+		hasAnyOption = true
+	}
+	if v, ok := getOptionalFloat(data, "sensitivity"); ok {
+		opts.SetSensitivity(v)
 		hasAnyOption = true
 	}
 
@@ -2708,6 +2727,9 @@ func buildTerraformDataQualityMonitorVariables(datadogVariables []datadogV1.Moni
 				}
 				if modelTypeOverride, ok := monitorOptions.GetModelTypeOverrideOk(); ok {
 					terraformMonitorOptions["model_type_override"] = modelTypeOverride
+				}
+				if sensitivity, ok := monitorOptions.GetSensitivityOk(); ok {
+					terraformMonitorOptions["sensitivity"] = sensitivity
 				}
 				terraformQuery["monitor_options"] = []map[string]interface{}{terraformMonitorOptions}
 			}

--- a/datadog/resource_datadog_monitor_unit_test.go
+++ b/datadog/resource_datadog_monitor_unit_test.go
@@ -1,0 +1,90 @@
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildDataQualityMonitorOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]interface{}
+		want *datadogV1.MonitorFormulaAndFunctionDataQualityMonitorOptions
+	}{
+		{
+			name: "no options set",
+			data: map[string]interface{}{},
+			want: nil,
+		},
+		{
+			name: "empty values are ignored",
+			data: map[string]interface{}{
+				"custom_sql":       "",
+				"custom_where":     "",
+				"group_by_columns": []interface{}{},
+				"sensitivity":      0.0,
+			},
+			want: nil,
+		},
+		{
+			name: "sensitivity only",
+			data: map[string]interface{}{"sensitivity": 2.5},
+			want: func() *datadogV1.MonitorFormulaAndFunctionDataQualityMonitorOptions {
+				o := datadogV1.NewMonitorFormulaAndFunctionDataQualityMonitorOptions()
+				o.SetSensitivity(2.5)
+				return o
+			}(),
+		},
+		{
+			name: "all options set",
+			data: map[string]interface{}{
+				"custom_sql":          "SELECT 1",
+				"custom_where":        "database = 'production'",
+				"group_by_columns":    []interface{}{"column1", "column2"},
+				"crontab_override":    "0 0 * * *",
+				"model_type_override": "freshness",
+				"sensitivity":         4.0,
+			},
+			want: func() *datadogV1.MonitorFormulaAndFunctionDataQualityMonitorOptions {
+				o := datadogV1.NewMonitorFormulaAndFunctionDataQualityMonitorOptions()
+				o.SetCustomSql("SELECT 1")
+				o.SetCustomWhere("database = 'production'")
+				o.SetGroupByColumns([]string{"column1", "column2"})
+				o.SetCrontabOverride("0 0 * * *")
+				o.SetModelTypeOverride(datadogV1.MONITORFORMULAANDFUNCTIONDATAQUALITYMODELTYPEOVERRIDE_FRESHNESS)
+				o.SetSensitivity(4.0)
+				return o
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, buildDataQualityMonitorOptions(tt.data))
+		})
+	}
+}
+
+func TestBuildTerraformDataQualityMonitorVariablesRoundTrip(t *testing.T) {
+	query := map[string]interface{}{
+		"name":        "query1",
+		"data_source": "data_quality_metrics",
+		"measure":     "row_count",
+		"filter":      "search for column where `database:production`",
+		"monitor_options": []interface{}{map[string]interface{}{
+			"sensitivity":         2.5,
+			"model_type_override": "percentage",
+		}},
+	}
+
+	definition := buildMonitorFormulaAndFunctionDataQualityQuery(query)
+	terraformVariables := buildTerraformDataQualityMonitorVariables([]datadogV1.MonitorFormulaAndFunctionQueryDefinition{*definition})
+
+	queries := terraformVariables[0]["data_quality_query"].([]map[string]interface{})
+	options := queries[0]["monitor_options"].([]map[string]interface{})[0]
+
+	assert.Equal(t, 2.5, *options["sensitivity"].(*float64))
+	assert.Equal(t, datadogV1.MONITORFORMULAANDFUNCTIONDATAQUALITYMODELTYPEOVERRIDE_PERCENTAGE, *options["model_type_override"].(*datadogV1.MonitorFormulaAndFunctionDataQualityModelTypeOverride))
+}

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -717,6 +717,7 @@ Optional:
 - `custom_where` (String) Custom WHERE clause for the query.
 - `group_by_columns` (List of String) Columns to group results by.
 - `model_type_override` (String) Override for the model type. Valid values are `freshness`, `percentage`, `any`.
+- `sensitivity` (Number) Sensitivity of the anomaly detection model, expressed as a multiplier on the width of the predicted bounds. Higher values widen the bounds and produce fewer alerts; lower values tighten them and produce more alerts. Defaults to `3.0`.
 
 
 

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -717,7 +717,7 @@ Optional:
 - `custom_where` (String) Custom WHERE clause for the query.
 - `group_by_columns` (List of String) Columns to group results by.
 - `model_type_override` (String) Override for the model type. Valid values are `freshness`, `percentage`, `any`.
-- `sensitivity` (Number) Sensitivity of the anomaly detection model, expressed as a multiplier on the width of the predicted bounds. Higher values widen the bounds and produce fewer alerts; lower values tighten them and produce more alerts. Defaults to `3.0`.
+- `sensitivity` (Number) Sensitivity of the anomaly detection model, expressed as a multiplier on the width of the predicted bounds. Higher values widen the bounds and produce fewer alerts. Lower values tighten them and produce more alerts. Defaults to `3.0`.
 
 
 


### PR DESCRIPTION
## What

Exposes `sensitivity` on the `data_quality_query.monitor_options` block of `datadog_monitor`.

`MonitorFormulaAndFunctionDataQualityMonitorOptions` has carried a `Sensitivity *float64` field since `datadog-api-client-go` v2.64.1, which this provider already depends on. The provider just never surfaced it, so the width of the anomaly detection bounds was not configurable from Terraform even though the API accepted it.

**No client bump needed** — the field is already in the pinned client.

## Changes

- `sensitivity` (optional, `TypeFloat`) on `data_quality_query.monitor_options`
- `getOptionalFloat` helper, and `buildDataQualityMonitorOptions` sets the field
- `buildTerraformDataQualityMonitorVariables` reads it back on refresh
- Docs regenerated

Zero is treated as unset, mirroring how `getOptionalString` treats `""`. Sensitivity is a multiplier on bound width, must be positive, and defaults to `3.0` server side, so zero is unambiguously "not configured" rather than a meaningful value being dropped.

## Testing

New `datadog/resource_datadog_monitor_unit_test.go` — the package had no unit coverage for these builders. It covers `buildDataQualityMonitorOptions` (unset, empty-value, sensitivity-only, all-fields) and a build → read round trip through `buildMonitorFormulaAndFunctionDataQualityQuery`. Both tests fail without the change and pass with it.

`go test ./datadog/` passes, and the five existing `TestAccDatadogMonitor_DataQuality_*` acceptance tests still replay green against their current cassettes.

No acceptance test exercises `sensitivity` itself, and this is a deliberate gap rather than an oversight.

Cassette matching compares request bodies, so adding `sensitivity` to the test config invalidates `TestAccDatadogMonitor_DataQuality_WithMonitorOptions.yaml` (`requested interaction not found`) until it is re-recorded. Nothing in CI records provider cassettes: `test.yml` replays with `RECORD: false` and `test_pr_integration.yml` runs live with `RECORD: "none"`. Recording is a local task needing test-org credentials, which I could not obtain. Committing the test change without a fresh cassette would just make this PR red, so it is left out.

**For whoever can record**, the whole job is these two edits plus `RECORD=true` on that one test:

```hcl
# testAccCheckDatadogDataQualityMonitorWithOptions, inside monitor_options
        model_type_override = "freshness"
+       sensitivity         = 2.5
```

```go
// TestAccDatadogMonitor_DataQuality_WithMonitorOptions, in the Check block
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.data_quality_with_options", "variables.0.data_quality_query.0.monitor_options.0.sensitivity", "2.5"),
```

Worth knowing while you are in there: the five existing `TestAccDatadogMonitor_DataQuality_*` cassettes were recorded against **org 2 (us1 prod)**, not the frog test org that `isTestOrg()` defaults to. Across the whole cassette directory it is 620 interactions on org 321813 versus 22 on org 2, and those 22 are these five files plus two Datastore tests. Re-recording against frog would fix that drift.

Also unrelated to this change but noticed while running them: these tests are flaky under `t.Parallel()`. `Basic` and `EmptyMonitorOptions` failed together in a full-suite run and both pass in isolation, as did `EmptyGroupBy` on an earlier run. Looks like contention over shared cassette state.

## Related

The remaining two `monitor_options` fields the backend supports, `source_to_target_config` and `model_configuration`, are not in the public API spec yet. Spec PR: https://github.com/DataDog/datadog-api-spec/pull/6591. The provider side of those is stacked on this branch and stays in draft until the generated client ships.

