### PR TITLE
[datadog_datastore] Fix inconsistent result after apply when description is omitted

### DIFF
--- a/datadog/fwprovider/resource_datadog_datastore.go
+++ b/datadog/fwprovider/resource_datadog_datastore.go
@@ -258,7 +258,11 @@ func (r *datastoreResource) updateState(ctx context.Context, state *datastoreMod
 	}
 
 	if description, ok := attributes.GetDescriptionOk(); ok && description != nil {
-		state.Description = types.StringValue(*description)
+		if *description == "" && state.Description.IsNull() {
+			state.Description = types.StringNull()
+		} else {
+			state.Description = types.StringValue(*description)
+		}
 	}
 
 	if modifiedAt, ok := attributes.GetModifiedAtOk(); ok && modifiedAt != nil {

--- a/datadog/tests/resource_datadog_datastore_test.go
+++ b/datadog/tests/resource_datadog_datastore_test.go
@@ -41,6 +41,59 @@ func TestAccDatastoreBasic(t *testing.T) {
 	})
 }
 
+// TestAccDatastore_NoDescription tests that omitting `description` keeps it null in
+// state rather than being read back as "", which previously failed with
+// "Provider produced inconsistent result after apply".
+func TestAccDatastore_NoDescription(t *testing.T) {
+	t.Parallel()
+	ctx, providers, accProviders := testAccFrameworkMuxProviders(context.Background(), t)
+	uniq := uniqueEntityName(ctx, t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: accProviders,
+		CheckDestroy:             testAccCheckDatadogDatastoreDestroy(providers.frameworkProvider),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDatadogDatastoreNoDescription(uniq),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogDatastoreExists(providers.frameworkProvider),
+					resource.TestCheckNoResourceAttr(
+						"datadog_datastore.no_description", "description"),
+					resource.TestCheckResourceAttr(
+						"datadog_datastore.no_description", "primary_column_name", "id"),
+				),
+			},
+			{
+				Config: testAccCheckDatadogDatastoreWithDescription(uniq, "Now described"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogDatastoreExists(providers.frameworkProvider),
+					resource.TestCheckResourceAttr(
+						"datadog_datastore.no_description", "description", "Now described"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDatadogDatastoreNoDescription(uniq string) string {
+	return fmt.Sprintf(`resource "datadog_datastore" "no_description" {
+    name = "tf-test-datastore-%s"
+    org_access = "manager"
+    primary_column_name = "id"
+    primary_key_generation_strategy = "none"
+}`, uniq)
+}
+
+func testAccCheckDatadogDatastoreWithDescription(uniq string, description string) string {
+	return fmt.Sprintf(`resource "datadog_datastore" "no_description" {
+    description = "%s"
+    name = "tf-test-datastore-%s"
+    org_access = "manager"
+    primary_column_name = "id"
+    primary_key_generation_strategy = "none"
+}`, description, uniq)
+}
+
 func testAccCheckDatadogDatastore(uniq string) string {
 	return fmt.Sprintf(`resource "datadog_datastore" "foo" {
     description = "Test datastore for acceptance testing"


### PR DESCRIPTION
The API returns "" for an unset description, which was written to state as a non-null value and conflicted with a config that omits the attribute.

Fixes #4106