### PR TITLE
[TF Gen] Add write-only field support

### DIFF
--- a/.generator-v2/internal/cli/generate_writeonly_test.go
+++ b/.generator-v2/internal/cli/generate_writeonly_test.go
@@ -1,0 +1,284 @@
+//go:build integration
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+	testinfra "github.com/terraform-providers/terraform-provider-datadog/generator/internal/testdata"
+)
+
+type writeOnlyResourceFixture struct {
+	name     string
+	spec     string
+	resource string
+}
+
+var writeOnlyResourceFixtures = []writeOnlyResourceFixture{
+	{
+		name:     "Twilio",
+		spec:     "mini-datadog_integration_twilio_account.yaml",
+		resource: "resource_datadog_integration_twilio_account.go",
+	},
+	{
+		name:     "Elastic Cloud",
+		spec:     "mini-datadog_integration_elastic_cloud_account.yaml",
+		resource: "resource_datadog_integration_elastic_cloud.go",
+	},
+}
+
+// TestGenerateWriteOnlyResources is the checked-in, offline full-pipeline gate
+// for the canonical generated write-only resources. It deliberately starts at
+// the CLI so parser, model, SDK binding, rendering, writing and reporting are
+// all covered before the generated code is compiled and its framework schema
+// is validated in the provider module.
+func TestGenerateWriteOnlyResources(t *testing.T) {
+	providerRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	tempRoot := t.TempDir()
+	var staged []testinfra.StagedFile
+
+	for _, fixture := range writeOnlyResourceFixtures {
+		fixture := fixture
+		t.Run(fixture.name, func(t *testing.T) {
+			tempProvider := filepath.Join(tempRoot, strings.ReplaceAll(fixture.name, " ", "_"), "provider")
+			outputRoot := filepath.Join(tempProvider, "datadog", "fwprovider")
+			reportPath := filepath.Join(tempProvider, "tfgen-report.json")
+			specPath := filepath.Join("..", "testdata", "mini-oas", fixture.spec)
+
+			if err := runTfgen(
+				"generate",
+				"--spec", specPath,
+				"--output-root", outputRoot,
+				"--hooks-root", filepath.Join(outputRoot, "hooks"),
+				"--tests-output-root", filepath.Join(tempProvider, "datadog", "tests"),
+				"--examples-output-root", filepath.Join(tempProvider, "examples", "resources"),
+				"--docs-root", filepath.Join(tempProvider, "docs", "resources"),
+				"--report", reportPath,
+			); err != nil {
+				t.Fatalf("generate %s resource: %v", fixture.name, err)
+			}
+
+			assertNoFailedArtifacts(t, reportPath)
+
+			generatedPath := filepath.Join(outputRoot, fixture.resource)
+			generated, err := os.ReadFile(generatedPath)
+			if err != nil {
+				t.Fatalf("read generated %s resource: %v", fixture.name, err)
+			}
+			checkedInPath := filepath.Join(providerRoot, "datadog", "fwprovider", fixture.resource)
+			checkedIn, err := os.ReadFile(checkedInPath)
+			if err != nil {
+				t.Fatalf("read checked-in %s resource: %v", fixture.name, err)
+			}
+			if !bytes.Equal(generated, checkedIn) {
+				t.Fatalf("freshly generated %s resource differs from %s", fixture.name, checkedInPath)
+			}
+
+			assertGeneratedWriteOnlyContract(t, generated)
+			staged = append(staged, testinfra.StagedFile{
+				ProviderPath: filepath.Join("datadog", "fwprovider", fixture.resource),
+				SourcePath:   generatedPath,
+			})
+		})
+	}
+
+	probeDir := t.TempDir()
+	probePath := filepath.Join(probeDir, "zz_tfgen_writeonly_schema_test.go")
+	if err := os.WriteFile(probePath, []byte(writeOnlySchemaProbe), 0o644); err != nil {
+		t.Fatalf("write generated schema probe: %v", err)
+	}
+	staged = append(staged, testinfra.StagedFile{
+		ProviderPath: filepath.Join("datadog", "fwprovider", "zz_tfgen_writeonly_schema_test.go"),
+		SourcePath:   probePath,
+	})
+
+	result, err := testinfra.RunTests(staged, "^TestTfgenWriteOnlySchemasValidate$")
+	if err != nil {
+		t.Fatalf("run staged provider schema validation: %v", err)
+	}
+	if !result.OK() {
+		t.Fatalf("generated resources do not compile or validate against the pinned provider and SDK:\n%s", result.Diagnostics)
+	}
+}
+
+func assertNoFailedArtifacts(t *testing.T, reportPath string) {
+	t.Helper()
+	reportBytes, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("read generation report: %v", err)
+	}
+	var report model.RunReport
+	if err := json.Unmarshal(reportBytes, &report); err != nil {
+		t.Fatalf("decode generation report: %v", err)
+	}
+	if report.Summary == nil {
+		t.Fatal("generation report has no summary")
+	}
+	if report.Summary.Failed != 0 {
+		t.Fatalf("generation report contains %d failed artifacts: %s", report.Summary.Failed, reportBytes)
+	}
+	for _, artifact := range report.Artifacts {
+		if artifact.Status == model.ArtifactStatusFailed {
+			t.Fatalf("artifact %q failed despite zero summary: %s", artifact.Name, reportBytes)
+		}
+	}
+}
+
+func assertGeneratedWriteOnlyContract(t *testing.T, source []byte) {
+	t.Helper()
+	text := string(source)
+
+	for _, want := range []string{
+		`OriginalAttr: "password"`,
+		`WriteOnlyAttr: "password_wo"`,
+		`TriggerAttr: "password_wo_version"`,
+		`ParentBlocks: []string{"authentication", "integration_account_basic_auth"}`,
+		`Mode: fwutils.WriteOnlySecretModeOnly`,
+		`fwutils.CreateWriteOnlySecretAttributes(`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("generated resource is missing write-only contract %q", want)
+		}
+	}
+	if got := strings.Count(text, "`tfsdk:\"password_wo\"`"); got != 1 {
+		t.Errorf("password_wo model field count = %d, want 1", got)
+	}
+	if got := strings.Count(text, "`tfsdk:\"password_wo_version\"`"); got != 1 {
+		t.Errorf("password_wo_version model field count = %d, want 1", got)
+	}
+	for _, forbidden := range []string{
+		"`tfsdk:\"password\"`",
+		`"password": schema.StringAttribute{`,
+		"Sensitive: true",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Errorf("generated resource contains forbidden plaintext/sensitive schema form %q", forbidden)
+		}
+	}
+
+	for _, method := range []struct {
+		name       string
+		secretCall string
+	}{
+		{name: "Create", secretCall: "GetSecretForCreate(ctx, &request.Config)"},
+		{name: "Update", secretCall: "GetSecretForUpdate(ctx, &request.Config, &request)"},
+	} {
+		body := generatedMethod(t, source, method.name)
+		if !strings.Contains(body, method.secretCall) {
+			t.Errorf("%s does not retrieve password through its write-only handler", method.name)
+		}
+		if got := strings.Count(body, "request.Config"); got != 1 {
+			t.Errorf("%s configuration read count = %d, want only the write-only handler read", method.name, got)
+		}
+		setters := regexp.MustCompile(`SetPassword\(([^)]*)\)`).FindAllStringSubmatch(body, -1)
+		if len(setters) != 1 || !strings.HasSuffix(setters[0][1], "PasswordSecretResult.Value") {
+			t.Errorf("%s password setters = %v, want exactly one SecretResult.Value setter", method.name, setters)
+		}
+	}
+
+	updateState := generatedMethod(t, source, "updateState")
+	if strings.Contains(updateState, "Password") {
+		t.Error("updateState must not assign or otherwise map the write-only password")
+	}
+
+	lower := strings.ToLower(text)
+	for _, forbidden := range []string{
+		"private.set",
+		"privatestate",
+		"sha256",
+		"secret hash",
+		"digest",
+		"keepers",
+	} {
+		if strings.Contains(lower, forbidden) {
+			t.Errorf("generated resource contains forbidden secret-persistence mechanism %q", forbidden)
+		}
+	}
+}
+
+func generatedMethod(t *testing.T, source []byte, methodName string) string {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "generated.go", source, 0)
+	if err != nil {
+		t.Fatalf("parse generated resource: %v", err)
+	}
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Recv == nil || function.Name.Name != methodName {
+			continue
+		}
+		start := fset.Position(function.Pos()).Offset
+		end := fset.Position(function.End()).Offset
+		return string(source[start:end])
+	}
+	t.Fatalf("generated resource has no %s method", methodName)
+	return ""
+}
+
+const writeOnlySchemaProbe = `package fwprovider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+func TestTfgenWriteOnlySchemasValidate(t *testing.T) {
+	constructors := map[string]func() resource.Resource{
+		"twilio": NewDatadogIntegrationTwilioAccountResource,
+		"elastic_cloud": NewDatadogIntegrationElasticCloudResource,
+	}
+	for name, constructor := range constructors {
+		t.Run(name, func(t *testing.T) {
+			var response resource.SchemaResponse
+			constructor().Schema(context.Background(), resource.SchemaRequest{}, &response)
+			if response.Diagnostics.HasError() {
+				t.Fatalf("Schema returned errors: %v", response.Diagnostics)
+			}
+
+			authentication, ok := response.Schema.Attributes["authentication"].(resourceschema.SingleNestedAttribute)
+			if !ok {
+				t.Fatalf("authentication is %T, want SingleNestedAttribute", response.Schema.Attributes["authentication"])
+			}
+			basic, ok := authentication.Attributes["integration_account_basic_auth"].(resourceschema.SingleNestedAttribute)
+			if !ok {
+				t.Fatalf("integration_account_basic_auth is %T, want SingleNestedAttribute", authentication.Attributes["integration_account_basic_auth"])
+			}
+			if _, exists := basic.Attributes["password"]; exists {
+				t.Fatal("plaintext password attribute is exposed")
+			}
+			password, ok := basic.Attributes["password_wo"].(resourceschema.StringAttribute)
+			if !ok {
+				t.Fatalf("password_wo is %T, want StringAttribute", basic.Attributes["password_wo"])
+			}
+			if !password.WriteOnly || password.Sensitive || !password.Required || password.Optional || password.Computed {
+				t.Fatalf("password_wo flags = %#v, want required write-only and not sensitive/optional/computed", password)
+			}
+			version, ok := basic.Attributes["password_wo_version"].(resourceschema.StringAttribute)
+			if !ok {
+				t.Fatalf("password_wo_version is %T, want StringAttribute", basic.Attributes["password_wo_version"])
+			}
+			if version.WriteOnly || version.Sensitive || !version.Required || version.Optional || version.Computed {
+				t.Fatalf("password_wo_version flags = %#v, want required stateful trigger", version)
+			}
+
+			if diagnostics := response.Schema.ValidateImplementation(context.Background()); diagnostics.HasError() {
+				t.Fatalf("Schema.ValidateImplementation returned errors: %v", diagnostics)
+			}
+		})
+	}
+}
+`

--- a/.generator-v2/internal/cli/generate_writeonly_test.go
+++ b/.generator-v2/internal/cli/generate_writeonly_test.go
@@ -37,57 +37,32 @@ var writeOnlyResourceFixtures = []writeOnlyResourceFixture{
 	},
 }
 
-// TestGenerateWriteOnlyResources is the checked-in, offline full-pipeline gate
+// TestGenerateWriteOnlyResources is the offline full-pipeline gate
 // for the canonical generated write-only resources. It deliberately starts at
 // the CLI so parser, model, SDK binding, rendering, writing and reporting are
 // all covered before the generated code is compiled and its framework schema
 // is validated in the provider module.
 func TestGenerateWriteOnlyResources(t *testing.T) {
-	providerRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	tempRoot := t.TempDir()
-	var staged []testinfra.StagedFile
+	var firstStaged, secondStaged []testinfra.StagedFile
 
 	for _, fixture := range writeOnlyResourceFixtures {
 		fixture := fixture
 		t.Run(fixture.name, func(t *testing.T) {
-			tempProvider := filepath.Join(tempRoot, strings.ReplaceAll(fixture.name, " ", "_"), "provider")
-			outputRoot := filepath.Join(tempProvider, "datadog", "fwprovider")
-			reportPath := filepath.Join(tempProvider, "tfgen-report.json")
-			specPath := filepath.Join("..", "testdata", "mini-oas", fixture.spec)
-
-			if err := runTfgen(
-				"generate",
-				"--spec", specPath,
-				"--output-root", outputRoot,
-				"--hooks-root", filepath.Join(outputRoot, "hooks"),
-				"--tests-output-root", filepath.Join(tempProvider, "datadog", "tests"),
-				"--examples-output-root", filepath.Join(tempProvider, "examples", "resources"),
-				"--docs-root", filepath.Join(tempProvider, "docs", "resources"),
-				"--report", reportPath,
-			); err != nil {
-				t.Fatalf("generate %s resource: %v", fixture.name, err)
+			firstPath, first := generateWriteOnlyFixture(t, tempRoot, fixture, "first")
+			secondPath, second := generateWriteOnlyFixture(t, tempRoot, fixture, "second")
+			if !bytes.Equal(first, second) {
+				t.Fatalf("two independent generations of the %s resource differ", fixture.name)
 			}
 
-			assertNoFailedArtifacts(t, reportPath)
-
-			generatedPath := filepath.Join(outputRoot, fixture.resource)
-			generated, err := os.ReadFile(generatedPath)
-			if err != nil {
-				t.Fatalf("read generated %s resource: %v", fixture.name, err)
-			}
-			checkedInPath := filepath.Join(providerRoot, "datadog", "fwprovider", fixture.resource)
-			checkedIn, err := os.ReadFile(checkedInPath)
-			if err != nil {
-				t.Fatalf("read checked-in %s resource: %v", fixture.name, err)
-			}
-			if !bytes.Equal(generated, checkedIn) {
-				t.Fatalf("freshly generated %s resource differs from %s", fixture.name, checkedInPath)
-			}
-
-			assertGeneratedWriteOnlyContract(t, generated)
-			staged = append(staged, testinfra.StagedFile{
+			assertGeneratedWriteOnlyContract(t, first)
+			firstStaged = append(firstStaged, testinfra.StagedFile{
 				ProviderPath: filepath.Join("datadog", "fwprovider", fixture.resource),
-				SourcePath:   generatedPath,
+				SourcePath:   firstPath,
+			})
+			secondStaged = append(secondStaged, testinfra.StagedFile{
+				ProviderPath: filepath.Join("datadog", "fwprovider", fixture.resource),
+				SourcePath:   secondPath,
 			})
 		})
 	}
@@ -97,18 +72,57 @@ func TestGenerateWriteOnlyResources(t *testing.T) {
 	if err := os.WriteFile(probePath, []byte(writeOnlySchemaProbe), 0o644); err != nil {
 		t.Fatalf("write generated schema probe: %v", err)
 	}
-	staged = append(staged, testinfra.StagedFile{
+	probe := testinfra.StagedFile{
 		ProviderPath: filepath.Join("datadog", "fwprovider", "zz_tfgen_writeonly_schema_test.go"),
 		SourcePath:   probePath,
-	})
+	}
+	for _, run := range []struct {
+		name   string
+		staged []testinfra.StagedFile
+	}{
+		{name: "first", staged: firstStaged},
+		{name: "second", staged: secondStaged},
+	} {
+		run := run
+		t.Run(run.name+" generation compiles and validates", func(t *testing.T) {
+			result, err := testinfra.RunTests(append(run.staged, probe), "^TestTfgenWriteOnlySchemasValidate$")
+			if err != nil {
+				t.Fatalf("run staged provider schema validation: %v", err)
+			}
+			if !result.OK() {
+				t.Fatalf("generated resources do not compile or validate against the pinned provider and SDK:\n%s", result.Diagnostics)
+			}
+		})
+	}
+}
 
-	result, err := testinfra.RunTests(staged, "^TestTfgenWriteOnlySchemasValidate$")
+func generateWriteOnlyFixture(t *testing.T, tempRoot string, fixture writeOnlyResourceFixture, run string) (string, []byte) {
+	t.Helper()
+	tempProvider := filepath.Join(tempRoot, strings.ReplaceAll(fixture.name, " ", "_"), run, "provider")
+	outputRoot := filepath.Join(tempProvider, "datadog", "fwprovider")
+	reportPath := filepath.Join(tempProvider, "tfgen-report.json")
+	specPath := filepath.Join("..", "testdata", "mini-oas", fixture.spec)
+
+	if err := runTfgen(
+		"generate",
+		"--spec", specPath,
+		"--output-root", outputRoot,
+		"--hooks-root", filepath.Join(outputRoot, "hooks"),
+		"--tests-output-root", filepath.Join(tempProvider, "datadog", "tests"),
+		"--examples-output-root", filepath.Join(tempProvider, "examples", "resources"),
+		"--docs-root", filepath.Join(tempProvider, "docs", "resources"),
+		"--report", reportPath,
+	); err != nil {
+		t.Fatalf("generate %s resource (%s run): %v", fixture.name, run, err)
+	}
+
+	assertNoFailedArtifacts(t, reportPath)
+	generatedPath := filepath.Join(outputRoot, fixture.resource)
+	generated, err := os.ReadFile(generatedPath)
 	if err != nil {
-		t.Fatalf("run staged provider schema validation: %v", err)
+		t.Fatalf("read generated %s resource (%s run): %v", fixture.name, run, err)
 	}
-	if !result.OK() {
-		t.Fatalf("generated resources do not compile or validate against the pinned provider and SDK:\n%s", result.Diagnostics)
-	}
+	return generatedPath, generated
 }
 
 func assertNoFailedArtifacts(t *testing.T, reportPath string) {

--- a/.generator-v2/internal/e2e_resource_test.go
+++ b/.generator-v2/internal/e2e_resource_test.go
@@ -1,0 +1,112 @@
+package internal_test
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/emit"
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/parser"
+)
+
+// TestSparseUpdatePreservesPlannedOptionalComputedValue drives the real
+// incident-type fixture through the complete offline generation pipeline. It
+// pins the three generated-code contracts that make a sparse PATCH response
+// safe: Terraform carries the prior Optional+Computed value into the plan,
+// Update decodes that complete plan, and updateState assigns the field only
+// when the API returned it. Consequently, an omitted description leaves the
+// planned model value untouched when the response is overlaid.
+func TestSparseUpdatePreservesPlannedOptionalComputedValue(t *testing.T) {
+	specPath := filepath.Join("testdata", "fixtures", "resource_incident_type", "openapi.yaml")
+	spec, err := parser.LoadSpec(specPath)
+	if err != nil {
+		t.Fatalf("load incident-type fixture: %v", err)
+	}
+
+	var operation *model.Operation
+	for _, candidate := range spec.Operations {
+		if candidate.Tracking != nil &&
+			candidate.Tracking.ArtifactKind == model.ArtifactKindResource &&
+			candidate.Tracking.ArtifactName == "incident_type" {
+			operation = candidate
+			break
+		}
+	}
+	if operation == nil {
+		t.Fatal("incident-type fixture has no tracked resource operation")
+	}
+
+	artifact, err := model.BuildArtifact(operation)
+	if err != nil {
+		t.Fatalf("build incident-type artifact: %v", err)
+	}
+	view, err := emit.BuildResourceView(artifact)
+	if err != nil {
+		t.Fatalf("build incident-type resource view: %v", err)
+	}
+	sourceBytes, err := emit.RenderResource(view)
+	if err != nil {
+		t.Fatalf("render incident-type resource: %v", err)
+	}
+	source := string(sourceBytes)
+
+	descriptionSchema := section(t, source,
+		`"description": schema.StringAttribute{`, "\n\t\t\t},")
+	for _, want := range []string{
+		`Optional:\s+true`,
+		`Computed:\s+true`,
+		`stringplanmodifier\.UseStateForUnknown\(\)`,
+	} {
+		if !regexp.MustCompile(want).MatchString(descriptionSchema) {
+			t.Errorf("description schema does not match %q:\n%s", want, descriptionSchema)
+		}
+	}
+
+	update := section(t, source,
+		`func (r *datadogIncidentTypeResource) Update(`,
+		`func (r *datadogIncidentTypeResource) Delete(`)
+	if !strings.Contains(update, `response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...)`) ||
+		!strings.Contains(update, `response.Diagnostics.Append(plan.As(ctx, &state, basetypes.ObjectAsOptions{UnhandledUnknownAsEmpty: true})...)`) {
+		t.Errorf("Update does not seed state from the complete unknown-capable planned value:\n%s", update)
+	}
+
+	create := section(t, source,
+		`func (r *datadogIncidentTypeResource) Create(`,
+		`func (r *datadogIncidentTypeResource) Read(`)
+	if !strings.Contains(create, `if state.Description.IsUnknown() {
+		state.Description = types.StringNull()
+	}`) {
+		t.Errorf("Create does not normalize a computed value omitted by a sparse response:\n%s", create)
+	}
+
+	updateState := section(t, source,
+		`func (r *datadogIncidentTypeResource) updateState(`, "")
+	guardedAssignment := `if description, ok := attributes.GetDescriptionOk(); ok && description != nil {
+		state.Description = types.StringValue(*description)
+	}`
+	if !strings.Contains(updateState, guardedAssignment) {
+		t.Errorf("updateState does not guard the sparse description overlay:\n%s", updateState)
+	}
+	if count := strings.Count(updateState, `state.Description =`); count != 1 {
+		t.Errorf("updateState has %d description assignments, want only the guarded overlay:\n%s", count, updateState)
+	}
+}
+
+func section(t *testing.T, source, start, end string) string {
+	t.Helper()
+	startIndex := strings.Index(source, start)
+	if startIndex < 0 {
+		t.Fatalf("generated source missing section start %q", start)
+	}
+	section := source[startIndex:]
+	if end == "" {
+		return section
+	}
+	endIndex := strings.Index(section, end)
+	if endIndex < 0 {
+		t.Fatalf("generated source section %q missing end %q", start, end)
+	}
+	return section[:endIndex]
+}

--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -196,22 +196,24 @@ func oneOfListAssignment(
 	tfName, receiver, lhs string,
 	collection bool,
 	preserveExisting bool,
+	preserveConfiguredPresence bool,
 ) ListAssignment {
 	outer := leafVar(tfName)
 	assignment := &OneOfAssignment{
-		Path:             env.Path,
-		SDKType:          env.SDKType,
-		GoModel:          render.goModel,
-		LHS:              lhs,
-		GetterOk:         getterOk(receiver, tfName),
-		Var:              outer,
-		Receiver:         outer,
-		ModelVar:         outer + "Envelope",
-		MatchVar:         outer + "Matches",
-		Optional:         env.Optional,
-		PreserveExisting: preserveExisting,
-		Collection:       collection,
-		Variants:         render.variants,
+		Path:                       env.Path,
+		SDKType:                    env.SDKType,
+		GoModel:                    render.goModel,
+		LHS:                        lhs,
+		GetterOk:                   getterOk(receiver, tfName),
+		Var:                        outer,
+		Receiver:                   outer,
+		ModelVar:                   outer + "Envelope",
+		MatchVar:                   outer + "Matches",
+		Optional:                   env.Optional,
+		PreserveExisting:           preserveExisting,
+		PreserveConfiguredPresence: preserveConfiguredPresence,
+		Collection:                 collection,
+		Variants:                   render.variants,
 	}
 	if collection {
 		// The members are read off each element, not off the slice pointer.
@@ -951,7 +953,7 @@ func (b *dataSourceBuilder) walk(structName, stem, receiver, lhsPrefix string, a
 			})
 			if b.responds(a) {
 				lists = append(lists, oneOfListAssignment(
-					a.OneOf, render, tfName, receiver, lhsPrefix+"."+field, collection, b.filterByResponse))
+					a.OneOf, render, tfName, receiver, lhsPrefix+"."+field, collection, b.filterByResponse, a.PreserveConfiguredPresence))
 			}
 			continue
 		}
@@ -1057,18 +1059,19 @@ func (b *dataSourceBuilder) walk(structName, stem, receiver, lhsPrefix string, a
 			})
 			if b.responds(a) {
 				lists = append(lists, ListAssignment{
-					Kind:             "object",
-					LHS:              lhsPrefix + "." + field,
-					GetterOk:         getterOk(receiver, tfName),
-					Var:              leafVar(tfName),
-					LoopVar:          loopVar,
-					LoopIndex:        base + "Index",
-					ExistingVar:      base + "Existing",
-					ElemVar:          elemVar,
-					ElemStruct:       elemStruct,
-					Scalars:          childScalars,
-					Lists:            childLists,
-					PreserveExisting: b.filterByResponse,
+					Kind:                       "object",
+					LHS:                        lhsPrefix + "." + field,
+					GetterOk:                   getterOk(receiver, tfName),
+					Var:                        leafVar(tfName),
+					LoopVar:                    loopVar,
+					LoopIndex:                  base + "Index",
+					ExistingVar:                base + "Existing",
+					ElemVar:                    elemVar,
+					ElemStruct:                 elemStruct,
+					Scalars:                    childScalars,
+					Lists:                      childLists,
+					PreserveExisting:           b.filterByResponse,
+					PreserveConfiguredPresence: a.PreserveConfiguredPresence,
 				})
 			}
 
@@ -1095,15 +1098,16 @@ func (b *dataSourceBuilder) walk(structName, stem, receiver, lhsPrefix string, a
 			})
 			if b.responds(a) {
 				lists = append(lists, ListAssignment{
-					Kind:             "object_single",
-					LHS:              lhsPrefix + "." + field,
-					GetterOk:         getterOk(receiver, tfName),
-					Var:              objVar,
-					ElemVar:          elemVar,
-					ElemStruct:       childStruct,
-					Scalars:          childScalars,
-					Lists:            childLists,
-					PreserveExisting: b.filterByResponse,
+					Kind:                       "object_single",
+					LHS:                        lhsPrefix + "." + field,
+					GetterOk:                   getterOk(receiver, tfName),
+					Var:                        objVar,
+					ElemVar:                    elemVar,
+					ElemStruct:                 childStruct,
+					Scalars:                    childScalars,
+					Lists:                      childLists,
+					PreserveExisting:           b.filterByResponse,
+					PreserveConfiguredPresence: a.PreserveConfiguredPresence,
 				})
 			}
 
@@ -1524,7 +1528,7 @@ func buildPluralView(a *model.Artifact) (DataSourceView, error) {
 				Blocks:      render.blocks,
 			})
 			itemLists = append(itemLists, oneOfListAssignment(
-				n.OneOf, render, tfName, "item.Attributes", "r."+field, collection, false))
+				n.OneOf, render, tfName, "item.Attributes", "r."+field, collection, false, false))
 			continue
 		}
 

--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -1150,12 +1150,24 @@ func unsupportedWriteOnlyCollision(path, name string) UnsupportedNode {
 	}
 }
 
+func unsupportedWriteOnlyIdentifierCollision(path, otherPath, identifier string) UnsupportedNode {
+	return UnsupportedNode{
+		Path: path,
+		Reason: fmt.Sprintf(
+			"write-only handler identifier %q collides with write-only field %q",
+			identifier,
+			otherPath,
+		),
+	}
+}
+
 // validateWriteOnlySecrets checks the complete, unflattened resource tree so
 // diagnostics retain their canonical OpenAPI-derived paths. Expansion later in
 // walk can stay a single-purpose transformation instead of duplicating these
 // support-boundary checks after paths have been rewritten for rendering.
 func validateWriteOnlySecrets(attributes []*model.Attribute) []UnsupportedNode {
 	var unsupported []UnsupportedNode
+	handlerIdentifiers := make(map[string]string)
 	var walk func([]*model.Attribute, string)
 	walk = func(nodes []*model.Attribute, containment string) {
 		siblingNames := make(map[string]struct{}, len(nodes))
@@ -1175,10 +1187,21 @@ func validateWriteOnlySecrets(attributes []*model.Attribute) []UnsupportedNode {
 					})
 				default:
 					name := tfNameOf(attribute.Path)
+					companionCollision := false
 					for _, companion := range []string{name + "_wo", name + "_wo_version"} {
 						if _, exists := siblingNames[companion]; exists {
 							unsupported = append(unsupported, unsupportedWriteOnlyCollision(attribute.Path, companion))
+							companionCollision = true
 							break
+						}
+					}
+					if !companionCollision {
+						identifier := writeOnlyLocalStem(writeOnlyParentBlocks(attribute.Path), name)
+						if otherPath, exists := handlerIdentifiers[identifier]; exists && otherPath != attribute.Path {
+							unsupported = append(unsupported,
+								unsupportedWriteOnlyIdentifierCollision(attribute.Path, otherPath, identifier))
+						} else {
+							handlerIdentifiers[identifier] = attribute.Path
 						}
 					}
 				}
@@ -1221,7 +1244,7 @@ func buildWriteOnlySecretView(attribute *model.Attribute, artifactBase string) W
 	}
 	writeOnlyAttr := tfName + "_wo"
 	parentBlocks := writeOnlyParentBlocks(attribute.Path)
-	localStem := lowerFirst(model.SdkName(strings.Join(append(append([]string(nil), parentBlocks...), tfName), "_")))
+	localStem := writeOnlyLocalStem(parentBlocks, tfName)
 	return WriteOnlySecretView{
 		OriginalAttr:         tfName,
 		WriteOnlyAttr:        writeOnlyAttr,
@@ -1242,11 +1265,17 @@ func (b *dataSourceBuilder) collectWriteOnlySecret(secret WriteOnlySecretView) {
 	if b.writeOnlySeen == nil {
 		b.writeOnlySeen = make(map[string]struct{})
 	}
-	if _, exists := b.writeOnlySeen[secret.ConfigVar]; exists {
+	pathKey := strings.Join(append(append([]string(nil), secret.ParentBlocks...), secret.OriginalAttr), ".")
+	if _, exists := b.writeOnlySeen[pathKey]; exists {
 		return
 	}
-	b.writeOnlySeen[secret.ConfigVar] = struct{}{}
+	b.writeOnlySeen[pathKey] = struct{}{}
 	b.writeOnlySecrets = append(b.writeOnlySecrets, secret)
+}
+
+func writeOnlyLocalStem(parentBlocks []string, tfName string) string {
+	path := append(append([]string(nil), parentBlocks...), tfName)
+	return lowerFirst(model.SdkName(strings.Join(path, "_")))
 }
 
 func writeOnlyParentBlocks(attributePath string) []string {

--- a/.generator-v2/internal/emit/builder.go
+++ b/.generator-v2/internal/emit/builder.go
@@ -44,7 +44,12 @@ const envelopeReceiver = "attributes"
 // OneOfVariantAssignment because the mapper must unwrap the SDK member first.
 func (b *dataSourceBuilder) oneOfEnvelope(a *model.Attribute) oneOfRender {
 	env := a.OneOf
-	if cached, ok := b.oneOfRenders[env.Name]; ok {
+	// Schema views containing write-only configuration carry an absolute
+	// ParentBlocks path, so the same reusable union reached at two resource
+	// locations needs one render per location. Model declarations remain
+	// deduplicated by dedupeModels after the walk.
+	cacheKey := env.Name + "\x00" + a.Path
+	if cached, ok := b.oneOfRenders[cacheKey]; ok {
 		return cached
 	}
 
@@ -89,16 +94,17 @@ func (b *dataSourceBuilder) oneOfEnvelope(a *model.Attribute) oneOfRender {
 
 		variantValidators, variantValidatorType := b.oneOfVariantValidators(env, v)
 		render.blocks = append(render.blocks, AttrView{
-			TFName:        v.TFName,
-			Description:   v.Attribute.Description,
-			Optional:      v.Attribute.Optional,
-			Computed:      v.Attribute.Computed,
-			Sensitive:     v.Attribute.Sensitive,
-			IsBlock:       true,
-			Attributes:    attrs,
-			Blocks:        blocks,
-			Validators:    variantValidators,
-			ValidatorType: variantValidatorType,
+			TFName:              v.TFName,
+			Description:         v.Attribute.Description,
+			Optional:            v.Attribute.Optional,
+			Computed:            v.Attribute.Computed,
+			Sensitive:           v.Attribute.Sensitive,
+			IsBlock:             true,
+			Attributes:          attrs,
+			Blocks:              blocks,
+			HasWriteOnlySecrets: hasWriteOnlySecrets(attrs),
+			Validators:          variantValidators,
+			ValidatorType:       variantValidatorType,
 		})
 		envFields = append(envFields, ModelFieldView{
 			GoField: v.GoField,
@@ -112,7 +118,7 @@ func (b *dataSourceBuilder) oneOfEnvelope(a *model.Attribute) oneOfRender {
 	if b.oneOfRenders == nil {
 		b.oneOfRenders = make(map[string]oneOfRender)
 	}
-	b.oneOfRenders[env.Name] = render
+	b.oneOfRenders[cacheKey] = render
 	return render
 }
 
@@ -779,6 +785,11 @@ type dataSourceBuilder struct {
 	// usesObjectValidators records oneOf selection validators, kept separate from
 	// the string ones so only the referenced constructor packages are imported.
 	usesObjectValidators bool
+	// writeOnlySecrets is populated by the resource schema walk in stable tree
+	// order. Data-source walks never append because resource-only model metadata
+	// is the sole selector.
+	writeOnlySecrets []WriteOnlySecretView
+	writeOnlySeen    map[string]struct{}
 }
 
 // responds reports whether walk should build a's response-mapping assignment.
@@ -898,6 +909,16 @@ func (b *dataSourceBuilder) walk(structName, stem, receiver, lhsPrefix string, a
 	for _, a := range attrs {
 		tfName := tfNameOf(a.Path)
 		field := model.SdkName(tfName)
+		if a.WriteOnlySecret {
+			secret := buildWriteOnlySecretView(a, b.namer.base)
+			attrViews = append(attrViews, AttrView{TFName: tfName, WriteOnlySecret: &secret})
+			fields = append(fields,
+				ModelFieldView{GoField: model.SdkName(secret.WriteOnlyAttr), GoType: "types.String", TFName: secret.WriteOnlyAttr},
+				ModelFieldView{GoField: model.SdkName(secret.TriggerAttr), GoType: "types.String", TFName: secret.TriggerAttr},
+			)
+			b.collectWriteOnlySecret(secret)
+			continue
+		}
 		// A function of a alone, so computed before the oneOf branch, which
 		// returns without reaching the switch.
 		pmNames, pmType := b.planModifierViews(a)
@@ -915,17 +936,18 @@ func (b *dataSourceBuilder) walk(structName, stem, receiver, lhsPrefix string, a
 			collection := isCollectionForm(a.TfType)
 			fields = append(fields, ModelFieldView{GoField: field, GoType: goType, TFName: tfName})
 			blockViews = append(blockViews, AttrView{
-				TFName:           tfName,
-				Description:      a.Description,
-				Required:         a.Required,
-				Optional:         a.Optional,
-				Computed:         a.Computed,
-				Sensitive:        a.Sensitive,
-				IsBlock:          true,
-				ListBlock:        collection,
-				Blocks:           render.blocks,
-				PlanModifiers:    pmNames,
-				PlanModifierType: pmType,
+				TFName:              tfName,
+				Description:         a.Description,
+				Required:            a.Required,
+				Optional:            a.Optional,
+				Computed:            a.Computed,
+				Sensitive:           a.Sensitive,
+				IsBlock:             true,
+				ListBlock:           collection,
+				Blocks:              render.blocks,
+				HasWriteOnlySecrets: false,
+				PlanModifiers:       pmNames,
+				PlanModifierType:    pmType,
 			})
 			if b.responds(a) {
 				lists = append(lists, oneOfListAssignment(
@@ -1019,18 +1041,19 @@ func (b *dataSourceBuilder) walk(structName, stem, receiver, lhsPrefix string, a
 			fields = append(fields, ModelFieldView{GoField: field, GoType: "[]*" + elemStruct, TFName: tfName})
 			childAttrs, childBlocks, childScalars, childLists := b.walk(elemStruct, childStem, loopVar, elemVar, a.Children)
 			blockViews = append(blockViews, AttrView{
-				TFName:           tfName,
-				Description:      a.Description,
-				Required:         a.Required,
-				Optional:         a.Optional,
-				Computed:         a.Computed,
-				Sensitive:        a.Sensitive,
-				IsBlock:          true,
-				ListBlock:        true,
-				Attributes:       childAttrs,
-				Blocks:           childBlocks,
-				PlanModifiers:    pmNames,
-				PlanModifierType: pmType,
+				TFName:              tfName,
+				Description:         a.Description,
+				Required:            a.Required,
+				Optional:            a.Optional,
+				Computed:            a.Computed,
+				Sensitive:           a.Sensitive,
+				IsBlock:             true,
+				ListBlock:           true,
+				Attributes:          childAttrs,
+				Blocks:              childBlocks,
+				HasWriteOnlySecrets: hasWriteOnlySecrets(childAttrs),
+				PlanModifiers:       pmNames,
+				PlanModifierType:    pmType,
 			})
 			if b.responds(a) {
 				lists = append(lists, ListAssignment{
@@ -1056,18 +1079,19 @@ func (b *dataSourceBuilder) walk(structName, stem, receiver, lhsPrefix string, a
 			fields = append(fields, ModelFieldView{GoField: field, GoType: "*" + childStruct, TFName: tfName})
 			childAttrs, childBlocks, childScalars, childLists := b.walk(childStruct, childStem, objVar, elemVar, a.Children)
 			blockViews = append(blockViews, AttrView{
-				TFName:           tfName,
-				Description:      a.Description,
-				Required:         a.Required,
-				Optional:         a.Optional,
-				Computed:         a.Computed,
-				Sensitive:        a.Sensitive,
-				IsBlock:          true,
-				ListBlock:        false,
-				Attributes:       childAttrs,
-				Blocks:           childBlocks,
-				PlanModifiers:    pmNames,
-				PlanModifierType: pmType,
+				TFName:              tfName,
+				Description:         a.Description,
+				Required:            a.Required,
+				Optional:            a.Optional,
+				Computed:            a.Computed,
+				Sensitive:           a.Sensitive,
+				IsBlock:             true,
+				ListBlock:           false,
+				Attributes:          childAttrs,
+				Blocks:              childBlocks,
+				HasWriteOnlySecrets: hasWriteOnlySecrets(childAttrs),
+				PlanModifiers:       pmNames,
+				PlanModifierType:    pmType,
 			})
 			if b.responds(a) {
 				lists = append(lists, ListAssignment{
@@ -1090,6 +1114,154 @@ func (b *dataSourceBuilder) walk(structName, stem, receiver, lhsPrefix string, a
 
 	b.models[idx].Fields = fields
 	return attrViews, blockViews, scalars, lists
+}
+
+func writeOnlyContainment(inherited, tfType string) string {
+	if inherited != "" {
+		return inherited
+	}
+	switch tfType {
+	case "schema.ListAttribute", "schema.ListNestedAttribute", "schema.ListNestedBlock":
+		return "list"
+	case "schema.MapAttribute", "schema.MapNestedAttribute":
+		return "map"
+	case "schema.SetAttribute", "schema.SetNestedAttribute", "schema.SetNestedBlock":
+		return "set"
+	default:
+		return ""
+	}
+}
+
+func unsupportedWriteOnlyContainment(path, category string) UnsupportedNode {
+	return UnsupportedNode{
+		Path:   path,
+		Reason: fmt.Sprintf("write-only secret nested beneath a %s is not supported", category),
+	}
+}
+
+func unsupportedWriteOnlyCollision(path, name string) UnsupportedNode {
+	return UnsupportedNode{
+		Path:   path,
+		Reason: fmt.Sprintf("write-only companion name collision with %q", name),
+	}
+}
+
+// validateWriteOnlySecrets checks the complete, unflattened resource tree so
+// diagnostics retain their canonical OpenAPI-derived paths. Expansion later in
+// walk can stay a single-purpose transformation instead of duplicating these
+// support-boundary checks after paths have been rewritten for rendering.
+func validateWriteOnlySecrets(attributes []*model.Attribute) []UnsupportedNode {
+	var unsupported []UnsupportedNode
+	var walk func([]*model.Attribute, string)
+	walk = func(nodes []*model.Attribute, containment string) {
+		siblingNames := make(map[string]struct{}, len(nodes))
+		for _, sibling := range nodes {
+			siblingNames[tfNameOf(sibling.Path)] = struct{}{}
+		}
+
+		for _, attribute := range nodes {
+			if attribute.WriteOnlySecret {
+				switch {
+				case containment != "":
+					unsupported = append(unsupported, unsupportedWriteOnlyContainment(attribute.Path, containment))
+				case attribute.TfType != "schema.StringAttribute":
+					unsupported = append(unsupported, UnsupportedNode{
+						Path:   attribute.Path,
+						Reason: "write-only secret support is limited to string attributes",
+					})
+				default:
+					name := tfNameOf(attribute.Path)
+					for _, companion := range []string{name + "_wo", name + "_wo_version"} {
+						if _, exists := siblingNames[companion]; exists {
+							unsupported = append(unsupported, unsupportedWriteOnlyCollision(attribute.Path, companion))
+							break
+						}
+					}
+				}
+			}
+
+			childContainment := writeOnlyContainment(containment, attribute.TfType)
+			walk(attribute.Children, childContainment)
+			if attribute.OneOf != nil {
+				for _, variant := range attribute.OneOf.Variants {
+					walk(variant.Attribute.Children, childContainment)
+				}
+			}
+		}
+	}
+	walk(attributes, "")
+	return unsupported
+}
+
+func hasWriteOnlySecrets(attributes []AttrView) bool {
+	for _, attribute := range attributes {
+		if attribute.WriteOnlySecret != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func buildWriteOnlySecretView(attribute *model.Attribute, artifactBase string) WriteOnlySecretView {
+	tfName := tfNameOf(attribute.Path)
+	sdkField := model.SdkName(attribute.OpenAPIName)
+	if sdkField == "" {
+		sdkField = model.SdkName(tfName)
+	}
+	description := strings.TrimSpace(attribute.WriteOnlyDescription)
+	if description == "" {
+		description = strings.TrimSpace(attribute.Description)
+	}
+	if description != "" {
+		description += " "
+	}
+	writeOnlyAttr := tfName + "_wo"
+	parentBlocks := writeOnlyParentBlocks(attribute.Path)
+	localStem := lowerFirst(model.SdkName(strings.Join(append(append([]string(nil), parentBlocks...), tfName), "_")))
+	return WriteOnlySecretView{
+		OriginalAttr:         tfName,
+		WriteOnlyAttr:        writeOnlyAttr,
+		TriggerAttr:          tfName + "_wo_version",
+		SDKField:             sdkField,
+		ParentBlocks:         parentBlocks,
+		RequiredOnCreate:     attribute.SecretRequiredOnCreate,
+		RequiredOnUpdate:     attribute.SecretRequiredOnUpdate,
+		WriteOnlyDescription: description + "This write-only value is not stored in Terraform state.",
+		TriggerDescription:   "Version trigger for " + writeOnlyAttr + " rotation.",
+		ConfigVar:            artifactBase + upperFirst(localStem) + "WriteOnlySecretConfig",
+		HandlerVar:           localStem + "WriteOnlySecretHandler",
+		ResultVar:            localStem + "SecretResult",
+	}
+}
+
+func (b *dataSourceBuilder) collectWriteOnlySecret(secret WriteOnlySecretView) {
+	if b.writeOnlySeen == nil {
+		b.writeOnlySeen = make(map[string]struct{})
+	}
+	if _, exists := b.writeOnlySeen[secret.ConfigVar]; exists {
+		return
+	}
+	b.writeOnlySeen[secret.ConfigVar] = struct{}{}
+	b.writeOnlySecrets = append(b.writeOnlySecrets, secret)
+}
+
+func writeOnlyParentBlocks(attributePath string) []string {
+	const attributesMarker = ".data.attributes."
+	if index := strings.Index(attributePath, attributesMarker); index >= 0 {
+		attributePath = attributePath[index+len(attributesMarker):]
+	} else {
+		attributePath = strings.TrimPrefix(attributePath, "resource.")
+		attributePath = strings.TrimPrefix(attributePath, "response.")
+	}
+	segments := strings.Split(attributePath, ".")
+	if len(segments) <= 1 {
+		return nil
+	}
+	parents := make([]string, 0, len(segments)-1)
+	for _, segment := range segments[:len(segments)-1] {
+		parents = append(parents, stripMarkers(segment))
+	}
+	return parents
 }
 
 // getterOk builds the SDK optional getter reading name off receiver, e.g.
@@ -1634,6 +1806,9 @@ func BuildResourceView(a *model.Artifact) (ResourceView, error) {
 			return ResourceView{}, err
 		}
 	}
+	if unsupported := validateWriteOnlySecrets(a.Schema.Attributes); len(unsupported) > 0 {
+		return ResourceView{}, &UnsupportedEmitError{Nodes: unsupported}
+	}
 
 	primary := lc.Read
 	goName := dsGoName(a.Name)
@@ -1667,6 +1842,8 @@ func BuildResourceView(a *model.Artifact) (ResourceView, error) {
 	// update body would not compile.
 	createFields, requestImps := buildRequestFields(
 		env.leaves, lc.Create.RequestAttributesSchema, "state", requestAttributesVar, primary.GoPackage, &b.unsupported)
+	createWriteOnlySecrets := writeOnlySecretsForFields(
+		b.writeOnlySecrets, createFields, "GetSecretForCreate(ctx, &request.Config)")
 	createArgs, createUUID, createStrconv := buildArgumentViews(lc.Create, &b.unsupported)
 	readArgs, readUUID, readStrconv := buildArgumentViews(lc.Read, &b.unsupported)
 	deleteArgs, deleteUUID, deleteStrconv := buildArgumentViews(lc.Delete, &b.unsupported)
@@ -1694,6 +1871,8 @@ func BuildResourceView(a *model.Artifact) (ResourceView, error) {
 			Method: lc.Update.GoMethod, GoRequestType: lc.Update.GoRequestType,
 			GoResponseType: lc.Update.GoResponseType, Arguments: updateArgs,
 			Envelope: buildRequestEnvelope(a.Name, "Update", primary.GoPackage, lc.Update, updateFields, &b.unsupported),
+			WriteOnlySecrets: writeOnlySecretsForFields(
+				b.writeOnlySecrets, updateFields, "GetSecretForUpdate(ctx, &request.Config, &request)"),
 		}
 		// Keyed on whether the body itself declares an id, and of what type —
 		// not on env.idAssign, which describes only the response side.
@@ -1746,7 +1925,8 @@ func BuildResourceView(a *model.Artifact) (ResourceView, error) {
 		Create: CRUDCallView{
 			Method: lc.Create.GoMethod, GoRequestType: lc.Create.GoRequestType,
 			GoResponseType: lc.Create.GoResponseType, Arguments: createArgs,
-			Envelope: createEnvelope,
+			Envelope: createEnvelope, WriteOnlySecrets: createWriteOnlySecrets,
+			NormalizeUnknowns: buildUnknownNormalizations(env.leaves, "state"),
 		},
 		Read: CRUDCallView{
 			Method: lc.Read.GoMethod, GoResponseType: lc.Read.GoResponseType, Arguments: readArgs,
@@ -1757,7 +1937,12 @@ func BuildResourceView(a *model.Artifact) (ResourceView, error) {
 			Method: lc.Delete.GoMethod, Arguments: deleteArgs,
 		},
 		Models: models,
-		Schema: SchemaView{Attributes: recordAttrs, Blocks: recordBlocks},
+		Schema: SchemaView{
+			Attributes:          recordAttrs,
+			Blocks:              recordBlocks,
+			HasWriteOnlySecrets: hasWriteOnlySecrets(recordAttrs),
+			IncludeResourceID:   true,
+		},
 		State: StateView{
 			ParamName:   "resp",
 			ParamType:   "*" + primary.GoPackage + "." + primary.GoResponseType,
@@ -1779,6 +1964,8 @@ func BuildResourceView(a *model.Artifact) (ResourceView, error) {
 		UsesUUID:             createUUID || readUUID || updateUUID || deleteUUID || requestImps.uuid,
 		UsesStrconv:          createStrconv || readStrconv || updateStrconv || deleteStrconv,
 		UsesTime:             requestImps.time,
+		WriteOnlySecrets:     b.writeOnlySecrets,
+		UsesWriteOnly:        len(b.writeOnlySecrets) > 0,
 		Dropped:              b.dropped,
 	}, nil
 }
@@ -1977,6 +2164,15 @@ func buildRequestFields(attrs []*model.Attribute, role *model.Schema, stateExpr,
 		}
 		field := model.SdkName(tfName)
 		childState := stateExpr + "." + field
+		if a.WriteOnlySecret {
+			secret := buildWriteOnlySecretView(a, "")
+			fields = append(fields, RequestFieldView{
+				GoField:         secret.SDKField,
+				Target:          target,
+				WriteOnlyResult: secret.ResultVar,
+			})
+			continue
+		}
 
 		if a.OneOf != nil {
 			rf, oneOfImports, ok := buildOneOfRequestField(a, roleChildSchema, tfName, field, childState, target, sdkPackage, unsupported)
@@ -2039,6 +2235,103 @@ func buildRequestFields(attrs []*model.Attribute, role *model.Schema, stateExpr,
 		imports.time = imports.time || t
 	}
 	return fields, imports
+}
+
+func writeOnlySecretsForFields(all []WriteOnlySecretView, fields []RequestFieldView, getterCall string) []WriteOnlySecretView {
+	used := make(map[string]struct{})
+	var collect func([]RequestFieldView)
+	collect = func(nodes []RequestFieldView) {
+		for _, field := range nodes {
+			if field.WriteOnlyResult != "" {
+				used[field.WriteOnlyResult] = struct{}{}
+			}
+			if field.Nested != nil {
+				collect(field.Nested.Fields)
+			}
+			if field.Collection != nil {
+				collect(field.Collection.Fields)
+			}
+			if field.OneOf != nil {
+				for _, variant := range field.OneOf.Variants {
+					collect(variant.Fields)
+				}
+			}
+		}
+	}
+	collect(fields)
+	if len(used) == 0 {
+		return nil
+	}
+
+	result := make([]WriteOnlySecretView, 0, len(used))
+	for _, secret := range all {
+		if _, exists := used[secret.ResultVar]; !exists {
+			continue
+		}
+		secret.GetterCall = getterCall
+		result = append(result, secret)
+	}
+	return result
+}
+
+func buildUnknownNormalizations(attributes []*model.Attribute, stateExpr string) []UnknownNormalizationView {
+	var result []UnknownNormalizationView
+	for _, attribute := range attributes {
+		if attribute.WriteOnlySecret {
+			continue
+		}
+		field := model.SdkName(tfNameOf(attribute.Path))
+		expr := stateExpr + "." + field
+
+		switch attribute.TfType {
+		case "schema.SingleNestedBlock", "schema.SingleNestedAttribute":
+			children := buildUnknownNormalizations(attribute.Children, expr)
+			if len(children) != 0 {
+				result = append(result, UnknownNormalizationView{Kind: "object", Expr: expr, Children: children})
+			}
+			continue
+		case "schema.ListNestedBlock", "schema.ListNestedAttribute":
+			itemVar := leafVar(field + "Item")
+			children := buildUnknownNormalizations(attribute.Children, itemVar)
+			if len(children) != 0 {
+				result = append(result, UnknownNormalizationView{
+					Kind: "list_object", Expr: expr, ItemVar: itemVar, Children: children,
+				})
+			}
+			continue
+		}
+
+		if !attribute.Computed {
+			continue
+		}
+		nullExpr := computedNullExpr(attribute)
+		if nullExpr != "" {
+			result = append(result, UnknownNormalizationView{Kind: "value", Expr: expr, NullExpr: nullExpr})
+		}
+	}
+	return result
+}
+
+func computedNullExpr(attribute *model.Attribute) string {
+	switch attribute.GoType {
+	case "types.String":
+		return "types.StringNull()"
+	case "types.Bool":
+		return "types.BoolNull()"
+	case "types.Int64":
+		return "types.Int64Null()"
+	case "types.Float64":
+		return "types.Float64Null()"
+	case "types.List":
+		if attribute.ElementType != "" {
+			return "types.ListNull(" + attribute.ElementType + ")"
+		}
+	case "types.Map":
+		if attribute.ElementType != "" {
+			return "types.MapNull(" + attribute.ElementType + ")"
+		}
+	}
+	return ""
 }
 
 // roleChild resolves one role body's schema node for attribute a at the current

--- a/.generator-v2/internal/emit/resource_builder_test.go
+++ b/.generator-v2/internal/emit/resource_builder_test.go
@@ -44,6 +44,11 @@ var _ = Describe("BuildResourceView", func() {
 				TypeExpr:       `datadogV2.IncidentTypeType("incident_types")`,
 				AttributesType: "IncidentTypeAttributes",
 			},
+			NormalizeUnknowns: []UnknownNormalizationView{
+				{Kind: "value", Expr: "state.Description", NullExpr: "types.StringNull()"},
+				{Kind: "value", Expr: "state.LastSeen", NullExpr: "types.StringNull()"},
+				{Kind: "value", Expr: "state.ResolutionPlaybook", NullExpr: "types.StringNull()"},
+			},
 		}))
 		Expect(view.Read).To(Equal(CRUDCallView{
 			Method: "GetIncidentType", GoResponseType: "IncidentTypeResponse",
@@ -451,6 +456,39 @@ var _ = Describe("BuildResourceView", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("differs from Read's"))
 	})
+
+	It("normalizes computed unknowns recursively without touching configured siblings", func() {
+		attributes := []*model.Attribute{
+			{
+				Path: "response.settings", TfType: "schema.SingleNestedAttribute",
+				Children: []*model.Attribute{
+					{Path: "response.settings.tags", GoType: "types.String", Computed: true},
+					{Path: "response.settings.url", GoType: "types.String", Required: true},
+				},
+			},
+			{
+				Path: "response.items", TfType: "schema.ListNestedAttribute",
+				Children: []*model.Attribute{
+					{Path: "response.items.status", GoType: "types.String", Computed: true},
+				},
+			},
+		}
+
+		Expect(buildUnknownNormalizations(attributes, "state")).To(Equal([]UnknownNormalizationView{
+			{
+				Kind: "object", Expr: "state.Settings",
+				Children: []UnknownNormalizationView{
+					{Kind: "value", Expr: "state.Settings.Tags", NullExpr: "types.StringNull()"},
+				},
+			},
+			{
+				Kind: "list_object", Expr: "state.Items", ItemVar: "itemsItem",
+				Children: []UnknownNormalizationView{
+					{Kind: "value", Expr: "itemsItem.Status", NullExpr: "types.StringNull()"},
+				},
+			},
+		}))
+	})
 })
 
 var _ = Describe("RenderResource", func() {
@@ -467,10 +505,20 @@ var _ = Describe("RenderResource", func() {
 		Expect(err).NotTo(HaveOccurred(), "rendered output must already be gofmt-canonical Go:\n%s", src)
 
 		out := string(src)
-		Expect(out).To(ContainSubstring(`func (r *datadogIncidentTypeResource) Create(`))
-		By("decoding request fields from configuration so omitted computed nested attributes remain null instead of becoming unknown native Go values")
-		Expect(out).To(ContainSubstring("response.Diagnostics.Append(request.Config.Get(ctx, &state)...)"))
-		Expect(out).NotTo(ContainSubstring("response.Diagnostics.Append(request.Plan.Get(ctx, &state)...)"))
+		createStart := strings.Index(out, `func (r *datadogIncidentTypeResource) Create(`)
+		readStart := strings.Index(out, `func (r *datadogIncidentTypeResource) Read(`)
+		Expect(createStart).To(BeNumerically(">=", 0))
+		Expect(readStart).To(BeNumerically(">", createStart))
+		createMethod := out[createStart:readStart]
+		By("decoding ordinary request fields from an unknown-capable plan value while write-only values are retrieved separately from configuration")
+		Expect(createMethod).To(ContainSubstring("var plan types.Object"))
+		Expect(createMethod).To(ContainSubstring("response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...)"))
+		Expect(createMethod).To(ContainSubstring("response.Diagnostics.Append(plan.As(ctx, &state, basetypes.ObjectAsOptions{UnhandledUnknownAsEmpty: true})...)"))
+		Expect(createMethod).NotTo(ContainSubstring("response.Diagnostics.Append(request.Plan.Get(ctx, &state)...)"))
+		Expect(createMethod).NotTo(ContainSubstring("response.Diagnostics.Append(request.Config.Get(ctx, &state)...)"))
+		Expect(createMethod).To(ContainSubstring(`if state.Description.IsUnknown() {
+		state.Description = types.StringNull()
+	}`))
 		By("Create builds the envelope innermost-first, so the data component's own constructor sets the JSON:API type discriminator (T138)")
 		for _, want := range []string{
 			"bodyAttributes := datadogV2.NewIncidentTypeAttributesWithDefaults()",
@@ -492,8 +540,6 @@ var _ = Describe("RenderResource", func() {
 		Expect(out).To(ContainSubstring(`response.State.RemoveResource(ctx)`))
 
 		Expect(out).To(ContainSubstring(`func (r *datadogIncidentTypeResource) Update(`))
-		By("recovering the computed resource ID from prior state after decoding the desired configuration")
-		Expect(out).To(ContainSubstring(`response.Diagnostics.Append(request.State.GetAttribute(ctx, path.Root("id"), &state.ID)...)`))
 		for _, want := range []string{
 			"bodyAttributes := datadogV2.NewIncidentTypeUpdateAttributesWithDefaults()",
 			"bodyData := datadogV2.NewIncidentTypeUpdateDataWithDefaults()",
@@ -517,6 +563,65 @@ var _ = Describe("RenderResource", func() {
 
 		Expect(out).To(ContainSubstring(`resource.ImportStatePassthroughID(ctx, path.Root("id"), request, response)`))
 		Expect(out).To(ContainSubstring(`"id": utils.ResourceIDAttribute(),`))
+	})
+
+	It("seeds Update from the planned model and reserves configuration reads for write-only handlers", func() {
+		art, err := model.BuildArtifact(incidentTypeResourceOperation(true))
+		Expect(err).NotTo(HaveOccurred())
+		view, err := BuildResourceView(art)
+		Expect(err).NotTo(HaveOccurred())
+
+		out := string(mustRenderResource(view))
+		updateStart := strings.Index(out, `func (r *datadogIncidentTypeResource) Update(`)
+		deleteStart := strings.Index(out, `func (r *datadogIncidentTypeResource) Delete(`)
+		Expect(updateStart).To(BeNumerically(">=", 0))
+		Expect(deleteStart).To(BeNumerically(">", updateStart))
+		updateMethod := out[updateStart:deleteStart]
+
+		Expect(updateMethod).To(ContainSubstring(`response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...)`))
+		Expect(updateMethod).To(ContainSubstring(
+			`response.Diagnostics.Append(plan.As(ctx, &state, basetypes.ObjectAsOptions{UnhandledUnknownAsEmpty: true})...)`))
+		Expect(updateMethod).NotTo(ContainSubstring(`response.Diagnostics.Append(request.Plan.Get(ctx, &state)...)`))
+		Expect(updateMethod).NotTo(ContainSubstring(`request.Config.Get(ctx, &state)`),
+			"only dedicated write-only handlers may retrieve values through request.Config")
+		Expect(updateMethod).NotTo(ContainSubstring(`request.State.GetAttribute(ctx, path.Root("id"), &state.ID)`),
+			"the planned model already carries the resource ID and prior Optional+Computed values")
+	})
+
+	It("preserves a planned Optional+Computed value when a sparse Update response omits it", func() {
+		art, err := model.BuildArtifact(incidentTypeResourceOperation(true))
+		Expect(err).NotTo(HaveOccurred())
+		view, err := BuildResourceView(art)
+		Expect(err).NotTo(HaveOccurred())
+
+		out := string(mustRenderResource(view))
+		By("carrying the prior description into the plan instead of making it unknown")
+		descriptionSchema := out[strings.Index(out, `"description": schema.StringAttribute{`):]
+		descriptionSchema = descriptionSchema[:strings.Index(descriptionSchema, "\n\t\t\t},")]
+		Expect(descriptionSchema).To(MatchRegexp(`Optional:\s+true`))
+		Expect(descriptionSchema).To(MatchRegexp(`Computed:\s+true`))
+		Expect(descriptionSchema).To(ContainSubstring("stringplanmodifier.UseStateForUnknown()"))
+
+		By("seeding Update with that planned value")
+		updateStart := strings.Index(out, `func (r *datadogIncidentTypeResource) Update(`)
+		deleteStart := strings.Index(out, `func (r *datadogIncidentTypeResource) Delete(`)
+		Expect(updateStart).To(BeNumerically(">=", 0))
+		Expect(deleteStart).To(BeNumerically(">", updateStart))
+		Expect(out[updateStart:deleteStart]).To(ContainSubstring(
+			`response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...)`))
+		Expect(out[updateStart:deleteStart]).To(ContainSubstring(
+			`response.Diagnostics.Append(plan.As(ctx, &state, basetypes.ObjectAsOptions{UnhandledUnknownAsEmpty: true})...)`))
+
+		By("overlaying description only when the API actually returned it")
+		updateStateStart := strings.Index(out, `func (r *datadogIncidentTypeResource) updateState(`)
+		Expect(updateStateStart).To(BeNumerically(">=", 0))
+		updateState := out[updateStateStart:]
+		guardedAssignment := `if description, ok := attributes.GetDescriptionOk(); ok && description != nil {
+		state.Description = types.StringValue(*description)
+	}`
+		Expect(updateState).To(ContainSubstring(guardedAssignment))
+		Expect(strings.Count(updateState, `state.Description =`)).To(Equal(1),
+			"an unguarded fallback assignment would erase the planned value on a sparse response")
 	})
 
 	It("stubs Update with an error rather than a request builder when the group resolves no Update role", func() {

--- a/.generator-v2/internal/emit/resource_writeonly_test.go
+++ b/.generator-v2/internal/emit/resource_writeonly_test.go
@@ -283,6 +283,40 @@ func modelAttributeByPath(attributes []*model.Attribute, path string) *model.Att
 }
 
 var _ = Describe("generated write-only support boundary", func() {
+	It("rejects distinct static paths that collapse to one handler identifier", func() {
+		secret := func(path string) *model.Attribute {
+			return &model.Attribute{Path: path, TfType: "schema.StringAttribute", WriteOnlySecret: true}
+		}
+		attributes := []*model.Attribute{
+			{
+				Path:   "resource.data.attributes.foo_bar",
+				TfType: "schema.SingleNestedAttribute",
+				Children: []*model.Attribute{
+					secret("resource.data.attributes.foo_bar.token"),
+				},
+			},
+			{
+				Path:   "resource.data.attributes.foo",
+				TfType: "schema.SingleNestedAttribute",
+				Children: []*model.Attribute{
+					{
+						Path:   "resource.data.attributes.foo.bar",
+						TfType: "schema.SingleNestedAttribute",
+						Children: []*model.Attribute{
+							secret("resource.data.attributes.foo.bar.token"),
+						},
+					},
+				},
+			},
+		}
+
+		unsupported := validateWriteOnlySecrets(attributes)
+		Expect(unsupported).To(HaveLen(1))
+		err := (&UnsupportedEmitError{Nodes: unsupported}).Error()
+		Expect(err).To(ContainSubstring("resource.data.attributes.foo_bar.token"))
+		Expect(err).To(ContainSubstring("resource.data.attributes.foo.bar.token"))
+	})
+
 	DescribeTable("fails unsupported shapes before template rendering with their path and category",
 		func(build func() *model.Artifact, wantPath, wantCategory string) {
 			artifact := build()

--- a/.generator-v2/internal/emit/resource_writeonly_test.go
+++ b/.generator-v2/internal/emit/resource_writeonly_test.go
@@ -179,6 +179,15 @@ var _ = Describe("generated resource write-only-only contract", func() {
 		Expect(username.PlanModifiers).To(ContainElement("stringplanmodifier.UseStateForUnknown"))
 	})
 
+	It("does not materialize an omitted optional response-backed secret container", func() {
+		_, _, source := renderWriteOnlyResource(oneLevelWriteOnlyOperation())
+		updateStateOffset := strings.LastIndex(source, " updateState(")
+		Expect(updateStateOffset).NotTo(Equal(-1))
+		updateState := source[updateStateOffset:]
+
+		Expect(updateState).To(ContainSubstring("ok && settings != nil && state.Settings != nil {"))
+	})
+
 	It("suppresses a same-path Read assignment and emits one value-free warning", func() {
 		artifact, _, source := renderWriteOnlyResource(oneLevelWriteOnlyOperation())
 		Expect(source).NotTo(ContainSubstring("state.Settings.Url ="))

--- a/.generator-v2/internal/emit/resource_writeonly_test.go
+++ b/.generator-v2/internal/emit/resource_writeonly_test.go
@@ -1,0 +1,347 @@
+package emit
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/model"
+	"github.com/terraform-providers/terraform-provider-datadog/generator/internal/sdkbind"
+)
+
+const testSecretDescription = "Secret password or private key."
+
+func operationAttributes(body *model.Schema) *model.Schema {
+	return body.Properties["data"].Properties["attributes"]
+}
+
+func addRootSecret(op *model.Operation, name string, schema *model.Schema, requiredOnCreate, requiredOnUpdate bool) {
+	create := operationAttributes(op.ResolvedGroup.Create.RequestSchema)
+	update := operationAttributes(op.ResolvedGroup.Update.RequestSchema)
+	create.Properties[name] = model.CloneSchema(schema)
+	update.Properties[name] = model.CloneSchema(schema)
+	if requiredOnCreate {
+		create.Required = append(create.Required, name)
+	}
+	if requiredOnUpdate {
+		update.Required = append(update.Required, name)
+	}
+}
+
+func rootWriteOnlyOperation(requiredOnCreate, requiredOnUpdate bool) *model.Operation {
+	op := widgetResourceOperation()
+	addRootSecret(op, "apiToken", &model.Schema{
+		Kind:            model.SchemaKindPrimitive,
+		Type:            "string",
+		Description:     "API token.",
+		Sensitive:       true,
+		WriteOnlySecret: true,
+	}, requiredOnCreate, requiredOnUpdate)
+	return op
+}
+
+func oneLevelWriteOnlyOperation() *model.Operation {
+	op := widgetResourceOperation()
+	for _, body := range []*model.Schema{
+		op.ResolvedGroup.Create.RequestSchema,
+		op.ResolvedGroup.Update.RequestSchema,
+	} {
+		url := operationAttributes(body).Properties["settings"].Properties["url"]
+		url.Description = testSecretDescription
+		url.Sensitive = true
+		url.WriteOnlySecret = true
+	}
+	operationAttributes(op.ResolvedGroup.Read.ResponseSchema).Properties["settings"].Properties["url"].Description =
+		"response-description-must-not-enter-warning"
+	return op
+}
+
+func renameAuthProperty(body *model.Schema, request bool) *model.Schema {
+	attributes := operationAttributes(body)
+	union := attributes.Properties["auth"]
+	delete(attributes.Properties, "auth")
+	attributes.Properties["authentication"] = union
+	for index, name := range attributes.Required {
+		if name == "auth" {
+			attributes.Required[index] = "authentication"
+		}
+	}
+	if request {
+		union.OneOf.Path = "request.data.attributes.authentication"
+	} else {
+		union.OneOf.Path = "response.data.attributes.authentication"
+	}
+	return union.OneOf.Variants[0].Schema
+}
+
+func recursiveWriteOnlyOperation(requiredOnUpdate bool) *model.Operation {
+	op := widgetUnionOperation(
+		roleUnion("IntegrationAccountAuthenticationRequest", roleBasicAuth("IntegrationAccountBasicAuthRequest", true)),
+		roleUnion("IntegrationAccountAuthenticationUpdate", roleBasicAuth("IntegrationAccountBasicAuthUpdate", true)),
+		roleUnion("IntegrationAccountAuthenticationResponse", roleBasicAuth("IntegrationAccountBasicAuthResponse", false)),
+	)
+	createBasic := renameAuthProperty(op.ResolvedGroup.Create.RequestSchema, true)
+	updateBasic := renameAuthProperty(op.ResolvedGroup.Update.RequestSchema, true)
+	responseBasic := renameAuthProperty(op.ResolvedGroup.Read.ResponseSchema, false)
+
+	for _, basic := range []*model.Schema{createBasic, updateBasic} {
+		basic.Properties["password"].Description = testSecretDescription
+		basic.Properties["password"].Sensitive = true
+		basic.Properties["password"].WriteOnlySecret = true
+		basic.Properties["username"].Description = "Readable username."
+		basic.Required = nil
+	}
+	createBasic.Required = []string{"password"}
+	if requiredOnUpdate {
+		updateBasic.Required = []string{"password"}
+	}
+	responseBasic.Properties["username"].Description = "Readable username."
+	responseBasic.Required = nil
+	return op
+}
+
+func buildResourceForWriteOnly(op *model.Operation) (*model.Artifact, ResourceView) {
+	GinkgoHelper()
+	for _, role := range []*model.Operation{
+		op.ResolvedGroup.Create,
+		op.ResolvedGroup.Update,
+		op.ResolvedGroup.Read,
+	} {
+		Expect(sdkbind.BindOperation(role)).To(Succeed())
+	}
+	artifact, err := model.BuildArtifact(op)
+	Expect(err).NotTo(HaveOccurred())
+	view, err := BuildResourceView(artifact)
+	Expect(err).NotTo(HaveOccurred())
+	return artifact, view
+}
+
+func renderWriteOnlyResource(op *model.Operation) (*model.Artifact, ResourceView, string) {
+	GinkgoHelper()
+	artifact, view := buildResourceForWriteOnly(op)
+	return artifact, view, string(mustRenderResource(view))
+}
+
+var _ = Describe("generated resource write-only-only contract", func() {
+	DescribeTable("replaces the original Terraform field at every supported static depth",
+		func(build func() *model.Operation, original, goName, parentBlocks, description string) {
+			_, _, source := renderWriteOnlyResource(build())
+
+			Expect(source).To(ContainSubstring(`"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/fwutils"`))
+			Expect(source).To(ContainSubstring("fwutils.CreateWriteOnlySecretAttributes"))
+			Expect(source).To(ContainSubstring(`WriteOnlyAttr: "` + original + `_wo"`))
+			Expect(source).To(ContainSubstring(`TriggerAttr: "` + original + `_wo_version"`))
+			Expect(regexp.MustCompile(`ParentBlocks:\s+\[\]string\{` + regexp.QuoteMeta(parentBlocks) + `\}`).MatchString(source)).To(BeTrue())
+			Expect(source).To(ContainSubstring("Mode: fwutils.WriteOnlySecretModeOnly"))
+			Expect(source).To(ContainSubstring(`WriteOnlyDescription: "` + description + ` This write-only value is not stored in Terraform state."`))
+			Expect(source).To(ContainSubstring(`TriggerDescription: "Version trigger for ` + original + `_wo rotation."`))
+
+			Expect(regexp.MustCompile(goName + `Wo\s+types\.String\s+` + "`tfsdk:\"" + original + `_wo"` + "`").MatchString(source)).To(BeTrue())
+			Expect(regexp.MustCompile(goName + `WoVersion\s+types\.String\s+` + "`tfsdk:\"" + original + `_wo_version"` + "`").MatchString(source)).To(BeTrue())
+			Expect(source).NotTo(ContainSubstring(goName + ` types.String ` + "`tfsdk:\"" + original + `\"` + "`"))
+			Expect(strings.Count(source, "`tfsdk:\""+original+"_wo\"`")).To(Equal(1))
+			Expect(strings.Count(source, "`tfsdk:\""+original+"_wo_version\"`")).To(Equal(1))
+		},
+		Entry("resource root", func() *model.Operation { return rootWriteOnlyOperation(true, false) }, "api_token", "ApiToken", "", "API token."),
+		Entry("one single-nested ancestor", oneLevelWriteOnlyOperation, "url", "Url", `"settings"`, testSecretDescription),
+		Entry("recursive single-nested path through oneOf", func() *model.Operation { return recursiveWriteOnlyOperation(false) }, "password", "Password", `"authentication", "integration_account_basic_auth"`, testSecretDescription),
+	)
+
+	DescribeTable("routes the original SDK setter through handlers with role-specific Update requiredness",
+		func(requiredOnUpdate bool) {
+			_, _, source := renderWriteOnlyResource(recursiveWriteOnlyOperation(requiredOnUpdate))
+			Expect(source).To(ContainSubstring("fwutils.WriteOnlySecretHandler"))
+			Expect(source).To(ContainSubstring("SecretRequiredOnUpdate: " + map[bool]string{false: "false", true: "true"}[requiredOnUpdate]))
+			Expect(source).To(ContainSubstring("GetSecretForCreate(ctx, &request.Config)"))
+			Expect(source).To(ContainSubstring("GetSecretForUpdate(ctx, &request.Config, &request)"))
+			Expect(source).To(ContainSubstring("SetPassword("))
+			Expect(source).NotTo(ContainSubstring("SetPasswordWo("))
+			Expect(source).NotTo(ContainSubstring("state.Password.ValueString()"))
+		},
+		Entry("Update may omit the secret", false),
+		Entry("Update requires the secret", true),
+	)
+
+	It("keeps nested ancestors configuration-owned and readable siblings independently computed", func() {
+		_, view := buildResourceForWriteOnly(recursiveWriteOnlyOperation(false))
+		authentication := attrByPath(schemaTree(view), "authentication")
+		basic := attrByPath(schemaTree(view), "integration_account_basic_auth")
+		username := attrByPath(schemaTree(view), "username")
+		for _, ancestor := range []AttrView{authentication, basic} {
+			Expect(ancestor.Computed).To(BeFalse())
+			Expect(ancestor.PlanModifiers).NotTo(ContainElement("objectplanmodifier.UseStateForUnknown"))
+		}
+		Expect(username.Optional).To(BeTrue())
+		Expect(username.Computed).To(BeTrue())
+		Expect(username.PlanModifiers).To(ContainElement("stringplanmodifier.UseStateForUnknown"))
+	})
+
+	It("suppresses a same-path Read assignment and emits one value-free warning", func() {
+		artifact, _, source := renderWriteOnlyResource(oneLevelWriteOnlyOperation())
+		Expect(source).NotTo(ContainSubstring("state.Settings.Url ="))
+		var warnings []model.Diagnostic
+		for _, diagnostic := range artifact.Diagnostics {
+			if diagnostic.Severity == model.SeverityWarning {
+				warnings = append(warnings, diagnostic)
+			}
+		}
+		Expect(warnings).To(HaveLen(1))
+		Expect(warnings[0].Message).To(ContainSubstring("data.attributes.settings.url"))
+		Expect(warnings[0].Message).NotTo(ContainSubstring("response-description-must-not-enter-warning"))
+	})
+
+	DescribeTable("does not select write-only handling from display sensitivity",
+		func(_ string) {
+			op := widgetResourceOperation()
+			addRootSecret(op, "credential", &model.Schema{
+				Kind: model.SchemaKindPrimitive, Type: "string", Description: "Credential.", Sensitive: true,
+			}, false, false)
+			_, _, source := renderWriteOnlyResource(op)
+			Expect(source).To(ContainSubstring(`"credential": schema.StringAttribute{`))
+			credentialSchema := source[strings.Index(source, `"credential": schema.StringAttribute{`):]
+			Expect(regexp.MustCompile(`Sensitive:\s+true`).MatchString(credentialSchema[:strings.Index(credentialSchema, "\n\t\t\t},")])).To(BeTrue())
+			Expect(regexp.MustCompile("types\\.String\\s+`tfsdk:\"credential\"`").MatchString(source)).To(BeTrue())
+			Expect(source).NotTo(ContainSubstring("credential_wo"))
+			Expect(source).NotTo(ContainSubstring("WriteOnlySecretHandler"))
+			Expect(source).NotTo(ContainSubstring("datadog/internal/fwutils"))
+		},
+		Entry("x-secret:true only", "x-secret"),
+		Entry("tracking sensitive:true only", "tracking-sensitive"),
+	)
+
+	It("keeps response/data-source sensitivity ordinary and never emits write-only companions", func() {
+		op := incidentTypeOperation()
+		secret := &model.Schema{
+			Kind: model.SchemaKindPrimitive, Type: "string", Description: "Observed secret.",
+			Sensitive: true, WriteOnlySecret: true,
+		}
+		operationAttributes(op.ResponseSchema).Properties["observed_secret"] = secret
+		artifact, err := model.BuildArtifact(op)
+		Expect(err).NotTo(HaveOccurred())
+		view, err := BuildDataSourceView(artifact)
+		Expect(err).NotTo(HaveOccurred())
+		source, err := RenderDataSource(view)
+		Expect(err).NotTo(HaveOccurred())
+		out := string(source)
+		Expect(out).To(ContainSubstring(`"observed_secret": schema.StringAttribute{`))
+		Expect(regexp.MustCompile(`Sensitive:\s+true`).MatchString(out)).To(BeTrue())
+		Expect(out).NotTo(ContainSubstring("observed_secret_wo"))
+		Expect(out).NotTo(ContainSubstring("WriteOnlySecretHandler"))
+	})
+
+	It("contains no private-state hash, digest comparison, keepers, or generated secret cleanup", func() {
+		_, _, source := renderWriteOnlyResource(recursiveWriteOnlyOperation(false))
+		lower := strings.ToLower(source)
+		for _, forbidden := range []string{"private.set", "sha256", "secret hash", "digest", "keepers", "passwordwo = types.stringnull"} {
+			Expect(lower).NotTo(ContainSubstring(forbidden))
+		}
+	})
+})
+
+func collectionNestedSecret(kind model.SchemaKind, refName string) *model.Schema {
+	secret := &model.Schema{
+		Kind: model.SchemaKindPrimitive, Type: "string", Description: "Nested token.", WriteOnlySecret: true,
+	}
+	item := &model.Schema{
+		Kind: model.SchemaKindObject, RefName: refName,
+		Properties: map[string]*model.Schema{"token": secret},
+	}
+	return &model.Schema{Kind: kind, Items: item, Description: "Credentials collection."}
+}
+
+func addUnsupportedWriteOnly(op *model.Operation, name string, schema *model.Schema) {
+	for _, body := range []*model.Schema{
+		op.ResolvedGroup.Create.RequestSchema,
+		op.ResolvedGroup.Update.RequestSchema,
+	} {
+		operationAttributes(body).Properties[name] = model.CloneSchema(schema)
+	}
+}
+
+func modelAttributeByPath(attributes []*model.Attribute, path string) *model.Attribute {
+	for _, attribute := range attributes {
+		if attribute.Path == path {
+			return attribute
+		}
+		if found := modelAttributeByPath(attribute.Children, path); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+var _ = Describe("generated write-only support boundary", func() {
+	DescribeTable("fails unsupported shapes before template rendering with their path and category",
+		func(build func() *model.Artifact, wantPath, wantCategory string) {
+			artifact := build()
+			_, err := BuildResourceView(artifact)
+			Expect(err).To(HaveOccurred())
+			var unsupported *UnsupportedEmitError
+			Expect(errors.As(err, &unsupported)).To(BeTrue(), "expected UnsupportedEmitError, got %v", err)
+			Expect(strings.ToLower(err.Error())).To(ContainSubstring(strings.ToLower(wantPath)))
+			Expect(strings.ToLower(err.Error())).To(ContainSubstring(strings.ToLower(wantCategory)))
+		},
+		Entry("string nested below a list element",
+			func() *model.Artifact {
+				op := widgetResourceOperation()
+				addUnsupportedWriteOnly(op, "credentials", collectionNestedSecret(model.SchemaKindArray, "CredentialRequest"))
+				artifact, err := model.BuildArtifact(op)
+				Expect(err).NotTo(HaveOccurred())
+				return artifact
+			},
+			"resource.data.attributes.credentials[].token", "list"),
+		Entry("string nested below a map element",
+			func() *model.Artifact {
+				op := widgetResourceOperation()
+				addUnsupportedWriteOnly(op, "credentials", collectionNestedSecret(model.SchemaKindMap, "CredentialRequest"))
+				artifact, err := model.BuildArtifact(op)
+				Expect(err).NotTo(HaveOccurred())
+				return artifact
+			},
+			"resource.data.attributes.credentials{}.token", "map"),
+		Entry("set containment",
+			func() *model.Artifact {
+				op := widgetResourceOperation()
+				addUnsupportedWriteOnly(op, "credentials", collectionNestedSecret(model.SchemaKindArray, "CredentialRequest"))
+				artifact, err := model.BuildArtifact(op)
+				Expect(err).NotTo(HaveOccurred())
+				container := modelAttributeByPath(artifact.Schema.Attributes, "resource.data.attributes.credentials")
+				Expect(container).NotTo(BeNil())
+				container.TfType = "schema.SetNestedAttribute"
+				return artifact
+			},
+			"resource.data.attributes.credentials[].token", "set"),
+		Entry("non-string value",
+			func() *model.Artifact {
+				op := widgetResourceOperation()
+				addUnsupportedWriteOnly(op, "enabled_secret", &model.Schema{
+					Kind: model.SchemaKindPrimitive, Type: "boolean", Description: "Unsupported boolean secret.", WriteOnlySecret: true,
+				})
+				artifact, err := model.BuildArtifact(op)
+				Expect(err).NotTo(HaveOccurred())
+				return artifact
+			},
+			"resource.data.attributes.enabled_secret", "string"),
+		Entry("_wo companion collision",
+			func() *model.Artifact {
+				op := rootWriteOnlyOperation(false, false)
+				addRootSecret(op, "apiTokenWo", prim("string", "Colliding field."), false, false)
+				artifact, err := model.BuildArtifact(op)
+				Expect(err).NotTo(HaveOccurred())
+				return artifact
+			},
+			"resource.data.attributes.api_token", "collision"),
+		Entry("_wo_version companion collision",
+			func() *model.Artifact {
+				op := rootWriteOnlyOperation(false, false)
+				addRootSecret(op, "apiTokenWoVersion", prim("string", "Colliding field."), false, false)
+				artifact, err := model.BuildArtifact(op)
+				Expect(err).NotTo(HaveOccurred())
+				return artifact
+			},
+			"resource.data.attributes.api_token", "collision"),
+	)
+})

--- a/.generator-v2/internal/emit/templates/data_source_common.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_common.go.tmpl
@@ -86,17 +86,55 @@ type {{ .Name }} struct {
 {{- end }}
 {{- end -}}
 
-{{/* nestedBody renders one combined Attributes map for a nested attribute. */}}
-{{- define "nestedBody" -}}
-{{- if or .Attributes .Blocks }}
-Attributes: map[string]schema.Attribute{
+{{/* writeOnlySecretConfigValue is shared by schema expansion and request handlers. */}}
+{{- define "writeOnlySecretConfigValue" -}}
+fwutils.WriteOnlySecretConfig{OriginalAttr: {{ printf "%q" .OriginalAttr }}, WriteOnlyAttr: {{ printf "%q" .WriteOnlyAttr }}, TriggerAttr: {{ printf "%q" .TriggerAttr }}, WriteOnlyDescription: {{ printf "%q" .WriteOnlyDescription }}, TriggerDescription: {{ printf "%q" .TriggerDescription }}, ParentBlocks: []string{ {{- range .ParentBlocks }}{{ printf "%q" . }},{{- end }}}, Mode: fwutils.WriteOnlySecretModeOnly, Required: {{ .RequiredOnCreate }}}
+{{- end -}}
+
+{{/* writeOnlySecretAttributes expands one generated write-only-only pair. */}}
+{{- define "writeOnlySecretAttributes" -}}
+fwutils.CreateWriteOnlySecretAttributes({{ .ConfigVar }}),
+{{- end -}}
+
+{{/* schemaBody renders one combined Attributes map for a resource root or nested attribute. */}}
+{{- define "schemaBody" -}}
+{{- if or .IncludeResourceID .Attributes .Blocks }}
+{{- if .HasWriteOnlySecrets }}
+Attributes: fwutils.MergeAttributes(
+	map[string]schema.Attribute{
+{{- if .IncludeResourceID }}
+		"id": utils.ResourceIDAttribute(),
+{{- end }}
 {{- range .Attributes }}
+{{- if not .WriteOnlySecret }}
 {{ template "schemaAttribute" . }}
+{{- end }}
+{{- end }}
+{{- range .Blocks }}
+{{ template "schemaNestedAttribute" . }}
+{{- end }}
+	},
+{{- range .Attributes }}
+{{- with .WriteOnlySecret }}
+{{ template "writeOnlySecretAttributes" . }}
+{{- end }}
+{{- end }}
+),
+{{- else }}
+Attributes: map[string]schema.Attribute{
+{{- if .IncludeResourceID }}
+	"id": utils.ResourceIDAttribute(),
+{{- end }}
+{{- range .Attributes }}
+{{- if not .WriteOnlySecret }}
+{{ template "schemaAttribute" . }}
+{{- end }}
 {{- end }}
 {{- range .Blocks }}
 {{ template "schemaNestedAttribute" . }}
 {{- end }}
 },
+{{- end }}
 {{- end }}
 {{- end -}}
 
@@ -106,7 +144,7 @@ Attributes: map[string]schema.Attribute{
 "{{ .TFName }}": schema.ListNestedAttribute{
 	Description: {{ printf "%q" .Description }},
 	NestedObject: schema.NestedAttributeObject{
-{{ template "nestedBody" . }}
+{{ template "schemaBody" . }}
 	},
 {{- template "presenceFlags" . }}
 {{ template "validators" . }}
@@ -115,7 +153,7 @@ Attributes: map[string]schema.Attribute{
 {{- else }}
 "{{ .TFName }}": schema.SingleNestedAttribute{
 	Description: {{ printf "%q" .Description }},
-{{ template "nestedBody" . }}
+{{ template "schemaBody" . }}
 {{- template "presenceFlags" . }}
 {{ template "validators" . }}
 {{ template "planModifiers" . }}

--- a/.generator-v2/internal/emit/templates/data_source_common.go.tmpl
+++ b/.generator-v2/internal/emit/templates/data_source_common.go.tmpl
@@ -207,7 +207,7 @@ if {{ .Var }}, ok := {{ .GetterOk }}; ok && {{ .Var }} != nil {
 	{{- end }}
 }
 {{- else if eq .Kind "object" -}}
-if {{ .Var }}, ok := {{ .GetterOk }}; ok && {{ .Var }} != nil {
+if {{ .Var }}, ok := {{ .GetterOk }}; ok && {{ .Var }} != nil{{ if .PreserveConfiguredPresence }} && {{ .LHS }} != nil{{ end }} {
 	{{- if .PreserveExisting }}
 	{{ .ExistingVar }} := {{ .LHS }}
 	{{ .LHS }} = nil
@@ -232,7 +232,7 @@ if {{ .Var }}, ok := {{ .GetterOk }}; ok && {{ .Var }} != nil {
 	}
 }
 {{- else if eq .Kind "object_single" -}}
-if {{ .Var }}, ok := {{ .GetterOk }}; ok && {{ .Var }} != nil {
+if {{ .Var }}, ok := {{ .GetterOk }}; ok && {{ .Var }} != nil{{ if .PreserveConfiguredPresence }} && {{ .LHS }} != nil{{ end }} {
 	{{- if .PreserveExisting }}
 	{{ .ElemVar }} := {{ .LHS }}
 	if {{ .ElemVar }} == nil {
@@ -264,7 +264,7 @@ if {{ .Var }}, ok := {{ .GetterOk }}; ok && {{ .Var }} != nil {
   Ok-getters, so they are read with `:=`.
 */}}
 {{- define "renderOneOf" -}}
-if {{ .Var }}, ok := {{ .GetterOk }}; ok && {{ .Var }} != nil {
+if {{ .Var }}, ok := {{ .GetterOk }}; ok && {{ .Var }} != nil{{ if .PreserveConfiguredPresence }} && {{ .LHS }} != nil{{ end }} {
 {{- if .Collection }}
 	{{- if .PreserveExisting }}
 	{{ .ExistingVar }} := {{ .LHS }}

--- a/.generator-v2/internal/emit/templates/resource.go.tmpl
+++ b/.generator-v2/internal/emit/templates/resource.go.tmpl
@@ -43,10 +43,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 {{- end }}
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 {{- if .UsesUUID }}
 	"github.com/google/uuid"
 {{- end }}
 
+{{- if .UsesWriteOnly }}
+	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/fwutils"
+{{- end }}
 	"github.com/terraform-providers/terraform-provider-datadog/datadog/internal/utils"
 )
 
@@ -54,6 +58,10 @@ var (
 	_ resource.ResourceWithConfigure   = &{{ .GoName }}Resource{}
 	_ resource.ResourceWithImportState = &{{ .GoName }}Resource{}
 )
+
+{{- range .WriteOnlySecrets }}
+var {{ .ConfigVar }} = {{ template "writeOnlySecretConfigValue" . }}
+{{- end }}
 
 {{ template "modelStructs" . }}
 type {{ .GoName }}Resource struct {
@@ -82,15 +90,7 @@ func (r *{{ .GoName }}Resource) Metadata(_ context.Context, request resource.Met
 func (r *{{ .GoName }}Resource) Schema(_ context.Context, _ resource.SchemaRequest, response *resource.SchemaResponse) {
 	response.Schema = schema.Schema{
 		Description: {{ printf "%q" .Description }},
-		Attributes: map[string]schema.Attribute{
-			"id": utils.ResourceIDAttribute(),
-{{- range .Schema.Attributes }}
-{{ template "schemaAttribute" . }}
-{{- end }}
-{{- range .Schema.Blocks }}
-{{ template "schemaNestedAttribute" . }}
-{{- end }}
-		},
+{{ template "schemaBody" .Schema }}
 	}
 }
 
@@ -114,11 +114,9 @@ func (r *{{ .GoName }}Resource) ImportState(ctx context.Context, request resourc
 
 func (r *{{ .GoName }}Resource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
 	var state {{ .GoName }}ResourceModel
-	response.Diagnostics.Append(request.Config.Get(ctx, &state)...)
-	if response.Diagnostics.HasError() {
-		return
-	}
+{{ template "decodePlan" . }}
 
+{{ template "writeOnlySecretResults" .Create.WriteOnlySecrets }}
 {{ template "argPrep" .Create.Arguments }}
 {{ template "requestBody" .Create }}
 	resp, _, err := r.Api.{{ .Create.Method }}(r.Auth{{ range .Create.Arguments }}, {{ .Expression }}{{ end }}, *body)
@@ -126,7 +124,7 @@ func (r *{{ .GoName }}Resource) Create(ctx context.Context, request resource.Cre
 		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error creating {{ .TypeName }}"))
 		return
 	}
-{{ template "commitState" . }}
+{{ template "commitState" .Create }}
 }
 
 func (r *{{ .GoName }}Resource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
@@ -146,7 +144,7 @@ func (r *{{ .GoName }}Resource) Read(ctx context.Context, request resource.ReadR
 		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error reading {{ .TypeName }}"))
 		return
 	}
-{{ template "commitState" . }}
+{{ template "commitState" .Read }}
 }
 
 func (r *{{ .GoName }}Resource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
@@ -154,12 +152,9 @@ func (r *{{ .GoName }}Resource) Update(ctx context.Context, request resource.Upd
 	response.Diagnostics.AddError("Update should not be called", "Updating this resource should replace it.")
 {{- else }}
 	var state {{ .GoName }}ResourceModel
-	response.Diagnostics.Append(request.Config.Get(ctx, &state)...)
-	response.Diagnostics.Append(request.State.GetAttribute(ctx, path.Root("id"), &state.ID)...)
-	if response.Diagnostics.HasError() {
-		return
-	}
+{{ template "decodePlan" . }}
 
+{{ template "writeOnlySecretResults" .Update.WriteOnlySecrets }}
 {{ template "argPrep" .Update.Arguments }}
 {{ template "requestBody" .Update }}
 	resp, _, err := r.Api.{{ .Update.Method }}(r.Auth{{ range .Update.Arguments }}, {{ .Expression }}{{ end }}, *body)
@@ -167,7 +162,7 @@ func (r *{{ .GoName }}Resource) Update(ctx context.Context, request resource.Upd
 		response.Diagnostics.Append(utils.FrameworkErrorDiag(err, "error updating {{ .TypeName }}"))
 		return
 	}
-{{ template "commitState" . }}
+{{ template "commitState" .Update }}
 {{- end }}
 }
 
@@ -208,7 +203,69 @@ func (r *{{ .GoName }}Resource) updateState(ctx context.Context, state *{{ .GoNa
 	if response.Diagnostics.HasError() {
 		return
 	}
+{{ template "normalizeUnknowns" .NormalizeUnknowns }}
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
+{{- end -}}
+
+{{/* normalizeUnknowns prevents computed plan placeholders that a sparse
+response omitted from reaching final Create state. */}}
+{{- define "normalizeUnknowns" -}}
+{{- range . }}
+{{- if eq .Kind "value" }}
+	if {{ .Expr }}.IsUnknown() {
+		{{ .Expr }} = {{ .NullExpr }}
+	}
+{{- else if eq .Kind "object" }}
+	if {{ .Expr }} != nil {
+{{ template "normalizeUnknowns" .Children }}
+	}
+{{- else if eq .Kind "list_object" }}
+	for _, {{ .ItemVar }} := range {{ .Expr }} {
+		if {{ .ItemVar }} != nil {
+{{ template "normalizeUnknowns" .Children }}
+		}
+	}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+  decodePlan first preserves the complete Terraform value in a Framework
+  object, then converts it into the generated native model. Computed-only
+  nested values may legitimately be unknown during Create/Update; native
+  pointer structs cannot represent that state, so they remain empty until the
+  API response overlays them. Framework value fields continue to retain their
+  own null and unknown states.
+*/}}
+{{- define "decodePlan" -}}
+	var plan types.Object
+	response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+	response.Diagnostics.Append(plan.As(ctx, &state, basetypes.ObjectAsOptions{UnhandledUnknownAsEmpty: true})...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+{{- end -}}
+
+{{/*
+  writeOnlySecretResults retrieves write-only values from configuration before
+  any request body is constructed. GetterCall is role-specific; the shared
+  package-scoped configuration keeps schema and lifecycle routing aligned.
+*/}}
+{{- define "writeOnlySecretResults" -}}
+{{- range . }}
+	{{ .HandlerVar }} := fwutils.WriteOnlySecretHandler{
+		Config:                 {{ .ConfigVar }},
+		SecretRequiredOnUpdate: {{ .RequiredOnUpdate }},
+	}
+	{{ .ResultVar }} := {{ .HandlerVar }}.{{ .GetterCall }}
+	response.Diagnostics.Append({{ .ResultVar }}.Diagnostics...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+{{- end }}
 {{- end -}}
 
 {{/*
@@ -286,6 +343,10 @@ func (r *{{ .GoName }}Resource) updateState(ctx context.Context, state *{{ .GoNa
 		)
 		return
 	}{{ end }}
+{{- else if .WriteOnlyResult }}
+	if {{ .WriteOnlyResult }}.ShouldSetValue {
+		{{ .Target }}.Set{{ .GoField }}({{ .WriteOnlyResult }}.Value)
+	}
 {{- else if .Required }}
 {{ template "requestFieldBody" . }}
 {{- else }}

--- a/.generator-v2/internal/emit/unstable_operations.go
+++ b/.generator-v2/internal/emit/unstable_operations.go
@@ -25,7 +25,7 @@ const generatedUnstableOperationsHeader = `package fwprovider
 // the operations it produced into the existing set (union, sorted) so a scoped
 // --include run never drops entries another artifact needs. Do not edit by hand.
 //
-// enrichFrameworkProviderConfig enables each of these on the client config.
+// EnableGeneratedUnstableOperations enables each of these on the client config.
 var generatedUnstableOperations = []string{`
 
 // SyncUnstableOperations rewrites path's generatedUnstableOperations slice to

--- a/.generator-v2/internal/emit/view.go
+++ b/.generator-v2/internal/emit/view.go
@@ -422,6 +422,10 @@ type ListAssignment struct {
 	// PreserveExisting is enabled for resource response mapping so fields the
 	// request owns but the API never returns survive a nested-model rebuild.
 	PreserveExisting bool
+	// PreserveConfiguredPresence guards response mapping with an existing model
+	// check so an optional configuration-owned container remains absent when the
+	// API returns server defaults for it.
+	PreserveConfiguredPresence bool
 
 	// The fields below back an object list (Kind == "object").
 
@@ -479,6 +483,9 @@ type OneOfAssignment struct {
 	// PreserveExisting retains the previously selected variant model when the
 	// response selects that same variant, preserving request-only leaves.
 	PreserveExisting bool
+	// PreserveConfiguredPresence has the same container-presence semantics as
+	// ListAssignment.PreserveConfiguredPresence for a oneOf envelope.
+	PreserveConfiguredPresence bool
 	// Collection marks a list whose element is an envelope; LoopVar is then the
 	// per-element local.
 	Collection bool

--- a/.generator-v2/internal/emit/view.go
+++ b/.generator-v2/internal/emit/view.go
@@ -229,8 +229,34 @@ type FilterParamView struct {
 // here. Attributes holds top-level leaves; Blocks holds top-level nested
 // objects/lists (for a plural data source, that includes the items block).
 type SchemaView struct {
-	Attributes []AttrView
-	Blocks     []AttrView
+	Attributes          []AttrView
+	Blocks              []AttrView
+	HasWriteOnlySecrets bool
+	IncludeResourceID   bool
+}
+
+// WriteOnlySecretView is one generated write-only-only Terraform pair. The
+// Terraform names and descriptions drive schema expansion, while SDKField
+// deliberately retains the original OpenAPI setter identity for request
+// routing. ParentBlocks contains only statically addressed single nested
+// attributes and is empty for a resource-root secret.
+type WriteOnlySecretView struct {
+	OriginalAttr         string
+	WriteOnlyAttr        string
+	TriggerAttr          string
+	SDKField             string
+	ParentBlocks         []string
+	RequiredOnCreate     bool
+	RequiredOnUpdate     bool
+	WriteOnlyDescription string
+	TriggerDescription   string
+	// ConfigVar is the package-scoped configuration shared by schema expansion
+	// and lifecycle handlers. HandlerVar and ResultVar are method-local names;
+	// GetterCall selects Create or Update retrieval on per-call copies.
+	ConfigVar  string
+	HandlerVar string
+	ResultVar  string
+	GetterCall string
 }
 
 // AttrView is one node of the Terraform schema tree. A leaf renders a typed
@@ -279,6 +305,14 @@ type AttrView struct {
 	// attribute's GoType (e.g. "String", "Object", "List"). Empty unless
 	// PlanModifiers is non-empty.
 	PlanModifierType string
+
+	// WriteOnlySecret replaces an original write-only leaf. It is rendered by
+	// the containing attribute map through fwutils rather than as an ordinary
+	// schema attribute. HasWriteOnlySecrets marks a nested container whose
+	// immediate Attributes slice contains at least one such replacement.
+	WriteOnlySecret     *WriteOnlySecretView
+	HasWriteOnlySecrets bool
+	IncludeResourceID   bool
 
 	// Attributes and Blocks are the leaf and nested children of a container; both
 	// are empty for a leaf attribute.
@@ -533,6 +567,12 @@ type ResourceView struct {
 	// time.Parse call (see RequestFieldView.ParseCall).
 	UsesTime bool
 
+	// WriteOnlySecrets is the deterministic resource-wide list used by request
+	// routing. UsesWriteOnly controls the fwutils import; schema placement is
+	// carried independently by the placeholder AttrViews at each nesting level.
+	WriteOnlySecrets []WriteOnlySecretView
+	UsesWriteOnly    bool
+
 	// Dropped lists response members skipped from the rendered view (e.g.
 	// relationships), surfaced as diagnostics in the run report.
 	Dropped []DroppedMember
@@ -551,6 +591,25 @@ type CRUDCallView struct {
 	// Envelope describes how this role builds its JSON:API request body. Nil
 	// for a call that sends none (Read, Delete).
 	Envelope *RequestEnvelopeView
+	// WriteOnlySecrets contains only secrets declared by this call's own
+	// request body, in deterministic resource-tree order.
+	WriteOnlySecrets []WriteOnlySecretView
+	// NormalizeUnknowns contains the computed Framework values that may remain
+	// unknown after a sparse Create response. It is populated only for Create;
+	// Read begins from state and Update preserves its planned values.
+	NormalizeUnknowns []UnknownNormalizationView
+}
+
+// UnknownNormalizationView describes one recursively-addressable generated
+// model value whose computed unknown state must not reach post-Create state.
+// Kind is value, object, or list_object. Value nodes carry NullExpr; container
+// nodes carry only descendants that can themselves remain unknown.
+type UnknownNormalizationView struct {
+	Kind     string
+	Expr     string
+	NullExpr string
+	ItemVar  string
+	Children []UnknownNormalizationView
 }
 
 // ImportView describes how a resource recovers its identity from a terraform
@@ -646,6 +705,10 @@ type RequestFieldView struct {
 	// TFName names the field in a parse-failure diagnostic. Set only when
 	// ParsedVar is.
 	TFName string
+	// WriteOnlyResult names the SecretResult retrieved from configuration before
+	// request construction. When set, the original SDK setter receives its Value
+	// only when ShouldSetValue is true; no Terraform model field is read.
+	WriteOnlyResult string
 
 	// Nested is set for an object field: the request-side SDK type to build
 	// via New<SDKType>WithDefaults(), and its own Set<GoField> calls

--- a/.generator-v2/internal/model/merge.go
+++ b/.generator-v2/internal/model/merge.go
@@ -25,12 +25,14 @@ func MergeNormalizedSchemas(variant, common *Schema) *Schema {
 	}
 	if common.Kind == SchemaKindUnsupported {
 		out := CloneSchema(common)
+		out.WriteOnlySecret = out.WriteOnlySecret || variant.WriteOnlySecret
 		if out.Description == "" {
 			out.Description = variant.Description
 		}
 		return out
 	}
 	if variant.Kind == SchemaKindOneOf && variant.OneOf != nil {
+		variant.WriteOnlySecret = variant.WriteOnlySecret || common.WriteOnlySecret
 		for i := range variant.OneOf.Variants {
 			variant.OneOf.Variants[i].Schema = MergeNormalizedSchemas(variant.OneOf.Variants[i].Schema, common)
 			variant.OneOf.Variants[i].ValueWrapped = OneOfValueWrapped(variant.OneOf.Variants[i].Schema)
@@ -38,6 +40,7 @@ func MergeNormalizedSchemas(variant, common *Schema) *Schema {
 		return variant
 	}
 	if variant.Kind == SchemaKindUnsupported {
+		variant.WriteOnlySecret = variant.WriteOnlySecret || common.WriteOnlySecret
 		if variant.UnsupportedReason != "" {
 			return variant
 		}
@@ -50,6 +53,7 @@ func MergeNormalizedSchemas(variant, common *Schema) *Schema {
 		return &Schema{
 			Kind:              SchemaKindUnsupported,
 			Description:       variant.Description,
+			WriteOnlySecret:   variant.WriteOnlySecret || common.WriteOnlySecret,
 			UnsupportedReason: fmt.Sprintf("oneOf alternative kind %q conflicts with adjacent schema kind %q", variant.Kind, common.Kind),
 		}
 	}
@@ -74,6 +78,7 @@ func MergeNormalizedSchemas(variant, common *Schema) *Schema {
 			return &Schema{
 				Kind:              SchemaKindUnsupported,
 				Description:       variant.Description,
+				WriteOnlySecret:   variant.WriteOnlySecret || common.WriteOnlySecret,
 				UnsupportedReason: fmt.Sprintf("oneOf alternative type %q conflicts with adjacent type %q", variant.Type, common.Type),
 			}
 		}
@@ -84,6 +89,7 @@ func MergeNormalizedSchemas(variant, common *Schema) *Schema {
 			return &Schema{
 				Kind:              SchemaKindUnsupported,
 				Description:       variant.Description,
+				WriteOnlySecret:   variant.WriteOnlySecret || common.WriteOnlySecret,
 				UnsupportedReason: fmt.Sprintf("oneOf alternative format %q conflicts with adjacent format %q", variant.Format, common.Format),
 			}
 		}
@@ -99,6 +105,7 @@ func MergeNormalizedSchemas(variant, common *Schema) *Schema {
 				return &Schema{
 					Kind:              SchemaKindUnsupported,
 					Description:       variant.Description,
+					WriteOnlySecret:   variant.WriteOnlySecret || common.WriteOnlySecret,
 					UnsupportedReason: "oneOf alternative enum has no values in common with adjacent enum",
 				}
 			}
@@ -106,6 +113,7 @@ func MergeNormalizedSchemas(variant, common *Schema) *Schema {
 		}
 	}
 	variant.Sensitive = variant.Sensitive || common.Sensitive
+	variant.WriteOnlySecret = variant.WriteOnlySecret || common.WriteOnlySecret
 	return variant
 }
 
@@ -218,8 +226,11 @@ func MergeResourceSchema(group *ResolvedGroup) (*Schema, []Diagnostic, error) {
 		updateRequest = group.Update.RequestSchema
 	}
 
-	m := &resourceMerger{}
-	merged, err := m.mergeNode(group.Create.RequestSchema, updateRequest, group.Read.ResponseSchema, false, "")
+	m := &resourceMerger{
+		artifact:        resourceArtifactName(group),
+		warnedWriteOnly: make(map[string]struct{}),
+	}
+	merged, err := m.mergeNode(group.Create.RequestSchema, updateRequest, group.Read.ResponseSchema, false, false, "")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -229,60 +240,113 @@ func MergeResourceSchema(group *ResolvedGroup) (*Schema, []Diagnostic, error) {
 // resourceMerger accumulates the info diagnostics raised while walking the
 // three bodies.
 type resourceMerger struct {
-	diagnostics []Diagnostic
+	artifact        string
+	diagnostics     []Diagnostic
+	warnedWriteOnly map[string]struct{}
+}
+
+func resourceArtifactName(group *ResolvedGroup) string {
+	for _, operation := range []*Operation{group.Create, group.Update, group.Read, group.Delete, group.Search} {
+		if operation != nil && operation.Tracking != nil && operation.Tracking.ArtifactName != "" {
+			return operation.Tracking.ArtifactName
+		}
+	}
+	return ""
+}
+
+// writeOnlyMetadata selects generated write-only behavior only from request
+// roles. Sensitivity remains an independent cosmetic field, and a response-only
+// writeOnly marker therefore cannot opt a resource or data source into generated
+// write-only handling.
+func (m *resourceMerger) writeOnlyMetadata(
+	create, update, read *Schema,
+	createRequired, updateRequired bool,
+	path string,
+) (writeOnly, requiredOnCreate, requiredOnUpdate bool, description string) {
+	writeOnly = create != nil && create.WriteOnlySecret || update != nil && update.WriteOnlySecret
+	if !writeOnly {
+		return false, false, false, ""
+	}
+	requiredOnCreate = create != nil && createRequired
+	requiredOnUpdate = update != nil && updateRequired
+	for _, request := range []*Schema{create, update} {
+		if request != nil && request.WriteOnlySecret && request.Description != "" {
+			description = request.Description
+			break
+		}
+	}
+	if read != nil {
+		m.warnWriteOnlyResponseConflict(path)
+	}
+	return writeOnly, requiredOnCreate, requiredOnUpdate, description
+}
+
+func (m *resourceMerger) warnWriteOnlyResponseConflict(path string) {
+	key := m.artifact + "\x00" + path
+	if _, exists := m.warnedWriteOnly[key]; exists {
+		return
+	}
+	m.warnedWriteOnly[key] = struct{}{}
+	m.diagnostics = append(m.diagnostics, Diagnostic{
+		Severity: SeverityWarning,
+		Message: fmt.Sprintf(
+			"resource %q: request write-only field %q is also present in the Read response; suppressing response mapping",
+			m.artifact,
+			path,
+		),
+	})
 }
 
 // mergeNode combines the three bodies' schemas at one correlated tree
 // position. create/update/read are nil when that body does not reach this
-// position; createRequired is fixed by the caller from the enclosing object's
-// Create-body Required list (a node cannot answer this about itself).
-func (m *resourceMerger) mergeNode(create, update, read *Schema, createRequired bool, path string) (*Schema, error) {
+// position; createRequired and updateRequired are fixed independently by the
+// caller from each enclosing request object's Required list (a node cannot
+// answer either fact about itself).
+func (m *resourceMerger) mergeNode(create, update, read *Schema, createRequired, updateRequired bool, path string) (*Schema, error) {
 	kind, err := kindConflict(create, update, read, path)
 	if err != nil {
 		return nil, err
 	}
 	switch kind {
 	case SchemaKindObject:
-		return m.mergeObject(create, update, read, createRequired, path)
+		return m.mergeObject(create, update, read, createRequired, updateRequired, path)
 	case SchemaKindArray, SchemaKindMap:
-		return m.mergeCollection(kind, create, update, read, createRequired, path)
+		return m.mergeCollection(kind, create, update, read, createRequired, updateRequired, path)
 	case SchemaKindPrimitive:
-		return m.mergePrimitive(create, update, read, createRequired, path)
+		return m.mergePrimitive(create, update, read, createRequired, updateRequired, path)
 	case SchemaKindOneOf:
-		return m.mergeOneOf(create, update, read, createRequired, path)
+		return m.mergeOneOf(create, update, read, createRequired, updateRequired, path)
 	default:
 		// Unsupported, RefCycle, DepthExceeded: nothing under such a node is
 		// representable, so there is no subtree worth correlating — the merged node
 		// is the preferred side's clone.
-		return m.mergeVerbatim(create, update, read, createRequired, path)
+		return m.mergeVerbatim(create, update, read, createRequired, updateRequired, path)
 	}
 }
 
-func (m *resourceMerger) mergeObject(create, update, read *Schema, createRequired bool, path string) (*Schema, error) {
-	// The create body's required list is consulted once per property, so index
-	// it up front rather than rescanning the slice for every key.
-	createRequiredKeys := map[string]struct{}{}
-	if create != nil {
-		for _, key := range create.Required {
-			createRequiredKeys[key] = struct{}{}
-		}
-	}
+func (m *resourceMerger) mergeObject(create, update, read *Schema, createRequired, updateRequired bool, path string) (*Schema, error) {
+	// Each body's required list is consulted once per property, so index both
+	// up front rather than rescanning the slices for every key.
+	createRequiredKeys := requiredKeySet(create)
+	updateRequiredKeys := requiredKeySet(update)
 
 	properties := make(map[string]*Schema)
 	for _, key := range unionObjectKeys(create, update, read) {
 		var childCreate, childUpdate, childRead *Schema
-		childRequired := false
+		childCreateRequired := false
+		childUpdateRequired := false
 		if create != nil {
 			childCreate = create.Properties[key]
-			_, childRequired = createRequiredKeys[key]
+			_, childCreateRequired = createRequiredKeys[key]
 		}
 		if update != nil {
 			childUpdate = update.Properties[key]
+			_, childUpdateRequired = updateRequiredKeys[key]
 		}
 		if read != nil {
 			childRead = read.Properties[key]
 		}
-		child, err := m.mergeNode(childCreate, childUpdate, childRead, childRequired, ChildPath(path, key))
+		child, err := m.mergeNode(childCreate, childUpdate, childRead, childCreateRequired, childUpdateRequired, ChildPath(path, key))
 		if err != nil {
 			return nil, err
 		}
@@ -292,21 +356,37 @@ func (m *resourceMerger) mergeObject(create, update, read *Schema, createRequire
 		Kind:       SchemaKindObject,
 		Properties: properties,
 		Required:   requiredFromCreate(create),
-	}, create, update, read, createRequired, path), nil
+	}, create, update, read, createRequired, updateRequired, path), nil
+}
+
+// requiredKeySet indexes a body's Required list for O(1) membership tests. A
+// nil body yields a nil set, which reads as "requires nothing".
+func requiredKeySet(s *Schema) map[string]struct{} {
+	if s == nil {
+		return nil
+	}
+	keys := make(map[string]struct{}, len(s.Required))
+	for _, key := range s.Required {
+		keys[key] = struct{}{}
+	}
+	return keys
 }
 
 // stampCommon fills the fields every merged node carries whatever its kind: the
 // cosmetic trio (RefName, Description, Enum, Sensitive), the request-side
-// component name, and the provenance stamp. It returns out, so a merge can
-// construct its kind-specific fields and stamp the rest in one expression.
-func (m *resourceMerger) stampCommon(out, create, update, read *Schema, createRequired bool, path string) *Schema {
+// component name, the write-only quartet, and the provenance stamp. It returns
+// out, so a merge can construct its kind-specific fields and stamp the rest in
+// one expression.
+func (m *resourceMerger) stampCommon(out, create, update, read *Schema, createRequired, updateRequired bool, path string) *Schema {
 	out.RefName, out.Description, out.Enum, out.Sensitive = m.cosmeticFields(create, update, read, path)
 	out.RequestRefName = pickRequestRefName(create, update)
-	out.Provenance = stampProvenance(create, update, read, createRequired)
+	out.WriteOnlySecret, out.SecretRequiredOnCreate, out.SecretRequiredOnUpdate, out.WriteOnlyDescription =
+		m.writeOnlyMetadata(create, update, read, createRequired, updateRequired, path)
+	out.Provenance = stampProvenance(create, update, read, createRequired, out.WriteOnlySecret)
 	return out
 }
 
-func (m *resourceMerger) mergeCollection(kind SchemaKind, create, update, read *Schema, createRequired bool, path string) (*Schema, error) {
+func (m *resourceMerger) mergeCollection(kind SchemaKind, create, update, read *Schema, createRequired, updateRequired bool, path string) (*Schema, error) {
 	var childCreate, childUpdate, childRead *Schema
 	if create != nil {
 		childCreate = create.Items
@@ -323,17 +403,17 @@ func (m *resourceMerger) mergeCollection(kind SchemaKind, create, update, read *
 	}
 	// An array/map element has no name of its own to appear in a parent's
 	// Required list, so it is never itself request-required.
-	items, err := m.mergeNode(childCreate, childUpdate, childRead, false, ChildPath(path, suffix))
+	items, err := m.mergeNode(childCreate, childUpdate, childRead, false, false, ChildPath(path, suffix))
 	if err != nil {
 		return nil, err
 	}
 	return m.stampCommon(&Schema{
 		Kind:  kind,
 		Items: items,
-	}, create, update, read, createRequired, path), nil
+	}, create, update, read, createRequired, updateRequired, path), nil
 }
 
-func (m *resourceMerger) mergePrimitive(create, update, read *Schema, createRequired bool, path string) (*Schema, error) {
+func (m *resourceMerger) mergePrimitive(create, update, read *Schema, createRequired, updateRequired bool, path string) (*Schema, error) {
 	present := presentSchemas(create, update, read)
 	typ, err := reconcileField(path, "type", present, func(s *Schema) string { return s.Type })
 	if err != nil {
@@ -347,12 +427,12 @@ func (m *resourceMerger) mergePrimitive(create, update, read *Schema, createRequ
 		Kind:   SchemaKindPrimitive,
 		Type:   typ,
 		Format: format,
-	}, create, update, read, createRequired, path), nil
+	}, create, update, read, createRequired, updateRequired, path), nil
 }
 
-func (m *resourceMerger) mergeVerbatim(create, update, read *Schema, createRequired bool, path string) (*Schema, error) {
+func (m *resourceMerger) mergeVerbatim(create, update, read *Schema, createRequired, updateRequired bool, path string) (*Schema, error) {
 	out := CloneSchema(preferredSchema(create, update, read))
-	return m.stampCommon(out, create, update, read, createRequired, path), nil
+	return m.stampCommon(out, create, update, read, createRequired, updateRequired, path), nil
 }
 
 // pickRequestRefName returns the Create body's component name at this node,
@@ -393,11 +473,11 @@ func (m *resourceMerger) cosmeticFields(create, update, read *Schema, path strin
 	return refName, description, enum, sensitive
 }
 
-func stampProvenance(create, update, read *Schema, createRequired bool) *SchemaProvenance {
+func stampProvenance(create, update, read *Schema, createRequired, writeOnly bool) *SchemaProvenance {
 	return &SchemaProvenance{
 		InRequest:       create != nil || update != nil,
 		RequestRequired: createRequired,
-		InResponse:      read != nil,
+		InResponse:      read != nil && !writeOnly,
 	}
 }
 
@@ -593,13 +673,13 @@ func (e *OneOfMergeError) Error() string {
 // Provenance at every property. The name alternatives correlate under is also
 // the name the variant block is published under, so the two cannot drift. The
 // SDK binding stays the preferred (Read) body's, as RefName does.
-func (m *resourceMerger) mergeOneOf(create, update, read *Schema, createRequired bool, path string) (*Schema, error) {
+func (m *resourceMerger) mergeOneOf(create, update, read *Schema, createRequired, updateRequired bool, path string) (*Schema, error) {
 	// A node classified oneOf but carrying no normalized union has no
 	// alternatives to correlate. That defect is reported elsewhere with its own
 	// actionable message, so hand it on untouched.
 	for _, s := range presentSchemas(create, update, read) {
 		if s.OneOf == nil {
-			return m.mergeVerbatim(create, update, read, createRequired, path)
+			return m.mergeVerbatim(create, update, read, createRequired, updateRequired, path)
 		}
 	}
 
@@ -623,7 +703,7 @@ func (m *resourceMerger) mergeOneOf(create, update, read *Schema, createRequired
 		}
 		// An alternative is a choice, never an entry in an enclosing object's
 		// required list, so it is never itself request-required.
-		merged, err := m.mergeNode(altCreate, altUpdate, altRead, false, ChildPath(path, name))
+		merged, err := m.mergeNode(altCreate, altUpdate, altRead, false, false, ChildPath(path, name))
 		if err != nil {
 			return nil, err
 		}
@@ -660,7 +740,7 @@ func (m *resourceMerger) mergeOneOf(create, update, read *Schema, createRequired
 	return m.stampCommon(&Schema{
 		Kind:  SchemaKindOneOf,
 		OneOf: spec,
-	}, create, update, read, createRequired, path), nil
+	}, create, update, read, createRequired, updateRequired, path), nil
 }
 
 // correlateOneOf lines the three bodies' alternatives up under one name each,

--- a/.generator-v2/internal/model/merge.go
+++ b/.generator-v2/internal/model/merge.go
@@ -212,6 +212,22 @@ func (e *SchemaMergeError) Error() string {
 	return fmt.Sprintf("model: resource schema merge conflict at %q: %s %q vs %q", e.Path, e.Aspect, e.Left, e.Right)
 }
 
+// WriteOnlyLifecycleError reports a write-only field that cannot be routed
+// through both request-writing lifecycle roles. Exposing its Terraform pair
+// would otherwise accept a secret that one of Create or Update never sends.
+type WriteOnlyLifecycleError struct {
+	Path        string
+	MissingRole string
+}
+
+func (e *WriteOnlyLifecycleError) Error() string {
+	return fmt.Sprintf(
+		"model: write-only field %q is missing from the %s request; write-only fields must be present in both Create and Update",
+		e.Path,
+		e.MissingRole,
+	)
+}
+
 // MergeResourceSchema unions the Create request, Update request and Read
 // response bodies of group into one Schema tree, stamping Provenance at every
 // correlated position. Nodes correlate by property name at equal depth from
@@ -303,6 +319,12 @@ func (m *resourceMerger) warnWriteOnlyResponseConflict(path string) {
 // caller from each enclosing request object's Required list (a node cannot
 // answer either fact about itself).
 func (m *resourceMerger) mergeNode(create, update, read *Schema, createRequired, updateRequired bool, path string) (*Schema, error) {
+	if create != nil && create.WriteOnlySecret && update == nil {
+		return nil, &WriteOnlyLifecycleError{Path: path, MissingRole: "Update"}
+	}
+	if update != nil && update.WriteOnlySecret && create == nil {
+		return nil, &WriteOnlyLifecycleError{Path: path, MissingRole: "Create"}
+	}
 	kind, err := kindConflict(create, update, read, path)
 	if err != nil {
 		return nil, err

--- a/.generator-v2/internal/model/merge_test.go
+++ b/.generator-v2/internal/model/merge_test.go
@@ -128,6 +128,49 @@ var _ = Describe("MergeResourceSchema", func() {
 		Entry("required by both roles", true, true),
 	)
 
+	DescribeTable("rejects write-only fields absent from one request lifecycle role",
+		func(createHasSecret, updateHasSecret bool, missingRole string) {
+			createAttributes := map[string]*Schema{}
+			updateAttributes := map[string]*Schema{}
+			if createHasSecret {
+				createAttributes["password"] = secretSchema(true, false)
+			}
+			if updateHasSecret {
+				updateAttributes["password"] = secretSchema(true, false)
+			}
+
+			_, _, err := MergeResourceSchema(&ResolvedGroup{
+				Create: &Operation{OperationId: "CreateAccount", RequestSchema: jsonAPIBody(
+					"AccountCreateRequest", createAttributes, nil)},
+				Update: &Operation{OperationId: "UpdateAccount", RequestSchema: jsonAPIBody(
+					"AccountUpdateRequest", updateAttributes, nil)},
+				Read: &Operation{OperationId: "GetAccount", ResponseSchema: jsonAPIBody(
+					"AccountResponse", map[string]*Schema{}, nil)},
+			})
+
+			Expect(err).To(HaveOccurred())
+			var lifecycleErr *WriteOnlyLifecycleError
+			Expect(errors.As(err, &lifecycleErr)).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("data.attributes.password"))
+			Expect(err.Error()).To(ContainSubstring(missingRole))
+		},
+		Entry("Create-only secret", true, false, "Update"),
+		Entry("Update-only secret", false, true, "Create"),
+	)
+
+	It("rejects a write-only field when the resource has no Update role", func() {
+		_, _, err := MergeResourceSchema(&ResolvedGroup{
+			Create: &Operation{OperationId: "CreateAccount", RequestSchema: jsonAPIBody(
+				"AccountCreateRequest", map[string]*Schema{"password": secretSchema(true, false)}, nil)},
+			Read: &Operation{OperationId: "GetAccount", ResponseSchema: jsonAPIBody(
+				"AccountResponse", map[string]*Schema{}, nil)},
+		})
+
+		var lifecycleErr *WriteOnlyLifecycleError
+		Expect(errors.As(err, &lifecycleErr)).To(BeTrue())
+		Expect(lifecycleErr.MissingRole).To(Equal("Update"))
+	})
+
 	It("suppresses a request write-only field returned by Read and emits one deterministic value-free warning", func() {
 		requestPassword := secretSchema(true, false)
 		requestPassword.Description = "configured-secret-must-not-appear"

--- a/.generator-v2/internal/model/merge_test.go
+++ b/.generator-v2/internal/model/merge_test.go
@@ -2,6 +2,8 @@ package model
 
 import (
 	"errors"
+	"reflect"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,7 +36,148 @@ func attributesOf(s *Schema) map[string]*Schema {
 	return s.Properties["data"].Properties["attributes"].Properties
 }
 
+// setTestBoolField/testBoolField keep T153 executable before T154 adds the
+// write-only metadata fields. The intended red result is a Ginkgo failure that
+// names the missing contract, not a Go compilation error that obscures it.
+func setTestBoolField(target any, name string, value bool) {
+	GinkgoHelper()
+	field := reflect.ValueOf(target).Elem().FieldByName(name)
+	Expect(field.IsValid()).To(BeTrue(), "%T is missing %s metadata", target, name)
+	Expect(field.CanSet()).To(BeTrue(), "%T.%s cannot be set", target, name)
+	Expect(field.Kind()).To(Equal(reflect.Bool), "%T.%s must be boolean", target, name)
+	field.SetBool(value)
+}
+
+func testBoolField(target any, name string) bool {
+	GinkgoHelper()
+	field := reflect.ValueOf(target).Elem().FieldByName(name)
+	Expect(field.IsValid()).To(BeTrue(), "%T is missing %s metadata", target, name)
+	Expect(field.Kind()).To(Equal(reflect.Bool), "%T.%s must be boolean", target, name)
+	return field.Bool()
+}
+
+func secretSchema(writeOnly, sensitive bool) *Schema {
+	schema := &Schema{Kind: SchemaKindPrimitive, Type: "string", Sensitive: sensitive}
+	if writeOnly {
+		setTestBoolField(schema, "WriteOnlySecret", true)
+	}
+	return schema
+}
+
 var _ = Describe("MergeResourceSchema", func() {
+	DescribeTable("selects generated write-only handling only from a request-role writeOnly marker",
+		func(createWriteOnly, updateWriteOnly, readWriteOnly, requestSensitive, wantWriteOnly, wantSensitive bool) {
+			createReq := jsonAPIBody("AccountCreateRequest", map[string]*Schema{
+				"password": secretSchema(createWriteOnly, requestSensitive),
+			}, nil)
+			updateReq := jsonAPIBody("AccountUpdateRequest", map[string]*Schema{
+				"password": secretSchema(updateWriteOnly, requestSensitive),
+			}, nil)
+			readResp := jsonAPIBody("AccountResponse", map[string]*Schema{
+				"password": secretSchema(readWriteOnly, readWriteOnly),
+			}, nil)
+
+			merged, _, err := MergeResourceSchema(&ResolvedGroup{
+				Create: &Operation{OperationId: "CreateAccount", RequestSchema: createReq},
+				Update: &Operation{OperationId: "UpdateAccount", RequestSchema: updateReq},
+				Read:   &Operation{OperationId: "GetAccount", ResponseSchema: readResp},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			password := attributesOf(merged)["password"]
+			Expect(testBoolField(password, "WriteOnlySecret")).To(Equal(wantWriteOnly))
+			Expect(password.Sensitive).To(Equal(wantSensitive))
+		},
+		Entry("Create writeOnly:true selects it", true, false, false, false, true, false),
+		Entry("Update writeOnly:true selects it", false, true, false, false, true, false),
+		Entry("request x-secret/tracking-sensitive does not select it", false, false, false, true, false, true),
+		Entry("response writeOnly:true does not select it", false, false, true, false, false, true),
+		Entry("no marker selects neither behavior", false, false, false, false, false, false),
+	)
+
+	DescribeTable("records write-only requiredness independently for Create and Update",
+		func(createRequired, updateRequired bool) {
+			createReq := jsonAPIBody("AccountCreateRequest", map[string]*Schema{
+				"password": secretSchema(true, false),
+			}, nil)
+			updateReq := jsonAPIBody("AccountUpdateRequest", map[string]*Schema{
+				"password": secretSchema(true, false),
+			}, nil)
+			if createRequired {
+				createReq.Properties["data"].Properties["attributes"].Required = []string{"password"}
+			}
+			if updateRequired {
+				updateReq.Properties["data"].Properties["attributes"].Required = []string{"password"}
+			}
+
+			merged, _, err := MergeResourceSchema(&ResolvedGroup{
+				Create: &Operation{OperationId: "CreateAccount", RequestSchema: createReq},
+				Update: &Operation{OperationId: "UpdateAccount", RequestSchema: updateReq},
+				Read: &Operation{OperationId: "GetAccount", ResponseSchema: jsonAPIBody(
+					"AccountResponse", map[string]*Schema{}, nil)},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			password := attributesOf(merged)["password"]
+			Expect(testBoolField(password, "SecretRequiredOnCreate")).To(Equal(createRequired))
+			Expect(testBoolField(password, "SecretRequiredOnUpdate")).To(Equal(updateRequired))
+		},
+		Entry("optional in both roles", false, false),
+		Entry("required only by Create", true, false),
+		Entry("required only by Update", false, true),
+		Entry("required by both roles", true, true),
+	)
+
+	It("suppresses a request write-only field returned by Read and emits one deterministic value-free warning", func() {
+		requestPassword := secretSchema(true, false)
+		requestPassword.Description = "configured-secret-must-not-appear"
+		responsePassword := secretSchema(false, true)
+		responsePassword.Description = "observed-secret-must-not-appear"
+		group := &ResolvedGroup{
+			Create: &Operation{OperationId: "CreateAccount", RequestSchema: jsonAPIBody(
+				"AccountCreateRequest", map[string]*Schema{"password": requestPassword}, []string{"password"})},
+			Update: &Operation{OperationId: "UpdateAccount", RequestSchema: jsonAPIBody(
+				"AccountUpdateRequest", map[string]*Schema{"password": secretSchema(true, false)}, nil)},
+			Read: &Operation{
+				OperationId: "GetAccount",
+				Tracking: &TrackingFieldMetadata{
+					ArtifactKind: ArtifactKindResource,
+					ArtifactName: "integration_account",
+				},
+				ResponseSchema: jsonAPIBody(
+					"AccountResponse", map[string]*Schema{"password": responsePassword}, nil),
+			},
+		}
+
+		merged, firstDiags, err := MergeResourceSchema(group)
+		Expect(err).NotTo(HaveOccurred())
+		password := attributesOf(merged)["password"]
+		Expect(testBoolField(password, "WriteOnlySecret")).To(BeTrue())
+		Expect(password.Provenance.InResponse).To(BeFalse(),
+			"a write-only response field must not produce an updateState assignment")
+
+		_, secondDiags, err := MergeResourceSchema(group)
+		Expect(err).NotTo(HaveOccurred())
+		warnings := func(diags []Diagnostic) []Diagnostic {
+			var out []Diagnostic
+			for _, diagnostic := range diags {
+				if diagnostic.Severity == SeverityWarning {
+					out = append(out, diagnostic)
+				}
+			}
+			return out
+		}
+		firstWarnings := warnings(firstDiags)
+		Expect(firstWarnings).To(HaveLen(1))
+		Expect(warnings(secondDiags)).To(Equal(firstWarnings))
+		message := firstWarnings[0].Message
+		Expect(message).To(ContainSubstring("integration_account"))
+		Expect(message).To(ContainSubstring("data.attributes.password"))
+		Expect(message).NotTo(ContainSubstring("configured-secret-must-not-appear"))
+		Expect(message).NotTo(ContainSubstring("observed-secret-must-not-appear"))
+		Expect(strings.ToLower(message)).NotTo(ContainSubstring("value="))
+	})
+
 	It("correlates by property position across three differently-named components and stamps the provenance bits", func() {
 		createReq := jsonAPIBody("IncidentTypeCreateRequest", map[string]*Schema{
 			"name":          {Kind: SchemaKindPrimitive, Type: "string", Description: "name (create)"},

--- a/.generator-v2/internal/model/schema.go
+++ b/.generator-v2/internal/model/schema.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -97,7 +98,12 @@ func BuildRequestTree(s *Schema) (*AttributeTree, []Diagnostic, error) {
 // plan modifiers follow from those flags plus updateUnsupported — when true,
 // every request-settable attribute gets RequiresReplace().
 func BuildResourceTree(s *Schema, updateUnsupported bool) (*AttributeTree, []Diagnostic, error) {
-	return (&treeBuilder{kind: resourceTree, updateUnsupported: updateUnsupported}).build(s, "resource")
+	tree, diagnostics, err := (&treeBuilder{kind: resourceTree, updateUnsupported: updateUnsupported}).build(s, "resource")
+	if err != nil {
+		return nil, nil, err
+	}
+	markWriteOnlyAncestorsConfigurationOwned(tree.Attributes)
+	return tree, diagnostics, nil
 }
 
 // treeBuilder carries the state of one AttributeTree conversion; the recursion
@@ -181,6 +187,7 @@ func (b *treeBuilder) attribute(s *Schema, path string, required bool) (*Attribu
 		Sensitive:   s.Sensitive,
 		Description: s.Description,
 	}
+	b.applyWriteOnlyMetadata(attr, s)
 	if err := b.applyPresence(attr, s, required); err != nil {
 		return nil, err
 	}
@@ -324,6 +331,7 @@ func (b *treeBuilder) envelope(s *Schema, path string, required bool) (*Attribut
 		Children:    variants,
 		OneOf:       envelope,
 	}
+	b.applyWriteOnlyMetadata(attr, s)
 	// Required only when the containing field demands a value and the union may
 	// not be absent — a nullable union is an absent envelope, not a null
 	// variant. Keyed on Nullable alone: OneOf.Optional either restates
@@ -429,8 +437,10 @@ func (b *treeBuilder) oneOfVariant(
 		Sensitive:   variant.Schema.Sensitive,
 		Description: variant.Schema.Description,
 	}
+	b.applyWriteOnlyMetadata(block, variant.Schema)
 	// A variant is a choice, never mandatory: exactly-one selection is enforced
-	// by the envelope's validator, not by marking every branch Required.
+	// by the envelope's validator and by request mapping, not by marking every
+	// branch Required.
 	if err := b.applyPresence(block, union, false); err != nil {
 		return fail("", err)
 	}
@@ -476,6 +486,40 @@ func (b *treeBuilder) oneOfVariant(
 		ValueWrapped:   valueWrapped,
 		Attribute:      block,
 	}, nil
+}
+
+// applyWriteOnlyMetadata copies a schema's write-only facts onto attribute, and
+// only for a resourceTree: a response schema may carry OpenAPI writeOnly for
+// normalization and display sensitivity, but only a request-selected
+// managed-resource field drives write-only expansion.
+func (b *treeBuilder) applyWriteOnlyMetadata(attribute *Attribute, schema *Schema) {
+	if b.kind != resourceTree {
+		return
+	}
+	attribute.WriteOnlySecret = schema.WriteOnlySecret
+	attribute.SecretRequiredOnCreate = schema.SecretRequiredOnCreate
+	attribute.SecretRequiredOnUpdate = schema.SecretRequiredOnUpdate
+	attribute.WriteOnlyDescription = schema.WriteOnlyDescription
+}
+
+// markWriteOnlyAncestorsConfigurationOwned enforces the Framework containment
+// rule over an already-projected tree: a request-settable nested ancestor of a
+// write-only descendant keeps its Required or Optional flag but loses Computed
+// and UseStateForUnknown. Sibling branches are untouched. Reports whether this
+// level contains a write-only attribute.
+func markWriteOnlyAncestorsConfigurationOwned(attributes []*Attribute) bool {
+	containsWriteOnly := false
+	for _, attribute := range attributes {
+		descendantWriteOnly := markWriteOnlyAncestorsConfigurationOwned(attribute.Children)
+		if descendantWriteOnly && (attribute.Required || attribute.Optional) {
+			attribute.Computed = false
+			attribute.PlanModifiers = slices.DeleteFunc(attribute.PlanModifiers, func(modifier PlanModifierSpec) bool {
+				return strings.HasSuffix(modifier.Name, ".UseStateForUnknown")
+			})
+		}
+		containsWriteOnly = containsWriteOnly || attribute.WriteOnlySecret || descendantWriteOnly
+	}
+	return containsWriteOnly
 }
 
 // applyPresence sets a's presence flags, plus resourceTree's plan modifiers.

--- a/.generator-v2/internal/model/schema.go
+++ b/.generator-v2/internal/model/schema.go
@@ -512,6 +512,7 @@ func markWriteOnlyAncestorsConfigurationOwned(attributes []*Attribute) bool {
 	for _, attribute := range attributes {
 		descendantWriteOnly := markWriteOnlyAncestorsConfigurationOwned(attribute.Children)
 		if descendantWriteOnly && (attribute.Required || attribute.Optional) {
+			attribute.PreserveConfiguredPresence = attribute.Optional && attribute.Computed && attribute.InResponse
 			attribute.Computed = false
 			attribute.PlanModifiers = slices.DeleteFunc(attribute.PlanModifiers, func(modifier PlanModifierSpec) bool {
 				return strings.HasSuffix(modifier.Name, ".UseStateForUnknown")

--- a/.generator-v2/internal/model/schema_test.go
+++ b/.generator-v2/internal/model/schema_test.go
@@ -1214,6 +1214,8 @@ var _ = Describe("BuildResourceTree write-only metadata", func() {
 			for _, path := range ancestorPaths {
 				attribute := attrByPath(tree, path)
 				Expect(attribute.Computed).To(BeFalse(), "Computed at %q", path)
+				Expect(attribute.PreserveConfiguredPresence).To(Equal(attribute.Optional && attribute.InResponse),
+					"response mapping presence guard at %q", path)
 				Expect(attribute.PlanModifiers).NotTo(ContainElement(
 					PlanModifierSpec{Name: PlanModifierPackage(attribute.GoType) + ".UseStateForUnknown"}),
 					"UseStateForUnknown at %q", path)

--- a/.generator-v2/internal/model/schema_test.go
+++ b/.generator-v2/internal/model/schema_test.go
@@ -856,6 +856,13 @@ func provSchema(typ string, p SchemaProvenance) *Schema {
 	return &Schema{Kind: SchemaKindPrimitive, Type: typ, Provenance: &p}
 }
 
+func writeOnlySchema(schema *Schema, requiredOnCreate, requiredOnUpdate bool) *Schema {
+	setTestBoolField(schema, "WriteOnlySecret", true)
+	setTestBoolField(schema, "SecretRequiredOnCreate", requiredOnCreate)
+	setTestBoolField(schema, "SecretRequiredOnUpdate", requiredOnUpdate)
+	return schema
+}
+
 var _ = Describe("BuildResourceTree presence flags", func() {
 	assertFlags := func(tree *AttributeTree, path string, required, optional, computed bool) {
 		GinkgoHelper()
@@ -1151,4 +1158,110 @@ var _ = Describe("BuildResourceTree plan modifiers", func() {
 		Expect(attrByPath(tree, "resource.choice").PlanModifiers).To(Equal(
 			[]PlanModifierSpec{{Name: "objectplanmodifier.UseStateForUnknown"}}))
 	})
+})
+
+// ---------------------------------------------------------------------------
+//  BuildResourceTree — write-only metadata and containment (T153 red tests)
+// ---------------------------------------------------------------------------
+
+var _ = Describe("BuildResourceTree write-only metadata", func() {
+	DescribeTable("carries selector metadata and the original SDK property identity without expanding companions",
+		func(schema *Schema, openAPIName, wantPath string, requiredOnCreate, requiredOnUpdate bool) {
+			schema.Provenance = &SchemaProvenance{
+				InRequest:       true,
+				RequestRequired: requiredOnCreate,
+				InResponse:      false,
+			}
+			writeOnlySchema(schema, requiredOnCreate, requiredOnUpdate)
+			root := objSchema(map[string]*Schema{openAPIName: schema})
+			if requiredOnCreate {
+				root.Required = []string{openAPIName}
+			}
+
+			tree, _, err := BuildResourceTree(root, false)
+			Expect(err).NotTo(HaveOccurred())
+			attribute := attrByPath(tree, wantPath)
+			Expect(attribute.OpenAPIName).To(Equal(openAPIName))
+			Expect(testBoolField(attribute, "WriteOnlySecret")).To(BeTrue())
+			Expect(testBoolField(attribute, "SecretRequiredOnCreate")).To(Equal(requiredOnCreate))
+			Expect(testBoolField(attribute, "SecretRequiredOnUpdate")).To(Equal(requiredOnUpdate))
+			Expect(pathsOf(allAttrs(tree))).NotTo(ContainElement(wantPath + "_wo"))
+			Expect(pathsOf(allAttrs(tree))).NotTo(ContainElement(wantPath + "_wo_version"))
+		},
+		Entry("required root string", primSchema("string"), "apiToken", "resource.api_token", true, false),
+		Entry("optional root string required by Update", primSchema("string"), "password", "resource.password", false, true),
+		Entry("non-string marker retained for the emitter support decision", primSchema("boolean"), "enabledSecret", "resource.enabled_secret", false, false),
+		Entry("collection marker retained for the emitter support decision", arrSchema(primSchema("string")), "secretItems", "resource.secret_items", false, false),
+	)
+
+	It("never turns normalized response/data-source writeOnly metadata into a Terraform write-only attribute", func() {
+		responseSecret := writeOnlySchema(primSchema("string"), false, false)
+		responseSecret.Sensitive = true
+		tree, _, err := BuildResponseTree(objSchema(map[string]*Schema{"password": responseSecret}))
+		Expect(err).NotTo(HaveOccurred())
+
+		attribute := attrByPath(tree, "response.password")
+		Expect(testBoolField(attribute, "WriteOnlySecret")).To(BeFalse())
+		Expect(attribute.Sensitive).To(BeTrue(), "response-side sensitivity remains ordinary display redaction")
+	})
+
+	DescribeTable("makes every request-settable nested ancestor configuration-owned while preserving readable siblings",
+		func(buildRoot func() *Schema, ancestorPaths []string, readablePath string) {
+			root := buildRoot()
+			tree, _, err := BuildResourceTree(root, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, path := range ancestorPaths {
+				attribute := attrByPath(tree, path)
+				Expect(attribute.Computed).To(BeFalse(), "Computed at %q", path)
+				Expect(attribute.PlanModifiers).NotTo(ContainElement(
+					PlanModifierSpec{Name: PlanModifierPackage(attribute.GoType) + ".UseStateForUnknown"}),
+					"UseStateForUnknown at %q", path)
+			}
+			readable := attrByPath(tree, readablePath)
+			Expect(readable.Optional).To(BeTrue())
+			Expect(readable.Computed).To(BeTrue())
+			Expect(readable.PlanModifiers).To(ContainElement(
+				PlanModifierSpec{Name: PlanModifierPackage(readable.GoType) + ".UseStateForUnknown"}))
+		},
+		Entry("one-level nested object",
+			func() *Schema {
+				password := provSchema("string", SchemaProvenance{InRequest: true, InResponse: false})
+				writeOnlySchema(password, false, false)
+				authentication := objSchema(map[string]*Schema{
+					"password": password,
+					"username": provSchema("string", SchemaProvenance{InRequest: true, InResponse: true}),
+				})
+				authentication.Provenance = &SchemaProvenance{InRequest: true, InResponse: true}
+				return objSchema(map[string]*Schema{"authentication": authentication})
+			},
+			[]string{"resource.authentication"},
+			"resource.authentication.username",
+		),
+		Entry("recursive object path through a oneOf variant",
+			func() *Schema {
+				password := writeOnlySchema(primSchema("string"), true, true)
+				credentials := objSchema(map[string]*Schema{
+					"password": password,
+					"username": primSchema("string"),
+				})
+				credentials.Required = []string{"password"}
+				basic := objectOneOfVariant("basic", map[string]*Schema{"credentials": credentials})
+				basic.Schema.Required = []string{"credentials"}
+				method := oneOfSchema("resource.authentication.method", "AuthenticationMethod", basic)
+				method.Provenance = &SchemaProvenance{InRequest: true, InResponse: true}
+				authentication := objSchema(map[string]*Schema{"method": method})
+				authentication.Required = []string{"method"}
+				authentication.Provenance = &SchemaProvenance{InRequest: true, InResponse: true}
+				return objSchema(map[string]*Schema{"authentication": authentication})
+			},
+			[]string{
+				"resource.authentication",
+				"resource.authentication.method",
+				"resource.authentication.method.basic",
+				"resource.authentication.method.basic.credentials",
+			},
+			"resource.authentication.method.basic.credentials.username",
+		),
+	)
 })

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -557,6 +557,10 @@ type Attribute struct {
 	// tree. Required alone cannot answer it: a required write-only field and a
 	// required field that is also read back both come out Required.
 	InResponse bool
+	// PreserveConfiguredPresence marks an optional response-backed container
+	// made configuration-owned because it contains a write-only descendant.
+	// Response mapping must not materialize it when configuration omitted it.
+	PreserveConfiguredPresence bool
 
 	// OpenAPIName is the property name this attribute was built from, before
 	// SnakeCase normalized it for Terraform (e.g. "hostTagsLists" behind the

--- a/.generator-v2/internal/model/types.go
+++ b/.generator-v2/internal/model/types.go
@@ -351,6 +351,20 @@ type Schema struct {
 	// not object/array, not readOnly).
 	HasDefault bool
 	ReadOnly   bool
+	// WriteOnlySecret retains the OpenAPI writeOnly marker independently from
+	// Terraform display sensitivity. On a normalized schema it is the raw
+	// OpenAPI annotation; on a merged resource schema it is selected only from
+	// the Create or Update request role.
+	WriteOnlySecret bool
+	// SecretRequiredOnCreate and SecretRequiredOnUpdate record the containing
+	// request object's requiredness independently. They are meaningful only
+	// when WriteOnlySecret is true and are consumed by generated request routing.
+	SecretRequiredOnCreate bool
+	SecretRequiredOnUpdate bool
+	// WriteOnlyDescription retains the request-side description for generated
+	// write-only configuration. The ordinary Description may independently
+	// prefer the Read response during cosmetic resource merging.
+	WriteOnlyDescription string
 	// Sensitive is true when explicitly annotated sensitive or inferred from an
 	// unoverridden OpenAPI writeOnly / Datadog x-secret marker.
 	Sensitive bool
@@ -531,6 +545,13 @@ type Attribute struct {
 	Optional  bool
 	Computed  bool
 	Sensitive bool
+	// WriteOnlySecret and its role-specific requiredness are copied only while
+	// building a managed-resource tree. Response/data-source trees deliberately
+	// leave them false even if their OpenAPI response schema carries writeOnly.
+	WriteOnlySecret        bool
+	SecretRequiredOnCreate bool
+	SecretRequiredOnUpdate bool
+	WriteOnlyDescription   string
 
 	// InResponse mirrors Schema.Provenance.InResponse, set only for a resource
 	// tree. Required alone cannot answer it: a required write-only field and a

--- a/.generator-v2/internal/parser/schema.go
+++ b/.generator-v2/internal/parser/schema.go
@@ -630,14 +630,15 @@ func (n *schemaNormalizer) normalizeSchema(s *base.Schema, depth int, ctx schema
 		return n.normalizeAllOf(s, depth, ctx)
 	}
 	out := &model.Schema{
-		Kind:        classifyKind(s),
-		Type:        firstType(s),
-		Format:      s.Format,
-		Enum:        enumValues(s),
-		HasDefault:  s.Default != nil,
-		ReadOnly:    schemaReadOnly(s),
-		Sensitive:   n.isSensitive(s),
-		Description: s.Description,
+		Kind:            classifyKind(s),
+		Type:            firstType(s),
+		Format:          s.Format,
+		Enum:            enumValues(s),
+		HasDefault:      s.Default != nil,
+		ReadOnly:        schemaReadOnly(s),
+		WriteOnlySecret: schemaWriteOnly(s),
+		Sensitive:       n.isSensitive(s),
+		Description:     s.Description,
 		// The component name that led here — the go-sdk names its generated
 		// model after it. ctx carries the first $ref of the chain; a node
 		// reached inline leaves this empty.
@@ -983,6 +984,7 @@ type allOfAnnotations struct {
 	branchDescription string
 	sensitive         bool
 	readOnly          bool
+	writeOnlySecret   bool
 	hasDefault        bool
 }
 
@@ -991,6 +993,7 @@ func (n *schemaNormalizer) outerAnnotations(s *base.Schema) allOfAnnotations {
 		outerDescription: s.Description,
 		sensitive:        n.isSensitive(s),
 		readOnly:         schemaReadOnly(s),
+		writeOnlySecret:  schemaWriteOnly(s),
 		hasDefault:       s.Default != nil,
 	}
 }
@@ -1005,6 +1008,7 @@ func (a *allOfAnnotations) absorb(branch *model.Schema) {
 	}
 	a.sensitive = a.sensitive || branch.Sensitive
 	a.readOnly = a.readOnly || branch.ReadOnly
+	a.writeOnlySecret = a.writeOnlySecret || branch.WriteOnlySecret
 	a.hasDefault = a.hasDefault || branch.HasDefault
 }
 
@@ -1012,6 +1016,7 @@ func (a *allOfAnnotations) absorb(branch *model.Schema) {
 func (a allOfAnnotations) applyTo(out *model.Schema) {
 	out.Sensitive = out.Sensitive || a.sensitive
 	out.ReadOnly = out.ReadOnly || a.readOnly
+	out.WriteOnlySecret = out.WriteOnlySecret || a.writeOnlySecret
 	out.HasDefault = out.HasDefault || a.hasDefault
 	switch {
 	case a.outerDescription != "":
@@ -1027,8 +1032,14 @@ func (a allOfAnnotations) applyTo(out *model.Schema) {
 // but their metadata is unioned in. Anything outside the subset becomes an
 // Unsupported schema carrying a reason rather than an error.
 func (n *schemaNormalizer) normalizeAllOf(s *base.Schema, depth int, ctx schemaContext) (*model.Schema, error) {
+	annotations := n.outerAnnotations(s)
+	unsupported := func(reason string) *model.Schema {
+		out := unsupportedSchema(reason)
+		annotations.applyTo(out)
+		return out
+	}
 	if reason := unsupportedAllOfOuterStructure(s); reason != "" {
-		return unsupportedSchema(reason), nil
+		return unsupported(reason), nil
 	}
 
 	type structuralBranch struct {
@@ -1036,16 +1047,15 @@ func (n *schemaNormalizer) normalizeAllOf(s *base.Schema, depth int, ctx schemaC
 		schema *model.Schema
 	}
 	branches := make([]structuralBranch, 0, len(s.AllOf))
-	annotations := n.outerAnnotations(s)
-
 	for i, proxy := range s.AllOf {
 		branch, err := n.normalizeProxyAt(proxy, depth, ctx)
 		if err != nil {
 			return nil, err
 		}
 		if branch == nil {
-			return unsupportedSchema(fmt.Sprintf("allOf branch %d has no schema", i+1)), nil
+			return unsupported(fmt.Sprintf("allOf branch %d has no schema", i+1)), nil
 		}
+		annotations.writeOnlySecret = annotations.writeOnlySecret || branch.WriteOnlySecret
 
 		raw, err := n.resolveToSchema(proxy)
 		if err != nil {
@@ -1061,31 +1071,31 @@ func (n *schemaNormalizer) normalizeAllOf(s *base.Schema, depth int, ctx schemaC
 			if reason == "" {
 				reason = fmt.Sprintf("allOf branch %d has unsupported schema kind %q", i+1, branch.Kind)
 			}
-			return unsupportedSchema(reason), nil
+			return unsupported(reason), nil
 		}
 		branches = append(branches, structuralBranch{index: i + 1, schema: branch})
 	}
 
 	if len(branches) == 0 {
-		return unsupportedSchema("allOf has no structural branches"), nil
+		return unsupported("allOf has no structural branches"), nil
 	}
 
 	outerType := firstType(s)
 	if len(s.Type) > 1 {
-		return unsupportedSchema("allOf declares multiple outer types"), nil
+		return unsupported("allOf declares multiple outer types"), nil
 	}
 
 	if len(branches) == 1 {
 		out := model.CloneSchema(branches[0].schema)
 		if outerType != "" && !schemaKindMatchesType(out, outerType) {
-			return unsupportedSchema(fmt.Sprintf("allOf outer type %q conflicts with branch %d schema kind %q", outerType, branches[0].index, out.Kind)), nil
+			return unsupported(fmt.Sprintf("allOf outer type %q conflicts with branch %d schema kind %q", outerType, branches[0].index, out.Kind)), nil
 		}
 		if reason := applyAllOfScalarConstraints(out, s, branches[0].index); reason != "" {
-			return unsupportedSchema(reason), nil
+			return unsupported(reason), nil
 		}
 		if len(s.Required) > 0 {
 			if out.Kind != model.SchemaKindObject {
-				return unsupportedSchema(fmt.Sprintf("allOf declares outer required fields for branch %d schema kind %q", branches[0].index, out.Kind)), nil
+				return unsupported(fmt.Sprintf("allOf declares outer required fields for branch %d schema kind %q", branches[0].index, out.Kind)), nil
 			}
 			out.Required = unionRequired(out.Required, s.Required)
 		}
@@ -1094,10 +1104,10 @@ func (n *schemaNormalizer) normalizeAllOf(s *base.Schema, depth int, ctx schemaC
 	}
 
 	if outerType != "" && outerType != "object" {
-		return unsupportedSchema(fmt.Sprintf("allOf object composition conflicts with outer type %q", outerType)), nil
+		return unsupported(fmt.Sprintf("allOf object composition conflicts with outer type %q", outerType)), nil
 	}
 	if s.Format != "" || len(s.Enum) > 0 {
-		return unsupportedSchema("allOf object composition declares scalar outer constraints"), nil
+		return unsupported("allOf object composition declares scalar outer constraints"), nil
 	}
 
 	out := &model.Schema{
@@ -1115,15 +1125,16 @@ func (n *schemaNormalizer) normalizeAllOf(s *base.Schema, depth int, ctx schemaC
 	}
 	for _, branch := range branches {
 		if branch.schema.Kind != model.SchemaKindObject {
-			return unsupportedSchema(fmt.Sprintf(
+			return unsupported(fmt.Sprintf(
 				"allOf branch %d has schema kind %q; multi-branch composition supports objects only",
 				branch.index, branch.schema.Kind,
 			)), nil
 		}
 		out.Sensitive = out.Sensitive || branch.schema.Sensitive
+		out.WriteOnlySecret = out.WriteOnlySecret || branch.schema.WriteOnlySecret
 		for name, child := range branch.schema.Properties {
 			if previous, exists := propertyBranch[name]; exists {
-				return unsupportedSchema(fmt.Sprintf(
+				return unsupported(fmt.Sprintf(
 					"allOf property %q is declared by branches %d and %d",
 					name, previous, branch.index,
 				)), nil

--- a/.generator-v2/internal/parser/schema_test.go
+++ b/.generator-v2/internal/parser/schema_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"errors"
 	"path/filepath"
+	"reflect"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -28,6 +29,19 @@ func opByID(spec *model.Spec, operationId string) *model.Operation {
 	}
 	Fail("operation " + operationId + " not found in spec")
 	return nil
+}
+
+// schemaBoolField lets this test-first task describe metadata that T154 has
+// not added to model.Schema yet. Keeping the assertion reflective means the
+// suite compiles in the intended red state and fails specifically by naming
+// the missing field, rather than failing package compilation before Ginkgo can
+// report which contract is absent.
+func schemaBoolField(schema *model.Schema, name string) bool {
+	GinkgoHelper()
+	value := reflect.ValueOf(schema).Elem().FieldByName(name)
+	Expect(value.IsValid()).To(BeTrue(), "model.Schema is missing %s metadata", name)
+	Expect(value.Kind()).To(Equal(reflect.Bool), "model.Schema.%s must be boolean", name)
+	return value.Bool()
 }
 
 // -------------------------------------------------------------------
@@ -203,6 +217,24 @@ var _ = Describe("NormalizeSchemas field carrying", func() {
 		Expect(properties["explicit_false"].Sensitive).To(BeFalse())
 		Expect(properties["plain"].Sensitive).To(BeFalse())
 	})
+
+	DescribeTable("retains OpenAPI writeOnly independently from display-sensitivity selectors",
+		func(property string, wantWriteOnly, wantSensitive bool) {
+			schema := opByID(spec, "CreateSensitive").RequestSchema.Properties[property]
+			Expect(schema).NotTo(BeNil())
+			Expect(schemaBoolField(schema, "WriteOnlySecret")).To(Equal(wantWriteOnly))
+			Expect(schema.Sensitive).To(Equal(wantSensitive))
+		},
+		Entry("writeOnly:true selects write-only handling", "write_only", true, true),
+		Entry("x-secret:true affects redaction only", "x_secret", false, true),
+		Entry("tracking sensitive:true affects redaction only", "tracking_sensitive", false, true),
+		Entry("tracking sensitive:false cannot disable writeOnly", "explicit_false", true, false),
+		Entry("tracking sensitive:false still overrides x-secret sensitivity", "x_secret_explicit_false", false, false),
+		Entry("x-secret:false selects neither behavior", "x_secret_false", false, false),
+		Entry("malformed x-secret selects neither behavior", "x_secret_malformed", false, false),
+		Entry("writeOnly:false selects neither behavior", "write_only_false", false, false),
+		Entry("an unmarked field selects neither behavior", "plain", false, false),
+	)
 
 	It("marks the unannotated Elastic Cloud password sensitive from its OpenAPI secret markers", func() {
 		elastic, err := LoadSpec(filepath.Join(

--- a/.generator-v2/internal/testdata/compile.go
+++ b/.generator-v2/internal/testdata/compile.go
@@ -93,6 +93,53 @@ func Compile(files []StagedFile) (CompileResult, error) {
 	return CompileResult{Diagnostics: out}, nil
 }
 
+// RunTests compiles staged files as members of their provider packages and
+// runs only the tests selected by runPattern. It uses the same hermetic Go
+// overlay and pinned provider module as Compile, while allowing a full-pipeline
+// regression to execute framework validation that a compile-only gate cannot
+// observe. Test files must be included in files like any other staged source.
+func RunTests(files []StagedFile, runPattern string) (CompileResult, error) {
+	if len(files) == 0 {
+		return CompileResult{}, fmt.Errorf("test gate: no files staged")
+	}
+	if runPattern == "" {
+		return CompileResult{}, fmt.Errorf("test gate: no test pattern provided")
+	}
+
+	providerRoot, err := providermod.Root("")
+	if err != nil {
+		return CompileResult{}, fmt.Errorf("test gate: %w", err)
+	}
+
+	packages, err := stagedPackages(files)
+	if err != nil {
+		return CompileResult{}, fmt.Errorf("test gate: %w", err)
+	}
+	if err := baseline(providerRoot, packages); err != nil {
+		return CompileResult{}, fmt.Errorf("test gate: %w", err)
+	}
+
+	dir, err := os.MkdirTemp("", "tfgen-test-overlay-")
+	if err != nil {
+		return CompileResult{}, fmt.Errorf("test gate: create overlay dir: %w", err)
+	}
+	defer os.RemoveAll(dir)
+
+	overlay, err := writeOverlay(dir, providerRoot, files)
+	if err != nil {
+		return CompileResult{}, fmt.Errorf("test gate: %w", err)
+	}
+
+	out, err := runTests(providerRoot, packages, overlay, runPattern)
+	if err == nil {
+		return CompileResult{}, nil
+	}
+	if out == "" {
+		return CompileResult{}, fmt.Errorf("test gate: go test in %s: %w", providerRoot, err)
+	}
+	return CompileResult{Diagnostics: out}, nil
+}
+
 // stagedPackages reduces the staged files to the sorted set of package patterns
 // to build, one per directory they land in.
 func stagedPackages(files []StagedFile) ([]string, error) {
@@ -177,6 +224,16 @@ func writeOverlay(dir, providerRoot string, files []StagedFile) (string, error) 
 // cache fails loudly here instead of being fetched from the network mid-test.
 func build(providerRoot string, packages []string, extraArgs ...string) (string, error) {
 	args := append([]string{"build"}, extraArgs...)
+	args = append(args, packages...)
+	cmd := exec.Command("go", args...)
+	cmd.Dir = providerRoot
+	cmd.Env = append(os.Environ(), "GOPROXY=off")
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func runTests(providerRoot string, packages []string, overlay, runPattern string) (string, error) {
+	args := []string{"test", "-overlay", overlay, "-run", runPattern, "-count=1"}
 	args = append(args, packages...)
 	cmd := exec.Command("go", args...)
 	cmd.Dir = providerRoot

--- a/.generator-v2/internal/testdata/parser/schema_normalize_kinds.yaml
+++ b/.generator-v2/internal/testdata/parser/schema_normalize_kinds.yaml
@@ -203,6 +203,10 @@ paths:
                 write_only:
                   type: string
                   writeOnly: true
+                tracking_sensitive:
+                  type: string
+                  x-datadog-tf-generator:
+                    sensitive: true
                 x_secret_false:
                   type: string
                   x-secret: false
@@ -215,6 +219,11 @@ paths:
                 explicit_false:
                   type: string
                   writeOnly: true
+                  x-secret: true
+                  x-datadog-tf-generator:
+                    sensitive: false
+                x_secret_explicit_false:
+                  type: string
                   x-secret: true
                   x-datadog-tf-generator:
                     sensitive: false

--- a/datadog/fwprovider/framework_provider.go
+++ b/datadog/fwprovider/framework_provider.go
@@ -31,6 +31,16 @@ import (
 
 var _ provider.Provider = &FrameworkProvider{}
 
+// EnableGeneratedUnstableOperations enables every unstable SDK operation used
+// by generated provider artifacts. Keeping this in the provider package lets
+// alternate client construction paths, including acceptance tests, consume the
+// generator-owned registry without duplicating operation identifiers.
+func EnableGeneratedUnstableOperations(config *datadog.Configuration) {
+	for _, operation := range generatedUnstableOperations {
+		config.SetUnstableOperationEnabled(operation, true)
+	}
+}
+
 var Resources = []func() resource.Resource{
 	NewAgentlessScanningAwsScanOptionsResource,
 	NewAgentlessScanningAzureScanOptionsResource,
@@ -881,6 +891,8 @@ func defaultConfigureFunc(p *FrameworkProvider, request *provider.ConfigureReque
 	ddClientConfig.SetUnstableOperationEnabled("v2.UpdateExecutionPolicy", true)
 	ddClientConfig.SetUnstableOperationEnabled("v2.DeleteExecutionPolicy", true)
 	ddClientConfig.SetUnstableOperationEnabled("v2.ListExecutionPolicies", true)
+
+	EnableGeneratedUnstableOperations(ddClientConfig)
 
 	if !config.ApiUrl.IsNull() && config.ApiUrl.ValueString() != "" {
 		parsedAPIURL, parseErr := url.Parse(config.ApiUrl.ValueString())

--- a/datadog/fwprovider/framework_provider_test.go
+++ b/datadog/fwprovider/framework_provider_test.go
@@ -4,9 +4,27 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+func TestEnableGeneratedUnstableOperations(t *testing.T) {
+	originalOperations := generatedUnstableOperations
+	generatedUnstableOperations = []string{"v2.CreateElasticCloudIntegrationAccount"}
+	t.Cleanup(func() {
+		generatedUnstableOperations = originalOperations
+	})
+
+	config := datadog.NewConfiguration()
+
+	EnableGeneratedUnstableOperations(config)
+
+	const operation = "v2.CreateElasticCloudIntegrationAccount"
+	if !config.IsUnstableOperationEnabled(operation) {
+		t.Fatalf("generated operation %q was not enabled", operation)
+	}
+}
 
 func TestDefaultConfigureFuncRetryConfiguration(t *testing.T) {
 	p := New().(*FrameworkProvider)

--- a/datadog/fwprovider/unstable_operations_generated.go
+++ b/datadog/fwprovider/unstable_operations_generated.go
@@ -1,0 +1,11 @@
+package fwprovider
+
+// generatedUnstableOperations lists the x-unstable operations the generated
+// artifacts call. The pinned SDK defaults every one of them to disabled, so an
+// artifact naming an operation absent from this slice compiles and registers
+// and then fails every call at runtime. tfgen owns this file: each run merges
+// the operations it produced into the existing set (union, sorted) so a scoped
+// --include run never drops entries another artifact needs. Do not edit by hand.
+//
+// EnableGeneratedUnstableOperations enables each of these on the client config.
+var generatedUnstableOperations = []string{}

--- a/datadog/internal/fwutils/writeonly_helpers.go
+++ b/datadog/internal/fwutils/writeonly_helpers.go
@@ -25,9 +25,19 @@ func MergeAttributes(attributeMaps ...map[string]schema.Attribute) map[string]sc
 	return result
 }
 
-// WriteOnlySecretConfig configures a secret attribute that supports both modes:
-// - Plaintext mode: for Terraform <1.11 or users preferring state storage
-// - Write-only mode: for Terraform 1.11+ with secrets not stored in state
+// WriteOnlySecretMode selects whether a schema keeps the legacy plaintext
+// attribute alongside its write-only companion or exposes only the write-only
+// interface. The zero value preserves all existing callers.
+type WriteOnlySecretMode uint8
+
+const (
+	WriteOnlySecretModeLegacy WriteOnlySecretMode = iota
+	WriteOnlySecretModeOnly
+)
+
+// WriteOnlySecretConfig configures a secret attribute. Legacy mode supports
+// both a stateful plaintext attribute and its write-only companion. ModeOnly
+// exposes only the write-only attribute and its stateful version trigger.
 type WriteOnlySecretConfig struct {
 	OriginalAttr         string // Plaintext attribute (e.g., "secret_key")
 	WriteOnlyAttr        string // Write-only attribute (e.g., "secret_key_wo")
@@ -38,6 +48,10 @@ type WriteOnlySecretConfig struct {
 	// ParentBlocks scopes the three attributes under static nested blocks, e.g.
 	// []string{"authentication", "basic"}. Empty means the resource root.
 	ParentBlocks []string
+	// Mode defaults to WriteOnlySecretModeLegacy for backwards compatibility.
+	Mode WriteOnlySecretMode
+	// Required controls both ModeOnly attributes. Legacy mode ignores it.
+	Required bool
 }
 
 func (secretConfig WriteOnlySecretConfig) attrPath(attributeName string) frameworkPath.Path {
@@ -68,6 +82,36 @@ func (secretConfig WriteOnlySecretConfig) attrExpression(attributeName string) f
 // 3. Version trigger - when changed, applies the write-only secret
 // Users choose one mode via ExactlyOneOf validator.
 func CreateWriteOnlySecretAttributes(config WriteOnlySecretConfig) map[string]schema.Attribute {
+	if config.Mode == WriteOnlySecretModeOnly {
+		writeOnly := schema.StringAttribute{
+			Description: config.WriteOnlyDescription,
+			WriteOnly:   true,
+		}
+		trigger := schema.StringAttribute{
+			Description: config.TriggerDescription,
+			Validators: []validator.String{
+				stringvalidator.LengthAtLeast(1),
+			},
+		}
+		if config.Required {
+			writeOnly.Required = true
+			trigger.Required = true
+		} else {
+			writeOnly.Optional = true
+			trigger.Optional = true
+			writeOnly.Validators = []validator.String{
+				stringvalidator.AlsoRequires(config.attrExpression(config.TriggerAttr)),
+			}
+			trigger.Validators = append(trigger.Validators,
+				stringvalidator.AlsoRequires(config.attrExpression(config.WriteOnlyAttr)),
+			)
+		}
+		return map[string]schema.Attribute{
+			config.WriteOnlyAttr: writeOnly,
+			config.TriggerAttr:   trigger,
+		}
+	}
+
 	attrs := map[string]schema.Attribute{
 		config.OriginalAttr: schema.StringAttribute{
 			Optional:    true,
@@ -151,6 +195,9 @@ func (h *WriteOnlySecretHandler) GetSecretForCreate(ctx context.Context, config 
 		result.ShouldSetValue = true
 		return result
 	}
+	if h.Config.Mode == WriteOnlySecretModeOnly {
+		return result
+	}
 
 	// Fall back to plaintext attribute
 	var plaintextSecret types.String
@@ -215,6 +262,9 @@ func (h *WriteOnlySecretHandler) GetSecretForUpdate(ctx context.Context, config 
 		// Version changed - return secret for rotation
 		result.Value = writeOnlySecret.ValueString()
 		result.ShouldSetValue = true
+		return result
+	}
+	if h.Config.Mode == WriteOnlySecretModeOnly {
 		return result
 	}
 

--- a/datadog/internal/fwutils/writeonly_helpers.go
+++ b/datadog/internal/fwutils/writeonly_helpers.go
@@ -2,6 +2,7 @@ package fwutils
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -177,6 +178,20 @@ type WriteOnlySecretHandler struct {
 	SecretRequiredOnUpdate bool // If true, API requires secret in every update; if false (default), secret is optional
 }
 
+func (h *WriteOnlySecretHandler) requireUpdateSecret(result SecretResult) SecretResult {
+	if !h.SecretRequiredOnUpdate || result.ShouldSetValue || result.Diagnostics.HasError() {
+		return result
+	}
+	result.Diagnostics.AddError(
+		"Missing write-only secret required for update",
+		fmt.Sprintf(
+			"The API requires the write-only attribute %q for every update, but configuration did not provide a known value.",
+			h.Config.attrPath(h.Config.WriteOnlyAttr).String(),
+		),
+	)
+	return result
+}
+
 // GetSecretForCreate retrieves secret for resource creation.
 // Checks write-only attribute first, then falls back to plaintext attribute.
 // Returns ShouldSetValue=true if either attribute has a value.
@@ -225,6 +240,7 @@ func (h *WriteOnlySecretHandler) GetSecretForCreate(ctx context.Context, config 
 // When SecretRequiredOnUpdate is true:
 //   - Pattern 2: API requires secret in every update request
 //   - Returns ShouldSetValue=true if write-only or plaintext attr exists in config
+//   - Returns an error diagnostic if configuration has no known secret value
 //   - Version trigger only matters for forcing Terraform to detect a change
 func (h *WriteOnlySecretHandler) GetSecretForUpdate(ctx context.Context, config *tfsdk.Config, req *resource.UpdateRequest) SecretResult {
 	result := SecretResult{}
@@ -265,7 +281,7 @@ func (h *WriteOnlySecretHandler) GetSecretForUpdate(ctx context.Context, config 
 		return result
 	}
 	if h.Config.Mode == WriteOnlySecretModeOnly {
-		return result
+		return h.requireUpdateSecret(result)
 	}
 
 	// Fall back to plaintext attribute
@@ -280,5 +296,5 @@ func (h *WriteOnlySecretHandler) GetSecretForUpdate(ctx context.Context, config 
 		result.ShouldSetValue = true
 	}
 
-	return result
+	return h.requireUpdateSecret(result)
 }

--- a/datadog/internal/fwutils/writeonly_helpers_test.go
+++ b/datadog/internal/fwutils/writeonly_helpers_test.go
@@ -680,3 +680,32 @@ func TestWriteOnlySecretHandlerModeOnlyUpdateRotation(t *testing.T) {
 		})
 	}
 }
+
+func TestWriteOnlySecretHandlerModeOnlyRequiredUpdateRejectsMissingSecret(t *testing.T) {
+	config := modeOnlySecretConfig(t, false)
+	testSchema := schema.Schema{Attributes: CreateWriteOnlySecretAttributes(config)}
+	handler := &WriteOnlySecretHandler{Config: config, SecretRequiredOnUpdate: true}
+	tfConfig := &tfsdk.Config{Raw: modeOnlyValue(nil, nil), Schema: testSchema}
+	request := &resource.UpdateRequest{
+		State: tfsdk.State{Raw: modeOnlyValue(nil, nil), Schema: testSchema},
+		Plan:  tfsdk.Plan{Raw: modeOnlyValue(nil, nil), Schema: testSchema},
+	}
+
+	result := handler.GetSecretForUpdate(context.Background(), tfConfig, request)
+
+	if !result.Diagnostics.HasError() {
+		t.Fatal("required Update secret omission must return an error diagnostic")
+	}
+	if result.ShouldSetValue {
+		t.Fatal("missing required Update secret must not be sent")
+	}
+	for _, diagnostic := range result.Diagnostics {
+		message := diagnostic.Summary() + " " + diagnostic.Detail()
+		if !strings.Contains(message, "api_key_wo") {
+			t.Errorf("diagnostic must identify api_key_wo, got %q", message)
+		}
+		if strings.Contains(message, "configuration-only-secret") {
+			t.Errorf("diagnostic exposed a secret value: %q", message)
+		}
+	}
+}

--- a/datadog/internal/fwutils/writeonly_helpers_test.go
+++ b/datadog/internal/fwutils/writeonly_helpers_test.go
@@ -3,6 +3,7 @@ package fwutils
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -484,6 +485,197 @@ func TestGetSecretForCreateFromNestedBlock(t *testing.T) {
 			}
 			if result.Value != tc.wantValue {
 				t.Errorf("Value = %q, want %q", result.Value, tc.wantValue)
+			}
+		})
+	}
+}
+
+// modeOnlySecretConfig uses reflection so this red test remains executable
+// before T156 adds the Mode and Required contract to WriteOnlySecretConfig.
+// A missing field is reported as the intended contract failure rather than a
+// package compilation error that would hide the rest of the provider suite.
+func modeOnlySecretConfig(t *testing.T, required bool) WriteOnlySecretConfig {
+	t.Helper()
+	config := WriteOnlySecretConfig{
+		OriginalAttr:         "api_key",
+		WriteOnlyAttr:        "api_key_wo",
+		TriggerAttr:          "api_key_wo_version",
+		OriginalDescription:  "The API key for the account.",
+		WriteOnlyDescription: "Write-only API key for the account.",
+		TriggerDescription:   "Version for `api_key_wo` rotation.",
+	}
+	value := reflect.ValueOf(&config).Elem()
+	mode := value.FieldByName("Mode")
+	if !mode.IsValid() {
+		t.Fatal("WriteOnlySecretConfig is missing Mode; T156 must add WriteOnlySecretModeOnly")
+	}
+	switch mode.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		mode.SetInt(1)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		mode.SetUint(1)
+	default:
+		t.Fatalf("WriteOnlySecretConfig.Mode must be an integer-backed enum, got %s", mode.Kind())
+	}
+	requiredField := value.FieldByName("Required")
+	if !requiredField.IsValid() {
+		t.Fatal("WriteOnlySecretConfig is missing Required")
+	}
+	if requiredField.Kind() != reflect.Bool {
+		t.Fatalf("WriteOnlySecretConfig.Required must be bool, got %s", requiredField.Kind())
+	}
+	requiredField.SetBool(required)
+	return config
+}
+
+func modeOnlyValue(secret, version *string) tftypes.Value {
+	stringValue := func(value *string) tftypes.Value {
+		if value == nil {
+			return tftypes.NewValue(tftypes.String, nil)
+		}
+		return tftypes.NewValue(tftypes.String, *value)
+	}
+	objectType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"api_key_wo":         tftypes.String,
+		"api_key_wo_version": tftypes.String,
+	}}
+	return tftypes.NewValue(objectType, map[string]tftypes.Value{
+		"api_key_wo":         stringValue(secret),
+		"api_key_wo_version": stringValue(version),
+	})
+}
+
+func TestCreateWriteOnlySecretAttributesModeOnly(t *testing.T) {
+	for _, required := range []bool{false, true} {
+		t.Run(fmt.Sprintf("required=%t", required), func(t *testing.T) {
+			config := modeOnlySecretConfig(t, required)
+			attrs := CreateWriteOnlySecretAttributes(config)
+
+			if len(attrs) != 2 {
+				t.Fatalf("mode-only schema must expose exactly _wo and _wo_version, got keys %#v", reflect.ValueOf(attrs).MapKeys())
+			}
+			if _, exists := attrs[config.OriginalAttr]; exists {
+				t.Fatalf("mode-only schema must not expose plaintext attribute %q", config.OriginalAttr)
+			}
+			writeOnly, ok := attrs[config.WriteOnlyAttr].(schema.StringAttribute)
+			if !ok {
+				t.Fatalf("%s must be schema.StringAttribute, got %T", config.WriteOnlyAttr, attrs[config.WriteOnlyAttr])
+			}
+			version, ok := attrs[config.TriggerAttr].(schema.StringAttribute)
+			if !ok {
+				t.Fatalf("%s must be schema.StringAttribute, got %T", config.TriggerAttr, attrs[config.TriggerAttr])
+			}
+			if !writeOnly.WriteOnly || writeOnly.Sensitive || writeOnly.Computed {
+				t.Errorf("_wo flags = WriteOnly:%t Sensitive:%t Computed:%t; want true, false, false", writeOnly.WriteOnly, writeOnly.Sensitive, writeOnly.Computed)
+			}
+			if required {
+				if !writeOnly.Required || writeOnly.Optional || !version.Required || version.Optional {
+					t.Errorf("required mode-only pair must make both attributes Required: _wo=%#v version=%#v", writeOnly, version)
+				}
+				return
+			}
+			if !writeOnly.Optional || writeOnly.Required || !version.Optional || version.Required {
+				t.Errorf("optional mode-only pair must make both attributes Optional: _wo=%#v version=%#v", writeOnly, version)
+			}
+			writeOnlyValidators := validatorDescriptions(t, writeOnly)
+			versionValidators := validatorDescriptions(t, version)
+			if !strings.Contains(writeOnlyValidators, `"[api_key_wo_version]"`) {
+				t.Errorf("optional _wo must require its version, got:\n%s", writeOnlyValidators)
+			}
+			if !strings.Contains(versionValidators, `"[api_key_wo]"`) {
+				t.Errorf("optional version must require _wo, got:\n%s", versionValidators)
+			}
+		})
+	}
+}
+
+func TestCreateWriteOnlySecretAttributesModeOnlyValidNestedSchema(t *testing.T) {
+	config := modeOnlySecretConfig(t, false)
+	config.ParentBlocks = []string{"authentication", "basic"}
+	basicAttributes := CreateWriteOnlySecretAttributes(config)
+	basicAttributes["username"] = schema.StringAttribute{
+		Optional:    true,
+		Computed:    true,
+		Description: "Readable username returned by the API.",
+	}
+
+	testSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"authentication": schema.SingleNestedAttribute{
+				Required:    true,
+				Description: "Authentication configuration.",
+				Attributes: map[string]schema.Attribute{
+					"basic": schema.SingleNestedAttribute{
+						Optional:    true,
+						Description: "Basic authentication configuration.",
+						Attributes:  basicAttributes,
+					},
+				},
+			},
+		},
+	}
+
+	if diagnostics := testSchema.ValidateImplementation(context.Background()); diagnostics.HasError() {
+		t.Fatalf("mode-only nested resource schema must pass framework validation: %v", diagnostics)
+	}
+}
+
+func TestWriteOnlySecretHandlerModeOnlyReadsConfigurationWithoutPlaintextFallback(t *testing.T) {
+	config := modeOnlySecretConfig(t, false)
+	testSchema := schema.Schema{Attributes: CreateWriteOnlySecretAttributes(config)}
+	handler := &WriteOnlySecretHandler{Config: config}
+
+	for _, tc := range []struct {
+		name      string
+		secret    *string
+		wantSet   bool
+		wantValue string
+	}{
+		{name: "configured write-only value", secret: ptr("configuration-only-secret"), wantSet: true, wantValue: "configuration-only-secret"},
+		{name: "optional secret omitted"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tfConfig := &tfsdk.Config{Raw: modeOnlyValue(tc.secret, ptr("1")), Schema: testSchema}
+			result := handler.GetSecretForCreate(context.Background(), tfConfig)
+			if result.Diagnostics.HasError() {
+				t.Fatalf("mode-only Create must not look up absent plaintext attribute: %v", result.Diagnostics)
+			}
+			if result.ShouldSetValue != tc.wantSet || result.Value != tc.wantValue {
+				t.Errorf("result = (%t, %q), want (%t, %q)", result.ShouldSetValue, result.Value, tc.wantSet, tc.wantValue)
+			}
+		})
+	}
+}
+
+func TestWriteOnlySecretHandlerModeOnlyUpdateRotation(t *testing.T) {
+	config := modeOnlySecretConfig(t, false)
+	testSchema := schema.Schema{Attributes: CreateWriteOnlySecretAttributes(config)}
+	handler := &WriteOnlySecretHandler{Config: config}
+
+	for _, tc := range []struct {
+		name         string
+		priorVersion string
+		planVersion  string
+		wantSet      bool
+	}{
+		{name: "unchanged version omits secret", priorVersion: "1", planVersion: "1", wantSet: false},
+		{name: "changed version rotates once", priorVersion: "1", planVersion: "2", wantSet: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tfConfig := &tfsdk.Config{Raw: modeOnlyValue(ptr("rotated-secret"), ptr(tc.planVersion)), Schema: testSchema}
+			request := &resource.UpdateRequest{
+				State: tfsdk.State{Raw: modeOnlyValue(nil, ptr(tc.priorVersion)), Schema: testSchema},
+				Plan:  tfsdk.Plan{Raw: modeOnlyValue(nil, ptr(tc.planVersion)), Schema: testSchema},
+			}
+			result := handler.GetSecretForUpdate(context.Background(), tfConfig, request)
+			if result.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", result.Diagnostics)
+			}
+			if result.ShouldSetValue != tc.wantSet {
+				t.Errorf("ShouldSetValue = %t, want %t", result.ShouldSetValue, tc.wantSet)
+			}
+			if tc.wantSet && result.Value != "rotated-secret" {
+				t.Errorf("Value = %q, want rotated-secret", result.Value)
 			}
 		})
 	}

--- a/datadog/tests/framework_provider_test.go
+++ b/datadog/tests/framework_provider_test.go
@@ -207,6 +207,7 @@ func buildFrameworkDatadogClient(ctx context.Context, httpClient *http.Client) *
 	config.SetUnstableOperationEnabled("v2.UpdateExecutionPolicy", true)
 	config.SetUnstableOperationEnabled("v2.DeleteExecutionPolicy", true)
 	config.SetUnstableOperationEnabled("v2.ListExecutionPolicies", true)
+	fwprovider.EnableGeneratedUnstableOperations(config)
 
 	if ctx.Value("http_retry_enable") == true {
 		config.RetryConfiguration.EnableRetry = true


### PR DESCRIPTION
### Motivation

Secret values belong in a request body, never in Terraform state. The OpenAPI specs already mark those properties `writeOnly`, but the generator treated them like any other string and emitted an attribute that persists the secret. This PR teaches every tfgen layer to recognize `writeOnly` and project it into the framework's write-only attribute interface, and wires up the CI job that proves the generated code actually honors that contract.

The generated resources this unblocks (`datadog_integration_elastic_cloud`, `datadog_integration_twilio_account`), their docs/examples, and the acceptance-test cassette are **not** part of this PR — they land in the next PR in the stack.

### Changes

- parser carries the OpenAPI `writeOnly` keyword onto the normalized schema.
- model reconciles that fact across the Create, Update and Read bodies, and now answers separately whether a secret is required on create and on update. Every merge function takes an `updateRequired` parameter to carry the second answer.
- model applies the framework containment rule once the tree is projected: a request-settable ancestor of a secret keeps its input flag but loses `Computed` and `UseStateForUnknown`.
- emit expands one `writeOnly` property into a pair of attributes, `<name>_wo` and `<name>_wo_version`, and routes the request through a handler that reads the value from configuration and sets the SDK field only when a value should be sent.
- emit normalizes computed unknowns to null, so a plan stays consistent where a secret backs no readable state.
- The resource and shared templates render that pair in the schema and the guarded setter in the request body.
- fwutils gains a write-only mode that drops the plaintext attribute, a `SecretResult`, and a handler with separate create and update retrieval, so an API accepting partial updates omits an unchanged secret while one demanding it on every update always sends it.
- fwprovider enables the generator-owned unstable-operation registry on the client config through `EnableGeneratedUnstableOperations`, so a generated artifact calling a beta endpoint no longer compiles and registers only to fail at apply time.
- Adds a CI job (`integration-test` in `.github/workflows/tfgen.yml`) that runs `make tfgen-test-integration` — the integration-tagged compile-and-schema-validate gate that previously only ran locally. It proves a generated write-only resource compiles against the provider module and that its framework schema keeps the plaintext attribute out while marking `_wo` write-only and `_wo_version` as a required stateful trigger.

### Tests

- Unit tests per layer: parser normalization of the keyword, the three-way merge of write-only facts and the required-on-create versus required-on-update split, and the tree projection including the ancestor containment rule.
- emit tests over the generated schema, the model fields and the guarded request mapping.
- fwutils tests cover the handler directly: retrieval on create, the partial-update path where an unchanged version trigger sends nothing, and the path where the API requires the secret on every update.
- New CI job runs the integration-tagged tests (`tfgen-test-integration`), which previously only ran locally: the CLI-driven compile gate that builds a generated write-only resource against the provider module and validates its framework schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
