### PR TITLE
Automation pipelines reorder use different request and response types

### DIFF
--- a/datadog/fwprovider/resource_datadog_security_findings_automation_common.go
+++ b/datadog/fwprovider/resource_datadog_security_findings_automation_common.go
@@ -196,6 +196,11 @@ func readRulesOrder[Resp any, Rule any](
 
 // reorderSecurityFindingsAutomationRules submits a reorder request for the given rule IDs.
 //
+// If you encounter a compile error after bumping the API client version, this is related to the PLANNED SPEC
+// CHANGE mentionned below, and a fix PR is ready https://github.com/DataDog/terraform-provider-datadog/pull/4219.
+// You can reach out in #k9-automation-and-notifications if anything is unclear or the if spec change is different
+// than expected.
+//
 // PLANNED SPEC CHANGE (https://github.com/DataDog/datadog-api-spec/pull/6634): the security findings automation
 // OpenAPI spec is being updated so every reorder endpoint (mute, due date, ticket creation) gets its own separate
 // response type. Once this PR is merged and datadog-api-client-go is re-generated,
@@ -203,11 +208,6 @@ func readRulesOrder[Resp any, Rule any](
 // *ReorderResponse type instead of reusing the *ReorderRequest type. That is expected to break compilation at
 // exactly one line in each of resource_datadog_security_findings_{mute,due_date,ticket_creation}_rules_order.go:
 // the `getRespItems` closure passed into this function, which is currently typed as the request type.
-//
-// If you encounter this compile error after bumping the API client version: this function's signature already
-// supports Req != Resp, so the fix is simple: update the affected closure's parameter type from the old
-// *ReorderRequest name to the new *ReorderResponse type. You can reach out in #k9-automation-and-notifications if
-// anything is unclear or the if spec change is different than expected.
 func reorderSecurityFindingsAutomationRules[I any, Req any, Resp any](
 	auth context.Context,
 	ruleIDs []string,

--- a/datadog/fwprovider/resource_datadog_security_findings_automation_common.go
+++ b/datadog/fwprovider/resource_datadog_security_findings_automation_common.go
@@ -195,19 +195,6 @@ func readRulesOrder[Resp any, Rule any](
 }
 
 // reorderSecurityFindingsAutomationRules submits a reorder request for the given rule IDs.
-//
-// If you encounter a compile error after bumping the API client version, this is related to the PLANNED SPEC
-// CHANGE mentionned below, and a fix PR is ready https://github.com/DataDog/terraform-provider-datadog/pull/4219.
-// You can reach out in #k9-automation-and-notifications if anything is unclear or the if spec change is different
-// than expected.
-//
-// PLANNED SPEC CHANGE (https://github.com/DataDog/datadog-api-spec/pull/6634): the security findings automation
-// OpenAPI spec is being updated so every reorder endpoint (mute, due date, ticket creation) gets its own separate
-// response type. Once this PR is merged and datadog-api-client-go is re-generated,
-// ReorderSecurityFindingsAutomationMuteRules/DueDateRules/TicketCreationRules will each start returning a new
-// *ReorderResponse type instead of reusing the *ReorderRequest type. That is expected to break compilation at
-// exactly one line in each of resource_datadog_security_findings_{mute,due_date,ticket_creation}_rules_order.go:
-// the `getRespItems` closure passed into this function, which is currently typed as the request type.
 func reorderSecurityFindingsAutomationRules[I any, Req any, Resp any](
 	auth context.Context,
 	ruleIDs []string,

--- a/datadog/fwprovider/resource_datadog_security_findings_automation_common.go
+++ b/datadog/fwprovider/resource_datadog_security_findings_automation_common.go
@@ -195,13 +195,26 @@ func readRulesOrder[Resp any, Rule any](
 }
 
 // reorderSecurityFindingsAutomationRules submits a reorder request for the given rule IDs.
-func reorderSecurityFindingsAutomationRules[I any, Req any](
+//
+// PLANNED SPEC CHANGE (https://github.com/DataDog/datadog-api-spec/pull/6634): the security findings automation
+// OpenAPI spec is being updated so every reorder endpoint (mute, due date, ticket creation) gets its own separate
+// response type. Once this PR is merged and datadog-api-client-go is re-generated,
+// ReorderSecurityFindingsAutomationMuteRules/DueDateRules/TicketCreationRules will each start returning a new
+// *ReorderResponse type instead of reusing the *ReorderRequest type. That is expected to break compilation at
+// exactly one line in each of resource_datadog_security_findings_{mute,due_date,ticket_creation}_rules_order.go:
+// the `getRespItems` closure passed into this function, which is currently typed as the request type.
+//
+// If you encounter this compile error after bumping the API client version: this function's signature already
+// supports Req != Resp, so the fix is simple: update the affected closure's parameter type from the old
+// *ReorderRequest name to the new *ReorderResponse type. You can reach out in #k9-automation-and-notifications if
+// anything is unclear or the if spec change is different than expected.
+func reorderSecurityFindingsAutomationRules[I any, Req any, Resp any](
 	auth context.Context,
 	ruleIDs []string,
 	makeItem func(uuid.UUID) I,
 	makeRequest func([]I) Req,
-	reorderFn func(context.Context, Req) (Req, *http.Response, error),
-	getRespItems func(Req) []I,
+	reorderFn func(context.Context, Req) (Resp, *http.Response, error),
+	getRespItems func(Resp) []I,
 	getID func(I) string,
 ) ([]string, diag.Diagnostics) {
 	var diags diag.Diagnostics

--- a/datadog/fwprovider/resource_datadog_security_findings_due_date_rules_order.go
+++ b/datadog/fwprovider/resource_datadog_security_findings_due_date_rules_order.go
@@ -83,9 +83,7 @@ func (r *securityFindingsDueDateRulesOrderResource) applyOrder(ctx context.Conte
 			return *datadogV2.NewDueDateRuleReorderRequest(items)
 		},
 		r.Api.ReorderSecurityFindingsAutomationDueDateRules,
-		// NOTE: This is expected to break compilation in an upcoming client version bump, see the comment on
-		// reorderSecurityFindingsAutomationRules in resource_datadog_security_findings_automation_common.go.
-		func(resp datadogV2.DueDateRuleReorderRequest) []datadogV2.DueDateRuleReorderItem {
+		func(resp datadogV2.DueDateRuleReorderResponse) []datadogV2.DueDateRuleReorderItem {
 			return resp.GetData()
 		},
 		func(item datadogV2.DueDateRuleReorderItem) string { return item.GetId().String() },

--- a/datadog/fwprovider/resource_datadog_security_findings_due_date_rules_order.go
+++ b/datadog/fwprovider/resource_datadog_security_findings_due_date_rules_order.go
@@ -83,6 +83,8 @@ func (r *securityFindingsDueDateRulesOrderResource) applyOrder(ctx context.Conte
 			return *datadogV2.NewDueDateRuleReorderRequest(items)
 		},
 		r.Api.ReorderSecurityFindingsAutomationDueDateRules,
+		// NOTE: This is expected to break compilation in an upcoming client version bump, see the comment on
+		// reorderSecurityFindingsAutomationRules in resource_datadog_security_findings_automation_common.go.
 		func(resp datadogV2.DueDateRuleReorderRequest) []datadogV2.DueDateRuleReorderItem {
 			return resp.GetData()
 		},

--- a/datadog/fwprovider/resource_datadog_security_findings_due_date_rules_order.go
+++ b/datadog/fwprovider/resource_datadog_security_findings_due_date_rules_order.go
@@ -83,8 +83,6 @@ func (r *securityFindingsDueDateRulesOrderResource) applyOrder(ctx context.Conte
 			return *datadogV2.NewDueDateRuleReorderRequest(items)
 		},
 		r.Api.ReorderSecurityFindingsAutomationDueDateRules,
-		// NOTE: This is expected to break compilation in an upcoming client version bump, see the comment on
-		// reorderSecurityFindingsAutomationRules in resource_datadog_security_findings_automation_common.go.
 		func(resp datadogV2.DueDateRuleReorderRequest) []datadogV2.DueDateRuleReorderItem {
 			return resp.GetData()
 		},

--- a/datadog/fwprovider/resource_datadog_security_findings_mute_rules_order.go
+++ b/datadog/fwprovider/resource_datadog_security_findings_mute_rules_order.go
@@ -83,6 +83,8 @@ func (r *securityFindingsMuteRulesOrderResource) applyOrder(ctx context.Context,
 			return *datadogV2.NewMuteRuleReorderRequest(items)
 		},
 		r.Api.ReorderSecurityFindingsAutomationMuteRules,
+		// NOTE: This is expected to break compilation in an upcoming client version bump, see the comment on
+		// reorderSecurityFindingsAutomationRules in resource_datadog_security_findings_automation_common.go.
 		func(resp datadogV2.MuteRuleReorderRequest) []datadogV2.MuteRuleReorderItem { return resp.GetData() },
 		func(item datadogV2.MuteRuleReorderItem) string { return item.GetId().String() },
 	)

--- a/datadog/fwprovider/resource_datadog_security_findings_mute_rules_order.go
+++ b/datadog/fwprovider/resource_datadog_security_findings_mute_rules_order.go
@@ -83,8 +83,6 @@ func (r *securityFindingsMuteRulesOrderResource) applyOrder(ctx context.Context,
 			return *datadogV2.NewMuteRuleReorderRequest(items)
 		},
 		r.Api.ReorderSecurityFindingsAutomationMuteRules,
-		// NOTE: This is expected to break compilation in an upcoming client version bump, see the comment on
-		// reorderSecurityFindingsAutomationRules in resource_datadog_security_findings_automation_common.go.
 		func(resp datadogV2.MuteRuleReorderRequest) []datadogV2.MuteRuleReorderItem { return resp.GetData() },
 		func(item datadogV2.MuteRuleReorderItem) string { return item.GetId().String() },
 	)

--- a/datadog/fwprovider/resource_datadog_security_findings_mute_rules_order.go
+++ b/datadog/fwprovider/resource_datadog_security_findings_mute_rules_order.go
@@ -83,9 +83,7 @@ func (r *securityFindingsMuteRulesOrderResource) applyOrder(ctx context.Context,
 			return *datadogV2.NewMuteRuleReorderRequest(items)
 		},
 		r.Api.ReorderSecurityFindingsAutomationMuteRules,
-		// NOTE: This is expected to break compilation in an upcoming client version bump, see the comment on
-		// reorderSecurityFindingsAutomationRules in resource_datadog_security_findings_automation_common.go.
-		func(resp datadogV2.MuteRuleReorderRequest) []datadogV2.MuteRuleReorderItem { return resp.GetData() },
+		func(resp datadogV2.MuteRuleReorderResponse) []datadogV2.MuteRuleReorderItem { return resp.GetData() },
 		func(item datadogV2.MuteRuleReorderItem) string { return item.GetId().String() },
 	)
 	diags.Append(d...)

--- a/datadog/fwprovider/resource_datadog_security_findings_ticket_creation_rules_order.go
+++ b/datadog/fwprovider/resource_datadog_security_findings_ticket_creation_rules_order.go
@@ -85,6 +85,8 @@ func (r *securityFindingsTicketCreationRulesOrderResource) applyOrder(ctx contex
 			return *datadogV2.NewTicketCreationRuleReorderRequest(items)
 		},
 		r.Api.ReorderSecurityFindingsAutomationTicketCreationRules,
+		// NOTE: This is expected to break compilation in an upcoming client version bump, see the comment on
+		// reorderSecurityFindingsAutomationRules in resource_datadog_security_findings_automation_common.go.
 		func(resp datadogV2.TicketCreationRuleReorderRequest) []datadogV2.TicketCreationRuleReorderItem {
 			return resp.GetData()
 		},

--- a/datadog/fwprovider/resource_datadog_security_findings_ticket_creation_rules_order.go
+++ b/datadog/fwprovider/resource_datadog_security_findings_ticket_creation_rules_order.go
@@ -85,9 +85,7 @@ func (r *securityFindingsTicketCreationRulesOrderResource) applyOrder(ctx contex
 			return *datadogV2.NewTicketCreationRuleReorderRequest(items)
 		},
 		r.Api.ReorderSecurityFindingsAutomationTicketCreationRules,
-		// NOTE: This is expected to break compilation in an upcoming client version bump, see the comment on
-		// reorderSecurityFindingsAutomationRules in resource_datadog_security_findings_automation_common.go.
-		func(resp datadogV2.TicketCreationRuleReorderRequest) []datadogV2.TicketCreationRuleReorderItem {
+		func(resp datadogV2.TicketCreationRuleReorderResponse) []datadogV2.TicketCreationRuleReorderItem {
 			return resp.GetData()
 		},
 		func(item datadogV2.TicketCreationRuleReorderItem) string { return item.GetId().String() },

--- a/datadog/fwprovider/resource_datadog_security_findings_ticket_creation_rules_order.go
+++ b/datadog/fwprovider/resource_datadog_security_findings_ticket_creation_rules_order.go
@@ -85,8 +85,6 @@ func (r *securityFindingsTicketCreationRulesOrderResource) applyOrder(ctx contex
 			return *datadogV2.NewTicketCreationRuleReorderRequest(items)
 		},
 		r.Api.ReorderSecurityFindingsAutomationTicketCreationRules,
-		// NOTE: This is expected to break compilation in an upcoming client version bump, see the comment on
-		// reorderSecurityFindingsAutomationRules in resource_datadog_security_findings_automation_common.go.
 		func(resp datadogV2.TicketCreationRuleReorderRequest) []datadogV2.TicketCreationRuleReorderItem {
 			return resp.GetData()
 		},


### PR DESCRIPTION
> [!NOTE]  
> While the corresponding API spec [PR](https://github.com/DataDog/datadog-api-spec/pull/6634) hasn't been merged, the new version of the auto-generated Go client is not available so the version used by the Terraform provider could not be bumped yet, and therefore PR does not compile.

## Motivation [SEC-36958](https://datadoghq.atlassian.net/browse/SEC-36958)

Currently, mute, due date, ticket creation automation pipelines use the same schema for both their reorder request and their reorder response, which violates rule `DD-API-REQRES-001` of `datadog-api-spec` repository. On the other hand, severity modifiers rules, and soon inbox rules, use a separate schema (although the underlying JSON payload uses the same format). This leads to an inconsistent experience when using the auto-generated clients.

This API spec change will break the compilation of the Terraform provider when bumping the version of the Go client version. This PR bumps the Go client version and fixes compilation errors.

### Plan

1. [PR](https://github.com/DataDog/terraform-provider-datadog/pull/4218) to make preparatory changes in the Terraform provider to decouple the request and response types.
2. [PR](https://github.com/DataDog/datadog-api-spec/pull/6634) to update the API spec to use a separate schemas for reorder requests and reorder responses.
3. This PR: Bump the Go client version used by the Terraform provider and change the type names in code. Must be merged right after the second PR to avoid breaking compilation for other developers.

[SEC-36958]: https://datadoghq.atlassian.net/browse/SEC-36958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ