### PR TITLE
[datadog_dashboard_v2] Preserve monitor display and SLO rollup fields

### DIFF
--- a/datadog/dashboardmapping/engine.go
+++ b/datadog/dashboardmapping/engine.go
@@ -1822,11 +1822,9 @@ func (ctx mapBuildContext) block(key string, index int) mapBuildContext {
 }
 
 func (ctx mapBuildContext) explicitlyConfiguredZero(data map[string]interface{}, field FieldSpec) bool {
-	if _, present := data[field.HCLKey]; present {
-		return true
-	}
 	if ctx.rawConfig == nil {
-		return false
+		_, present := data[field.HCLKey]
+		return present
 	}
 	value, diags := ctx.rawConfig.GetRawConfigAt(ctx.path.GetAttr(field.HCLKey))
 	if diags.HasError() || !value.IsKnown() || value.IsNull() {

--- a/datadog/dashboardmapping/engine.go
+++ b/datadog/dashboardmapping/engine.go
@@ -94,7 +94,7 @@ type FieldSpec struct {
 	// Derived by comparing cassette request bodies against HCL configs.
 	OmitEmpty bool
 
-	// PreserveZero keeps an explicitly configured numeric zero in JSON while still
+	// PreserveZero keeps an explicitly configured numeric zero or false in JSON while still
 	// omitting an unset optional field. SDKv2 drops zero values from some nested
 	// decoded maps, so the build engine consults raw configuration when available.
 	PreserveZero bool
@@ -1063,6 +1063,9 @@ func flattenEventQueryJSON(q map[string]interface{}) map[string]interface{} {
 				continue
 			}
 			flatGB := map[string]interface{}{}
+			if v, ok := gbMap["should_exclude_missing"].(bool); ok {
+				flatGB["should_exclude_missing"] = v
+			}
 			if v, ok := gbMap["facet"].(string); ok {
 				flatGB["facet"] = v
 			}
@@ -1826,8 +1829,11 @@ func (ctx mapBuildContext) explicitlyConfiguredZero(data map[string]interface{},
 		return false
 	}
 	value, diags := ctx.rawConfig.GetRawConfigAt(ctx.path.GetAttr(field.HCLKey))
-	return !diags.HasError() && value.IsKnown() && !value.IsNull() &&
-		value.Type() == cty.Number && value.AsBigFloat().Sign() == 0
+	if diags.HasError() || !value.IsKnown() || value.IsNull() {
+		return false
+	}
+	return (value.Type() == cty.Number && value.AsBigFloat().Sign() == 0) ||
+		(value.Type() == cty.Bool && !value.True())
 }
 
 // BuildEngineJSONFromMap converts a SDKv2 data map to a JSON map using FieldSpec declarations.
@@ -1853,7 +1859,7 @@ func buildEngineJSONFromMap(data map[string]interface{}, fields []FieldSpec, ctx
 
 		case TypeBool:
 			boolVal := getBoolFromMap(data, f.HCLKey)
-			if f.OmitEmpty && !boolVal {
+			if f.OmitEmpty && !boolVal && (!f.PreserveZero || !ctx.explicitlyConfiguredZero(data, f)) {
 				continue
 			}
 			setAtJSONPath(result, f.effectiveJSONPath(), boolVal)
@@ -2334,6 +2340,9 @@ func buildEventQueryJSONFromMap(attrs map[string]interface{}) map[string]interfa
 		groupBys := make([]interface{}, 0, len(groupByList))
 		for _, gbMap := range groupByList {
 			gb := map[string]interface{}{}
+			if v, ok := gbMap["should_exclude_missing"].(bool); ok {
+				gb["should_exclude_missing"] = v
+			}
 			if v := getStringFromMap(gbMap, "facet"); v != "" {
 				gb["facet"] = v
 			}

--- a/datadog/dashboardmapping/engine_dashboard_display_fields_test.go
+++ b/datadog/dashboardmapping/engine_dashboard_display_fields_test.go
@@ -1,0 +1,92 @@
+package dashboardmapping
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+func TestDashboardDisplayFieldsRoundTrip(t *testing.T) {
+	for name, definition := range map[string]string{
+		"monitor_summary":              `{"type":"manage_status","query":"tag:service:example","count":50,"start":0,"last_triggered_format":"relative","show_status":true,"show_investigation":false}`,
+		"monitor_summary_false_status": `{"type":"manage_status","query":"tag:service:example","show_status":false,"show_investigation":true}`,
+		"slo_monthly_rollup":           `{"type":"slo_list","requests":[{"request_type":"slo_list","query":{"query_string":"team:example","rollup":{"type":"month"}}}]}`,
+		"event_grouping_and_palette":   `{"type":"timeseries","requests":[{"response_format":"timeseries","formulas":[{"formula":"events"}],"queries":[{"data_source":"events","name":"events","compute":{"aggregation":"count"},"group_by":[{"facet":"host","should_exclude_missing":true}]}],"style":{"palette":"dog_classic","color_order":"monotonic"}}]}`,
+		"include_missing_events":       `{"type":"timeseries","requests":[{"response_format":"timeseries","formulas":[{"formula":"events"}],"queries":[{"data_source":"events","name":"events","compute":{"aggregation":"count"},"group_by":[{"facet":"host","should_exclude_missing":false}]}]}]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			var expected map[string]interface{}
+			if err := json.Unmarshal([]byte(definition), &expected); err != nil {
+				t.Fatal(err)
+			}
+			apiWidget := map[string]interface{}{"definition": expected}
+			// Exercise the state-pruning path used by resource reads and imports.
+			flat, dropped := FlattenWidgetsForSDKv2([]interface{}{apiWidget})
+			if len(dropped) != 0 {
+				t.Fatalf("fields lost during import: %v", dropped)
+			}
+			rebuilt := BuildWidgetEngineJSONFromMap(flat[0].(map[string]interface{}))
+			encoded, err := json.Marshal(rebuilt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var actual map[string]interface{}
+			if err := json.Unmarshal(encoded, &actual); err != nil {
+				t.Fatal(err)
+			}
+			assertDashboardDisplaySubset(t, apiWidget, actual)
+		})
+	}
+}
+
+// Existing fields may acquire provider defaults; every supplied API field must survive.
+func assertDashboardDisplaySubset(t *testing.T, expected, actual interface{}) {
+	t.Helper()
+	switch want := expected.(type) {
+	case map[string]interface{}:
+		got, ok := actual.(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected object %v, got %v", want, actual)
+		}
+		for key, value := range want {
+			if _, ok := got[key]; !ok {
+				t.Fatalf("missing field %s in %v", key, got)
+			}
+			assertDashboardDisplaySubset(t, value, got[key])
+		}
+	case []interface{}:
+		got, ok := actual.([]interface{})
+		if !ok || len(want) != len(got) {
+			t.Fatalf("expected list %v, got %v", want, actual)
+		}
+		for i := range want {
+			assertDashboardDisplaySubset(t, want[i], got[i])
+		}
+	default:
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("expected %v, got %v", expected, actual)
+		}
+	}
+}
+
+func TestDashboardOptionalFalseRawConfig(t *testing.T) {
+	for _, configured := range []bool{false, true} {
+		t.Run(map[bool]string{false: "unset", true: "explicit_false"}[configured], func(t *testing.T) {
+			fields := []FieldSpec{{HCLKey: "show_status", Type: TypeBool, OmitEmpty: true, PreserveZero: true}}
+			ctx := mapBuildContext{rawConfig: rawConfigAtFunc(func(cty.Path) (cty.Value, diag.Diagnostics) {
+				if configured {
+					return cty.False, nil
+				}
+				return cty.NullVal(cty.Bool), nil
+			})}
+			got := buildEngineJSONFromMap(map[string]interface{}{}, fields, ctx)
+			value, present := got["show_status"]
+			if present != configured || (present && value != false) {
+				t.Fatalf("configured=%v: unexpected result %v", configured, got)
+			}
+		})
+	}
+}

--- a/datadog/dashboardmapping/engine_dashboard_display_fields_test.go
+++ b/datadog/dashboardmapping/engine_dashboard_display_fields_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func TestDashboardDisplayFieldsRoundTrip(t *testing.T) {
@@ -88,5 +89,26 @@ func TestDashboardOptionalFalseRawConfig(t *testing.T) {
 				t.Fatalf("configured=%v: unexpected result %v", configured, got)
 			}
 		})
+	}
+}
+
+func TestDashboardUnsetDisplayFieldsSDKData(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"widget": {Type: schema.TypeList, Optional: true, Elem: &schema.Resource{Schema: AllWidgetSDKv2Schema(false)}},
+	}, map[string]interface{}{
+		"widget": []interface{}{map[string]interface{}{
+			"manage_status_definition": []interface{}{map[string]interface{}{"query": "tag:service:example"}},
+		}},
+	})
+	widget := d.Get("widget").([]interface{})[0].(map[string]interface{})
+	rawConfig := rawConfigAtFunc(func(cty.Path) (cty.Value, diag.Diagnostics) {
+		return cty.NullVal(cty.Bool), nil
+	})
+	got := BuildWidgetEngineJSONFromMapWithRawConfig(widget, rawConfig, cty.GetAttrPath("widget").IndexInt(0))
+	definition := got["definition"].(map[string]interface{})
+	for _, field := range []string{"show_status", "show_investigation", "count", "start"} {
+		if _, present := definition[field]; present {
+			t.Errorf("unset %s must remain omitted; got %v", field, definition[field])
+		}
 	}
 }

--- a/datadog/dashboardmapping/field_groups.go
+++ b/datadog/dashboardmapping/field_groups.go
@@ -283,6 +283,8 @@ var formulaAndFunctionEventQueryGroupBySortFields = []FieldSpec{
 
 // formulaAndFunctionEventQueryGroupByFields corresponds to FormulaAndFunctionEventQueryGroupBy.
 var formulaAndFunctionEventQueryGroupByFields = []FieldSpec{
+	{HCLKey: "should_exclude_missing", Type: TypeBool, OmitEmpty: true, PreserveZero: true,
+		Description: "Whether to exclude events missing the group-by facet."},
 	{HCLKey: "facet", Type: TypeString, OmitEmpty: false, Required: true,
 		Description: "The event facet."},
 	{HCLKey: "limit", Type: TypeInt, OmitEmpty: true,
@@ -1864,6 +1866,12 @@ var sloListSortFields = []FieldSpec{
 // sloListQueryFields corresponds to OpenAPI
 // components/schemas/SLOListWidgetQuery.
 var sloListQueryFields = []FieldSpec{
+	{HCLKey: "rollup", Type: TypeBlock, OmitEmpty: true,
+		Description: "Calendar rollup configuration for the SLO list.",
+		Children: []FieldSpec{
+			{HCLKey: "type", Type: TypeString, Required: true,
+				Description: "The calendar rollup type, for example `month`."},
+		}},
 	{HCLKey: "query_string", Type: TypeString, OmitEmpty: false, Required: true, Description: "Widget query."},
 	{HCLKey: "limit", Type: TypeInt, OmitEmpty: true, Description: "Maximum number of results to display in the table."},
 	// sort: TypeBlockList (can be multiple)

--- a/datadog/dashboardmapping/widgets.go
+++ b/datadog/dashboardmapping/widgets.go
@@ -434,6 +434,16 @@ var ManageStatusWidgetSpec = WidgetSpec{
 	JSONType:    "manage_status",
 	Description: "The definition for an Manage Status widget.",
 	Fields: []FieldSpec{
+		{HCLKey: "count", Type: TypeInt, OmitEmpty: true, PreserveZero: true,
+			Description: "The number of monitors to display.", Deprecated: "This pagination field is deprecated by the Datadog API."},
+		{HCLKey: "start", Type: TypeInt, OmitEmpty: true, PreserveZero: true,
+			Description: "The start of the monitor list, typically zero.", Deprecated: "This pagination field is deprecated by the Datadog API."},
+		{HCLKey: "last_triggered_format", Type: TypeString, OmitEmpty: true,
+			Description: "The display format for the last triggered time."},
+		{HCLKey: "show_investigation", Type: TypeBool, OmitEmpty: true, PreserveZero: true,
+			Description: "Whether to display monitor investigation information."},
+		{HCLKey: "show_status", Type: TypeBool, OmitEmpty: true, PreserveZero: true,
+			Description: "Whether to display monitor status."},
 		{
 			HCLKey:      "query",
 			Type:        TypeString,
@@ -1731,6 +1741,8 @@ var splitGraphSourceWidgetTypes = map[string]bool{
 // timeseriesWidgetRequestStyleFields corresponds to OpenAPI
 // components/schemas/WidgetRequestStyle (inline on TimeseriesWidgetRequest).
 var timeseriesWidgetRequestStyleFields = []FieldSpec{
+	{HCLKey: "color_order", Type: TypeString, OmitEmpty: true,
+		Description: "The ordering of colors in the timeseries palette."},
 	{
 		HCLKey:      "palette",
 		Type:        TypeString,

--- a/docs/resources/dashboard_v2.md
+++ b/docs/resources/dashboard_v2.md
@@ -809,6 +809,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--bar_chart_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--bar_chart_definition--request--query--event_query--group_by--sort"></a>
@@ -2094,6 +2095,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--change_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--change_definition--request--query--event_query--group_by--sort"></a>
@@ -3567,6 +3569,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--distribution_definition--request--histogram_query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--distribution_definition--request--histogram_query--event_query--group_by--sort"></a>
@@ -3850,6 +3853,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--distribution_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--distribution_definition--request--query--event_query--group_by--sort"></a>
@@ -5222,6 +5226,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--geomap_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--geomap_definition--request--query--event_query--group_by--sort"></a>
@@ -6589,6 +6594,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--bar_chart_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--bar_chart_definition--request--query--event_query--group_by--sort"></a>
@@ -7874,6 +7880,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--change_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--change_definition--request--query--event_query--group_by--sort"></a>
@@ -9347,6 +9354,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--distribution_definition--request--histogram_query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--distribution_definition--request--histogram_query--event_query--group_by--sort"></a>
@@ -9630,6 +9638,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--distribution_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--distribution_definition--request--query--event_query--group_by--sort"></a>
@@ -11002,6 +11011,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--geomap_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--geomap_definition--request--query--event_query--group_by--sort"></a>
@@ -12237,6 +12247,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--heatmap_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--heatmap_definition--request--query--event_query--group_by--sort"></a>
@@ -13318,6 +13329,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--hostmap_definition--request--child--enrichment--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--hostmap_definition--request--child--enrichment--query--event_query--group_by--sort"></a>
@@ -14204,6 +14216,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--hostmap_definition--request--enrichment--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--hostmap_definition--request--enrichment--query--event_query--group_by--sort"></a>
@@ -15225,6 +15238,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--hostmap_definition--request--fill--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--hostmap_definition--request--fill--query--event_query--group_by--sort"></a>
@@ -16488,6 +16502,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--hostmap_definition--request--size--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--hostmap_definition--request--size--query--event_query--group_by--sort"></a>
@@ -17550,14 +17565,19 @@ Required:
 Optional:
 
 - `color_preference` (String) Whether to colorize text or background. Valid values are `background`, `text`.
+- `count` (Number, Deprecated) The number of monitors to display. **Deprecated.** This pagination field is deprecated by the Datadog API.
 - `description` (String) The description of the widget.
 - `display_format` (String) The display setting to use. Valid values are `counts`, `countsAndList`, `list`.
 - `hide_incomplete_cost_data` (Boolean) Hide any portion of the widget's timeframe that is incomplete due to cost data not being available.
 - `hide_zero_counts` (Boolean) A Boolean indicating whether to hide empty categories.
+- `last_triggered_format` (String) The display format for the last triggered time.
 - `live_span` (String) The timeframe to use when displaying the widget. Valid values are `1m`, `5m`, `10m`, `15m`, `30m`, `1h`, `4h`, `1d`, `2d`, `1w`, `1mo`, `3mo`, `6mo`, `week_to_date`, `month_to_date`, `1y`, `alert`.
+- `show_investigation` (Boolean) Whether to display monitor investigation information.
 - `show_last_triggered` (Boolean) Whether to show the time that has elapsed since the monitor/group triggered.
 - `show_priority` (Boolean) Whether to show the priorities column.
+- `show_status` (Boolean) Whether to display monitor status.
 - `sort` (String) The method to sort the monitors. Valid values are `name`, `group`, `status`, `tags`, `triggered`, `group,asc`, `group,desc`, `name,asc`, `name,desc`, `status,asc`, `status,desc`, `tags,asc`, `tags,desc`, `triggered,asc`, `triggered,desc`, `priority,asc`, `priority,desc`.
+- `start` (Number, Deprecated) The start of the monitor list, typically zero. **Deprecated.** This pagination field is deprecated by the Datadog API.
 - `summary_type` (String) The summary type to use. Valid values are `monitors`, `groups`, `combined`.
 - `time` (Block List, Max: 1) A nested block used to specify a time span for the widget. Use this or `live_span`, not both. (see [below for nested schema](#nestedblock--widget--group_definition--widget--manage_status_definition--time))
 - `title` (String) The title of the widget.
@@ -18526,6 +18546,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--query_table_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--query_table_definition--request--query--event_query--group_by--sort"></a>
@@ -19936,6 +19957,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--query_value_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--query_value_definition--request--query--event_query--group_by--sort"></a>
@@ -21494,6 +21516,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--scatterplot_definition--request--scatterplot_table--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--scatterplot_definition--request--scatterplot_table--query--event_query--group_by--sort"></a>
@@ -22516,6 +22539,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--scatterplot_definition--request--x--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--scatterplot_definition--request--x--query--event_query--group_by--sort"></a>
@@ -23666,6 +23690,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--scatterplot_definition--request--y--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--scatterplot_definition--request--y--query--event_query--group_by--sort"></a>
@@ -24609,7 +24634,16 @@ Required:
 Optional:
 
 - `limit` (Number) Maximum number of results to display in the table.
+- `rollup` (Block List, Max: 1) Calendar rollup configuration for the SLO list. (see [below for nested schema](#nestedblock--widget--group_definition--widget--slo_list_definition--request--query--rollup))
 - `sort` (Block List) The facet and order to sort the data, for example: `{"column": "status.sli", "order": "desc"}`. (see [below for nested schema](#nestedblock--widget--group_definition--widget--slo_list_definition--request--query--sort))
+
+<a id="nestedblock--widget--group_definition--widget--slo_list_definition--request--query--rollup"></a>
+### Nested Schema for `widget.group_definition.widget.slo_list_definition.request.query.rollup`
+
+Required:
+
+- `type` (String) The calendar rollup type, for example `month`.
+
 
 <a id="nestedblock--widget--group_definition--widget--slo_list_definition--request--query--sort"></a>
 ### Nested Schema for `widget.group_definition.widget.slo_list_definition.request.query.sort`
@@ -25235,6 +25269,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--sunburst_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--sunburst_definition--request--query--event_query--group_by--sort"></a>
@@ -26793,6 +26828,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--timeseries_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--timeseries_definition--request--query--event_query--group_by--sort"></a>
@@ -27543,6 +27579,7 @@ Optional:
 
 Optional:
 
+- `color_order` (String) The ordering of colors in the timeseries palette.
 - `has_value_labels` (Boolean) Whether to display value labels on the timeseries.
 - `line_type` (String) The type of lines displayed. Valid values are `dashed`, `dotted`, `solid`.
 - `line_width` (String) The width of line displayed. Valid values are `normal`, `thick`, `thin`.
@@ -28120,6 +28157,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--toplist_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--toplist_definition--request--query--event_query--group_by--sort"></a>
@@ -29388,6 +29426,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--treemap_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--treemap_definition--request--query--event_query--group_by--sort"></a>
@@ -30236,6 +30275,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--wildcard_definition--request--histogram_request--histogram_query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--wildcard_definition--request--histogram_request--histogram_query--event_query--group_by--sort"></a>
@@ -30773,6 +30813,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--wildcard_definition--request--timeseries_request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--wildcard_definition--request--timeseries_request--query--event_query--group_by--sort"></a>
@@ -31969,6 +32010,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--wildcard_definition--request--treemap_request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--wildcard_definition--request--treemap_request--query--event_query--group_by--sort"></a>
@@ -33308,6 +33350,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--heatmap_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--heatmap_definition--request--query--event_query--group_by--sort"></a>
@@ -34389,6 +34432,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--hostmap_definition--request--child--enrichment--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--hostmap_definition--request--child--enrichment--query--event_query--group_by--sort"></a>
@@ -35275,6 +35319,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--hostmap_definition--request--enrichment--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--hostmap_definition--request--enrichment--query--event_query--group_by--sort"></a>
@@ -36296,6 +36341,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--hostmap_definition--request--fill--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--hostmap_definition--request--fill--query--event_query--group_by--sort"></a>
@@ -37559,6 +37605,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--hostmap_definition--request--size--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--hostmap_definition--request--size--query--event_query--group_by--sort"></a>
@@ -38621,14 +38668,19 @@ Required:
 Optional:
 
 - `color_preference` (String) Whether to colorize text or background. Valid values are `background`, `text`.
+- `count` (Number, Deprecated) The number of monitors to display. **Deprecated.** This pagination field is deprecated by the Datadog API.
 - `description` (String) The description of the widget.
 - `display_format` (String) The display setting to use. Valid values are `counts`, `countsAndList`, `list`.
 - `hide_incomplete_cost_data` (Boolean) Hide any portion of the widget's timeframe that is incomplete due to cost data not being available.
 - `hide_zero_counts` (Boolean) A Boolean indicating whether to hide empty categories.
+- `last_triggered_format` (String) The display format for the last triggered time.
 - `live_span` (String) The timeframe to use when displaying the widget. Valid values are `1m`, `5m`, `10m`, `15m`, `30m`, `1h`, `4h`, `1d`, `2d`, `1w`, `1mo`, `3mo`, `6mo`, `week_to_date`, `month_to_date`, `1y`, `alert`.
+- `show_investigation` (Boolean) Whether to display monitor investigation information.
 - `show_last_triggered` (Boolean) Whether to show the time that has elapsed since the monitor/group triggered.
 - `show_priority` (Boolean) Whether to show the priorities column.
+- `show_status` (Boolean) Whether to display monitor status.
 - `sort` (String) The method to sort the monitors. Valid values are `name`, `group`, `status`, `tags`, `triggered`, `group,asc`, `group,desc`, `name,asc`, `name,desc`, `status,asc`, `status,desc`, `tags,asc`, `tags,desc`, `triggered,asc`, `triggered,desc`, `priority,asc`, `priority,desc`.
+- `start` (Number, Deprecated) The start of the monitor list, typically zero. **Deprecated.** This pagination field is deprecated by the Datadog API.
 - `summary_type` (String) The summary type to use. Valid values are `monitors`, `groups`, `combined`.
 - `time` (Block List, Max: 1) A nested block used to specify a time span for the widget. Use this or `live_span`, not both. (see [below for nested schema](#nestedblock--widget--manage_status_definition--time))
 - `title` (String) The title of the widget.
@@ -39681,6 +39733,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--query_table_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--query_table_definition--request--query--event_query--group_by--sort"></a>
@@ -41091,6 +41144,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--query_value_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--query_value_definition--request--query--event_query--group_by--sort"></a>
@@ -42649,6 +42703,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--scatterplot_definition--request--scatterplot_table--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--scatterplot_definition--request--scatterplot_table--query--event_query--group_by--sort"></a>
@@ -43671,6 +43726,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--scatterplot_definition--request--x--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--scatterplot_definition--request--x--query--event_query--group_by--sort"></a>
@@ -44821,6 +44877,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--scatterplot_definition--request--y--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--scatterplot_definition--request--y--query--event_query--group_by--sort"></a>
@@ -45764,7 +45821,16 @@ Required:
 Optional:
 
 - `limit` (Number) Maximum number of results to display in the table.
+- `rollup` (Block List, Max: 1) Calendar rollup configuration for the SLO list. (see [below for nested schema](#nestedblock--widget--slo_list_definition--request--query--rollup))
 - `sort` (Block List) The facet and order to sort the data, for example: `{"column": "status.sli", "order": "desc"}`. (see [below for nested schema](#nestedblock--widget--slo_list_definition--request--query--sort))
+
+<a id="nestedblock--widget--slo_list_definition--request--query--rollup"></a>
+### Nested Schema for `widget.slo_list_definition.request.query.rollup`
+
+Required:
+
+- `type` (String) The calendar rollup type, for example `month`.
+
 
 <a id="nestedblock--widget--slo_list_definition--request--query--sort"></a>
 ### Nested Schema for `widget.slo_list_definition.request.query.sort`
@@ -46338,6 +46404,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--split_graph_definition--source_widget_definition--change_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--split_graph_definition--source_widget_definition--change_definition--request--query--event_query--group_by--sort"></a>
@@ -47462,6 +47529,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--split_graph_definition--source_widget_definition--geomap_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--split_graph_definition--source_widget_definition--geomap_definition--request--query--event_query--group_by--sort"></a>
@@ -48678,6 +48746,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--split_graph_definition--source_widget_definition--query_table_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--split_graph_definition--source_widget_definition--query_table_definition--request--query--event_query--group_by--sort"></a>
@@ -50088,6 +50157,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--split_graph_definition--source_widget_definition--query_value_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--split_graph_definition--source_widget_definition--query_value_definition--request--query--event_query--group_by--sort"></a>
@@ -51082,6 +51152,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--split_graph_definition--source_widget_definition--scatterplot_definition--request--scatterplot_table--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--split_graph_definition--source_widget_definition--scatterplot_definition--request--scatterplot_table--query--event_query--group_by--sort"></a>
@@ -52104,6 +52175,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--split_graph_definition--source_widget_definition--scatterplot_definition--request--x--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--split_graph_definition--source_widget_definition--scatterplot_definition--request--x--query--event_query--group_by--sort"></a>
@@ -53254,6 +53326,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--split_graph_definition--source_widget_definition--scatterplot_definition--request--y--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--split_graph_definition--source_widget_definition--scatterplot_definition--request--y--query--event_query--group_by--sort"></a>
@@ -54638,6 +54711,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--split_graph_definition--source_widget_definition--sunburst_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--split_graph_definition--source_widget_definition--sunburst_definition--request--query--event_query--group_by--sort"></a>
@@ -56196,6 +56270,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--split_graph_definition--source_widget_definition--timeseries_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--split_graph_definition--source_widget_definition--timeseries_definition--request--query--event_query--group_by--sort"></a>
@@ -56946,6 +57021,7 @@ Optional:
 
 Optional:
 
+- `color_order` (String) The ordering of colors in the timeseries palette.
 - `has_value_labels` (Boolean) Whether to display value labels on the timeseries.
 - `line_type` (String) The type of lines displayed. Valid values are `dashed`, `dotted`, `solid`.
 - `line_width` (String) The width of line displayed. Valid values are `normal`, `thick`, `thin`.
@@ -57523,6 +57599,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--split_graph_definition--source_widget_definition--toplist_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--split_graph_definition--source_widget_definition--toplist_definition--request--query--event_query--group_by--sort"></a>
@@ -58656,6 +58733,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--split_graph_definition--source_widget_definition--treemap_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--split_graph_definition--source_widget_definition--treemap_definition--request--query--event_query--group_by--sort"></a>
@@ -59961,6 +60039,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--sunburst_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--sunburst_definition--request--query--event_query--group_by--sort"></a>
@@ -61519,6 +61598,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--timeseries_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--timeseries_definition--request--query--event_query--group_by--sort"></a>
@@ -62269,6 +62349,7 @@ Optional:
 
 Optional:
 
+- `color_order` (String) The ordering of colors in the timeseries palette.
 - `has_value_labels` (Boolean) Whether to display value labels on the timeseries.
 - `line_type` (String) The type of lines displayed. Valid values are `dashed`, `dotted`, `solid`.
 - `line_width` (String) The width of line displayed. Valid values are `normal`, `thick`, `thin`.
@@ -62846,6 +62927,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--toplist_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--toplist_definition--request--query--event_query--group_by--sort"></a>
@@ -64114,6 +64196,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--treemap_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--treemap_definition--request--query--event_query--group_by--sort"></a>
@@ -64962,6 +65045,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--wildcard_definition--request--histogram_request--histogram_query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--wildcard_definition--request--histogram_request--histogram_query--event_query--group_by--sort"></a>
@@ -65499,6 +65583,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--wildcard_definition--request--timeseries_request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--wildcard_definition--request--timeseries_request--query--event_query--group_by--sort"></a>
@@ -66695,6 +66780,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--wildcard_definition--request--treemap_request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--wildcard_definition--request--treemap_request--query--event_query--group_by--sort"></a>

--- a/docs/resources/powerpack_v2.md
+++ b/docs/resources/powerpack_v2.md
@@ -685,6 +685,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--bar_chart_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--bar_chart_definition--request--query--event_query--group_by--sort"></a>
@@ -1970,6 +1971,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--change_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--change_definition--request--query--event_query--group_by--sort"></a>
@@ -3443,6 +3445,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--distribution_definition--request--histogram_query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--distribution_definition--request--histogram_query--event_query--group_by--sort"></a>
@@ -3726,6 +3729,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--distribution_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--distribution_definition--request--query--event_query--group_by--sort"></a>
@@ -5098,6 +5102,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--geomap_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--geomap_definition--request--query--event_query--group_by--sort"></a>
@@ -6465,6 +6470,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--bar_chart_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--bar_chart_definition--request--query--event_query--group_by--sort"></a>
@@ -7750,6 +7756,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--change_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--change_definition--request--query--event_query--group_by--sort"></a>
@@ -9223,6 +9230,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--distribution_definition--request--histogram_query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--distribution_definition--request--histogram_query--event_query--group_by--sort"></a>
@@ -9506,6 +9514,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--distribution_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--distribution_definition--request--query--event_query--group_by--sort"></a>
@@ -10878,6 +10887,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--geomap_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--geomap_definition--request--query--event_query--group_by--sort"></a>
@@ -12113,6 +12123,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--heatmap_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--heatmap_definition--request--query--event_query--group_by--sort"></a>
@@ -13194,6 +13205,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--hostmap_definition--request--child--enrichment--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--hostmap_definition--request--child--enrichment--query--event_query--group_by--sort"></a>
@@ -14080,6 +14092,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--hostmap_definition--request--enrichment--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--hostmap_definition--request--enrichment--query--event_query--group_by--sort"></a>
@@ -15101,6 +15114,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--hostmap_definition--request--fill--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--hostmap_definition--request--fill--query--event_query--group_by--sort"></a>
@@ -16364,6 +16378,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--hostmap_definition--request--size--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--hostmap_definition--request--size--query--event_query--group_by--sort"></a>
@@ -17426,14 +17441,19 @@ Required:
 Optional:
 
 - `color_preference` (String) Whether to colorize text or background. Valid values are `background`, `text`.
+- `count` (Number, Deprecated) The number of monitors to display. **Deprecated.** This pagination field is deprecated by the Datadog API.
 - `description` (String) The description of the widget.
 - `display_format` (String) The display setting to use. Valid values are `counts`, `countsAndList`, `list`.
 - `hide_incomplete_cost_data` (Boolean) Hide any portion of the widget's timeframe that is incomplete due to cost data not being available.
 - `hide_zero_counts` (Boolean) A Boolean indicating whether to hide empty categories.
+- `last_triggered_format` (String) The display format for the last triggered time.
 - `live_span` (String) The timeframe to use when displaying the widget. Valid values are `1m`, `5m`, `10m`, `15m`, `30m`, `1h`, `4h`, `1d`, `2d`, `1w`, `1mo`, `3mo`, `6mo`, `week_to_date`, `month_to_date`, `1y`, `alert`.
+- `show_investigation` (Boolean) Whether to display monitor investigation information.
 - `show_last_triggered` (Boolean) Whether to show the time that has elapsed since the monitor/group triggered.
 - `show_priority` (Boolean) Whether to show the priorities column.
+- `show_status` (Boolean) Whether to display monitor status.
 - `sort` (String) The method to sort the monitors. Valid values are `name`, `group`, `status`, `tags`, `triggered`, `group,asc`, `group,desc`, `name,asc`, `name,desc`, `status,asc`, `status,desc`, `tags,asc`, `tags,desc`, `triggered,asc`, `triggered,desc`, `priority,asc`, `priority,desc`.
+- `start` (Number, Deprecated) The start of the monitor list, typically zero. **Deprecated.** This pagination field is deprecated by the Datadog API.
 - `summary_type` (String) The summary type to use. Valid values are `monitors`, `groups`, `combined`.
 - `time` (Block List, Max: 1) A nested block used to specify a time span for the widget. Use this or `live_span`, not both. (see [below for nested schema](#nestedblock--widget--group_definition--widget--manage_status_definition--time))
 - `title` (String) The title of the widget.
@@ -18402,6 +18422,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--query_table_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--query_table_definition--request--query--event_query--group_by--sort"></a>
@@ -19812,6 +19833,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--query_value_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--query_value_definition--request--query--event_query--group_by--sort"></a>
@@ -21370,6 +21392,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--scatterplot_definition--request--scatterplot_table--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--scatterplot_definition--request--scatterplot_table--query--event_query--group_by--sort"></a>
@@ -22392,6 +22415,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--scatterplot_definition--request--x--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--scatterplot_definition--request--x--query--event_query--group_by--sort"></a>
@@ -23542,6 +23566,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--scatterplot_definition--request--y--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--scatterplot_definition--request--y--query--event_query--group_by--sort"></a>
@@ -24485,7 +24510,16 @@ Required:
 Optional:
 
 - `limit` (Number) Maximum number of results to display in the table.
+- `rollup` (Block List, Max: 1) Calendar rollup configuration for the SLO list. (see [below for nested schema](#nestedblock--widget--group_definition--widget--slo_list_definition--request--query--rollup))
 - `sort` (Block List) The facet and order to sort the data, for example: `{"column": "status.sli", "order": "desc"}`. (see [below for nested schema](#nestedblock--widget--group_definition--widget--slo_list_definition--request--query--sort))
+
+<a id="nestedblock--widget--group_definition--widget--slo_list_definition--request--query--rollup"></a>
+### Nested Schema for `widget.group_definition.widget.slo_list_definition.request.query.rollup`
+
+Required:
+
+- `type` (String) The calendar rollup type, for example `month`.
+
 
 <a id="nestedblock--widget--group_definition--widget--slo_list_definition--request--query--sort"></a>
 ### Nested Schema for `widget.group_definition.widget.slo_list_definition.request.query.sort`
@@ -25111,6 +25145,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--sunburst_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--sunburst_definition--request--query--event_query--group_by--sort"></a>
@@ -26669,6 +26704,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--timeseries_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--timeseries_definition--request--query--event_query--group_by--sort"></a>
@@ -27419,6 +27455,7 @@ Optional:
 
 Optional:
 
+- `color_order` (String) The ordering of colors in the timeseries palette.
 - `has_value_labels` (Boolean) Whether to display value labels on the timeseries.
 - `line_type` (String) The type of lines displayed. Valid values are `dashed`, `dotted`, `solid`.
 - `line_width` (String) The width of line displayed. Valid values are `normal`, `thick`, `thin`.
@@ -27996,6 +28033,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--toplist_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--toplist_definition--request--query--event_query--group_by--sort"></a>
@@ -29264,6 +29302,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--treemap_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--treemap_definition--request--query--event_query--group_by--sort"></a>
@@ -30112,6 +30151,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--wildcard_definition--request--histogram_request--histogram_query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--wildcard_definition--request--histogram_request--histogram_query--event_query--group_by--sort"></a>
@@ -30649,6 +30689,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--wildcard_definition--request--timeseries_request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--wildcard_definition--request--timeseries_request--query--event_query--group_by--sort"></a>
@@ -31845,6 +31886,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--group_definition--widget--wildcard_definition--request--treemap_request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--group_definition--widget--wildcard_definition--request--treemap_request--query--event_query--group_by--sort"></a>
@@ -33184,6 +33226,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--heatmap_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--heatmap_definition--request--query--event_query--group_by--sort"></a>
@@ -34265,6 +34308,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--hostmap_definition--request--child--enrichment--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--hostmap_definition--request--child--enrichment--query--event_query--group_by--sort"></a>
@@ -35151,6 +35195,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--hostmap_definition--request--enrichment--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--hostmap_definition--request--enrichment--query--event_query--group_by--sort"></a>
@@ -36172,6 +36217,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--hostmap_definition--request--fill--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--hostmap_definition--request--fill--query--event_query--group_by--sort"></a>
@@ -37435,6 +37481,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--hostmap_definition--request--size--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--hostmap_definition--request--size--query--event_query--group_by--sort"></a>
@@ -38497,14 +38544,19 @@ Required:
 Optional:
 
 - `color_preference` (String) Whether to colorize text or background. Valid values are `background`, `text`.
+- `count` (Number, Deprecated) The number of monitors to display. **Deprecated.** This pagination field is deprecated by the Datadog API.
 - `description` (String) The description of the widget.
 - `display_format` (String) The display setting to use. Valid values are `counts`, `countsAndList`, `list`.
 - `hide_incomplete_cost_data` (Boolean) Hide any portion of the widget's timeframe that is incomplete due to cost data not being available.
 - `hide_zero_counts` (Boolean) A Boolean indicating whether to hide empty categories.
+- `last_triggered_format` (String) The display format for the last triggered time.
 - `live_span` (String) The timeframe to use when displaying the widget. Valid values are `1m`, `5m`, `10m`, `15m`, `30m`, `1h`, `4h`, `1d`, `2d`, `1w`, `1mo`, `3mo`, `6mo`, `week_to_date`, `month_to_date`, `1y`, `alert`.
+- `show_investigation` (Boolean) Whether to display monitor investigation information.
 - `show_last_triggered` (Boolean) Whether to show the time that has elapsed since the monitor/group triggered.
 - `show_priority` (Boolean) Whether to show the priorities column.
+- `show_status` (Boolean) Whether to display monitor status.
 - `sort` (String) The method to sort the monitors. Valid values are `name`, `group`, `status`, `tags`, `triggered`, `group,asc`, `group,desc`, `name,asc`, `name,desc`, `status,asc`, `status,desc`, `tags,asc`, `tags,desc`, `triggered,asc`, `triggered,desc`, `priority,asc`, `priority,desc`.
+- `start` (Number, Deprecated) The start of the monitor list, typically zero. **Deprecated.** This pagination field is deprecated by the Datadog API.
 - `summary_type` (String) The summary type to use. Valid values are `monitors`, `groups`, `combined`.
 - `time` (Block List, Max: 1) A nested block used to specify a time span for the widget. Use this or `live_span`, not both. (see [below for nested schema](#nestedblock--widget--manage_status_definition--time))
 - `title` (String) The title of the widget.
@@ -39473,6 +39525,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--query_table_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--query_table_definition--request--query--event_query--group_by--sort"></a>
@@ -40883,6 +40936,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--query_value_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--query_value_definition--request--query--event_query--group_by--sort"></a>
@@ -42441,6 +42495,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--scatterplot_definition--request--scatterplot_table--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--scatterplot_definition--request--scatterplot_table--query--event_query--group_by--sort"></a>
@@ -43463,6 +43518,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--scatterplot_definition--request--x--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--scatterplot_definition--request--x--query--event_query--group_by--sort"></a>
@@ -44613,6 +44669,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--scatterplot_definition--request--y--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--scatterplot_definition--request--y--query--event_query--group_by--sort"></a>
@@ -45556,7 +45613,16 @@ Required:
 Optional:
 
 - `limit` (Number) Maximum number of results to display in the table.
+- `rollup` (Block List, Max: 1) Calendar rollup configuration for the SLO list. (see [below for nested schema](#nestedblock--widget--slo_list_definition--request--query--rollup))
 - `sort` (Block List) The facet and order to sort the data, for example: `{"column": "status.sli", "order": "desc"}`. (see [below for nested schema](#nestedblock--widget--slo_list_definition--request--query--sort))
+
+<a id="nestedblock--widget--slo_list_definition--request--query--rollup"></a>
+### Nested Schema for `widget.slo_list_definition.request.query.rollup`
+
+Required:
+
+- `type` (String) The calendar rollup type, for example `month`.
+
 
 <a id="nestedblock--widget--slo_list_definition--request--query--sort"></a>
 ### Nested Schema for `widget.slo_list_definition.request.query.sort`
@@ -46182,6 +46248,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--sunburst_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--sunburst_definition--request--query--event_query--group_by--sort"></a>
@@ -47740,6 +47807,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--timeseries_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--timeseries_definition--request--query--event_query--group_by--sort"></a>
@@ -48490,6 +48558,7 @@ Optional:
 
 Optional:
 
+- `color_order` (String) The ordering of colors in the timeseries palette.
 - `has_value_labels` (Boolean) Whether to display value labels on the timeseries.
 - `line_type` (String) The type of lines displayed. Valid values are `dashed`, `dotted`, `solid`.
 - `line_width` (String) The width of line displayed. Valid values are `normal`, `thick`, `thin`.
@@ -49067,6 +49136,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--toplist_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--toplist_definition--request--query--event_query--group_by--sort"></a>
@@ -50335,6 +50405,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--treemap_definition--request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--treemap_definition--request--query--event_query--group_by--sort"></a>
@@ -51183,6 +51254,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--wildcard_definition--request--histogram_request--histogram_query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--wildcard_definition--request--histogram_request--histogram_query--event_query--group_by--sort"></a>
@@ -51720,6 +51792,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--wildcard_definition--request--timeseries_request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--wildcard_definition--request--timeseries_request--query--event_query--group_by--sort"></a>
@@ -52916,6 +52989,7 @@ Required:
 Optional:
 
 - `limit` (Number) The number of groups to return.
+- `should_exclude_missing` (Boolean) Whether to exclude events missing the group-by facet.
 - `sort` (Block List, Max: 1) The options for sorting group by results. (see [below for nested schema](#nestedblock--widget--wildcard_definition--request--treemap_request--query--event_query--group_by--sort))
 
 <a id="nestedblock--widget--wildcard_definition--request--treemap_request--query--event_query--group_by--sort"></a>
@@ -53749,5 +53823,5 @@ Import is supported using the following syntax:
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-terraform import datadog_powerpack_v2.foo 11111111-2222-3333-4444-555555555555
+terraform import datadog_powerpack_v2.foo abcdefab-cdef-abcd-efab-cdefabcdefab
 ```

--- a/examples/resources/datadog_dashboard_v2/display_fields.tf
+++ b/examples/resources/datadog_dashboard_v2/display_fields.tf
@@ -1,0 +1,56 @@
+resource "datadog_dashboard_v2" "display_fields" {
+  title       = "Dashboard display options"
+  layout_type = "ordered"
+
+  widget {
+    manage_status_definition {
+      query                 = "tag:service:example"
+      count                 = 50
+      start                 = 0
+      last_triggered_format = "relative"
+      show_status           = true
+      show_investigation    = false
+    }
+  }
+
+  widget {
+    slo_list_definition {
+      request {
+        request_type = "slo_list"
+        query {
+          query_string = "team:example"
+          rollup {
+            type = "month"
+          }
+        }
+      }
+    }
+  }
+
+  widget {
+    timeseries_definition {
+      request {
+        formula {
+          formula_expression = "events"
+        }
+        query {
+          event_query {
+            data_source = "events"
+            name        = "events"
+            compute {
+              aggregation = "count"
+            }
+            group_by {
+              facet                  = "host"
+              should_exclude_missing = true
+            }
+          }
+        }
+        style {
+          palette     = "dog_classic"
+          color_order = "monotonic"
+        }
+      }
+    }
+  }
+}

--- a/examples/resources/datadog_powerpack_v2/import.sh
+++ b/examples/resources/datadog_powerpack_v2/import.sh
@@ -1,1 +1,1 @@
-terraform import datadog_powerpack_v2.foo 11111111-2222-3333-4444-555555555555
+terraform import datadog_powerpack_v2.foo abcdefab-cdef-abcd-efab-cdefabcdefab


### PR DESCRIPTION
Dashboard imports can drop API fields that have no v2 mapping, and subsequent updates cannot preserve them. Add mappings for monitor summary display/pagination options, SLO-list calendar rollups, event-query missing-facet filtering, and timeseries color ordering.

This adds `count`, `start`, `last_triggered_format`, `show_status`, and `show_investigation` to monitor summaries; `query.rollup.type` to SLO lists; `group_by.should_exclude_missing` to event queries; and `style.color_order` to timeseries. The shared mapping also exposes the applicable fields on powerpack v2. Pagination fields are marked deprecated, matching the API client.

Explicit false/zero settings survive serialization while unset options remain omitted. Tests exercise the SDKv2 import/pruning path followed by serialization, including both boolean values. Query-table sorting is already supported on the base branch and needs no changes here.

## Validation

- `make test`: 342 unit tests passed, including 72 dashboard mapping tests and an SDK-decoded unset-field regression test.
- `make fmtcheck` and `make vet`: passed.
- `make docs` and `make check-docs`: generated dashboard and powerpack documentation and verified reproducibility.
- `make errcheck`: fails on existing unchecked errors in untouched files; no findings in `datadog/dashboardmapping`.
- Live API acceptance tests were not run: sandbox Datadog credentials are unavailable.

## Review and live validation

Draft pending API validation. Several fields are present in dashboard API payloads but absent from the public generated API models (`rollup`, `last_triggered_format`, `show_status`, `show_investigation`, and `color_order`). Maintainers should confirm their supported semantics; no speculative enum restrictions are introduced.

`examples/resources/datadog_dashboard_v2/display_fields.tf` provides a standalone configuration with synthetic queries for sandbox validation using a locally built provider. Verify create/update, import, explicit false/zero values, and a subsequent no-change plan before marking ready. No live dashboard definitions or identifiers are included in this PR.
