### PR TITLE
[datadog_status_page_component] Fix ValidateConfig error under for_each/count

### DIFF
--- a/datadog/fwprovider/resource_datadog_status_page_component.go
+++ b/datadog/fwprovider/resource_datadog_status_page_component.go
@@ -165,6 +165,11 @@ func (r *statusPageComponentResource) Configure(_ context.Context, request resou
 }
 
 func (r *statusPageComponentResource) ValidateConfig(ctx context.Context, request resource.ValidateConfigRequest, response *resource.ValidateConfigResponse) {
+	if !request.Config.Raw.IsFullyKnown() {
+		// for_each/count instances can validate before expansion, with components still unknown.
+		return
+	}
+
 	var cfg statusPageComponentModel
 	response.Diagnostics.Append(request.Config.Get(ctx, &cfg)...)
 	if response.Diagnostics.HasError() {

--- a/datadog/fwprovider/resource_datadog_status_page_component_test.go
+++ b/datadog/fwprovider/resource_datadog_status_page_component_test.go
@@ -9,10 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
-// A for_each/count resource can be validated by Terraform core before its instances are
-// expanded, at which point each.value (and anything derived from it, like components) is
-// unknown. Regression test for the Value Conversion Error reported in
-// https://github.com/DataDog/terraform-provider-datadog/issues/4220.
 func TestStatusPageComponentValidateConfigSkipsWhenNotFullyKnown(t *testing.T) {
 	t.Parallel()
 

--- a/datadog/fwprovider/resource_datadog_status_page_component_test.go
+++ b/datadog/fwprovider/resource_datadog_status_page_component_test.go
@@ -1,0 +1,36 @@
+package fwprovider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// A for_each/count resource can be validated by Terraform core before its instances are
+// expanded, at which point each.value (and anything derived from it, like components) is
+// unknown. Regression test for the Value Conversion Error reported in
+// https://github.com/DataDog/terraform-provider-datadog/issues/4220.
+func TestStatusPageComponentValidateConfigSkipsWhenNotFullyKnown(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := &statusPageComponentResource{}
+
+	var schemaResponse resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResponse)
+
+	config := tfsdk.Config{
+		Raw:    tftypes.NewValue(schemaResponse.Schema.Type().TerraformType(ctx), tftypes.UnknownValue),
+		Schema: schemaResponse.Schema,
+	}
+
+	var response resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, resource.ValidateConfigRequest{Config: config}, &response)
+
+	if response.Diagnostics.HasError() {
+		t.Fatalf("ValidateConfig returned diagnostics for a not-fully-known config: %v", response.Diagnostics.Errors())
+	}
+}


### PR DESCRIPTION
Terraform core validates for_each/count resource configs before per-instance expansion, when each.value-derived attributes (like components) are Unknown. statusPageComponentModel.Components is a plain Go slice, which can't represent Unknown, so decoding the config crashed with a Value Conversion Error. Skip validation when the raw config isn't fully known; Create/Update still validate the real per-instance values.

Fixes #4220.