### PR TITLE
[datadog_integration_azure] Add app registration display name

### DIFF
--- a/datadog/fwprovider/resource_datadog_azure_integration.go
+++ b/datadog/fwprovider/resource_datadog_azure_integration.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	frameworkPath "github.com/hashicorp/terraform-plugin-framework/path"
@@ -15,7 +17,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
@@ -28,6 +33,11 @@ var (
 )
 
 var integrationAzureMutex = sync.Mutex{}
+
+var integrationAzureDisplayNameValidator = stringvalidator.RegexMatches(
+	regexp.MustCompile(`\S`),
+	"display_name must contain at least one non-whitespace character",
+)
 
 type integrationAzureResource struct {
 	Api  *datadogV1.AzureIntegrationApi
@@ -49,6 +59,7 @@ type integrationAzureModel struct {
 	ResourceCollectionEnabled types.Bool                     `tfsdk:"resource_collection_enabled"`
 	CspmEnabled               types.Bool                     `tfsdk:"cspm_enabled"`
 	CustomMetricsEnabled      types.Bool                     `tfsdk:"custom_metrics_enabled"`
+	DisplayName               types.String                   `tfsdk:"display_name"`
 	HostFilters               types.String                   `tfsdk:"host_filters"`
 	TenantName                types.String                   `tfsdk:"tenant_name"`
 	MetricsEnabled            types.Bool                     `tfsdk:"metrics_enabled"`
@@ -91,6 +102,16 @@ func (r *integrationAzureResource) Schema(_ context.Context, _ resource.SchemaRe
 				Optional:    true,
 				Description: "Your Azure web application secret key. Required unless `secretless_auth_enabled` is set to `true`.",
 				Sensitive:   true,
+			},
+			"display_name": schema.StringAttribute{
+				Optional:    true,
+				Description: "The display name of the Azure app registration. This value is sent only when the integration is created. Changing it recreates the integration.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					integrationAzureDisplayNameValidator,
+				},
 			},
 			"tenant_name": schema.StringAttribute{
 				Required:    true,
@@ -249,6 +270,7 @@ func (r *integrationAzureResource) Create(ctx context.Context, request resource.
 	defer integrationAzureMutex.Unlock()
 
 	body := r.buildIntegrationAzureRequestBody(ctx, &state, state.TenantName.ValueString(), state.ClientId.ValueString(), false)
+	addAzureIntegrationDisplayName(body, state.DisplayName)
 
 	_, _, err := r.Api.CreateAzureIntegration(r.Auth, *body)
 	if err != nil {
@@ -451,4 +473,17 @@ func (r *integrationAzureResource) buildIntegrationAzureRequestBody(ctx context.
 		}
 	}
 	return datadogDefinition
+}
+
+// addAzureIntegrationDisplayName adds the create-only display name to the API
+// client model. The generated client does not expose this field yet, but its
+// AdditionalProperties map is serialized into the request body.
+func addAzureIntegrationDisplayName(body *datadogV1.AzureAccount, displayName types.String) {
+	if displayName.IsNull() || displayName.IsUnknown() {
+		return
+	}
+	if body.AdditionalProperties == nil {
+		body.AdditionalProperties = make(map[string]interface{})
+	}
+	body.AdditionalProperties["display_name"] = displayName.ValueString()
 }

--- a/datadog/fwprovider/resource_datadog_azure_integration.go
+++ b/datadog/fwprovider/resource_datadog_azure_integration.go
@@ -34,10 +34,13 @@ var (
 
 var integrationAzureMutex = sync.Mutex{}
 
-var integrationAzureDisplayNameValidator = stringvalidator.RegexMatches(
-	regexp.MustCompile(`\S`),
-	"display_name must contain at least one non-whitespace character",
-)
+var integrationAzureDisplayNameValidators = []validator.String{
+	stringvalidator.RegexMatches(
+		regexp.MustCompile(`\S`),
+		"display_name must contain at least one non-whitespace character",
+	),
+	stringvalidator.LengthAtMost(256),
+}
 
 type integrationAzureResource struct {
 	Api  *datadogV1.AzureIntegrationApi
@@ -109,9 +112,7 @@ func (r *integrationAzureResource) Schema(_ context.Context, _ resource.SchemaRe
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
-				Validators: []validator.String{
-					integrationAzureDisplayNameValidator,
-				},
+				Validators: integrationAzureDisplayNameValidators,
 			},
 			"tenant_name": schema.StringAttribute{
 				Required:    true,

--- a/datadog/fwprovider/resource_datadog_azure_integration_test.go
+++ b/datadog/fwprovider/resource_datadog_azure_integration_test.go
@@ -1,0 +1,57 @@
+package fwprovider
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	frameworkPath "github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrationAzureDisplayNameValidator(t *testing.T) {
+	tests := []struct {
+		name        string
+		displayName string
+		wantError   bool
+	}{
+		{name: "nonblank", displayName: "datadog-azure-integration"},
+		{name: "blank", displayName: " \t\n", wantError: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var response validator.StringResponse
+			integrationAzureDisplayNameValidator.ValidateString(context.Background(), validator.StringRequest{
+				Path:        frameworkPath.Root("display_name"),
+				ConfigValue: types.StringValue(test.displayName),
+			}, &response)
+
+			require.Equal(t, test.wantError, response.Diagnostics.HasError())
+		})
+	}
+}
+
+func TestBuildIntegrationAzureRequestBodyDisplayName(t *testing.T) {
+	resource := integrationAzureResource{}
+	state := integrationAzureModel{
+		DisplayName: types.StringValue("datadog-azure-integration"),
+	}
+
+	createBody := resource.buildIntegrationAzureRequestBody(context.Background(), &state, "tenant", "client", false)
+	addAzureIntegrationDisplayName(createBody, state.DisplayName)
+	createPayload, err := json.Marshal(createBody)
+	require.NoError(t, err)
+	var createPayloadFields map[string]interface{}
+	require.NoError(t, json.Unmarshal(createPayload, &createPayloadFields))
+	require.Equal(t, "datadog-azure-integration", createPayloadFields["display_name"])
+
+	updateBody := resource.buildIntegrationAzureRequestBody(context.Background(), &state, "tenant", "client", true)
+	updatePayload, err := json.Marshal(updateBody)
+	require.NoError(t, err)
+	var updatePayloadFields map[string]interface{}
+	require.NoError(t, json.Unmarshal(updatePayload, &updatePayloadFields))
+	require.NotContains(t, updatePayloadFields, "display_name")
+}

--- a/datadog/fwprovider/resource_datadog_azure_integration_test.go
+++ b/datadog/fwprovider/resource_datadog_azure_integration_test.go
@@ -3,6 +3,7 @@ package fwprovider
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	frameworkPath "github.com/hashicorp/terraform-plugin-framework/path"
@@ -19,15 +20,19 @@ func TestIntegrationAzureDisplayNameValidator(t *testing.T) {
 	}{
 		{name: "nonblank", displayName: "datadog-azure-integration"},
 		{name: "blank", displayName: " \t\n", wantError: true},
+		{name: "maximum length", displayName: strings.Repeat("a", 256)},
+		{name: "too long", displayName: strings.Repeat("a", 257), wantError: true},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var response validator.StringResponse
-			integrationAzureDisplayNameValidator.ValidateString(context.Background(), validator.StringRequest{
-				Path:        frameworkPath.Root("display_name"),
-				ConfigValue: types.StringValue(test.displayName),
-			}, &response)
+			for _, displayNameValidator := range integrationAzureDisplayNameValidators {
+				displayNameValidator.ValidateString(context.Background(), validator.StringRequest{
+					Path:        frameworkPath.Root("display_name"),
+					ConfigValue: types.StringValue(test.displayName),
+				}, &response)
+			}
 
 			require.Equal(t, test.wantError, response.Diagnostics.HasError())
 		})

--- a/docs/resources/integration_azure.md
+++ b/docs/resources/integration_azure.md
@@ -18,6 +18,7 @@ resource "datadog_integration_azure" "sandbox" {
   tenant_name              = "<azure_tenant_name>"
   client_id                = "<azure_client_id>"
   client_secret            = "<azure_client_secret_key>"
+  display_name             = "datadog-azure-integration"
   host_filters             = "examplefilter:true,example:true"
   app_service_plan_filters = "examplefilter:true,example:another"
   container_app_filters    = "examplefilter:true,example:one_more"
@@ -52,6 +53,7 @@ resource "datadog_integration_azure" "sandbox_secretless" {
 - `cspm_enabled` (Boolean) When enabled, Datadog’s Cloud Security Management product scans resource configurations monitored by this app registration.
 Note: This requires `resource_collection_enabled` to be set to true. Defaults to `false`.
 - `custom_metrics_enabled` (Boolean) Enable custom metrics for your organization. Defaults to `false`.
+- `display_name` (String) The display name of the Azure app registration. This value is sent only when the integration is created. Changing it recreates the integration. Display_name must contain at least one non-whitespace character.
 - `host_filters` (String) String of host tag(s) (in the form `key:value,key:value`) defines a filter that Datadog will use when collecting metrics from Azure. Limit the Azure instances that are pulled into Datadog by using tags. Only hosts that match one of the defined tags are imported into Datadog. e.x. `env:production,deploymentgroup:red` Defaults to `""`.
 - `metrics_enabled` (Boolean) Enable Azure metrics for your organization. Defaults to `true`.
 - `metrics_enabled_default` (Boolean) Enable Azure metrics for your organization for resource providers where no resource provider config is specified. Defaults to `true`.

--- a/examples/resources/datadog_integration_azure/resource.tf
+++ b/examples/resources/datadog_integration_azure/resource.tf
@@ -3,6 +3,7 @@ resource "datadog_integration_azure" "sandbox" {
   tenant_name              = "<azure_tenant_name>"
   client_id                = "<azure_client_id>"
   client_secret            = "<azure_client_secret_key>"
+  display_name             = "datadog-azure-integration"
   host_filters             = "examplefilter:true,example:true"
   app_service_plan_filters = "examplefilter:true,example:another"
   container_app_filters    = "examplefilter:true,example:one_more"


### PR DESCRIPTION
## Summary

- add an optional nonblank, replacement-only display_name argument to datadog_integration_azure
- enforce the Azure display-name maximum of 256 characters at plan time
- send the field only in the Azure integration creation request
- keep PUT and DELETE behavior unchanged
- update the generated resource documentation and example

The pinned generated API client does not yet expose a typed display-name property, so Create uses its supported AdditionalProperties serialization. Typed client regeneration is follow-up work.

## Dependencies

Depends on ddoghq/dogweb#1750, stacked on ddoghq/dogweb#3721. The web-ui generated-template PR must wait for a provider release containing this change.

## Test plan

- boundary coverage: 256 characters accepted, 257 rejected, whitespace-only rejected
- Make-based focused unit run: 338 tests passed
- goimports portion of make fmtcheck passed; Terraform portion could not run because the test container lacks Terraform (no HCL files changed)
- gofmt and git diff --check passed